### PR TITLE
Fix to call MoviesTask when in background thread

### DIFF
--- a/libs/openFrameworks/video/ofQuickTimePlayer.cpp
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.cpp
@@ -174,6 +174,9 @@ void ofQuickTimePlayer::update(){
 					//ofLog( OF_LOG_NOTICE, "not on the main loop, calling MoviesTask") ;
 					MoviesTask(moviePtr,0);
 				}
+			#else
+				// on windows we always call MoviesTask
+				MoviesTask(moviePtr,0);
 			#endif
 
 		//--------------------------------------------------------------


### PR DESCRIPTION
If movies are only being read in a background thread and MoviesTask isn't being called, sometimes the movies don't end up being updated. 

this pull request addresses that.
