### PR TITLE
Texture allocation in ofxCvContourfinder disabled 

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvContourFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.cpp
@@ -61,6 +61,7 @@ int ofxCvContourFinder::findContours( ofxCvGrayscaleImage&  input,
     // 320x240 image better to make two ofxCvContourFinder objects then to use
     // one, because you will get penalized less.
 
+    inputCopy.setUseTexture(false);
 	if( inputCopy.getWidth() == 0 ) {
 		inputCopy.allocate( _width, _height );
 	} else if( inputCopy.getWidth() != _width || inputCopy.getHeight() != _height ) {


### PR DESCRIPTION
I've disabled the allocation of textures in inputImage in ofxCvContourfinder, since it gave me problems using the contour finder with odd resolutions multithreaded (because the thread cannot allocate a texture), and since I couldn't see any reason to generate a texture and use gpu space when its never used. 

Jonas Jongejan 
