### PR TITLE
Ignore a potential .git directory during make.

### DIFF
--- a/scripts/linux/template/config.make
+++ b/scripts/linux/template/config.make
@@ -31,4 +31,4 @@ USER_LIBS =
 USER_COMPILER_OPTIMIZATION = -march=native -mtune=native -Os
 
 
-EXCLUDE_FROM_SOURCE="bin,.xcodeproj,obj"
+EXCLUDE_FROM_SOURCE="bin,.xcodeproj,obj,.git"


### PR DESCRIPTION
Seeing as many people use git in their project, it makes sense to exclude this directory to ignore it during compilation.
I think that's reasonable, I just noticed in the make output that it seems to be crawling through .git, that's what gave me the idea.
