### PR TITLE
linux: Add zlib to the system libs in the template's makefile

### DIFF
--- a/scripts/linux/template/Makefile
+++ b/scripts/linux/template/Makefile
@@ -130,7 +130,7 @@ ifeq ($(ARCH),android)
 	SYSTEMLIBS += -lstdc++ -lsupc++ -lgcc -lz -lGLESv1_CM -llog -ldl -lm -lc
 else
 	LDFLAGS = -Wl,-rpath=./libs
-	SYSTEMLIBS += $(shell pkg-config  jack glew gstreamer-0.10 gstreamer-video-0.10 gstreamer-base-0.10 gstreamer-app-0.10 libudev cairo --libs)
+	SYSTEMLIBS += $(shell pkg-config  jack glew gstreamer-0.10 gstreamer-video-0.10 gstreamer-base-0.10 gstreamer-app-0.10 libudev cairo zlib --libs)
 	SYSTEMLIBS += -lglut -lGL -lasound -lopenal -lsndfile -lvorbis -lFLAC -logg -lfreeimage -lGLU
 endif
 


### PR DESCRIPTION
It was not compiling the examples because of this missing lib.

This happened on Fedora 15.
BTW, I also needed to install the jack library, maybe we should add it to the install_dependencies.sh, I can do it if you agree.
