### PR TITLE
Bugfix return bool on save xml

### DIFF
--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -86,15 +86,15 @@ bool ofxXmlSettings::loadFile(const string& xmlFile){
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::saveFile(const string& xmlFile){
+bool ofxXmlSettings::saveFile(const string& xmlFile){
 
 	string fullXmlFile = ofToDataPath(xmlFile);
-	doc.SaveFile(fullXmlFile);
+	return doc.SaveFile(fullXmlFile);
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::saveFile(){
-	doc.SaveFile();
+bool ofxXmlSettings::saveFile(){
+	return doc.SaveFile();
 }
 
 //---------------------------------------------------------
@@ -189,7 +189,7 @@ bool ofxXmlSettings::pushTag(const string&  tag, int which){
 
     // Either find the tag specified, or the first tag if colon-seperated.
     string tagToFind((pos > 0) ? tag.substr(0,pos) :tag);
-    
+
 	//we only allow to push one tag at a time.
 	TiXmlHandle isRealHandle = storedHandle.ChildElement(tagToFind, which);
 
@@ -301,7 +301,7 @@ int ofxXmlSettings::writeTag(const string&  tag, const string& valueStr, int whi
     elements.reserve(tokens.size());
 	for(int x=0;x<(int)tokens.size();x++)
         elements.push_back(tokens.at(x));
-	
+
 
 	TiXmlText Value(valueStr);
 
@@ -450,7 +450,7 @@ void ofxXmlSettings::removeAttribute(const string& tag, const string& attribute,
 		else
 			tagHandle = tagHandle.FirstChildElement(tokens.at(x));
 	}
-    
+
 	if (tagHandle.ToElement()) {
 		TiXmlElement* elem = tagHandle.ToElement();
 		elem->RemoveAttribute(attribute);
@@ -478,7 +478,7 @@ int ofxXmlSettings::getNumAttributes(const string& tag, int which){
 
 	if (tagHandle.ToElement()) {
 		TiXmlElement* elem = tagHandle.ToElement();
-		
+
 		// Do stuff with the element here
 		TiXmlAttribute* first = elem->FirstAttribute();
 		if (first) {
@@ -504,7 +504,7 @@ bool ofxXmlSettings::attributeExists(const string& tag, const string& attribute,
 
 	if (tagHandle.ToElement()) {
 		TiXmlElement* elem = tagHandle.ToElement();
-		
+
 		// Do stuff with the element here
 		for (TiXmlAttribute* a = elem->FirstAttribute(); a; a = a->Next()) {
 			if (a->Name() == attribute)
@@ -527,7 +527,7 @@ bool ofxXmlSettings::getAttributeNames(const string& tag, vector<string>& outNam
 
 	if (tagHandle.ToElement()) {
 		TiXmlElement* elem = tagHandle.ToElement();
-		
+
 		// Do stuff with the element here
 		for (TiXmlAttribute* a = elem->FirstAttribute(); a; a = a->Next())
 			outNames.push_back( string(a->Name()) );
@@ -593,7 +593,7 @@ TiXmlElement* ofxXmlSettings::getElementForAttribute(const string& tag, int whic
 
 //---------------------------------------------------------
 bool ofxXmlSettings::readIntAttribute(const string& tag, const string& attribute, int& outValue, int which){
-    
+
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
         return (elem->QueryIntAttribute(attribute, &outValue) == TIXML_SUCCESS);
@@ -602,7 +602,7 @@ bool ofxXmlSettings::readIntAttribute(const string& tag, const string& attribute
 
 //---------------------------------------------------------
 bool ofxXmlSettings::readDoubleAttribute(const string& tag, const string& attribute, double& outValue, int which){
-    
+
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
         return (elem->QueryDoubleAttribute(attribute, &outValue) == TIXML_SUCCESS);
@@ -611,7 +611,7 @@ bool ofxXmlSettings::readDoubleAttribute(const string& tag, const string& attrib
 
 //---------------------------------------------------------
 bool ofxXmlSettings::readStringAttribute(const string& tag, const string& attribute, string& outValue, int which){
-    
+
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
     {
@@ -635,12 +635,12 @@ int ofxXmlSettings::writeAttribute(const string& tag, const string& attribute, c
 		else
 			tagHandle = tagHandle.FirstChildElement(tokens.at(x));
 	}
-    
+
 	int ret = 0;
 	if (tagHandle.ToElement()) {
 		TiXmlElement* elem = tagHandle.ToElement();
 		elem->SetAttribute(attribute, valueString);
-        
+
         // Do we really need this?  We could just ignore this and remove the 'addAttribute' functions...
 		// Now, just get the ID.
 		int numSameTags;
@@ -656,20 +656,20 @@ int ofxXmlSettings::writeAttribute(const string& tag, const string& attribute, c
 //---------------------------------------------------------
 bool ofxXmlSettings::loadFromBuffer( string buffer )
 {
-	
+
     int size = buffer.size();
-	
+
     bool loadOkay = doc.ReadFromMemory( buffer.c_str(), size);//, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
-    
+
     return loadOkay;
-	
+
 }
 //---------------------------------------------------------
 void ofxXmlSettings::copyXmlToString(string & str)
 {
 	TiXmlPrinter printer;
 	doc.Accept(&printer);
-	
+
 	str = printer.CStr();
 }
 

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -52,8 +52,8 @@ class ofxXmlSettings{
 		void setVerbose(bool _verbose);
 
 		bool loadFile(const string& xmlFile);
-		void saveFile(const string& xmlFile);
-		void saveFile();
+		bool saveFile(const string& xmlFile);
+		bool saveFile();
 
 		void clearTagContents(const string& tag, int which = 0);
 		void removeTag(const string& tag, int which = 0);
@@ -107,40 +107,40 @@ class ofxXmlSettings{
 
 		int		addTag(const string& tag); //adds an empty tag at the current level
 
-    
+
         // Attribute-related methods
 		int		addAttribute(const string& tag, const string& attribute, int value, int which = 0);
 		int		addAttribute(const string& tag, const string& attribute, double value, int which = 0);
 		int		addAttribute(const string& tag, const string& attribute, const string& value, int which = 0);
-		
+
 		int		addAttribute(const string& tag, const string& attribute, int value);
 		int		addAttribute(const string& tag, const string& attribute, double value);
 		int		addAttribute(const string& tag, const string& attribute, const string& value);
-		
+
 		void	removeAttribute(const string& tag, const string& attribute, int which = 0);
 		void	clearTagAttributes(const string& tag, int which = 0);
-		
+
 		int		getNumAttributes(const string& tag, int which = 0);
-		
+
 		bool	attributeExists(const string& tag, const string& attribute, int which = 0);
-		
+
 		bool    getAttributeNames(const string& tag, vector<string>& outNames, int which = 0);
-		
+
 		int		getAttribute(const string& tag, const string& attribute, int defaultValue, int which = 0);
 		double	getAttribute(const string& tag, const string& attribute, double defaultValue, int which = 0);
 		string	getAttribute(const string& tag, const string& attribute, const string& defaultValue, int which = 0);
-		
+
 		int		setAttribute(const string& tag, const string& attribute, int value, int which = 0);
 		int		setAttribute(const string& tag, const string& attribute, double value, int which = 0);
 		int		setAttribute(const string& tag, const string& attribute, const string& value, int which = 0);
-		
+
 		int		setAttribute(const string& tag, const string& attribute, int value);
 		int		setAttribute(const string& tag, const string& attribute, double value);
 		int		setAttribute(const string& tag, const string& attribute, const string& value);
 
 		bool	loadFromBuffer( string buffer );
 		void	copyXmlToString(string & str);
-	
+
 		TiXmlDocument 	doc;
 		bool 			bDocLoaded;
 
@@ -149,11 +149,11 @@ class ofxXmlSettings{
 		TiXmlHandle     storedHandle;
 		int             level;
 
-    
+
 		int 	writeTag(const string&  tag, const string& valueString, int which = 0);
 		bool 	readTag(const string&  tag, TiXmlHandle& valHandle, int which = 0);	// max 1024 chars...
 
-    
+
 		int		writeAttribute(const string& tag, const string& attribute, const string& valueString, int which = 0);
 
         TiXmlElement* getElementForAttribute(const string& tag, int which);


### PR DESCRIPTION
Changed saveFile methods in ofxXmlSettings to return a boolean on success/failure to save a file...this let's you catch errors if it's not possible to save an xml file during or after modifications. 

(It's pretty basic, but figure I should start somewhere helping out ;-)
