### PR TITLE
Fix ofThread destructor behaviour

### DIFF
--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -12,7 +12,8 @@ ofThread::ofThread(){
 
 //------------------------------------------------- 
 ofThread::~ofThread(){ 
-   stopThread(true);
+	stopThread(true);
+	waitForThread();
 } 
 
 //------------------------------------------------- 
@@ -108,7 +109,7 @@ void ofThread::stopThread(bool close){
 	if(thread.isRunning()) {
 		threadRunning = false;
 		if(close && thread.isRunning()){
-			thread.tryJoin(0);
+			thread.tryJoin(0); 
 		}
 	}
 }


### PR DESCRIPTION
The way ofThread's destructor worked was causing cleanup code at the end of threadedFunction to be skipped, sometimes leaving shared resources in an unusable state. This patch makes sure that the ofThread destructor waits until the thread has properly exited. 

IMO this patch is critical, but it should be treated with caution, as this has the possibility to cause deadlocks in code with multiple threads where the cleanup order is not clearly defined.
