### PR TITLE
ofxOsc only adds int32_t typedef for VS vers < VS2010, fixes #559

### DIFF
--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -71,8 +71,10 @@ subclasses for each possible argument type
 */
 
 #if defined TARGET_WIN32 && defined _MSC_VER
-// required because MSVC isn't ANSI-C compliant
-typedef long int32_t;
+	#if _MSC_VER < 1600 // 1600 = VS2010
+		// required because MSVC < VS2010 aren't ANSI-C compliant
+		typedef long int32_t;
+	#endif
 #endif
 
 class ofxOscArgInt32 : public ofxOscArg


### PR DESCRIPTION
A small define fix as VS2010+ now have ANSI C typedefs. See https://github.com/openframeworks/openFrameworks/issues/559#issuecomment-2433189 for more info.
