### PR TITLE
Feature of vec things

### DIFF
--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -206,6 +206,12 @@ public:
     
     // use getRotated
     ofVec2f rotated( float angle, const ofVec2f& pivot ) const;    
+    
+    // return all zero vector
+    static ofVec2f zero() { return ofVec2f(0, 0); }
+
+    // return all one vector
+    static ofVec2f one() { return ofVec2f(1, 1); }
 };
 
 

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -228,6 +228,12 @@ public:
     ofVec3f 	rotated( float angle,
 						const ofVec3f& pivot,
 						const ofVec3f& axis ) const;    
+
+    // return all zero vector
+    static ofVec3f zero() { return ofVec3f(0, 0, 0); }
+    
+    // return all one vector
+    static ofVec3f one() { return ofVec3f(1, 1, 1); }
 };
 
 

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -144,6 +144,13 @@ public:
 	
     // use getMiddle
     ofVec4f 	middled( const ofVec4f& pnt ) const;    
+    
+    // return all zero vector
+    static ofVec4f zero() { return ofVec4f(0, 0, 0, 0); }
+    
+    // return all one vector
+    static ofVec4f one() { return ofVec4f(1, 1, 1, 1); }
+
 };
 
 


### PR DESCRIPTION
added some little additions to ofVec\* classes so generic external functions (e.g. templated functions and classes) can manipulate them without knowing if its a ofVec2f or ofVec3f etc. 
