### PR TITLE
Bugfix osx open dialog memory leak

### DIFF
--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -248,12 +248,12 @@ ofFileDialogResult ofSystemLoadDialog(string windowTitle, bool bFolderSelection)
 
 		char fileUrl[kBufferSize];
 		Boolean bool1 = CFStringGetCString(cfString,fileUrl,kBufferSize,kCFStringEncodingMacRoman);
-
+			
 		//char fileName[kBufferSize];
 		//Boolean bool2 = CFStringGetCString(reply.saveFileName,fileName,kBufferSize,kCFStringEncodingMacRoman);
 
 		// append strings together
-
+		CFRelease(cfString);
 		results.filePath = fileUrl;
 	}
 


### PR DESCRIPTION
The OS X open dialog has a memory leak as cfString was not being released.
