### PR TITLE
Just a little fix to ofxiPhone. the function ofxiPhoneSetGLViewTransparent now works.

### DIFF
--- a/addons/ofxiPhone/src/ofxiPhoneExtras.mm
+++ b/addons/ofxiPhone/src/ofxiPhoneExtras.mm
@@ -101,7 +101,7 @@ void ofxiPhoneSendGLViewToBack() {
 
 //--------------------------------------------------------------
 void ofxiPhoneSetGLViewTransparent(bool b) {
-	ofxiPhoneGetGLView().opaque = !b;
+	ofxiPhoneGetGLView().layer.opaque = !b;
 }
 
 


### PR DESCRIPTION
the change is minor but it was quite a headache trying to figure out what wasn't working.
changed from 

ofxiPhoneSetGLViewTransparent(bool b) {

```
ofxiPhoneGetGLView().opaque = !b;
```

}

to

ofxiPhoneSetGLViewTransparent(bool b) {

```
ofxiPhoneGetGLView().layer.opaque = !b;
```

}
