### PR TITLE
Fix poco include

### DIFF
--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -3,8 +3,8 @@
 #include "ofConstants.h"
 #include "ofTypes.h"
 
-#include "poco/Thread.h"
-#include "poco/Runnable.h"
+#include "Poco/Thread.h"
+#include "Poco/Runnable.h"
 
 /// a thread base class with a built in mutex
 ///


### PR DESCRIPTION
Fix a capitalisation error introduced in 6aa9d1037ed2 - the path is `openFrameworks/libs/poco/include/Poco` not `openFrameworks/libs/poco/include/poco`. 
OF does not build on my linux machine without this, but builds without problems after the fix. I was kinda surprised that nobody caught/encountered this yet...
