### PR TITLE
Added ofRoundedRect() functions to ofGraphics

### DIFF
--- a/apps/examples/polygonExample/src/testApp.cpp
+++ b/apps/examples/polygonExample/src/testApp.cpp
@@ -366,6 +366,25 @@ void testApp::draw(){
 	glPopMatrix();
 
 	//-------------------------------------
+
+	//------(j)--------------------------------------
+	// 
+	// 		ofRoundedRect
+	//
+
+	glPushMatrix();
+
+	ofSetPolyMode(OF_POLY_WINDING_ODD);
+	ofSetLineWidth(1.5);
+	ofEnableSmoothing();
+	ofNoFill();
+	ofSetHexColor(0x000000);
+	ofRoundedRect(630,520,80,60,9);
+	ofDisableSmoothing();
+
+	glPopMatrix();
+
+	//-------------------------------------
 	
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("(a) star\nwinding rule odd", 20,210);
@@ -394,7 +413,8 @@ void testApp::draw(){
 	
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("(i) ofNextContour\ncan even be used for CSG operations\nsuch as union and intersection", 260,620);
-	
+
+	ofDrawBitmapString("(j) ofRoundedRect\nrectangles with rounded corners", 600, 620);
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -762,6 +762,43 @@ void ofRect(float x,float y,float z,float w,float h){
 	renderer->drawRectangle(x,y,z,w,h);
 }
 
+//----------------------------------------------------------
+void ofRoundedRect(const ofRectangle & b,float r){
+	ofRoundedRect(b.x, b.y, 0.0f, b.width, b.height, r);
+}
+
+//----------------------------------------------------------
+void ofRoundedRect(const ofPoint & p,float w,float h,float r){
+	ofRoundedRect(p.x, p.y, p.z, w, h, r);
+}
+
+//----------------------------------------------------------
+void ofRoundedRect(float x,float y,float w,float h,float r){
+	ofRoundedRect(x, y, 0.0f, w, h, r);
+}
+
+//----------------------------------------------------------
+void ofRoundedRect(float x,float y,float z,float w,float h,float r){
+	float x2 = x + w;
+	float y2 = y + h;
+
+	if (r > w || r > h){
+		ofRect(x, y, z, w, h);
+		return;
+	}
+
+	shape.clear();
+	shape.lineTo(x+r, y);
+	shape.bezierTo(x,y, x,y+r, x,y+r);
+	shape.lineTo(x, y2-r);
+	shape.bezierTo(x,y2, x+r,y2, x+r,y2);
+	shape.lineTo(x2-r, y2);
+	shape.bezierTo(x2,y2, x2,y2-r, x2,y2-r);
+	shape.lineTo(x2, y+r);
+	shape.bezierTo(x2,y, x2-r,y, x2-r,y);
+	shape.lineTo(x+r, y);
+	shape.draw();
+}
 
 //----------------------------------------------------------
 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3){

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -197,6 +197,11 @@ void ofRect(const ofRectangle & r);
 void ofRect(const ofPoint & p,float w,float h);
 void ofRect(float x,float y,float z,float w,float h);
 
+void ofRoundedRect(const ofRectangle & b,float r);
+void ofRoundedRect(const ofPoint & p,float w,float h,float r);
+void ofRoundedRect(float x,float y,float w,float h,float r);
+void ofRoundedRect(float x,float y,float z,float w,float h,float r);
+
 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 


### PR DESCRIPTION
I find that I'm using rectangles with rounded corners quiet often and seems like a fairly simple addition.
An example of using this is as follows:

```
ofSetPolyMode(OF_POLY_WINDING_ODD);
ofSetLineWidth(1.5);
ofEnableSmoothing();
ofNoFill();
ofSetHexColor(0x000000);
ofRoundedRect(630,520,80,60,9);
ofDisableSmoothing();
```
