### PR TITLE
Fix const load data on of texture

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -415,6 +415,11 @@ void ofTexture::allocate(int w, int h, int internalGlDataType){
 }
 
 //----------------------------------------------------------
+void ofTexture::allocate(const ofPixels& pix){
+	allocate(pix.getWidth(), pix.getHeight(), ofGetGlFormat(pix), ofGetUsingArbTex());
+}
+
+//----------------------------------------------------------
 void ofTexture::allocate(int w, int h, int internalGlDataType, bool bUseARBExtention){
 	//our graphics card might not support arb so we have to see if it is supported.
 #ifndef TARGET_OPENGLES
@@ -525,32 +530,32 @@ void ofTexture::allocate(const ofTextureData & textureData){
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(unsigned char * data, int w, int h, int glFormat){
+void ofTexture::loadData(const unsigned char * data, int w, int h, int glFormat){
 	loadData( (void *)data, w, h, glFormat);
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(float * data, int w, int h, int glFormat){
+void ofTexture::loadData(const unsigned short * data, int w, int h, int glFormat){
 	loadData( (void *)data, w, h, glFormat);
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(unsigned short * data, int w, int h, int glFormat){
+void ofTexture::loadData(const float * data, int w, int h, int glFormat){
 	loadData( (void *)data, w, h, glFormat);
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(ofPixels & pix){
+void ofTexture::loadData(const ofPixels & pix){
 	loadData(pix.getPixels(), pix.getWidth(), pix.getHeight(), ofGetGlFormat(pix));
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(ofShortPixels & pix){
+void ofTexture::loadData(const ofShortPixels & pix){
 	loadData(pix.getPixels(), pix.getWidth(), pix.getHeight(), ofGetGlFormat(pix));
 }
 
 //----------------------------------------------------------
-void ofTexture::loadData(ofFloatPixels & pix){
+void ofTexture::loadData(const ofFloatPixels & pix){
 	loadData(pix.getPixels(), pix.getWidth(), pix.getHeight(), ofGetGlFormat(pix));
 }
 

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -102,14 +102,15 @@ class ofTexture : public ofBaseDraws {
 	virtual void allocate(const ofTextureData & textureData);
 	virtual void allocate(int w, int h, int glInternalFormat); //uses the currently set OF texture type - default ARB texture
 	virtual void allocate(int w, int h, int glInternalFormat, bool bUseARBExtention); //lets you overide the default OF texture type
+	virtual void allocate(const ofPixels& pix);
 	void clear();
 
-	void loadData(float* data, int w, int h, int glFormat);
-	void loadData(unsigned char* data, int w, int h, int glFormat);
-	void loadData(unsigned short* data, int w, int h, int glFormat);
-	void loadData(ofPixels & pix);		
-	void loadData(ofShortPixels & pix);
-	void loadData(ofFloatPixels & pix);
+	void loadData(const unsigned char* const data, int w, int h, int glFormat);
+	void loadData(const unsigned short* data, int w, int h, int glFormat);
+	void loadData(const float* data, int w, int h, int glFormat);
+	void loadData(const ofPixels & pix);		
+	void loadData(const ofShortPixels & pix);
+	void loadData(const ofFloatPixels & pix);
 	
 	void loadScreenData(int x, int y, int w, int h);
 


### PR DESCRIPTION
hey!
i know you guys must be busy

but here's a couple of small things that have been quite important to me
1. const correctness of ofTexture::loadData
2. ofTexture::allocate(const ofPIxels& pix)

i think it's also worth adding allocate(const ofShortPixels& pix) and allocate(const ofFloatPixels pix) in a seperate pull request later when they can be tested properly

pull pull pull!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

elliot
