### PR TITLE
closes #514, fixes issue with dirList on paths not ending with slashes

### DIFF
--- a/libs/openFrameworks/utils/ofDirectoryLister.cpp
+++ b/libs/openFrameworks/utils/ofDirectoryLister.cpp
@@ -1,6 +1,7 @@
 #include "ofDirectoryLister.h"
 
 #include "ofUtils.h"
+#include "ofFileUtils.h"
 #include "Poco/Path.h"
 #include "Poco/String.h"
 
@@ -42,6 +43,8 @@ void ofDirectoryLister::allowExt(string extension) {
 
 //----------------------------------------
 int ofDirectoryLister::listDir(string directory, bool absolute) {
+	directory = ofFileUtils::getPathForDirectory(directory);
+	
 	files.clear();
 
 	originalDirectory = directory;
@@ -49,7 +52,7 @@ int ofDirectoryLister::listDir(string directory, bool absolute) {
 	if(!absolute) {
 		absolutePath = ofToDataPath(directory);
 	}
-
+	
 	Path base(absolutePath);
 	File cur(base);
 	if(cur.exists()) {

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -239,6 +239,14 @@ using Poco::NotFoundException;
 }
 
 //------------------------------------------------------------------------------------------------------------
+string ofFileUtils::getPathForDirectory(string path) {
+	// if a trailing slash is missing from a path, this will clean it up
+	// if it's a windows-style \ path it will add a \
+	// if it's a unix-style / path it will add a /
+	return Path::forDirectory(path).toString();
+}
+
+//------------------------------------------------------------------------------------------------------------
  string ofFileUtils::removeTrailingSlash(string path){
 	if( path.length() > 0 && path[path.length()-1] == '/' ){
 		path = path.substr(0, path.length()-1);

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -61,6 +61,7 @@ class ofFileUtils{
 	static string addLeadingSlash(string path);
 	static string addTrailingSlash(string path);
 	static string removeTrailingSlash(string path);
+	static string getPathForDirectory(string path);
 
 	//------------------------------------------------------------------------------------------------------------	
 	static string getFilenameFromPath(string filePath, bool bRelativeToData = true);


### PR DESCRIPTION
that's embarrassing, a user just reported this obvious problem i somehow failed to port from the old ofxDirList.

note that i solved it by adding a function ofFileUtils::getPathForDirectory(string path) which uses poco to add a trailing slash when necessary. i feel like this is probably more reliable than checking if the last character is a slash and adding it ourself (which was the old solution).
