### PR TITLE
XML loadFromBuffer() return value

### DIFF
--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -651,12 +651,14 @@ int ofxXmlSettings::writeAttribute(const string& tag, const string& attribute, c
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::loadFromBuffer( string buffer )
+bool ofxXmlSettings::loadFromBuffer( string buffer )
 {
 	
     int size = buffer.size();
 	
     bool loadOkay = doc.ReadFromMemory( buffer.c_str(), size);//, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
+    
+    return loadOkay;
 	
 }
 //---------------------------------------------------------

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -135,7 +135,7 @@ class ofxXmlSettings{
 		int		setAttribute(const string& tag, const string& attribute, double value);
 		int		setAttribute(const string& tag, const string& attribute, const string& value);
 
-		void	loadFromBuffer( string buffer );
+		bool	loadFromBuffer( string buffer );
 		void	copyXmlToString(string & str);
 	
 		TiXmlDocument 	doc;


### PR DESCRIPTION
I just added a return statement to the laodFromBuffer() method to indicated whether the operation was successful or not. The "loadOkay" var was already there but unused.
