### PR TITLE
fixed ofMesh saving colors and normals, added binary save

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -114,9 +114,6 @@ public:
 	bool hasNormals();
 	bool hasTexCoords();
 	bool hasIndices();
-
-	friend std::ostream& operator<<(std::ostream& os, ofMesh& data);
-	friend std::istream& operator>>(std::istream& is, ofMesh& data);
 	
 	void drawVertices();
 	void drawWireframe();
@@ -125,7 +122,7 @@ public:
 
 
 	void load(string path);
-	void save(string path);
+	void save(string path, bool useBinary = false);
 
 protected:
 	virtual void draw(ofPolyRenderMode renderType);


### PR DESCRIPTION
edit: sorry for the bad commit range in that last pull request :)

i tested all these changes against MeshLab, which uses VCGlib internally to parse the ply files.

i was considering replacing the save function entirely with the binary version, but decided against it because the load() doesn't support binary yet.

if this pull request can be done, it will help a ton with my next class at ITP where we're covering 3d. having built in load/save for ply clouds and meshes makes a huge difference.
