### PR TITLE
bugfix for ios imageLoaderExample

### DIFF
--- a/examples/ios/imageLoaderExample/src/testApp.mm
+++ b/examples/ios/imageLoaderExample/src/testApp.mm
@@ -28,21 +28,21 @@ void testApp::draw(){
 
 	ofScale(0.5, 0.5, 1.0);
 
-	ofSetColor(0xFFFFFF);
+	ofSetHexColor(0xFFFFFF);
 	
 	bikers.draw(0,0);
 	gears.draw(600,0);
 	tdf.draw(600,300);
 	
-	ofSetColor(0xDD3333);
+	ofSetHexColor(0xDD3333);
 	tdfSmall.draw(200,300);
 	
-	ofSetColor(0xFFFFFF);
+	ofSetHexColor(0xFFFFFF);
 	ofEnableAlphaBlending();
 	transparency.draw(sin(ofGetElapsedTimeMillis()/1000.0f) * 100 + 500,20);
 	ofDisableAlphaBlending();
 	
-	ofSetColor(0x000000);
+	ofSetHexColor(0x000000);
 	
 	// getting the pixels out of an image, 
 	// and then use the values to draw circles
@@ -57,7 +57,7 @@ void testApp::draw(){
 		}
 	}
 	
-	ofSetColor(0xFFFFFF);
+	ofSetHexColor(0xFFFFFF);
 	bikeIcon.draw(300,500, 20,20);
 }
 


### PR DESCRIPTION
noticed that hex colour values were being passed into ofSetColor which was displaying lots of log messages in the console.

changed to ofSetHexColor.
