### PR TITLE
added getFov() to ofCamera

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -27,6 +27,10 @@ void ofCamera::setFov(float f) {
 	fov = f;
 }
 
+float ofCamera::getFov(){
+	return fov;
+}
+
 //----------------------------------------
 void ofCamera::setNearClip(float f) {
 	nearClip = f;

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -37,6 +37,7 @@ public:
 	void enableOrtho();
 	void disableOrtho();
 	bool getOrtho() const;
+	float getFov();
 	
 	float getImagePlaneDistance(ofRectangle viewport = ofGetCurrentViewport()) const;
 	


### PR DESCRIPTION
otherwise there's no way to query the fov of a camera, even though you can set it.
