### PR TITLE
Fix OSX rtAudio path case 

### DIFF
--- a/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
@@ -7,7 +7,7 @@ HEADER_GLEW = "$(OF_PATH)/libs/glew/include"
 HEADER_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/include"
 HEADER_TESS2 = "$(OF_PATH)/libs/tess2/include"
 HEADER_CAIRO = "$(OF_PATH)/libs/cairo/include/cairo"
-HEADER_RTAUDIO = "$(OF_PATH)/libs/rtaudio/include"
+HEADER_RTAUDIO = "$(OF_PATH)/libs/rtAudio/include"
 
 LIB_FMODEX = "$(OF_PATH)/libs/fmodex/lib/osx/libfmodex.dylib"
 LIB_GLUT = "$(OF_PATH)/libs/glut/lib/osx/GLUT.framework/Versions/A/GLUT"


### PR DESCRIPTION
in core.xcconfig rtaudio should be rtAudio for HFS case sensitive filesystems, cf #733
