### PR TITLE
Fix multiple inheritance ambiguity

### DIFF
--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -114,7 +114,7 @@ public:
 // ofBaseImage
 //----------------------------------------------------------
 template<typename T>
-class ofBaseImage_: public ofAbstractImage, public ofBaseHasPixels_<T>{
+class ofBaseImage_: public ofAbstractImage, virtual public ofBaseHasPixels_<T>{
 public:
 	virtual ~ofBaseImage_<T>(){};
 };
@@ -166,7 +166,7 @@ class ofBaseSoundOutput{
 //----------------------------------------------------------
 // ofBaseVideo
 //----------------------------------------------------------
-class ofBaseVideo: public ofBaseHasPixels, public ofBaseUpdates{
+class ofBaseVideo: virtual public ofBaseHasPixels, public ofBaseUpdates{
 public:
 	virtual ~ofBaseVideo(){}
 	virtual bool isFrameNew()=0;


### PR DESCRIPTION
I found an inheritance ambiguity issue in within  ofVideoPlayer, which also was present in ofVideoGrabber.
I fixed it by making the inherited class virtual (I don't know if this is the correct way to call this). Just check the code diff.
This issue arose when I was trying to compile some of the examples from kyle's ofxCV addon.
