### PR TITLE
Add .mailmap for contributor collation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ Desktop.ini
 #Android
 .csettings
 
+# Miscellaneous
+.mailmap
+


### PR DESCRIPTION
I added a .mailmap file to the repo to correctly collate all the contributors in spite of changing nick names/email addresses. This is useful when trying to identify contributors for a changelog or similar, or when using the git logging functions like shortlog.

See the before/after situation here: https://gist.github.com/2710366

I have respected privacy and only used those real names that people have already given in a git ID in the repo. Mainly this addition only associates the different email addresses to one user. @arturoc wins the prize of most used emails! :-)
The list is pretty complete, I only had difficulties to associate some IDs to the correct Zachs, since it was not clear for some if @ofZach or @stfj (Zach Gage) was the contributor. Those were left as-is.

If anybody has objections to their various email being united under their name, please say so and I will correct/remove the relevant entries.
