### PR TITLE
bugfix #1182 - framebuffer not being created on iOS 4.1

### DIFF
--- a/addons/ofxiPhone/src/EAGLView.mm
+++ b/addons/ofxiPhone/src/EAGLView.mm
@@ -81,8 +81,6 @@
 			}
         }
 		
-		[[self context] renderbufferStorage:GL_RENDERBUFFER_OES fromDrawable:eaglLayer];
-		
 		self.multipleTouchEnabled = true;
 		self.opaque = true;
 		activeTouches = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
[[self context] renderbufferStorage:GL_RENDERBUFFER_OES fromDrawable:eaglLayer];
was stopping the framebuffer from being created on iOS 4.1
closes #1182
