### PR TITLE
resetROI on ofxCvHaarFinder::findHaarObjects

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
@@ -132,6 +132,7 @@ int ofxCvHaarFinder::findHaarObjects(const ofxCvGrayscaleImage& input,
 		// because we need to equalize it.
 
 		if (img.width == input.width && img.height == input.height) {
+                img.resetROI();
 				img = input;
 		} else {
 				img.clear();


### PR DESCRIPTION
adding img.resetROI before copying the input img in findHaarObjects
solves issue 558
https://github.com/openframeworks/openFrameworks/issues/558
but maybe someone with more knowledge of the haarFinder could review?
