### PR TITLE
Fix to get Android build working again

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -150,7 +150,11 @@ inline int ofGetGLTypeFromPixelFormat(ofPixelFormat pixelFormat){
 	case OF_PIXELS_RGBA:
 		return GL_RGBA;
     case OF_PIXELS_RGB565:
+#ifdef TARGET_ANDROID
+    	return GL_RGB;
+#else
         return GL_RGB5;
+#endif
 	}
 }
 #endif /* OFGLUTILS_H_ */


### PR DESCRIPTION
GL_RGB5 doesn't exist for OpenGL ES 1.0, so I added an ifdef to work around the problem
