### PR TITLE
bug fix for ofPixels::rotate90To with nRotations = 1

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -473,7 +473,7 @@ void ofPixels_<PixelType>::rotate90To(ofPixels_<PixelType> & dst, int nClockwise
 	}
 
 	// otherwise, we will need to do some new allocaiton.
-    dst.allocate(height,width,getImageType());
+	dst.allocate(height,width,getImageType());
     
 	int strideSrc = width * channels;
 	int strideDst = dst.width * channels;


### PR DESCRIPTION
problem was that when calculating strideDst, dst.width was 0, as the allocation of dst happened later. closes #1123
