### PR TITLE
fix loading of subsequent movies into QuickTimeVideoPlayer

### DIFF
--- a/libs/openFrameworks/video/ofQuickTimePlayer.cpp
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.cpp
@@ -277,9 +277,6 @@ bool ofQuickTimePlayer::loadMovie(string name){
 		}
 
 		bool bDoWeAlreadyHaveAGworld = false;
-		if (width != 0 && height != 0){
-			bDoWeAlreadyHaveAGworld = true;
-		}
 		Rect 				movieRect;
 		GetMovieBox(moviePtr, &(movieRect));
 		if (bDoWeAlreadyHaveAGworld){


### PR DESCRIPTION
This is a fix for loading more movies into the QuickTime instance of VideoPlayer on OS X. With the check that was commented out in this commit, it would not play any videos (aside from the first one of the instance) that were attempted to be loaded.
