### PR TITLE
opencv2 hole detection broken, here is the fix (thanks Golan)

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvContourFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.cpp
@@ -6,8 +6,8 @@
 //--------------------------------------------------------------------------------
 bool sort_carea_compare( const CvSeq* a, const CvSeq* b) {
 	// use opencv to calc size, then sort based on size
-	float areaa = fabs(cvContourArea(a, CV_WHOLE_SEQ));
-	float areab = fabs(cvContourArea(b, CV_WHOLE_SEQ));
+	float areaa = cvContourArea(a, CV_WHOLE_SEQ);
+	float areab = cvContourArea(b, CV_WHOLE_SEQ);
 
     //return 0;
 	return (areaa > areab);
@@ -84,7 +84,7 @@ int ofxCvContourFinder::findContours( ofxCvGrayscaleImage&  input,
 
 	// put the contours from the linked list, into an array for sorting
 	while( (contour_ptr != NULL) ) {
-		float area = fabs( cvContourArea(contour_ptr, CV_WHOLE_SEQ) );
+		float area = cvContourArea(contour_ptr, CV_WHOLE_SEQ);
 		if( (area > minArea) && (area < maxArea) ) {
             cvSeqBlobs.push_back(contour_ptr);
 		}
@@ -102,7 +102,7 @@ int ofxCvContourFinder::findContours( ofxCvGrayscaleImage&  input,
     // cvSeqBlobs let's get the data out and into our structures that we like
 	for( int i = 0; i < MIN(nConsidered, (int)cvSeqBlobs.size()); i++ ) {
 		blobs.push_back( ofxCvBlob() );
-		float area = cvContourArea( cvSeqBlobs[i], CV_WHOLE_SEQ );
+		float area = cvContourArea( cvSeqBlobs[i], CV_WHOLE_SEQ, true ); // oriented = true for holes
 		CvRect rect	= cvBoundingRect( cvSeqBlobs[i], 0 );
 		cvMoments( cvSeqBlobs[i], myMoments );
 


### PR DESCRIPTION
opencv2 cvContourArea runs fabs on the area by default unless the (new!) third variable is set to true, this breaks hole detection since no negative areas are returned. Also, the current fabs calls are redundant.

Golan noticed that hole detection was off in 007 and I tracked this down, although the function update is not actually reflected in the opencv2 documentation ... blah. See this [disgruntled post](http://opencv-users.1802565.n2.nabble.com/cvContourArea-changed-API-tt4817692.html#none).

I tracked down the [diff for the open cv update](https://code.ros.org/trac/opencv/changeset/2927) that clearly shows the new variable, int oriented, controls whether negative areas are returned or not.
