### PR TITLE
Skip fmodex

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -45,10 +45,12 @@ void ofSetupOpenGL(int w, int h, int screenMode){
 void ofExitCallback();
 void ofExitCallback(){
 
+#if defined(OS_USING_FMODEX)
 	//------------------------
 	// try to close FMOD:
 	ofSoundPlayer::closeFmod();
 	//------------------------
+#endif
 
 	//------------------------
 	// try to close rtAudio:

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -3,7 +3,7 @@
 
 #include "ofConstants.h"
 
-#ifndef TARGET_OF_IPHONE
+#if !defined(TARGET_OF_IPHONE) && defined(OF_USING_FMODEX)
 extern "C" {
 #include "fmod.h"
 #include "fmod_errors.h"
@@ -70,7 +70,7 @@ class ofSoundPlayer {
 		float speed; // -n to n, 1 = normal, -1 backwards
 		unsigned int length; // in samples;
 
-		#ifndef TARGET_OF_IPHONE
+		#if !defined(TARGET_OF_IPHONE) && defined(OF_USING_FMODEX)
 			FMOD_RESULT result;
 			FMOD_CHANNEL * channel;
 			FMOD_SOUND * sound;

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -192,6 +192,10 @@
 // comment out this line to disable all poco related code
 #define OF_USING_POCO
 
+#ifndef SKIP_FMODEX
+# define OF_USING_FMODEX
+#endif
+
 //we don't want to break old code that uses ofSimpleApp
 //so we forward declare ofBaseApp and make ofSimpleApp mean the same thing
 class ofBaseApp;


### PR DESCRIPTION
Added a couple of preprocessor defines to allow easy disabling of fmodex compilation. (important for debian packaging) This should have no real impact on other folks, or else I've done something horribly, horribly wrong.
