### PR TITLE
ofQuickTimePlayer with alpha

### DIFF
--- a/libs/openFrameworks/video/ofQtUtils.cpp
+++ b/libs/openFrameworks/video/ofQtUtils.cpp
@@ -47,14 +47,13 @@ void closeQuicktime(){
 
 
 //----------------------------------------
-void convertPixels(unsigned char * gWorldPixels, unsigned char * rgbPixels, int w, int h){
+void convertPixels(unsigned char * gWorldPixels, unsigned char * rgbPixels, int w, int h, int bpp){
 
 	// ok for macs?
 	// ok for intel macs?
 
 	int * rgbaPtr 			= (int *) gWorldPixels;
-	pix24 * rgbPtr 			= (pix24 *) rgbPixels;
-		unsigned char * rgbaStart;
+    unsigned char * rgbaStart;
 
 	//	putting in the boolean, so we can work on
 	//	0,0 in top right...
@@ -73,24 +72,44 @@ void convertPixels(unsigned char * gWorldPixels, unsigned char * rgbPixels, int 
 	if (!bFlipVertically){
 		//----- argb->rgb
 		for (int i = 0; i < h; i++){
-			pix24 * rgbPtr 			= (pix24 *) rgbPixels + ((i) * w);
-			for (int j = 0; j < w; j++){
-				rgbaStart = (unsigned char *)rgbaPtr;
-				memcpy (rgbPtr, rgbaStart+1, sizeof(pix24));
-				rgbPtr++;
-				rgbaPtr++;
-			}
+            if (bpp == 3) {
+                pix24 * rgbPtr = (pix24 *) rgbPixels + ((i) * w);
+                for (int j = 0; j < w; j++){
+                    rgbaStart = (unsigned char *)rgbaPtr;
+                    memcpy (rgbPtr, rgbaStart+1, sizeof(pix24));
+                    rgbPtr++;
+                    rgbaPtr++;
+                }
+            } else {
+                pix32 * rgbPtr = (pix32 *) rgbPixels + ((i) * w);
+                for (int j = 0; j < w; j++){
+                    rgbaStart = (unsigned char *)rgbaPtr;
+                    memcpy (rgbPtr, rgbaStart+1, sizeof(pix32));    
+                    rgbPtr++;
+                    rgbaPtr++;
+                }
+            }
 		}
 	} else {
 		//----- flip while argb->rgb
 		for (int i = 0; i < h; i++){
-			pix24 * rgbPtr 			= (pix24 *) rgbPixels + ((h-i-1) * w);
-			for (int j = 0; j < w; j++){
-				rgbaStart = (unsigned char *)rgbaPtr;
-				memcpy (rgbPtr, rgbaStart+1, sizeof(pix24));
-				rgbPtr++;
-				rgbaPtr++;
-			}
+            if (bpp == 3) {
+                pix24 * rgbPtr = (pix24 *) rgbPixels + ((h-i-1) * w);
+                for (int j = 0; j < w; j++){
+                    rgbaStart = (unsigned char *)rgbaPtr;
+                    memcpy (rgbPtr, rgbaStart+1, sizeof(pix24));    
+                    rgbPtr++;
+                    rgbaPtr++;
+                }
+            } else {
+                pix32 * rgbPtr = (pix32 *) rgbPixels + ((h-i-1) * w);
+                for (int j = 0; j < w; j++){
+                    rgbaStart = (unsigned char *)rgbaPtr;
+                    memcpy (rgbPtr, rgbaStart+1, sizeof(pix32));
+                    rgbPtr++;
+                    rgbaPtr++;
+                }
+            }
 		}
 	}
 }

--- a/libs/openFrameworks/video/ofQtUtils.h
+++ b/libs/openFrameworks/video/ofQtUtils.h
@@ -31,13 +31,20 @@ typedef struct{
 	unsigned char b;
 } pix24;
 
+typedef struct{
+	unsigned char a;	
+	unsigned char r;
+	unsigned char g;
+	unsigned char b;
+} pix32;
+
 
 
 //----------------------------------------
 
 void 		initializeQuicktime();
 void 		closeQuicktime();
-void 		convertPixels(unsigned char * gWorldPixels, unsigned char * rgbPixels, int w, int h);
+void 		convertPixels(unsigned char * gWorldPixels, unsigned char * rgbPixels, int w, int h, int bpp);
 Boolean 	SeqGrabberModalFilterUPP(DialogPtr theDialog, const EventRecord *theEvent, short *itemHit, long refCon);
 OSErr           IsMPEGMediaHandler(MediaHandler inMediaHandler, Boolean *outIsMPEG);
 ComponentResult MPEGMediaGetStaticFrameRate(MediaHandler inMPEGMediaHandler, Fixed *outStaticFrameRate);

--- a/libs/openFrameworks/video/ofQuickTimePlayer.h
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.h
@@ -16,50 +16,51 @@ class ofQuickTimePlayer : public ofBaseVideoPlayer{
 		ofQuickTimePlayer();
 		~ofQuickTimePlayer();
 
-		 bool			loadMovie(string name);
-		 void			closeMovie();	
-		 void			close();
-		 void			update();
+		bool			loadMovie(string name);
+		void			closeMovie();	
+		void			close();
+		void			update();
 
-		 void			play();
-		 void			stop();
-		 
-		 void			clearMemory();
-	
-		 bool 			isFrameNew();
-		 unsigned char * 	getPixels();
-		 ofPixelsRef		getPixelsRef();
-		 const ofPixels&	getPixelsRef() const;
+		void			play();
+		void			stop();
 		
-		 float 			getWidth();
-		 float 			getHeight();
+		void			clearMemory();
+	
+		bool 			isFrameNew();
+		unsigned char * getPixels();
+		ofPixelsRef		getPixelsRef();
+		const ofPixels&	getPixelsRef() const;
+		
+		float 			getWidth();
+		float 			getHeight();
 
-		 bool			isPaused();
-		 bool			isLoaded();
-		 bool			isPlaying();		 
+		bool			isPaused();
+		bool			isLoaded();
+		bool			isPlaying();		 
 
-		 float 			getPosition();
-		 float 			getDuration();
-		 int			getTotalNumFrames();
-		 float			getSpeed();
-		 bool			getIsMovieDone();
+		float 			getPosition();
+		float 			getDuration();
+		int             getTotalNumFrames();
+		float			getSpeed();
+		bool			getIsMovieDone();
 
-		 void 			setPosition(float pct);
-		 void 			setVolume(int volume);
-		 void 			setLoopState(ofLoopType state);
-		 void   		setSpeed(float speed);
-		 void			setFrame(int frame);  // frame 0 = first frame...
-		 void 			setPaused(bool bPause);
+		void 			setPosition(float pct);
+		void 			setVolume(int volume);
+		void 			setLoopState(ofLoopType state);
+		void            setSpeed(float speed);
+		void			setFrame(int frame);  // frame 0 = first frame...
+		void 			setPaused(bool bPause);
 
-		 int			getCurrentFrame();
+		int             getCurrentFrame();
 
-		 void			firstFrame();
-		 void			nextFrame();
-		 void			previousFrame();
-		 
-		bool 				bHavePixelsChanged;
-		 
-		 
+		void			firstFrame();
+		void			nextFrame();
+		void			previousFrame();
+		
+        void			setPixelFormat(ofPixelFormat pxFormat);
+
+        bool 			bHavePixelsChanged;
+    		 
 		
 	protected:
 		void createImgMemAndGWorld();
@@ -68,6 +69,7 @@ class ofQuickTimePlayer : public ofBaseVideoPlayer{
 		ofPixels		 	pixels;
 		int					width, height;
 		bool				bLoaded;
+        ofPixelFormat       pixelFormat;
 
 		//these are public because the ofQuickTimePlayer implementation has some callback functions that need access
 		//todo - fix this
@@ -75,7 +77,7 @@ class ofQuickTimePlayer : public ofBaseVideoPlayer{
 		int					nFrames;				// number of frames
 		bool				allocated;				// so we know to free pixels or not
 
-		ofLoopType					currentLoopState;
+		ofLoopType			currentLoopState;
 		bool 				bStarted;
 		bool 				bPlaying;
 		bool 				bPaused;
@@ -96,8 +98,3 @@ class ofQuickTimePlayer : public ofBaseVideoPlayer{
 		//--------------------------------------
 
 };
-
-
-
-
-


### PR DESCRIPTION
Updated ofQuickTimePlayer to properly handle videos with an alpha channel. This uses the setPixelFormat() method, so all you need to do is:

```
myVideoPlayer.setPixelFormat(OF_PIXELS_RGBA);
myVideoPlayer.loadMovie("path/to/movie.mov");   
myVideoPlayer.play();
```
