### PR TITLE
ofVec2f/ofVec3f: align() -> isAligned()

### DIFF
--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -42,6 +42,8 @@ public:
 	 * Checks if vectors look in the same direction.
 	 * Tolerance is specified in degree.
 	 */
+    bool isAligned( const ofVec2f& vec, float tolerance=0.0001 ) const;
+    bool isAlignedRad( const ofVec2f& vec, float tolerance=0.0001 ) const;
     bool align( const ofVec2f& vec, float tolerance=0.0001 ) const;
     bool alignRad( const ofVec2f& vec, float tolerance=0.0001 ) const;
 	
@@ -263,12 +265,18 @@ inline bool ofVec2f::match( const ofVec2f& vec, float tolerance ) const {
  * Checks if vectors look in the same direction.
  * Tolerance is specified in degree.
  */
-inline bool ofVec2f::align( const ofVec2f& vec, float tolerance ) const {
+inline bool ofVec2f::isAligned( const ofVec2f& vec, float tolerance ) const { 
 	return  fabs( this->angle( vec ) ) < tolerance;
 }
+inline bool ofVec2f::align( const ofVec2f& vec, float tolerance ) const {
+    return isAligned( vec, tolerance );
+}
 
-inline bool ofVec2f::alignRad( const ofVec2f& vec, float tolerance ) const {
+inline bool ofVec2f::isAlignedRad( const ofVec2f& vec, float tolerance ) const {
 	return  fabs( this->angleRad( vec ) ) < tolerance;
+}
+inline bool ofVec2f::alignRad( const ofVec2f& vec, float tolerance ) const {
+    return isAlignedRad( vec, tolerance );
 }
 
 

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -45,7 +45,9 @@ public:
     /**
 	 * Checks if vectors look in the same direction.
 	 */
+    bool isAligned( const ofVec3f& vec, float tolerance=0.0001 ) const;
     bool align( const ofVec3f& vec, float tolerance=0.0001 ) const;
+    bool isAlignedRad( const ofVec3f& vec, float tolerance=0.0001 ) const;
     bool alignRad( const ofVec3f& vec, float tolerance=0.0001 ) const;
 	
 	
@@ -284,14 +286,20 @@ inline bool ofVec3f::match( const ofVec3f& vec, float tolerance ) const{
 /**
  * Checks if vectors look in the same direction.
  */
-inline bool ofVec3f::align( const ofVec3f& vec, float tolerance ) const {
+inline bool ofVec3f::isAligned( const ofVec3f& vec, float tolerance ) const {
 	float angle = this->angle( vec );
 	return  angle < tolerance;
 }
+inline bool ofVec3f::align( const ofVec3f& vec, float tolerance ) const {
+    return isAligned( vec, tolerance );
+}
 
-inline bool ofVec3f::alignRad( const ofVec3f& vec, float tolerance ) const {
+inline bool ofVec3f::isAlignedRad( const ofVec3f& vec, float tolerance ) const {
 	float angle = this->angleRad( vec );
 	return  angle < tolerance;
+}
+inline bool ofVec3f::alignRad( const ofVec3f& vec, float tolerance ) const {
+    return isAlignedRad( vec, tolerance );
 }
 
 


### PR DESCRIPTION
ofVec2f and ofVec3f contain methods called align() that for consistency _should_ be called isAligned(). this pull request adds isAligned() methods, shifts functionality from align() to isAligned() and makes align() call isAligned().

i think that use of align() should be **deprecated** from now on.
