### PR TITLE
Fbo viewport fix

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -109,7 +109,6 @@ void ofViewport(float x, float y, float width, float height) {
 	if(height == 0) height = ofGetHeight();
 
 	glViewport(x, y, width, height);
-	viewportRect.set(x, y, width, height);
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
because the viewport was being saved, fbos would not properly draw to the screen.
