### PR TITLE
Bugfix of quicktime player

### DIFF
--- a/libs/openFrameworks/video/ofQuickTimePlayer.cpp
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.cpp
@@ -215,6 +215,8 @@ void ofQuickTimePlayer::closeMovie(){
 		DisposeMovieDrawingCompleteUPP(myDrawCompleteProc);
 
 		moviePtr = NULL;
+        
+        width = height = 0;
     }
 
    	//--------------------------------------


### PR DESCRIPTION
Tiny bug in closeMovie fixed by reseting width and height to 0; if we't then re-loading a movie in the same instance doesn't work because ofPixels and memGWorld do not get reallocated
