### PR TITLE
Fix cleanAllExamples script

### DIFF
--- a/scripts/linux/cleanAllExamples.sh
+++ b/scripts/linux/cleanAllExamples.sh
@@ -20,6 +20,7 @@ do
         rm -rf *.backup 2> /dev/null
         rm -rf *.depend 2> /dev/null
         rm *~ 2> /dev/null
+        cd ..
         echo "-----------------------------------------------------------------"
         echo ""
     done


### PR DESCRIPTION
I found a bug in the linux/cleanAllExamples.sh script - it only cleans the first example it encounters.
output e.g.

```
-----------------------------------------------------------------
cleaning  + meshFromCamera
./cleanAllExamples.sh: line 16: cd: meshFromCamera: No such file or directory
rm -rf obj/i686Release/
rm -f bin/advanced3dExample_debug bin/advanced3dExample
rm -r bin/libs
rm: cannot remove `bin/libs': No such file or directory
make: *** [clean] Error 1
-----------------------------------------------------------------
```

There's a `cd ..` missing at https://github.com/openframeworks/openFrameworks/blob/develop/scripts/linux/cleanAllExamples.sh#L24
This PR fixes teh bug.
