### PR TITLE
Patch for https://github.com/openframeworks/openFrameworks/issues/issue/251

### DIFF
--- a/libs/openFrameworks/utils/ofTypes.h
+++ b/libs/openFrameworks/utils/ofTypes.h
@@ -373,7 +373,7 @@ class ofColor{
 	// Return hex color
 	// ROGER: TESTAR ISSO AQUI!!!!
     int getHex(){
-		return ( ((int)r) << 16 + ((int)g) << 8 + ((int)b) );
+		return ( ((int)r) << (16 + ((int)g)) << (8 + ((int)b)) );
     }
 	
 	


### PR DESCRIPTION
My commit here:
https://github.com/tmatth/openFrameworks/commit/122e7081a2246cf2591f87cf0526d6683ab7e562
resolves compiler warnings for the getHex method of ofColor
