### PR TITLE
Re-enabled MoviesTask in ofQuickTimePlayer

### DIFF
--- a/libs/openFrameworks/video/ofQuickTimePlayer.cpp
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.cpp
@@ -164,8 +164,16 @@ void ofQuickTimePlayer::update(){
 		//--------------------------------------------------------------
 		#ifdef OF_VIDEO_PLAYER_QUICKTIME
 		//--------------------------------------------------------------
-
-            MoviesTask(moviePtr,0);
+			
+			// is this necessary on windows with quicktime?
+			#ifdef TARGET_OSX 
+				// call MoviesTask if we're not on the main thread
+				if ( CFRunLoopGetCurrent() != CFRunLoopGetMain() )
+				{
+					//ofLog( OF_LOG_NOTICE, "not on the main loop, calling MoviesTask") ;
+					MoviesTask(moviePtr,0);
+				}
+			#endif
 
 		//--------------------------------------------------------------
 		#endif


### PR DESCRIPTION
MoviesTask was #ifdef'd out by an #ifdef OF_QT_MOVIETASK which was not defined anywhere. Although MoviesTask is called automatically in most cases under OSX, when movie playback is heavily multithreaded failing to call MoviesTask manually can cause movies to freeze.
