### PR TITLE
ofMesh::addTriangle(index1, index2, index3)

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -188,6 +188,14 @@ void ofMesh::addIndices(const ofIndexType* inds, int amt){
 	bIndicesChanged = true;
 }
 
+//--------------------------------------------------------------
+void ofMesh::addTriangle(ofIndexType index1, ofIndexType index2, ofIndexType index3) {
+    addIndex(index1);
+    addIndex(index2);
+    addIndex(index3);
+}
+
+
 //GETTERS
 //--------------------------------------------------------------
 ofPrimitiveMode ofMesh::getMode() const{

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -65,6 +65,8 @@ public:
 	void setIndex(int i, ofIndexType val);
 	void clearIndices();
 	
+    void addTriangle(ofIndexType index1, ofIndexType index2, ofIndexType index3);
+	
 	int getNumVertices() const;
 	int getNumColors() const;
 	int getNumNormals() const;


### PR DESCRIPTION
to add a triangle to a mesh, you need to do it in 3 lines:
mesh.addIndex(0);
mesh.addIndex(1);
mesh.addIndex(2);
and that adds a triangle.

So I added a simple method which wraps that. 
mesh.addTriangle(0, 1, 2);
