### PR TITLE
Bugfix ofArduino update to be compatible with Arduino 1.0

### DIFF
--- a/apps/examples/firmataExample/src/testApp.cpp
+++ b/apps/examples/firmataExample/src/testApp.cpp
@@ -1,3 +1,27 @@
+/*
+ * This is a simple example use of ofArduino
+ *
+ * ofArduino currently only supports the standard Arduino boards
+ * (UNO, Duemilanove, Diecimila, NG, and other boards based on the
+ * ATMega168 or ATMega328 microcontrollers
+ * The Arduio FIO and Arduino Mini should also work.
+ * The Arduino MEGA and other variants based on microcontrollers
+ * other than the ATMega168 and ATMega328 are not currently supported.
+ * 
+ * To use this example, open Arduino (preferably Arduino 1.0) and 
+ * navigate to File -> Examples -> Firmata and open StandardFirmata.
+ * Compile and upload StandardFirmata for your board, then close
+ * the Arduino application and run this application.
+ *
+ * If you have a servo attached, press the left arrow key to rotate
+ * the servo head counterclockwise and press the right arrow key to
+ * rotate the servo head clockwise.
+ *
+ * Clicking the mouse over any part of the application will turn the
+ * on-board LED on and off.
+ *
+ */
+
 #include "testApp.h"
 
 
@@ -8,19 +32,23 @@ void testApp::setup(){
 	ofSetFrameRate(60);
 
 	ofBackground(255,0,130);
+    
+    buttonState = "digital pin:";
+    potValue = "analog pin:";
 
-	bgImage.loadImage("firmata.png");
+	bgImage.loadImage("background.png");
 	font.loadFont("franklinGothic.otf", 20);
+    smallFont.loadFont("franklinGothic.otf", 14);
 
-	ard.connect("/dev/tty.usbmodem1d11", 57600);
-	//ard.connect("/dev/ttyUSB0", 57600);
+    // replace the string below with the serial port for your Arduino board
+    // you can get this from the Arduino application or via command line
+    // for OSX, in your terminal type "ls /dev/tty.*" to get a list of serial devices
+	ard.connect("/dev/tty.usbmodemfd121", 57600);
 	
 	// listen for EInitialized notification. this indicates that
 	// the arduino is ready to receive commands and it is safe to
 	// call setupArduino()
 	ofAddListener(ard.EInitialized, this, &testApp::setupArduino);
-
-
 	bSetupArduino	= false;	// flag so we setup arduino when its ready, you don't need to touch this :)
 }
 
@@ -36,50 +64,115 @@ void testApp::setupArduino(const int & version) {
 	
 	// remove listener because we don't need it anymore
 	ofRemoveListener(ard.EInitialized, this, &testApp::setupArduino);
+    
+    // it is now safe to send commands to the Arduino
+    bSetupArduino = true;
+    
+    // print firmware name and version to the console
+    cout << ard.getFirmwareName() << endl; 
+    cout << "firmata v" << ard.getMajorFirmwareVersion() << "." << ard.getMinorFirmwareVersion() << endl;
+        
+    // Note: pins A0 - A5 can be used as digital input and output.
+    // Refer to them as pins 14 - 19 if using StandardFirmata from Arduino 1.0.
+    // If using Arduino 0022 or older, then use 16 - 21.
+    // Firmata pin numbering changed in version 2.3 (which is included in Arduino 1.0)
+    
+    // set pins D2 and A5 to digital input
+    ard.sendDigitalPinMode(2, ARD_INPUT);
+    ard.sendDigitalPinMode(19, ARD_INPUT);  // pin 21 if using StandardFirmata from Arduino 0022 or older
 
-	// this is where you setup all the pins and pin modes, etc
-	for (int i = 0; i < 13; i++){
-		ard.sendDigitalPinMode(i, ARD_OUTPUT);
-	}
-
+    // set pin A0 to analog input
+    ard.sendAnalogPinReporting(0, ARD_ANALOG);
+    
+    // set pin D13 as digital output
 	ard.sendDigitalPinMode(13, ARD_OUTPUT);
-	ard.sendAnalogPinReporting(0, ARD_ANALOG);	// AB: report data
-	ard.sendDigitalPinMode(11, ARD_PWM);		// on diecimelia: 11 pwm?*/
+    // set pin A4 as digital output
+    ard.sendDigitalPinMode(18, ARD_OUTPUT);  // pin 20 if using StandardFirmata from Arduino 0022 or older
+
+    // set pin D11 as PWM (analog output)
+	ard.sendDigitalPinMode(11, ARD_PWM);
+    
+    // attach a servo to pin D9
+    // servo motors can only be attached to pin D3, D5, D6, D9, D10, or D11
+    ard.sendServoAttach(9);
 	
-	bSetupArduino = true;
+    // Listen for changes on the digital and analog pins
+    ofAddListener(ard.EDigitalPinChanged, this, &testApp::digitalPinChanged);
+    ofAddListener(ard.EAnalogPinChanged, this, &testApp::analogPinChanged);    
 }
 
 //--------------------------------------------------------------
 void testApp::updateArduino(){
 
 	// update the arduino, get any data or messages.
+    // the call to ard.update() is required
 	ard.update();
 	
 	// do not send anything until the arduino has been set up
 	if (bSetupArduino) {
+        // fade the led connected to pin D11
 		ard.sendPwm(11, (int)(128 + 128 * sin(ofGetElapsedTimef())));   // pwm...
 	}
-	
 
+}
+
+// digital pin event handler, called whenever a digital pin value has changed
+// note: if an analog pin has been set as a digital pin, it will be handled
+// by the digitalPinChanged function rather than the analogPinChanged function.
+void testApp::digitalPinChanged(const int & pinNum) {
+    // do something with the digital input. here we're simply going to print the pin number and
+    // value to the screen each time it changes
+    buttonState = "digital pin: " + ofToString(pinNum) + " = " + ofToString(ard.getDigital(pinNum));
+}
+
+// analog pin event handler, called whenever an analog pin value has changed
+void testApp::analogPinChanged(const int & pinNum) {
+    // do something with the analog input. here we're simply going to print the pin number and
+    // value to the screen each time it changes
+    potValue = "analog pin: " + ofToString(pinNum) + " = " + ofToString(ard.getAnalog(pinNum));
 }
 
 
 //--------------------------------------------------------------
 void testApp::draw(){
 	bgImage.draw(0,0);
-
+    
+    ofEnableAlphaBlending();
+    ofSetColor(0, 0, 0, 127);
+    ofRect(510, 15, 275, 150);
+    ofDisableAlphaBlending();
+    
+    ofSetColor(255, 255, 255);
 	if (!bSetupArduino){
-		font.drawString("arduino not ready\n", 545, 40);
+		font.drawString("arduino not ready...\n", 515, 40);
 	} else {
-		font.drawString("analog pin 0: " + ofToString(ard.getAnalog(0)) +
-						"\nsending pwm: " + ofToString((int)(128 + 128 * sin(ofGetElapsedTimef()))), 545, 40);
+		font.drawString(potValue + "\n" + buttonState +
+						"\nsending pwm: " + ofToString((int)(128 + 128 * sin(ofGetElapsedTimef()))), 515, 40);
+        
+        ofSetColor(64, 64, 64);
+        smallFont.drawString("If a servo is attached, use the left arrow key to rotate " 
+                             "\ncounterclockwise and the right arrow key to rotate clockwise.", 200, 550);
+        ofSetColor(255, 255, 255);
 
 	}
 }
 
 //--------------------------------------------------------------
 void testApp::keyPressed  (int key){
-
+    switch (key) {
+        case OF_KEY_RIGHT:
+            // rotate servo head to 180 degrees
+            ard.sendServo(9, 180, false);
+            ard.sendDigital(18, ARD_HIGH);  // pin 20 if using StandardFirmata from Arduino 0022 or older
+            break;
+        case OF_KEY_LEFT:
+            // rotate servo head to 0 degrees
+            ard.sendServo(9, 0, false);
+            ard.sendDigital(18, ARD_LOW);  // pin 20 if using StandardFirmata from Arduino 0022 or older
+            break;
+        default:
+            break;
+    }
 }
 
 //--------------------------------------------------------------
@@ -99,11 +192,13 @@ void testApp::mouseDragged(int x, int y, int button){
 
 //--------------------------------------------------------------
 void testApp::mousePressed(int x, int y, int button){
+    // turn on the onboard LED when the application window is clicked
 	ard.sendDigital(13, ARD_HIGH);
 }
 
 //--------------------------------------------------------------
 void testApp::mouseReleased(int x, int y, int button){
+    // turn off the onboard LED when the application window is clicked
 	ard.sendDigital(13, ARD_LOW);
 }
 

--- a/apps/examples/firmataExample/src/testApp.h
+++ b/apps/examples/firmataExample/src/testApp.h
@@ -22,14 +22,22 @@ public:
 	void windowResized(int w, int h);
 	void dragEvent(ofDragInfo dragInfo);
 	void gotMessage(ofMessage msg);
-		
-	void setupArduino(const int & version);
-	void updateArduino();
 
 	ofImage				bgImage;
 	ofTrueTypeFont		font;
+    ofTrueTypeFont      smallFont;
 	ofArduino	ard;
 	bool		bSetupArduino;			// flag variable for setting up arduino once
+    
+private:
+    
+    void setupArduino(const int & version);
+    void digitalPinChanged(const int & pinNum);
+    void analogPinChanged(const int & pinNum);
+	void updateArduino();
+    
+    string buttonState;
+    string potValue;
 
 };
 

--- a/libs/openFrameworks/communication/ofArduino.cpp
+++ b/libs/openFrameworks/communication/ofArduino.cpp
@@ -1,10 +1,12 @@
 /*
+ * 9/28/11:
+ *   - updated to be Firmata 2.3/Arduino 1.0 compatible
+ *   - fixed ability to use analog pins as digital inputs
  *
- * Jeff Hoefs 
- * Initial updates for Firmata 2.2 compatibility:
- * - 3/5/17 added servo support for firmata 2.2 and greater (should be 
- *   backwards compatible with Erik Sjodin's older firmata servo
- *   implementation)
+ * 3/5/11:
+ *   - added servo support for firmata 2.2 and greater (should be 
+ *     backwards compatible with Erik Sjodin's older firmata servo
+ *     implementation)
  * 
  *
  * Copyright 2007-2008 (c) Erik Sjodin, eriksjodin.net
@@ -37,7 +39,6 @@
 #include "ofArduino.h"
 #include "ofUtils.h"
 
-// TODO update to be fully compatible with Firmata v2.2
 // TODO thread it?
 // TODO throw event or exception if the serial port goes down...
 //---------------------------------------------------------------------------
@@ -55,34 +56,56 @@ ofArduino::ofArduino(){
 	_minorFirmwareVersion = 0;
 	_firmwareName = "Unknown";
 
-    // ports
-	for(int i=0; i<ARD_TOTAL_PORTS; ++i) {
-		_digitalPortValue[i]=0;
-		_digitalPortReporting[i] = ARD_OFF;
-	}
-
-    // digital pins
-	for(int i=0; i<16; ++i) {
-		_digitalPinValue[i] = -1;
-		_digitalPinMode[i] = ARD_OUTPUT;
-		_digitalPinReporting[i] = ARD_OFF;
-	}
-
-	// analog in pins
-	for (int i=0; i<ARD_TOTAL_ANALOG_PINS; ++i) {
-		_analogPinReporting[i] = ARD_OFF;
-		// analog pins used as digital
-		_digitalPinMode[i]=ARD_ANALOG;
-		_digitalPinValue[i] = -1;
-	}
-	for (int i=0; i<ARD_TOTAL_DIGITAL_PINS; ++i) {
-		_servoValue[i] = -1;
-	}
 	bUseDelay = true;
 }
 
 ofArduino::~ofArduino() {
 	_port.close();
+}
+
+// initialize pins once we get the Firmata version back from the Arduino board
+// the version is sent automatically by the Arduino board on startup
+void ofArduino::initPins() {
+    int firstAnalogPin;
+    
+    if (_initialized) return;   // already initialized
+    
+    // support Firmata 2.3/Arduino 1.0 with backwards compatibility 
+    // to previous protocol versions
+    if (_firmwareVersionSum >= FIRMWARE2_3) {
+        _totalDigitalPins = 20;
+        firstAnalogPin = 14;
+    } else {
+        _totalDigitalPins = ARD_TOTAL_DIGITAL_PINS;
+        firstAnalogPin = 16;
+    }
+    
+    // ports
+	for(int i=0; i<ARD_TOTAL_PORTS; ++i) {
+		_digitalPortValue[i]=0;
+		_digitalPortReporting[i] = ARD_OFF;
+	}
+    
+    // digital pins
+	for(int i=0; i<firstAnalogPin; ++i) {
+		_digitalPinValue[i] = -1;
+		_digitalPinMode[i] = ARD_OUTPUT;
+		_digitalPinReporting[i] = ARD_OFF;
+	}
+    
+	// analog in pins
+    for (int i=firstAnalogPin; i<_totalDigitalPins; ++i) {
+		_analogPinReporting[i-firstAnalogPin] = ARD_OFF;
+		// analog pins used as digital
+		_digitalPinMode[i]=ARD_ANALOG;
+		_digitalPinValue[i] = -1;
+	}
+
+	for (int i=0; i<_totalDigitalPins; ++i) {
+		_servoValue[i] = -1;
+	}
+    
+    _initialized = true;
 }
 
 bool ofArduino::connect(string device, int baud){
@@ -93,11 +116,18 @@ bool ofArduino::connect(string device, int baud){
 	return connected;
 }
 
+// this method is not recommended
+// the preferred method is to listen for the EInitialized event in your application
 bool ofArduino::isArduinoReady(){	
-	if(bUseDelay)
-		return (ofGetElapsedTimef() - connectTime) > OF_ARDUINO_DELAY_LENGTH ? connected : false;
-	else
+	if(bUseDelay) {
+        if (_initialized || (ofGetElapsedTimef() - connectTime) > OF_ARDUINO_DELAY_LENGTH) {
+            initPins();
+            connected = true;
+            return connected;
+        }
+	} else {
 		return connected;
+    }
 }
 
 void  ofArduino::setUseDelay(bool bDelay){
@@ -182,16 +212,28 @@ void ofArduino::sendDigital(int pin, int value, bool force){
 
 		int port=0;
 		int bit=0;
+        int port1Offset;
+        int port2Offset;
+        
+        // support Firmata 2.3/Arduino 1.0 with backwards compatibility 
+        // to previous protocol versions
+        if (_firmwareVersionSum >= FIRMWARE2_3) {
+            port1Offset = 16;
+            port2Offset = 20;
+        } else {
+            port1Offset = 14;
+            port2Offset = 22;
+        }
 
 		if(pin < 8 && pin >1){
 			port=0;
 			bit = pin;
 		}
-		else if(pin>7 && pin <14){
+		else if(pin>7 && pin <port1Offset){
 			port = 1;
 			bit = pin-8;
 		}
-		else if(pin>15 && pin <22){
+		else if(pin>15 && pin <port2Offset){
 			port = 2;
 			bit = pin-16;
 		}
@@ -264,16 +306,22 @@ void ofArduino::sendReset(){
 }
 
 void ofArduino::sendAnalogPinReporting(int pin, int mode){
-	int i;
-	//bool send;
 
-    // disable reporting for all pins on port 2
-	for(i=16; i<22; ++i) {
-		if(_digitalPinReporting[i]==ARD_ON)
-			sendDigitalPinReporting(i, ARD_OFF);
-	}
+    int firstAnalogPin;
+    // support Firmata 2.3/Arduino 1.0 with backwards compatibility 
+    // to previous protocol versions
+    if (_firmwareVersionSum >= FIRMWARE2_3) {
+        firstAnalogPin = 14;
+    } else {
+        firstAnalogPin = 16;
+    }
+    
+    // if this analog pin is set as a digital input, disable digital pin reporting
+    if (_digitalPinReporting[pin + firstAnalogPin] == ARD_ON) {
+        sendDigitalPinReporting(pin + firstAnalogPin, ARD_OFF);
+    }
 
-	_digitalPinMode[16+pin]=ARD_ANALOG;
+	_digitalPinMode[firstAnalogPin+pin]=ARD_ANALOG;
 
 	sendByte(FIRMATA_REPORT_ANALOG+pin);
 	sendByte(mode);
@@ -282,7 +330,7 @@ void ofArduino::sendAnalogPinReporting(int pin, int mode){
 
 void ofArduino::sendDigitalPinMode(int pin, int mode){
 	sendByte(FIRMATA_SET_PIN_MODE);
-	sendByte(pin); // Tx pins 0-6
+	sendByte(pin);
 	sendByte(mode);
 	_digitalPinMode[pin]=mode;
 
@@ -464,8 +512,11 @@ void ofArduino::processSysExData(vector<unsigned char> data){
 			ofNotifyEvent(EFirmwareVersionReceived, _majorFirmwareVersion, this);
 
 			// trigger the initialization event
-			ofNotifyEvent(EInitialized, _majorFirmwareVersion, this);
-			_initialized = true;
+            if (!_initialized) {
+                initPins();
+                ofNotifyEvent(EInitialized, _majorFirmwareVersion, this);
+                
+            }
 
 		break;
 		case FIRMATA_SYSEX_FIRMATA_STRING:
@@ -501,49 +552,65 @@ void ofArduino::processDigitalPort(int port, unsigned char value){
 	int previous;
 	int i;
 	int pin;
+    int analogOffset;
+    int port1Pins;
+    int port2Pins;
+    
+    // support Firmata 2.3/Arduino 1.0 with backwards compatibility to previous protocol versions
+    if (_firmwareVersionSum >= FIRMWARE2_3) {
+        analogOffset = 14;
+        port1Pins = 8;
+        port2Pins = 4;
+    } else {
+        analogOffset = 16;
+        port1Pins = 6;
+        port2Pins = 6;
+    }
+    
 	switch(port) {
-		case 0: // pins 2-7  (0,1 are ignored as serial RX/TX)
-			for(i=2; i<8; ++i) {
-				pin = i;
-				if(_digitalPinMode[pin]==ARD_INPUT){
-					previous = _digitalHistory[pin].front();
+    case 0: // pins 2-7  (0,1 are ignored as serial RX/TX)
+        for(i=2; i<8; ++i) {
+            pin = i;
+            if(_digitalPinMode[pin]==ARD_INPUT){
+                previous = _digitalHistory[pin].front();
 
-					mask = 1 << i;
-					_digitalHistory[pin].push_front((value & mask)>>i);
+                mask = 1 << i;
+                _digitalHistory[pin].push_front((value & mask)>>i);
 
-					if((int)_digitalHistory[pin].size()>_digitalHistoryLength)
-							_digitalHistory[pin].pop_back();
+                if((int)_digitalHistory[pin].size()>_digitalHistoryLength)
+                        _digitalHistory[pin].pop_back();
 
-					// trigger an event if the pin has changed value
-					if(_digitalHistory[pin].front()!=previous){
-						ofNotifyEvent(EDigitalPinChanged, pin, this);
-					}
-				}
-			}
-	break;
-		case 1: // pins 8-13 (14,15 are disabled for the crystal)
-		 for(i=0; i<6; ++i) {
-			pin = i+8;
+                // trigger an event if the pin has changed value
+                if(_digitalHistory[pin].front()!=previous){
+                    ofNotifyEvent(EDigitalPinChanged, pin, this);
+                }
+            }
+        }
+        break;
+    case 1: // pins 8-13 (in Firmata 2.3/Arduino 1.0, pins 14 and 15 are analog 0 and 1)
+        for(i=0; i<port1Pins; ++i) {
+            pin = i+8;
 
-			if(_digitalPinMode[pin]==ARD_INPUT){
-				previous = _digitalHistory[pin].front();
+            if(_digitalPinMode[pin]==ARD_INPUT){
+                previous = _digitalHistory[pin].front();
 
-				mask = 1 << i;
-				_digitalHistory[pin].push_front((value & mask)>>i);
+                mask = 1 << i;
+                _digitalHistory[pin].push_front((value & mask)>>i);
 
-				if((int)_digitalHistory[pin].size()>_digitalHistoryLength)
-					_digitalHistory[pin].pop_back();
+                if((int)_digitalHistory[pin].size()>_digitalHistoryLength)
+                    _digitalHistory[pin].pop_back();
 
-				// trigger an event if the pin has changed value
-				if(_digitalHistory[pin].front()!=previous){
-					ofNotifyEvent(EDigitalPinChanged, pin, this);
-				}
-			}
-		 }
-	break;
-	case 2: // analog pins used as digital pins 16-21
-		for(i=0; i<6; ++i) {
-			pin = i+16;
+                // trigger an event if the pin has changed value
+                if(_digitalHistory[pin].front()!=previous){
+                    ofNotifyEvent(EDigitalPinChanged, pin, this);
+                }
+            }
+        }
+        break;
+	case 2: // analog pins used as digital pins 16-21 (in Firmata 2.3/Arduino 1.0, digital pins 14 - 19)
+		for(i=0; i<port2Pins; ++i) {
+			//pin = i+analogOffset;
+            pin = i+16;
 			if(_digitalPinMode[pin]==ARD_INPUT){
 				previous = _digitalHistory[pin].front();
 
@@ -559,20 +626,38 @@ void ofArduino::processDigitalPort(int port, unsigned char value){
 				}
 			}
 		}
-	break;
+        break;
 	}
 }
 
 // port 0: pins 2-7  (0,1 are serial RX/TX, don't change their values)
-// port 1: pins 8-13 (14,15 are disabled for the crystal)
-// port 2: pins 16-21 analog pins used as digital, all analog reporting will be turned off if this is set to ARD_ON
+// port 1: pins 8-13 (in Firmata 2.3/Arduino 1.0, pins 14 and 15 are analog pins 0 and 1 used as digital pins)
+// port 2: pins 16-21 analog pins used as digital (in Firmata 2.3/Arduino 1.0, pins 14 - 19),
+//         all analog reporting will be turned off if this is set to ARD_ON
+
 void ofArduino::sendDigitalPortReporting(int port, int mode){
 	sendByte(FIRMATA_REPORT_DIGITAL+port);
 	sendByte(mode);
 	_digitalPortReporting[port] = mode;
+    int offset;
+    
+    if (_firmwareVersionSum >= FIRMWARE2_3) {
+        offset = 2;
+    } else {
+        offset = 0;
+    }
+    
+    // for Firmata 2.3 and higher:
+    if(port==1 && mode==ARD_ON) {
+        for (int i=0; i<2; i++) {
+            _analogPinReporting[i] = ARD_OFF;
+		} 
+    }
+    
+    // for Firmata 2.3 and all prior Firmata protocol versions:
 	if(port==2 && mode==ARD_ON){ // if reporting is turned on on port 2 then ofArduino on the Arduino disables all analog reporting
 
-		for (int i=0; i<ARD_TOTAL_ANALOG_PINS; i++) {
+		for (int i=offset; i<ARD_TOTAL_ANALOG_PINS; i++) {
 				_analogPinReporting[i] = ARD_OFF;
 		}
 	}
@@ -580,18 +665,31 @@ void ofArduino::sendDigitalPortReporting(int port, int mode){
 
 void ofArduino::sendDigitalPinReporting(int pin, int mode){
 	_digitalPinReporting[pin] = mode;
+    int port1Offset;
+    int port2Offset;
+    
+    // Firmata backwards compatibility mess
+    if (_firmwareVersionSum >= FIRMWARE2_3) {
+        port1Offset = 15;
+        port2Offset = 19;
+    } else {
+        port1Offset = 13;
+        port2Offset = 21;
+    }
+    
 	if(mode==ARD_ON){	// enable reporting for the port
 		if(pin<=7 && pin>=2)
 			sendDigitalPortReporting(0, ARD_ON);
-		if(pin<=13 && pin>=8)
-			sendDigitalPortReporting(1, ARD_ON);
-		if(pin<=21 && pin>=16)
-			sendDigitalPortReporting(2, ARD_ON);
+        // Firmata backwards compatibility mess
+        if(pin<=port1Offset && pin>=8)
+            sendDigitalPortReporting(1, ARD_ON);
+        if(pin<=port2Offset && pin>=16)
+            sendDigitalPortReporting(2, ARD_ON);          
 	}
 	else if(mode==ARD_OFF){
 		int i;
 		bool send=true;
-		if(pin<8 && pin>=2){    // check if all pins on the port are off, if so set port reporting to off..
+		if(pin<=7 && pin>=2){    // check if all pins on the port are off, if so set port reporting to off..
 			for(i=2; i<8; ++i) {
 				if(_digitalPinReporting[i]==ARD_ON)
 						send=false;
@@ -599,23 +697,23 @@ void ofArduino::sendDigitalPinReporting(int pin, int mode){
 			if(send)
 				sendDigitalPortReporting(0, ARD_OFF);
 		}
-		if(pin<14 && pin>=8){
-			for(i=8; i<14; ++i) {
-				if(_digitalPinReporting[i]==ARD_ON)
-						send=false;
-			}
-			if(send)
-				sendDigitalPortReporting(1, ARD_OFF);
-		}
-		if(pin<22 && pin>=16){
-			for(i=16; i<22; ++i) {
-				if(_digitalPinReporting[i]==ARD_ON)
-						send=false;
-			}
-			if(send)
-				sendDigitalPortReporting(2, ARD_OFF);
-		}
-
+        // Firmata backwards compatibility mess
+        if(pin<=port1Offset && pin>=8){
+            for(i=8; i<=port1Offset; ++i) {
+                if(_digitalPinReporting[i]==ARD_ON)
+                        send=false;
+            }
+            if(send)
+                sendDigitalPortReporting(1, ARD_OFF);
+        }
+        if(pin<=port2Offset && pin>=16){
+            for(i=16; i<=port2Offset; ++i) {
+                if(_digitalPinReporting[i]==ARD_ON)
+                        send=false;
+            }
+            if(send)
+                sendDigitalPortReporting(2, ARD_OFF);
+        }
 	}
 }
 

--- a/libs/openFrameworks/communication/ofArduino.h
+++ b/libs/openFrameworks/communication/ofArduino.h
@@ -88,7 +88,7 @@
 
 // board settings
 #define ARD_TOTAL_DIGITAL_PINS							22 // total number of pins currently supported
-#define ARD_TOTAL_ANALOG_PINS							8
+#define ARD_TOTAL_ANALOG_PINS							6
 #define ARD_TOTAL_PORTS                                 3 // total number of ports for the board
 // pin modes
 #define ARD_INPUT                                       0x00
@@ -132,8 +132,8 @@
 
 #define OF_ARDUINO_DELAY_LENGTH					4.0
 
-// use to check if firmware version uploaded to arduino is >= 2.2 (22)
 #define FIRMWARE2_2								22
+#define FIRMWARE2_3                             23
 
 
 /**
@@ -334,6 +334,9 @@ class ofArduino{
 
 		protected:
 				bool _initialized;
+    
+                void initPins();
+                int _totalDigitalPins;
 
 				void sendDigitalPinReporting(int pin, int mode);
 				// sets pin reporting to ARD_ON or ARD_OFF


### PR DESCRIPTION
A change in the firmata protocol that ships with the upcoming Arduino 1.0 release will impact ofArduino (for OF users who load StandardFirmata from Arduino 1.0). The issue is a change in the pin numbering used in the Firmata library for the standard (ATMega168 and ATMega328 based) Arduinos. This commit fixes the issue while maintaining backwards compatibility with previous versions of firmata. I have also updated the firmataExample example to demonstrate how to set analog pins as digital I/O pins (this was previously broken) and also how to control a servo motor.

There are a number of new features in Firmata 2.3 that can make it easier to use Arduino with OF (and other frameworks). However ofArduino currently supports 3 different versions of Firmata so to add new features and maintain backwards compatibility would be a pain (not to mention a mess). In the near future I plan to create a new addon ofxArduino (or ofxFirmata) that will take full advantage of Firmata 2.3, adding support for pretty much any board that can be programmed via the Arduino IDE as well as new features such as I2C support (which is now part of StandardFirmata). I think ofArduino should remain as is to provide backwards compatibility, and the new addon will only support Firmata 2.3 (Arduino 1.0) and higher.
