### PR TITLE
ofArduino updated for firmata 2.2 servo protocol

### DIFF
--- a/libs/openFrameworks/communication/ofArduino.cpp
+++ b/libs/openFrameworks/communication/ofArduino.cpp
@@ -689,7 +689,7 @@ void ofArduino::sendServoAttach(int pin, int minPulse, int maxPulse, int angle) 
 	_digitalPinMode[pin]=ARD_SERVO;
 }
 
-// sendServoDetach depricated for Firmata 2.2
+// sendServoDetach depricated as of Firmata 2.2
 void ofArduino::sendServoDetach(int pin) {
 	sendByte(FIRMATA_START_SYSEX);
 	sendByte(SYSEX_SERVO_DETACH);

--- a/libs/openFrameworks/communication/ofArduino.h
+++ b/libs/openFrameworks/communication/ofArduino.h
@@ -132,7 +132,7 @@
 
 #define OF_ARDUINO_DELAY_LENGTH					4.0
 
-// use to check if firmware version uploaded to arduino is > 2.2 (22)
+// use to check if firmware version uploaded to arduino is >= 2.2 (22)
 #define FIRMWARE2_2								22
 
 


### PR DESCRIPTION
Fixed a couple of errors in a previous pull request.

This update fixes servo functionality for firmata v. 2.2 (and higher). It should still be backwards compatible with older versions of firmata that implemented a preliminary protocol for servos.

Example implementation available here: http://www.box.net/shared/static/32tfaon50q.zip

Also update to firmataExample to use EInitialized event rather than polling isArduinoReady(). The polling method was based on an arbitrary delay rather than the actual initialization event triggered when firmata.begin is called on the Arduino. The use of the EInitialized event is a much better approach than polling and is recommended. It is also necessary for proper Firmata v2.2 functionality.
