### PR TITLE
Fix ofShader's broken call to glGetProgramiv

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -126,6 +126,12 @@ bool ofShader::setupShaderFromSource(GLenum type, string source) {
 	// check compile status
 	GLint status = GL_FALSE;
 	glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+    GLuint err = glGetError();
+    if (err != GL_NO_ERROR){
+        ofLog( OF_LOG_ERROR, "OpenGL generated error " + ofToString(err) + " trying to get the compile status for " + nameForType(type) + " shader. Does your video card support this?" );
+        return false;
+    }
+    
 	if(status == GL_TRUE)
 		ofLog(OF_LOG_VERBOSE, nameForType(type) + " shader compiled.");
 	
@@ -167,14 +173,19 @@ int ofShader::getGeometryMaxOutputCount() {
 }
 
 //--------------------------------------------------------------
-bool ofShader::checkShaderLinkStatus(GLuint shader, GLenum type) {
+bool ofShader::checkProgramLinkStatus(GLuint program) {
 	GLint status;
-	glGetProgramiv(shader, GL_LINK_STATUS, &status);
+	glGetProgramiv(program, GL_LINK_STATUS, &status);
+    GLuint err = glGetError();
+    if (err != GL_NO_ERROR){
+        ofLog( OF_LOG_ERROR, "OpenGL generated error "+ofToString(err)+" trying to get the program link status. Does your video card support shader programs?" );
+        return false;
+    }
 	if(status == GL_TRUE)
-		ofLog(OF_LOG_VERBOSE, nameForType(type) + " shader linked.");
+		ofLog(OF_LOG_VERBOSE, "Program linked.");
 	else if (status == GL_FALSE) {
-		ofLog(OF_LOG_ERROR, nameForType(type) + " shader failed to link.");
-		checkShaderInfoLog(shader, type);
+		ofLog(OF_LOG_ERROR, "Program failed to link.");
+		checkProgramInfoLog(program);
 		return false;
 	}
 	return true;
@@ -234,16 +245,11 @@ bool ofShader::linkProgram() {
 			}
 			
 			glLinkProgram(program);
+            
+            checkProgramLinkStatus(program);
 
-			for(map<GLenum, GLuint>::const_iterator it = shaders.begin(); it != shaders.end(); ++it){
-				GLuint shader = it->second;
-				if(shader) {
-					checkShaderLinkStatus(shader, it->first);
-				}
-			}
-			
-			checkProgramInfoLog(program);
-			
+            // bLoaded means we have loaded shaders onto the graphics card;
+            // it doesn't necessarily mean that these shaders have compiled and linked successfully.
 			bLoaded = true;
 		}
 		return bLoaded;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -110,14 +110,14 @@ private:
 	GLint getUniformLocation(const char* name);
 	
 	void checkProgramInfoLog(GLuint program);
-	bool checkShaderLinkStatus(GLuint shader, GLenum type);
+	bool checkProgramLinkStatus(GLuint program);
 	void checkShaderInfoLog(GLuint shader, GLenum type);
 	
 	static string nameForType(GLenum type);
 	
 	void checkAndCreateProgram();
 	
-	bool bLoaded;
+	bool bLoaded; 
 };
 
 #endif


### PR DESCRIPTION
ofShader was calling glGetProgramiv incorrectly, passing a shader argument when it should have been a program argument.
