### PR TITLE
Bug fix advanced events example

### DIFF
--- a/examples/events/advancedEventsExample/src/eventsObject.h
+++ b/examples/events/advancedEventsExample/src/eventsObject.h
@@ -18,11 +18,11 @@ public:
 	}
 
 	void enable(){
-	    ofAddListener(ofEvents.update, this, &eventsObject::update);
+	    ofAddListener(ofEvents().update, this, &eventsObject::update);
 	}
 
 	void disable(){
-	    ofRemoveListener(ofEvents.update, this, &eventsObject::update);
+	    ofRemoveListener(ofEvents().update, this, &eventsObject::update);
 	}
 
 	void update(ofEventArgs & args){


### PR DESCRIPTION
Due to https://github.com/gameoverhack/openFrameworks/commit/68a9805c5a76fcf9bb620c317c1ad9087d49e456

it appears we need to use ofEvents().someEvent instead of ofEvents.someEvent...

...fixed the advancedEventsExample to use this syntax
