### PR TITLE
ofImage Quick Bug Fix

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -883,6 +883,11 @@ void ofImage_<PixelType>::update(){
 		}
 		tex.loadData(pixels);
 	}
+	
+	width	= pixels.getWidth();
+	height	= pixels.getHeight();
+	bpp		= pixels.getBitsPerPixel();
+	type	= pixels.getImageType();
 }
 
 //------------------------------------


### PR DESCRIPTION
A previous commit moved the setting of width/height/bpp/type into
allocate(). While these values should indeed be set during
allocation, possibly before an update(), they should also be set
in the case that some other program flow results in an update()
without an explicit call to allocate(), as occurs when calling
loadImage().

Tested on Windows against dirListExample and imageLoaderExample
and everything works again.

If anything, code added in this commit is resetting variables that, at
worst, have already been set, making it redundant.
