### PR TITLE
ofiPhoneVideoPlayer

### DIFF
--- a/libs/openFrameworks/video/ofiPhoneVideoPlayer.mm
+++ b/libs/openFrameworks/video/ofiPhoneVideoPlayer.mm
@@ -111,7 +111,8 @@ bool ofiPhoneVideoPlayer::isFrameNew() {
 //----------------------------------------
 
 unsigned char * ofiPhoneVideoPlayer::getPixels() {
-	if(videoPlayer != NULL)
+
+	if(videoPlayer != NULL && isPlaying())
 	{
 		CGImageRef currentFrameRef;
 		
@@ -144,7 +145,7 @@ unsigned char * ofiPhoneVideoPlayer::getPixels() {
 		/*We unlock the  image buffer*/
 		CVPixelBufferUnlockBaseAddress(imageBuffer,0);
 		
-		if(width==0 && widthIn != 0  && pixels != NULL) {
+		if(width==0 && widthIn != 0  && pixels == NULL) {
 			if(internalGLFormat == GL_RGB)
 				pixels = (GLubyte *) malloc(widthIn * heightIn * 3);
 			else
@@ -163,7 +164,7 @@ unsigned char * ofiPhoneVideoPlayer::getPixels() {
 			CGContextRef spriteContext;
 			
 			spriteContext = CGBitmapContextCreate(pixelsTmp, width, height, CGImageGetBitsPerComponent(currentFrameRef), width * 4, CGImageGetColorSpace(currentFrameRef), kCGImageAlphaPremultipliedLast);
-			
+						
 			CGContextDrawImage(spriteContext, CGRectMake(0.0, 0.0, (CGFloat)width, (CGFloat)height), currentFrameRef);
 			
 			CGContextRelease(spriteContext);
@@ -202,13 +203,15 @@ ofTexture * ofiPhoneVideoPlayer::getTexture()
 		uint8_t *bufferPixels = (uint8_t *)CVPixelBufferGetBaseAddress(imageBuffer); 
 		
 		if(width != min(size_t(1024),CVPixelBufferGetWidth(imageBuffer))) {
+			
 			if(videoTexture.bAllocated())
 				videoTexture.clear();
 				
 			int widthIn = min(size_t(1024),CVPixelBufferGetWidth(imageBuffer)); 
 			int heightIn = min(size_t(1024),CVPixelBufferGetHeight(imageBuffer));
 			
-			if( width==0 && widthIn != 0 && pixels != NULL) {
+			if( width==0 && widthIn != 0  && pixels == NULL) {
+								
 				if(internalGLFormat == GL_RGB)
 					pixels = (GLubyte *) malloc(widthIn * heightIn * 3);
 				else


### PR DESCRIPTION
a few issues though that make it different than the normal ofVideoPlayer
- it can't loop. if you need it to loop you can do something like:

if(!fingerMovie.isPlaying()){
        fingerMovie.loadMovie("fingers.mov");
        fingerMovie.play();
}

but i didn't want to put that in because it definitely pauses when it unloads the video
- getPixels() returns NULL sometimes. This is because the actual pixel array is malloced once the file has actually been loaded in. Not even the width or height are known until this has happened. They cannot be set independently. This could cause issues in getting pixels and expecting them to be there. the proper way to deal with this would be to use getWidth() and getHeight() instead of the static values that you know the video to be:

unsigned char \* pixels = fingerMovie.getPixels();

```
    for (int i = 4; i < fingerMovie.getWidth(); i+=8){
        for (int j = 4; j < fingerMovie.getHeight(); j+=8){
            unsigned char r = pixels[(j * 320 + i)*3];
            float val = 1 - ((float)r / 255.0f);
            ofCircle(i,j,10*val);
        }
    }
```
- lastly, movies are inverted, but it seemed like arturo was on this as it's a ofTexture issue
