### PR TITLE
Add libmpg123-devel to fedora codec install script

### DIFF
--- a/scripts/linux/fedora/install_codecs.sh
+++ b/scripts/linux/fedora/install_codecs.sh
@@ -1,3 +1,3 @@
 rpm -Uvh http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-stable.noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-stable.noarch.rpm
 
-yum install ffmpeg-devel mpg123 gstreamer-plugins-ugly gstreamer-ffmpeg
+yum install ffmpeg-devel libmpg123-devel mpg123 gstreamer-plugins-ugly gstreamer-ffmpeg


### PR DESCRIPTION
Since @benben seems to be off the radar, I prepared a PR for this.
CAUTION: Lacking a fedora install, I can't test/verify this, but it seems a logical/trivial change enough to warrant that. 
Closes #844.
