### PR TITLE
Fix pg ofpath overflow

### DIFF
--- a/apps/devApps/projectGenerator/src/testApp.cpp
+++ b/apps/devApps/projectGenerator/src/testApp.cpp
@@ -13,6 +13,8 @@ void testApp::setup(){
 
 	setOFRoot(getOFRootFromConfig());
 
+	setupDrawableOFPath();
+	
 	int targ = ofGetTargetPlatform();
 	//plat = OF_TARGET_IPHONE;
 
@@ -246,7 +248,12 @@ void testApp::createAndOpenPressed(bool & pressed){
 }
 
 void testApp::changeOFRootPressed(bool & pressed){
-	if(!pressed) askOFRoot();
+	if(!pressed){
+		askOFRoot();
+		cout << getOFRootFromConfig()<<endl;
+		setOFRoot(getOFRootFromConfig());
+		setupDrawableOFPath();
+	}
 }
 
 
@@ -268,11 +275,12 @@ void testApp::draw(){
 	examplesPanel.draw();
 
 	ofSetColor(0,0,0,100);
-	ofRect(ofGetWidth()-410,10,400,100);
+
+	ofRect(ofPathRect);
 
     /*ofDrawBitmapString("press 'm' to make all files\npress ' ' to make a specific file", ofPoint(30,30));*/
 	ofSetColor(255);
-    ofDrawBitmapString("OF path: " + getOFRoot(), ofPoint(ofGetWidth() - 390,30));
+    ofDrawBitmapString(drawableOfPath, ofPathDrawPoint);
 }
 
 //--------------------------------------------------------------
@@ -320,7 +328,7 @@ void testApp::mouseReleased(int x, int y, int button){
 
 //--------------------------------------------------------------
 void testApp::windowResized(int w, int h){
-
+	setupDrawableOFPath();
 }
 
 //--------------------------------------------------------------
@@ -330,5 +338,46 @@ void testApp::gotMessage(ofMessage msg){
 
 //--------------------------------------------------------------
 void testApp::dragEvent(ofDragInfo dragInfo){
+
+}
+
+//--------------------------------------------------------------
+void testApp::setupDrawableOFPath(){
+	vector<string> subdirs = ofSplitString("OF path: " + getOFRoot(), "/");
+	int textLength = 0;
+	int padding = 5;
+	string path = "";
+	int lines=1;
+	int fontSize = 8;
+	float leading = 1.7;
+	
+	ofPathRect.x = padding;
+	ofPathRect.y = padding;
+	ofPathDrawPoint.x = padding*2;
+	ofPathDrawPoint.y = padding*2 + fontSize * leading;
+	
+	for(int i = 0; i < subdirs.size(); i++) {
+		if (i > 0 && i<subdirs.size()-1) {
+			subdirs[i] += "/";
+		}
+		if(textLength + subdirs[i].length()*fontSize < ofGetWidth()-padding){
+			textLength += subdirs[i].length()*fontSize;
+			path += subdirs[i];
+		}else {
+			path += "\n";
+			textLength = 0;
+			lines++;
+		}
+	}
+	ofPathRect.width = textLength + padding*2;
+	if (lines > 1){
+		ofPathRect.width = ofGetWidth() - padding*2;
+	}
+	ofPathRect.height = lines * fontSize * leading + (padding*2);
+	
+	drawableOfPath = path;
+	
+	panelAddons.setPosition(panelAddons.getPosition().x, ofPathRect.y + ofPathRect.height + padding);
+	examplesPanel.setPosition(examplesPanel.getPosition().x, ofPathRect.y + ofPathRect.height + padding);
 
 }

--- a/apps/devApps/projectGenerator/src/testApp.h
+++ b/apps/devApps/projectGenerator/src/testApp.h
@@ -36,11 +36,17 @@ class testApp : public ofBaseApp{
         void updateProjectPressed(bool & pressed);
         void createAndOpenPressed(bool & pressed);
         void changeOFRootPressed(bool & pressed);
-
+		
+		void setupDrawableOFPath();
+		
 		baseProject * project;
     
         string projectPath;
         string target;
+	
+		string drawableOfPath;
+		ofRectangle ofPathRect;
+		ofPoint ofPathDrawPoint;
 
         ofxPanel panelAddons, panelOptions;
         ofxButton createProject, updateProject, createAndOpen, changeOFRoot;


### PR DESCRIPTION
The OF path in the project generator got easily overflowed at the right margin.
I moved tha of path to get drawn at the left and wrapped the path string in case it was to long.
the examples and addons panels get repositioned so the ofpath doesn't get drawn over the panels
