### PR TITLE
.gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,9 @@ examples/*/*/*.sln
 examples/*/*/*.vcxproj
 examples/*/*/*.vcxproj.user
 
-#rule to avoid non-official examples going into git
-#see examples/.gitignore
-apps/**
+#rule to avoid non-official apps going into git
+#see apps/.gitignore
+apps/*
 
 #codeblocks OF lib files
 libs/openFrameworksCompiled/project/*/*.depend

--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -1,3 +1,6 @@
-!devApps
-!devApps/*/**
-!devApps/**
+# devApps is the only official directory
+!devApps/
+
+# ignore bin folders' contents, except data folder therein
+/devApps/*/bin/*
+!/devApps/*/bin/data/


### PR DESCRIPTION
Some clean-up and fixes to the gitignores, to properly a compiled project generator.

Generally, the gitignore structure needs an overhaul. It's become really confusing to read, rules are duplicated (that could be interesting to debug :P), etc., but I'll postpone that to a later date. I'll be back, I guess.

This goes towards fixing part of #1076
