### PR TITLE
Fix 3d case problem

### DIFF
--- a/libs/openFrameworks/3d/of3d.h
+++ b/libs/openFrameworks/3d/of3d.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "ofNode3d.h"
+#include "ofNode3D.h"
 #include "ofCamera.h"
 #include "ofMeshNode.h"
 #include "ofScene3d.h"

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -13,7 +13,7 @@
 #pragma once
 
 
-#include "ofNode3d.h"
+#include "ofNode3D.h"
 #include "ofMain.h"
 
 class ofCamera : public ofNode3d {

--- a/libs/openFrameworks/3d/ofMeshNode.h
+++ b/libs/openFrameworks/3d/ofMeshNode.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include "ofNode3d.h"
+#include "ofNode3D.h"
 #include "ofMain.h"
 
 class ofMesh;

--- a/libs/openFrameworks/3d/ofNode3D.cpp
+++ b/libs/openFrameworks/3d/ofNode3D.cpp
@@ -1,5 +1,5 @@
 
-#include "ofNode3d.h"
+#include "ofNode3D.h"
 #include "ofMain.h"
 
 

--- a/libs/openFrameworks/3d/ofScene3d.h
+++ b/libs/openFrameworks/3d/ofScene3d.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "ofNode3d.h"
+#include "ofNode3D.h"
 
 class ofScene3d {
 public:


### PR DESCRIPTION
The recent move of ofNode3d.h wound up moving it to ofNode3D.h. I'm guessing folks are on mac laptops with case-insensitive filesystems. :) ... In any case, just a few includes had to be fixed for linux.
