### PR TITLE
Bugfix set orientation

### DIFF
--- a/addons/ofxiPhone/src/ofAppiPhoneWindow.mm
+++ b/addons/ofxiPhone/src/ofAppiPhoneWindow.mm
@@ -229,10 +229,8 @@ void ofAppiPhoneWindow::setOrientation(ofOrientation orientation) {
 			[[UIApplication sharedApplication] setStatusBarOrientation: UIInterfaceOrientationLandscapeLeft];
 			break;
 		case OF_ORIENTATION_90_LEFT:
-			[[UIApplication sharedApplication] setStatusBarOrientation: UIInterfaceOrientationLandscapeRight];			break;
-			
-		default:
-			break;
+			[[UIApplication sharedApplication] setStatusBarOrientation: UIInterfaceOrientationLandscapeRight];			
+            break;
 	}
 	
 	this->orientation = orientation;

--- a/addons/ofxiPhone/src/ofxiPhoneExtras.mm
+++ b/addons/ofxiPhone/src/ofxiPhoneExtras.mm
@@ -145,7 +145,7 @@ void ofxiPhoneEnableLoopInThread() {
 
 //--------------------------------------------------------------
 void ofxiPhoneSetOrientation(ofOrientation orientation) {
-	ofxiPhoneGetOFWindow()->setOrientation(orientation);
+	if (orientation != OF_ORIENTATION_UNKNOWN) ofxiPhoneGetOFWindow()->setOrientation(orientation);
 }
 
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -363,11 +363,11 @@ enum ofBlendMode{
 //this is done to match the iPhone defaults 
 //we don't say landscape, portrait etc becuase iPhone apps default to portrait while desktop apps are typically landscape
 enum ofOrientation{
-	OF_ORIENTATION_UNKNOWN = 0,
 	OF_ORIENTATION_DEFAULT = 1,	
 	OF_ORIENTATION_180 = 2,
-	OF_ORIENTATION_90_RIGHT = 3,
-	OF_ORIENTATION_90_LEFT = 4,
+    OF_ORIENTATION_90_LEFT = 3,
+	OF_ORIENTATION_90_RIGHT = 4,
+    OF_ORIENTATION_UNKNOWN = 5
 };
 
 // these are straight out of glu, but renamed and included here


### PR DESCRIPTION
setOrientation was not working on Ipad2 IOS4; could not check it on any other device or IOS.

Basically the the enum's for ofOrientation were making apps flip the wrong way left/right. Also was crashing sometimes because was not checking for OF_ORIENTATION_UNKNOWN before setting the orientation.
