### PR TITLE
Add missing multitouch set-up to the xmlSettingsExample testApp

### DIFF
--- a/apps/iPhoneAddonsExamples/xmlSettingsExample/src/testApp.mm
+++ b/apps/iPhoneAddonsExamples/xmlSettingsExample/src/testApp.mm
@@ -4,6 +4,12 @@
 //--------------------------------------------------------------
 void testApp::setup(){
 
+	// register touch events
+	ofxRegisterMultitouch(this);
+	
+	//iPhoneAlerts will be sent to this.
+	ofxiPhoneAlerts.addListener(this);
+	
 	ofxiPhoneSetOrientation(OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT);
 
 	ofBackground(255,255,255);


### PR DESCRIPTION
Latest version of xmlSettingsExample with the touch methods was missing the multitouch set-up.
