### PR TITLE
bugfix SKIP_INSTALL set to YES

### DIFF
--- a/libs/openFrameworksCompiled/project/iphone/iPhone+OF Lib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/iphone/iPhone+OF Lib.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "ofxiPhone_${PLATFORM_NAME}_Debug";
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -1033,6 +1034,7 @@
 				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "ofxiPhone_${PLATFORM_NAME}_Release";
+				SKIP_INSTALL = YES;
 				ZERO_LINK = NO;
 			};
 			name = Release;


### PR DESCRIPTION
this fixes the issue that people have been having with XCode4 and when trying to create Archive builds for the app store.

switching SKIP_INSTALL to YES fixes the issue.

fixes #1097
