### PR TITLE
Add missing include

### DIFF
--- a/addons/ofxAccelerometer/src/ofxAccelerometer.h
+++ b/addons/ofxAccelerometer/src/ofxAccelerometer.h
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "ofTypes.h"
+#include "ofPoint.h"
 
 typedef void (*ofxAccelCB)(ofPoint&);			// typedef for accelerometer callback
 


### PR DESCRIPTION
Missing include in ofxAccelerometer.h was causing the compile to bork. Added include of ofpoint.h and all is happy.
