### PR TITLE
check if RTAudio stream is open/running before closing/stopping

### DIFF
--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -148,7 +148,9 @@ void ofRtAudioSoundStream::stop(){
 	if( audio == NULL )return;
 	
 	try {
-    	audio->stopStream();
+    		if(audio->isStreamRunning()) {
+			audio->stopStream();
+		}
   	} catch (RtError &error) {
    		error.printMessage();
  	}
@@ -159,7 +161,9 @@ void ofRtAudioSoundStream::close(){
 	if(audio == NULL) return;
 	
 	try {
-    	audio->closeStream();
+    		if(audio->isStreamOpen()) {
+    			audio->closeStream();
+		}
   	} catch (RtError &error) {
    		error.printMessage();
  	}


### PR DESCRIPTION
check if RTAudio stream is open/running before closing/stopping, avoids error print on RT sound stream destructor if close was called during app::exit()
