### PR TITLE
Exclude iPhoneAddonsExamples from the apps folder .gitignore

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -4,6 +4,8 @@
 !addonsExamples/**
 !iPhoneExamples
 !iPhoneExamples/**
+!iPhoneAddonsExamples
+!iPhoneAddonsExamples/**
 !androidExamples
 !androidExamples/**
 !androidExamples/*/**


### PR DESCRIPTION
Hope this is ok to do... have a fix in the iPhoneAddonsExamples/xmlSettingsExample that I wanted to share, so need to edit the apps/.gitignore first
