### PR TITLE
Added 3D versions of ofCurve(), ofBezier(), ofVertex() and ofBezierVertex()

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -773,12 +773,32 @@ void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x
 	shape.draw();
 }
 
+//----------------------------------------------------------
+void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3)
+{
+	shape.clear();
+	shape.curveTo(x0,y0,z0);
+	shape.curveTo(x1,y1,z1);
+	shape.curveTo(x2,y2,z2);
+	shape.curveTo(x3,y3,z3);
+	shape.draw();
+}
+
 
 //----------------------------------------------------------
 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3){
 	shape.clear();
 	shape.moveTo(x0,y0);
 	shape.bezierTo(x1,y1,x2,y2,x3,y3);
+	shape.draw();
+}
+
+//----------------------------------------------------------
+void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3)
+{
+	shape.clear();
+	shape.moveTo(x0,y0,z0);
+	shape.bezierTo(x1,y1,z1,x2,y2,z2,x3,y3,z3);
 	shape.draw();
 }
 
@@ -790,6 +810,12 @@ void ofBeginShape(){
 //----------------------------------------------------------
 void ofVertex(float x, float y){
 	shape.lineTo(x,y);
+
+}
+
+//----------------------------------------------------------
+void ofVertex(float x, float y, float z){
+	shape.lineTo(x,y,z);
 
 }
 
@@ -825,6 +851,15 @@ void ofCurveVertex(ofPoint & p) {
 //---------------------------------------------------
 void ofBezierVertex(float x1, float y1, float x2, float y2, float x3, float y3){
 	shape.bezierTo(x1,y1,x2,y2,x3,y3);
+}
+
+void ofBezierVertex(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3){
+	shape.bezierTo(p1, p2, p3);
+}
+
+//---------------------------------------------------
+void ofBezierVertex(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3){
+	shape.bezierTo(x1,y1,z1,x2,y2,z2,x3,y3,z3);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -198,12 +198,15 @@ void ofRect(const ofPoint & p,float w,float h);
 void ofRect(float x,float y,float z,float w,float h);
 
 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 
 // for polygons
 void ofBeginShape();
 void ofVertex(float x, float y);
+void ofVertex(float x, float y, float z);
 void ofVertex(ofPoint & p);
 void ofVertexes(const vector <ofPoint> & polyPoints);
 
@@ -213,6 +216,8 @@ void ofCurveVertex(ofPoint & p);
 void ofCurveVertexes(const vector <ofPoint> & curvePoints);
 
 void ofBezierVertex(float x1, float y1, float x2, float y2, float x3, float y3);
+void ofBezierVertex(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3);
+void ofBezierVertex(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 void ofEndShape(bool bClose = false);
 void ofNextContour(bool bClose = false);  // for multi contour shapes!


### PR DESCRIPTION
ofGraphics.h already has 3D versions of ofTriangle(), ofCircle() etc. 

To match these, I've added 3D versions of ofCurve(), ofBezier(), ofVertex() and ofBezierVertex() which really just pass an additional (z) coordinate through to the underlying shape path.
