### PR TITLE
ofPath, ofPolyline, ofCairoRenderer :: arcNegative() support added.

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -339,6 +339,24 @@ void ofCairoRenderer::draw(ofSubPath & path){
 				cairo_arc(cr,commands[i].to.x,commands[i].to.y,commands[i].radiusX,commands[i].angleBegin*DEG_TO_RAD,commands[i].angleEnd*DEG_TO_RAD);
 			}
 			break;
+
+        case ofSubPath::Command::arcNegative:
+            curvePoints.clear();
+            // elliptic arcs not directly supported in cairo, lets scale y
+            if(commands[i].radiusX!=commands[i].radiusY){
+                float ellipse_ratio = commands[i].radiusY/commands[i].radiusX;
+                pushMatrix();
+                translate(0,-commands[i].to.y*ellipse_ratio);
+                scale(1,ellipse_ratio);
+                translate(0,commands[i].to.y/ellipse_ratio);
+                cairo_arc_negative(cr,commands[i].to.x,commands[i].to.y,commands[i].radiusX,commands[i].angleBegin*DEG_TO_RAD,commands[i].angleEnd*DEG_TO_RAD);
+                //cairo_set_matrix(cr,&stored_matrix);
+                popMatrix();
+            }else{
+                cairo_arc_negative(cr,commands[i].to.x,commands[i].to.y,commands[i].radiusX,commands[i].angleBegin*DEG_TO_RAD,commands[i].angleEnd*DEG_TO_RAD);
+            }
+        break;
+
 		}
 	}
 

--- a/libs/openFrameworks/graphics/ofPath.cpp
+++ b/libs/openFrameworks/graphics/ofPath.cpp
@@ -211,6 +211,15 @@ void ofPath::quadBezierTo(float cx1, float cy1, float cz1, float cx2, float cy2,
 }
 
 //----------------------------------------------------------
+void ofPath::arc(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd, bool clockwise){
+    if(clockwise) {
+        arc(centre,radiusX,radiusY,angleBegin,angleEnd);
+    } else {
+        arcNegative(centre,radiusX,radiusY,angleBegin,angleEnd);
+    }
+}
+
+//----------------------------------------------------------
 void ofPath::arc(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd){
 	if(mode==PATHS){
 		lastPath().addCommand(ofSubPath::Command(ofSubPath::Command::arc,centre,radiusX,radiusY,angleBegin,angleEnd));
@@ -229,6 +238,27 @@ void ofPath::arc(float x, float y, float radiusX, float radiusY, float angleBegi
 //----------------------------------------------------------
 void ofPath::arc(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd){
 	arc(ofPoint(x,y,z),radiusX,radiusY,angleBegin,angleEnd);
+}
+
+//----------------------------------------------------------
+void ofPath::arcNegative(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd){
+	if(mode==PATHS){
+		lastPath().addCommand(ofSubPath::Command(ofSubPath::Command::arcNegative,centre,radiusX,radiusY,angleBegin,angleEnd));
+		hasChanged = true;
+	}else{
+		lastPolyline().arcNegative(centre,radiusX,radiusY,angleBegin,angleEnd,arcResolution);
+		bNeedsTessellation = true;
+	}
+}
+
+//----------------------------------------------------------
+void ofPath::arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd){
+	arcNegative(ofPoint(x,y,0),radiusX,radiusY,angleBegin,angleEnd);
+}
+
+//----------------------------------------------------------
+void ofPath::arcNegative(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd){
+	arcNegative(ofPoint(x,y,z),radiusX,radiusY,angleBegin,angleEnd);
 }
 
 //----------------------------------------------------------
@@ -336,7 +366,6 @@ void ofPath::generatePolylinesFromPaths(){
 
 			for(int i=0; i<(int)commands.size();i++){
 				switch(commands[i].type){
-
 				case ofSubPath::Command::lineTo:
 					polylines[j].addVertex(commands[i].to);
 					break;
@@ -352,6 +381,9 @@ void ofPath::generatePolylinesFromPaths(){
 				case ofSubPath::Command::arc:
 					polylines[j].arc(commands[i].to,commands[i].radiusX,commands[i].radiusY,commands[i].angleBegin,commands[i].angleEnd, arcResolution);
 					break;
+                case ofSubPath::Command::arcNegative:
+                    polylines[j].arcNegative(commands[i].to,commands[i].radiusX,commands[i].radiusY,commands[i].angleBegin,commands[i].angleEnd, arcResolution);
+                    break;
 				}
 			}
 			polylines[j].setClosed(paths[j].isClosed());
@@ -560,7 +592,7 @@ void ofPath::rotate(float az, const ofVec3f& axis ){
 					paths[i].getCommands()[j].cp1.rotate(az,axis);
 					paths[i].getCommands()[j].cp2.rotate(az,axis);
 				}
-				if(paths[i].getCommands()[j].type==ofSubPath::Command::arc){
+				if(paths[i].getCommands()[j].type==ofSubPath::Command::arc || paths[i].getCommands()[j].type==ofSubPath::Command::arcNegative){
 					paths[i].getCommands()[j].angleBegin += az;
 					paths[i].getCommands()[j].angleEnd += az;
 				}
@@ -591,7 +623,7 @@ void ofPath::scale(float x, float y){
 					paths[i].getCommands()[j].cp2.x*=x;
 					paths[i].getCommands()[j].cp2.y*=y;
 				}
-				if(paths[i].getCommands()[j].type==ofSubPath::Command::arc){
+				if(paths[i].getCommands()[j].type==ofSubPath::Command::arc || paths[i].getCommands()[j].type==ofSubPath::Command::arcNegative){
 					paths[i].getCommands()[j].radiusX *= x;
 					paths[i].getCommands()[j].radiusY *= y;
 				}

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -43,10 +43,15 @@ public:
 	void quadBezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y);
 	void quadBezierTo(float cx1, float cy1, float cz1, float cx2, float cy2, float cz2, float x, float y, float z);
 
+    void arc(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd, bool clockwise);
+
 	void arc(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd);
 	void arc(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd);
 	void arc(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd);
 
+	void arcNegative(const ofPoint & centre, float radiusX, float radiusY, float angleBegin, float angleEnd);
+	void arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd);
+	void arcNegative(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd);
 
 	void setPolyWindingMode(ofPolyWindingMode mode);
 	void setFilled(bool hasFill); // default true
@@ -157,6 +162,7 @@ public:
 			bezierTo,
 			quadBezierTo,
 			arc,
+            arcNegative,
 		};
 
 		/// for lineTo and curveTo

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -31,14 +31,29 @@ public:
 	// if the arc doesn't start at the same point
 	// the last vertex finished a straight line will
 	// be created to join both
-	void arc( const ofPoint & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20 );
+    
+    void arc(const ofPoint & center, float radiusX, float radiusY, float angleBegin, float angleEnd, bool clockwise, int curveResolution = 20);
+    
+	void arc(const ofPoint & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20) {
+        arc(center, radiusX, radiusY, angleBegin, angleEnd,true, curveResolution);
+    }
 	void arc(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20){
-		arc(ofPoint(x,y),radiusX,radiusY,angleBegin,angleEnd,curveResolution);
+		arc(ofPoint(x,y),radiusX,radiusY,angleBegin,angleEnd,true, curveResolution);
 	}
 	void arc(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20){
-		arc(ofPoint(x,y,z),radiusX,radiusY,angleBegin,angleEnd,curveResolution);
+		arc(ofPoint(x,y,z),radiusX,radiusY,angleBegin,angleEnd,true,curveResolution);
 	}
-
+    void arcNegative(const ofPoint & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20) {
+        arc(center, radiusX, radiusY, angleBegin, angleEnd, false, curveResolution);
+    }
+	void arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20){
+        arc(ofPoint(x,y),radiusX,radiusY,angleBegin,angleEnd,false, curveResolution);
+    }
+	void arcNegative(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int curveResolution=20){
+		arc(ofPoint(x,y,z),radiusX,radiusY,angleBegin,angleEnd,false,curveResolution);
+    }
+    
+    
 	// catmull-rom curve
 	void curveTo( const ofPoint & to, int curveResolution=16 );
 	void curveTo(float x, float y, float z=0,  int curveResolution=16 ){
@@ -101,6 +116,8 @@ public:
 
 private:
 	void setCircleResolution(int res);
+    float wrapAngle(float angleRad);
+
 	vector<ofPoint> points;
 
 	deque<ofPoint> curveVertices;


### PR DESCRIPTION
All "arc" methods now accept any start or stop angle. Counter clockwise arcs can now be drawn with arcNegative method. Associated Cairo support for "arc_negative" added and tested. Circle Points LUT preserved for all. Arc method generally re-written to support both clockwise and counter-clockwise directions.

This PR fixed to leave out GLUT-keymod-related changes.
