### PR TITLE
ofImage Memory Reallocations

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -751,8 +751,11 @@ void ofImage_<PixelType>::allocate(int w, int h, ofImageType newType){
 	if (pixels.isAllocated() && bUseTexture){
 		tex.allocate(pixels.getWidth(), pixels.getHeight(), ofGetGlInternalFormat(pixels));
 	}
-
-	update();
+	
+	width	= pixels.getWidth();
+	height	= pixels.getHeight();
+	bpp		= pixels.getBitsPerPixel();
+	type	= pixels.getImageType();
 }
 
 
@@ -874,11 +877,6 @@ void ofImage_<PixelType>::update(){
 		}
 		tex.loadData(pixels);
 	}
-
-	width	= pixels.getWidth();
-	height	= pixels.getHeight();
-	bpp		= pixels.getBitsPerPixel();
-	type	= pixels.getImageType();
 }
 
 //------------------------------------


### PR DESCRIPTION
Streamline reallocation of memory in ofImage.

I have identified a few places in ofImage where it seems that pixel and texture memory was being reallocated in places that were not necessary, that is: when "allocating" memory of the same size as previously allocated. I have not tested these changes extensively, though they are fairly minor and logically easy-to-follow.

These changes provide a drastic speed increase when using setFromPixels() to repeatedly load pixels of the same width/height/bitdepth as one might do when playing back a image/frame sequence.
