### PR TITLE
Bugfix makefile.examples

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/Makefile.examples
+++ b/libs/openFrameworksCompiled/project/makefileCommon/Makefile.examples
@@ -78,7 +78,7 @@ INCLUDES_FLAGS += -I$(OF_ROOT)/libs/poco/include
 
 LIB_STATIC = $(shell ls $(OF_ROOT)/libs/*/lib/$(LIBSPATH)/*.a  2> /dev/null | grep -v openFrameworksCompiled | grep -v Poco)
 LIB_SHARED = $(shell ls $(OF_ROOT)/libs/*/lib/$(LIBSPATH)/*.so  2> /dev/null | grep -v openFrameworksCompiled | sed "s/.*\\/lib\([^/]*\)\.so/-l\1/")
-LIB_STATIC += $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoNet.a ../../../libs/poco/lib/$(LIBSPATH)/libPocoXML.a ../../../libs/poco/lib/$(LIBSPATH)/libPocoUtil.a ../../../libs/poco/lib/$(LIBSPATH)/libPocoFoundation.a
+LIB_STATIC += $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoNet.a $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoXML.a $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoUtil.a $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoFoundation.a
 LIB_PATHS_FLAGS = $(shell ls -d $(OF_ROOT)/libs/*/lib/$(LIBSPATH) | sed "s/\(\.*\)/-L\1/")
 
 CFLAGS += -Wall -fexceptions


### PR DESCRIPTION
... caused linker errors on linux (directory not found) if custom project directory not in default location.

Using makefile: Makefile
make: **\* No rule to make target `../../../libs/poco/lib/linux/libPocoXML.a', needed by`bin/testProject_debug'.  Stop.
Process terminated with status 2 (0 minutes, 0 seconds)
0 errors, 0 warnings
