### PR TITLE
Feature: ofToString float formatting arguments

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -102,7 +102,7 @@ string ofToString(const T& value, int width, char fill ){
 
 /// like sprintf "%04.2d" or "%04.2f" format, in this example precision=2, width=4, fill='0'
 template <class T>
-string ofToString(const T& value, int precision, int width, char fill=' ' ){
+string ofToString(const T& value, int precision, int width, char fill ){
 	ostringstream out;
 	out << fixed << setfill(fill) << setw(width) << setprecision(precision) << value;
 	return out.str();


### PR DESCRIPTION
Adds two new forms of ofToString:

```
string ofToString(const T& value, int width, char fill );
```

Behaves like `"%04d"` or `"%04f"` arguments to `printf`, with `width=4` and `fill='0'` in this example. Use to prettily align numbers, using `fill=' '`.

```
string ofToString(const T& value, int precision, int width, char fill=' ' );
```

Behaves like `"%04.2f"` with `width=4`, `precision=2` and `fill='0'` in this example.
