### PR TITLE
Make ofSoundPlayer's choice of backend overrideable

### DIFF
--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -35,14 +35,16 @@ void ofSoundShutdown();
 #include "ofBaseTypes.h"
 #include "ofBaseSoundPlayer.h"
 
-#ifdef TARGET_OF_IPHONE 
-	#define OF_SOUND_PLAYER_IPHONE
-#elif defined TARGET_LINUX
-	#define OF_SOUND_PLAYER_OPENAL
-#elif !defined(TARGET_ANDROID)
-	#define OF_SOUND_PLAYER_FMOD
-#else
-	void ofSoundShutdown(){}
+#if !defined(OF_SOUND_PLAYER_QUICKTIME) && !defined(OF_SOUND_PLAYER_FMOD) && !defined(OF_SOUND_PLAYER_OPENAL)
+  #ifdef TARGET_OF_IPHONE 
+  	#define OF_SOUND_PLAYER_IPHONE
+  #elif defined TARGET_LINUX
+  	#define OF_SOUND_PLAYER_OPENAL
+  #elif !defined(TARGET_ANDROID)
+  	#define OF_SOUND_PLAYER_FMOD
+  #else
+  	void ofSoundShutdown(){}
+  #endif
 #endif
 
 #ifdef OF_SOUND_PLAYER_QUICKTIME


### PR DESCRIPTION
The current implementation uses `TARGET_*` macros to determine which `OF_SOUND_PLAYER_*` macro to define and as a result which audio backend to use. This patch makes it so that if a `OF_SOUND_PLAYER_*` macro is defined beforehand, it is taken as authoritative and no further checking is done. It makes it possible to force an audio backend if needed.
