### PR TITLE
projectGenerator files missing .plist

### DIFF
--- a/apps/devApps/projectGenerator/src/projects/xcodeProject.cpp
+++ b/apps/devApps/projectGenerator/src/projects/xcodeProject.cpp
@@ -177,10 +177,10 @@ bool xcodeProject::createProjectFile(){
     ofFile::copyFromTo(ofFilePath::join(templatePath,"Project.xcconfig"),projectDir, true, true);
     
     if( target == "osx" ){
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"openFrameworks-Info.plist"),projectDir);
+        ofFile::copyFromTo(ofFilePath::join(templatePath,"openFrameworks-Info.plist"),projectDir, true, true);
     }else{
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"ofxiphone-Info.plist"),projectDir);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"iPhone_Prefix.pch"),projectDir);
+        ofFile::copyFromTo(ofFilePath::join(templatePath,"ofxiphone-Info.plist"),projectDir, true, true);
+        ofFile::copyFromTo(ofFilePath::join(templatePath,"iPhone_Prefix.pch"),projectDir, true, true);
     }
 
     // this is for xcode 4 sceme issues. but I'm not sure this is right. 


### PR DESCRIPTION
setting overwrite to true fixed it with xcode 3.2.6 and 10.6.8 (similar to lines above 181)
