### PR TITLE
fixed rt audio hang on exit

### DIFF
--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -21,7 +21,6 @@ ofRtAudioSoundStream::ofRtAudioSoundStream(){
 
 //------------------------------------------------------------------------------
 ofRtAudioSoundStream::~ofRtAudioSoundStream(){
-	stop();
 	close();
 }
 
@@ -134,7 +133,7 @@ bool ofRtAudioSoundStream::setup(ofBaseApp * app, int outChannels, int inChannel
 
 //------------------------------------------------------------------------------
 void ofRtAudioSoundStream::start(){
-	if( audio == NULL )return;
+	if( audio == NULL ) return;
 	
 	try{
 		audio->startStream();
@@ -145,11 +144,11 @@ void ofRtAudioSoundStream::start(){
 
 //------------------------------------------------------------------------------
 void ofRtAudioSoundStream::stop(){
-	if( audio == NULL )return;
+	if( audio == NULL ) return;
 	
 	try {
-    		if(audio->isStreamRunning()) {
-			audio->stopStream();
+		if(audio->isStreamRunning()) {
+    		audio->stopStream();
 		}
   	} catch (RtError &error) {
    		error.printMessage();
@@ -158,17 +157,18 @@ void ofRtAudioSoundStream::stop(){
 
 //------------------------------------------------------------------------------
 void ofRtAudioSoundStream::close(){
-	if(audio == NULL) return;
+	if( audio == NULL ) return;
 	
 	try {
-    		if(audio->isStreamOpen()) {
-    			audio->closeStream();
+		if(audio->isStreamOpen()) {
+    		audio->closeStream();
 		}
   	} catch (RtError &error) {
    		error.printMessage();
  	}
 	soundOutputPtr	= NULL;
-	soundInputPtr	= NULL;	
+	soundInputPtr	= NULL;
+	audio = ofPtr<RtAudio>();	// delete
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
fixed rt audio hang on exit by removing close() in destructor; now correctly deleting audio pointer when closing
