### PR TITLE
Fbo cleanup arturo

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -25,6 +25,7 @@
 #ifndef TARGET_OPENGLES
 	#define GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS			GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT
 	#define GL_FRAMEBUFFER_INCOMPLETE_FORMATS				GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT
+	#define GL_UNSIGNED_INT_24_8							GL_UNSIGNED_INT_24_8_EXT
 
 	/*#define glGenFramebuffers								glGenFramebuffersEXT
 	#define glGenRenderbuffers								glGenRenderbuffersEXT
@@ -78,7 +79,7 @@
 	#define GL_DEPTH_ATTACHMENT								GL_DEPTH_ATTACHMENT_OES
 	#define GL_STENCIL_ATTACHMENT							GL_STENCIL_ATTACHMENT_OES
 	//#define GL_DEPTH_STENCIL_ATTACHMENT						GL_DEPTH_STENCIL_ATTACHMENT_OES
-	#define GL_DEPTH_STENCIL								GL_DEPTH24_STENCIL8_OES
+	#define GL_DEPTH_STENCIL								GL_DEPTH_STENCIL_OES
 	#define GL_DEPTH_COMPONENT								GL_DEPTH_COMPONENT16_OES
 	#define GL_STENCIL_INDEX								GL_STENCIL_INDEX8_OES
 	#define GL_FRAMEBUFFER_BINDING							GL_FRAMEBUFFER_BINDING_OES
@@ -97,6 +98,7 @@
 	#define GL_FRAMEBUFFER_UNSUPPORTED						GL_FRAMEBUFFER_UNSUPPORTED_OES
 	#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE			GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_OES
 	#define GL_COLOR_ATTACHMENT0							GL_COLOR_ATTACHMENT0_OES
+	#define GL_UNSIGNED_INT_24_8							GL_UNSIGNED_INT_24_8_OES
 #endif
 
 
@@ -108,14 +110,14 @@ ofFbo::Settings::Settings() {
 	numColorbuffers			= 1;
 	useDepth				= false;
 	useStencil				= false;
-	depthAsTexture			= false;
+	depthStencilAsTexture			= false;
 #ifndef TARGET_OPENGLES
-	textureTarget			= GL_TEXTURE_RECTANGLE_ARB;
+	textureTarget			= ofGetUsingArbTex() ? GL_TEXTURE_RECTANGLE_ARB : GL_TEXTURE_2D;
 #else
 	textureTarget			= GL_TEXTURE_2D;
 #endif
 	internalformat			= GL_RGBA;
-	dethInternalFormat		= GL_DEPTH_COMPONENT;
+	depthStencilInternalFormat		= GL_DEPTH_COMPONENT24;
 	wrapModeHorizontal		= GL_CLAMP_TO_EDGE;
 	wrapModeVertical		= GL_CLAMP_TO_EDGE;
 	minFilter				= GL_LINEAR;
@@ -210,7 +212,7 @@ ofFbo::ofFbo(const ofFbo & mom){
 	if(settings.numSamples){
 		retainFB(fboTextures);
 	}
-	if(mom.settings.depthAsTexture){
+	if(mom.settings.depthStencilAsTexture){
 		depthBufferTex = mom.depthBufferTex;
 	}else{
 		depthBuffer = mom.depthBuffer;
@@ -240,7 +242,7 @@ ofFbo & ofFbo::operator=(const ofFbo & mom){
 	if(settings.numSamples){
 		retainFB(fboTextures);
 	}
-	if(mom.settings.depthAsTexture){
+	if(mom.settings.depthStencilAsTexture){
 		depthBufferTex = mom.depthBufferTex;
 	}else{
 		depthBuffer = mom.depthBuffer;
@@ -386,7 +388,6 @@ void ofFbo::allocate(int width, int height, int internalformat, int numSamples) 
 	allocate(settings);
 }
 
-
 void ofFbo::allocate(Settings _settings) {
 	if(!checkGLSupport()) return;
 
@@ -403,141 +404,90 @@ void ofFbo::allocate(Settings _settings) {
 	retainFB(fbo);
 	bind();
 
-	if(settings.depthAsTexture && settings.numSamples){
+	if(settings.depthStencilAsTexture && settings.numSamples){
 		ofLogWarning() << "multisampling not supported with depth as texture, setting 0 samples";
 		settings.numSamples = 0;
 	}
 
-	// If we want both a depth AND a stencil buffer tehn combine them into a single buffer
-#ifndef TARGET_OPENGLES
-	if( settings.useDepth && settings.useStencil )
-	{
-		if(!settings.depthAsTexture){
-			stencilBuffer = depthBuffer = createAndAttachRenderbuffer(GL_DEPTH_STENCIL, GL_DEPTH_STENCIL_ATTACHMENT);
-			retainRB(depthBuffer);
-			retainRB(stencilBuffer);
-		}else{
-			glGenTextures(1, &depthBufferTex.texData.textureID);
-			//retainRB(depthBuffer);
-			glBindTexture(GL_TEXTURE_2D, depthBufferTex.texData.textureID);
+	// is this needed? i think the problem is with separated buffers
+	// not with having only one of them?
+	// http://forum.openframeworks.cc/index.php/topic,6837.0.html
+/*#ifdef TARGET_OPENGLES
+	if(settings.useDepth){
+	  	settings.useStencil = true;
+	}
+#endif*/
 
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		#ifndef TARGET_OPENGLES
-			glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP );
-			glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP );
+	GLenum depthAttachment;
+	GLint depthPixelType;
+	GLint depthFormat;
+
+	if( settings.useDepth && settings.useStencil ){
+		depthFormat = GL_DEPTH_STENCIL;
+		settings.depthStencilInternalFormat = GL_DEPTH_STENCIL;
+		depthPixelType = GL_UNSIGNED_INT_24_8;
+		#ifdef TARGET_OPENGLES
+			depthAttachment = GL_DEPTH_ATTACHMENT;
 		#else
-			glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-			glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+			depthAttachment = GL_DEPTH_STENCIL_ATTACHMENT;
 		#endif
-			glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8_EXT, settings.width, settings.height, 0, GL_DEPTH_STENCIL_EXT, GL_UNSIGNED_INT_24_8_EXT, 0 );
-			glBindTexture( GL_TEXTURE_2D, 0 );
-
-			// allocate depthBufferTex as depth buffer;
-			depthBufferTex.texData.glTypeInternal = GL_DEPTH24_STENCIL8_EXT;
-			depthBufferTex.texData.glType = GL_DEPTH_STENCIL_EXT;
-			depthBufferTex.texData.pixelType = GL_UNSIGNED_INT_24_8_EXT;
-			depthBufferTex.texData.textureTarget = GL_TEXTURE_2D;
-			depthBufferTex.texData.bFlipTexture = false;
-			depthBufferTex.texData.tex_w = settings.width;
-			depthBufferTex.texData.tex_h = settings.height;
-			depthBufferTex.texData.tex_t = 1.0f;
-			depthBufferTex.texData.tex_u = 1.0f;
-			depthBufferTex.texData.width = settings.width;
-			depthBufferTex.texData.height = settings.height;
-
-			depthBufferTex.texData.bAllocated = true;
-
-
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,GL_TEXTURE_2D, depthBufferTex.texData.textureID, 0);
+	}else if(settings.useDepth){
+		depthPixelType = GL_UNSIGNED_SHORT;
+		if(settings.depthStencilInternalFormat==GL_DEPTH_COMPONENT16){
+			depthPixelType = GL_UNSIGNED_SHORT;
+		}else if(settings.depthStencilInternalFormat==GL_DEPTH_COMPONENT24){
+			depthPixelType = GL_UNSIGNED_INT;
+		}else if(settings.depthStencilInternalFormat==GL_DEPTH_COMPONENT32){
+			depthPixelType = GL_UNSIGNED_INT;
 		}
-	}else
-#endif
-	{
-		// if we want a depth buffer, create it, and attach to our main fbo
-		if(settings.useDepth){
-			GLint depthPixelType = GL_UNSIGNED_BYTE;
-			if(settings.dethInternalFormat==GL_DEPTH_COMPONENT){
-				depthPixelType = GL_UNSIGNED_BYTE;
-			}
-			#ifndef TARGET_OPENGLES
-			else if(settings.dethInternalFormat==GL_DEPTH_COMPONENT16){
-				depthPixelType = GL_UNSIGNED_SHORT;
-			}else if(settings.dethInternalFormat==GL_DEPTH_COMPONENT24){
-				depthPixelType = GL_UNSIGNED_INT;
-			}else if(settings.dethInternalFormat==GL_DEPTH_COMPONENT32){
-				depthPixelType = GL_UNSIGNED_INT;
-			}
-			#endif
-
-			if(!settings.depthAsTexture){
-				depthBuffer = createAndAttachRenderbuffer(settings.dethInternalFormat, GL_DEPTH_ATTACHMENT);
-				retainRB(depthBuffer);
-			}else{
-				glGenTextures(1, &depthBufferTex.texData.textureID);
-				//retainRB(depthBuffer);
-				glBindTexture(GL_TEXTURE_2D, depthBufferTex.texData.textureID);
-
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			#ifndef TARGET_OPENGLES
-				glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP );
-				glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP );
-			#else
-				glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-				glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-			#endif
-
-
-				glTexImage2D( GL_TEXTURE_2D, 0, settings.dethInternalFormat, settings.width, settings.height, 0, GL_DEPTH_COMPONENT, depthPixelType, 0 );
-				glBindTexture( GL_TEXTURE_2D, 0 );
-
-				// allocate depthBufferTex as depth buffer;
-				depthBufferTex.texData.glTypeInternal = settings.dethInternalFormat;
-				depthBufferTex.texData.glType = GL_DEPTH_COMPONENT;
-				depthBufferTex.texData.pixelType = depthPixelType;
-				depthBufferTex.texData.textureTarget = GL_TEXTURE_2D;
-				depthBufferTex.texData.bFlipTexture = false;
-				depthBufferTex.texData.tex_w = settings.width;
-				depthBufferTex.texData.tex_h = settings.height;
-				depthBufferTex.texData.tex_t = 1.0f;
-				depthBufferTex.texData.tex_u = 1.0f;
-				depthBufferTex.texData.width = settings.width;
-				depthBufferTex.texData.height = settings.height;
-
-				depthBufferTex.texData.bAllocated = true;
-
-
-				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,GL_TEXTURE_2D, depthBufferTex.texData.textureID, 0);
-
-			}
-		}
-
-		// if we want a stencil buffer, create it, and attach to our main fbo
-		if(settings.useStencil){
-			stencilBuffer = createAndAttachRenderbuffer(GL_STENCIL_INDEX, GL_STENCIL_ATTACHMENT);
-			retainRB(stencilBuffer);
-		}
-	}
-	// if we want MSAA, create a new fbo for textures
-#ifndef TARGET_OPENGLES
-	if(settings.numSamples){
-		glGenFramebuffers(1, &fboTextures);
-		retainFB(fboTextures);
+		depthAttachment = GL_DEPTH_ATTACHMENT;
+		depthFormat = GL_DEPTH_COMPONENT;
 	}else{
-		fboTextures = fbo;
+		depthAttachment = GL_STENCIL_ATTACHMENT;
+		settings.depthStencilInternalFormat = GL_STENCIL_INDEX;
+		depthFormat = GL_STENCIL_INDEX;
+		depthPixelType = GL_UNSIGNED_BYTE;
 	}
-#else
-	fboTextures = fbo;
-	if(settings.numSamples){
-		ofLog(OF_LOG_WARNING,"ofFbo: multisampling not supported in opengles");
-	}
+
+	if(!settings.depthStencilAsTexture){
+		if(settings.useDepth && settings.useStencil){
+			stencilBuffer = depthBuffer = createAndAttachRenderbuffer(settings.depthStencilInternalFormat, depthAttachment);
+		}else if(settings.useDepth){
+			depthBuffer = createAndAttachRenderbuffer(settings.depthStencilInternalFormat, depthAttachment);
+		}else{
+			stencilBuffer = createAndAttachRenderbuffer(settings.depthStencilInternalFormat, depthAttachment);
+		}
+	}else{
+		createAndAttachDepthStencilTexture(settings.textureTarget,settings.depthStencilInternalFormat,depthFormat,depthPixelType,depthAttachment);
+#ifdef TARGET_OPENGLES
+		// if there's depth and stencil the texture should be attached as
+		// depth and stencil attachments
+		// http://www.khronos.org/registry/gles/extensions/OES/OES_packed_depth_stencil.txt
+		if(settings.useDepth && settings.useStencil){
+	        glFramebufferTexture2D(GL_FRAMEBUFFER,
+	                               GL_STENCIL_ATTACHMENT,
+	                               GL_TEXTURE_2D, depthBufferTex.texData.textureID, 0);
+		}
 #endif
+	}
+
+	// if we want MSAA, create a new fbo for textures
+	#ifndef TARGET_OPENGLES
+		if(settings.numSamples){
+			glGenFramebuffers(1, &fboTextures);
+			retainFB(fboTextures);
+		}else{
+			fboTextures = fbo;
+		}
+	#else
+		fboTextures = fbo;
+		if(settings.numSamples){
+			ofLog(OF_LOG_WARNING,"ofFbo: multisampling not supported in opengles");
+		}
+	#endif
+
 	// now create all textures and color buffers
 	for(int i=0; i<settings.numColorbuffers; i++) createAndAttachTexture(i);
-
-
-
 
 	// if textures are attached to a different fbo (e.g. if using MSAA) check it's status
 	if(fbo != fboTextures) {
@@ -557,50 +507,6 @@ bool ofFbo::isAllocated(){
 	return bIsAllocated;
 }
 
-/*  removed by now, was crashing on draw
- *
-void ofFbo::allocateForShadow( int width, int height )
-{
-//#ifndef TARGET_OPENGLES
-	int old;
-	glGetIntegerv( GL_FRAMEBUFFER_BINDING, &old );
-
-	settings.width = width;
-	settings.height = height;
-
-	glGenTextures(1, &depthBuffer);
-	retainRB(depthBuffer);
-	glBindTexture(GL_TEXTURE_2D, depthBuffer);
-
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-#ifndef TARGET_OPENGLES
-	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP );
-	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP );
-#else
-	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-	glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-#endif
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, settings.width, settings.height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, 0 );
-	glBindTexture( GL_TEXTURE_2D, 0 );
-
-	glGenFramebuffers( 1, &fbo );
-	retainFB(fbo);
-	glBindFramebuffer( GL_FRAMEBUFFER, fbo );
-
-#ifndef TARGET_OPENGLES
-	glDrawBuffer( GL_NONE );
-	glReadBuffer( GL_NONE );
-#endif
-
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,GL_TEXTURE_2D, depthBuffer, 0);
-
-	if( glCheckFramebufferStatus( GL_FRAMEBUFFER ) != GL_FRAMEBUFFER_COMPLETE )
-		printf("Can't use FBOs !\n");
-
-	glBindFramebuffer( GL_FRAMEBUFFER, old );
-}*/
-
 GLuint ofFbo::createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint) {
 	GLuint buffer;
 	glGenRenderbuffers(1, &buffer);
@@ -609,7 +515,7 @@ GLuint ofFbo::createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachme
 	if(settings.numSamples==0) glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, settings.width, settings.height);
 	else glRenderbufferStorageMultisample(GL_RENDERBUFFER, settings.numSamples, internalFormat, settings.width, settings.height);
 #else
-	glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, settings.width, settings.height);
+	glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, ofNextPow2(settings.width), ofNextPow2(settings.height));
 #endif
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachmentPoint, GL_RENDERBUFFER, buffer);
 	return buffer;
@@ -637,6 +543,43 @@ void ofFbo::createAndAttachTexture(GLenum attachmentPoint) {
 		colorBuffers.push_back(colorBuffer);
 		retainRB(colorBuffer);
 	}
+}
+
+
+void ofFbo::createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum format, GLenum type, GLenum  attachment){
+	glGenTextures(1, &depthBufferTex.texData.textureID);
+	//retainRB(depthBuffer);
+	glBindTexture(target, depthBufferTex.texData.textureID);
+
+	glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+#ifndef TARGET_OPENGLES
+	glTexParameterf( target, GL_TEXTURE_WRAP_S, GL_CLAMP );
+	glTexParameterf( target, GL_TEXTURE_WRAP_T, GL_CLAMP );
+#else
+	glTexParameterf( target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+	glTexParameterf( target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+#endif
+	glTexImage2D( target, 0, internalformat, settings.width, settings.height, 0, format, type, 0 );
+	glBindTexture( target, 0 );
+
+	// allocate depthBufferTex as depth buffer;
+	depthBufferTex.texData.glTypeInternal = internalformat;
+	depthBufferTex.texData.glType = format;
+	depthBufferTex.texData.pixelType = type;
+	depthBufferTex.texData.textureTarget = target;
+	depthBufferTex.texData.bFlipTexture = false;
+	depthBufferTex.texData.tex_w = settings.width;
+	depthBufferTex.texData.tex_h = settings.height;
+	depthBufferTex.texData.tex_t = 1.0f;
+	depthBufferTex.texData.tex_u = 1.0f;
+	depthBufferTex.texData.width = settings.width;
+	depthBufferTex.texData.height = settings.height;
+
+	depthBufferTex.texData.bAllocated = true;
+
+
+	glFramebufferTexture2D(GL_FRAMEBUFFER, attachment,target, depthBufferTex.texData.textureID, 0);
 }
 
 
@@ -704,7 +647,7 @@ void ofFbo::setActiveDrawBuffer(int i){
 void ofFbo::setActiveDrawBuffers(const vector<int>& ids){
 	#ifndef TARGET_OPENGLES
     vector<GLenum> attachments;
-    for(int i=0; i < ids.size(); i++){
+    for(int i=0; i < (int)ids.size(); i++){
       int id = ids[i];
         if (id < getNumTextures()){
             GLenum e = GL_COLOR_ATTACHMENT0 + id;
@@ -751,10 +694,14 @@ ofTexture& ofFbo::getTextureReference(int attachmentPoint) {
 	updateTexture(attachmentPoint);
 	ofTexture & ref = textures[attachmentPoint];
 
+	//TODO: this should be cached!!!!
     if( ref.texData.textureTarget == GL_TEXTURE_2D ){
         ref.texData.tex_t = ofMap(ref.getWidth(), 0, ofNextPow2(ref.getWidth()), 0, 1, true);
         ref.texData.tex_u = ofMap(ref.getHeight(), 0, ofNextPow2(ref.getHeight()), 0, 1, true);
-    }  
+    }else{
+    	ref.texData.tex_t = ref.getWidth();
+    	ref.texData.tex_u = ref.getHeight();
+    }
     
     return ref;
 }
@@ -910,11 +857,8 @@ bool ofFbo::checkStatus() {
 }
 
 ofTexture & ofFbo::getDepthTexture(){
-	if(!settings.depthAsTexture){
+	if(!settings.depthStencilAsTexture){
 		ofLogError() << "fbo not allocated with depthAsTexture";
-	}
-	if(!settings.useDepth){
-		ofLogError() << "fbo not allocated with useDepth";
 	}
 	return depthBufferTex;
 }

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -2,7 +2,13 @@
 
 #include "ofTexture.h"
 
-//#ifndef TARGET_OPENGLES
+#ifdef TARGET_OPENGLES
+
+	#define GL_DEPTH24_STENCIL8								GL_DEPTH24_STENCIL8_OES
+	#define GL_DEPTH_COMPONENT16							GL_DEPTH_COMPONENT16_OES
+	#define GL_DEPTH_COMPONENT24							GL_DEPTH_COMPONENT24_OES
+	#define GL_DEPTH_COMPONENT32							GL_DEPTH_COMPONENT32_OES
+#endif
 
 class ofFbo : public ofBaseDraws, public ofBaseHasTexture {
 public:
@@ -70,10 +76,10 @@ public:
 		int		numColorbuffers;		// how many color buffers to create
 		bool	useDepth;				// whether to use depth buffer or not
 		bool	useStencil;				// whether to use stencil buffer or not
-		bool	depthAsTexture;			// use a texture instead of a renderbuffer for depth (useful to draw it or use it in a shader later)
+		bool	depthStencilAsTexture;			// use a texture instead of a renderbuffer for depth (useful to draw it or use it in a shader later)
 		GLenum	textureTarget;			// GL_TEXTURE_2D or GL_TEXTURE_RECTANGLE_ARB
 		GLint	internalformat;			// GL_RGBA, GL_RGBA16F_ARB, GL_RGBA32F_ARB, GL_LUMINANCE32F_ARB etc.
-		GLint	dethInternalFormat; 	// GL_DEPTH_COMPONENT(16/24/32)
+		GLint	depthStencilInternalFormat; 	// GL_DEPTH_COMPONENT(16/24/32)
 		int		wrapModeHorizontal;		// GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
 		int		wrapModeVertical;		// GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
 		int		minFilter;				// GL_NEAREST, GL_LINEAR etc.
@@ -86,7 +92,6 @@ private:
 
 	Settings 			settings;
 	int					isBound;
-	bool				bIsAllocated;
 
 	GLuint				fbo;			// main fbo which we bind for drawing into, all renderbuffers are attached to this
 	GLuint				fboTextures;	// textures are attached to this (if MSAA is disabled, this is equal to fbo, otherwise it's a new fbo)
@@ -107,12 +112,14 @@ private:
 	bool				dirty;
 
 	int 				defaultTextureIndex; //used for getTextureReference
+	bool				bIsAllocated;
 
 	void destroy();
 
 	bool checkStatus();
 	void createAndAttachTexture(GLenum attachmentPoint);
 	GLuint createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint);
+	void createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum format, GLenum type, GLenum attachment);
 
 	// if using MSAA, we will have rendered into a colorbuffer, not directly into the texture
 	// call this to blit from the colorbuffer into the texture so we can use the results for rendering, or input to a shader etc.


### PR DESCRIPTION
different refactoring of the fbo allocate function. now it has variables to setup the different options and less ifdefs. it also mantains the depth in texture for GL ES. actually in android depth and stencil is not supported except in openGL ES 2 so feel free to change it to whatever works in iOS

stencil only doesn't work for me in the desktop either but it's the same as before so it's probably my implementation which doesn't support stencil only or the current code is broken.

here's a simple test for the depthAsTexture:

```
ofFbo::Settings settings;
settings.depthStencilAsTexture = true;
settings.width=640;
settings.height=480;
settings.useDepth=true;
settings.useStencil=true;
settings.depthStencilInternalFormat=GL_DEPTH_COMPONENT32;
depth.allocate(settings);


depth.begin(true);
glEnable(GL_DEPTH_TEST);
ofBox(0,0,0,100);
ofBox(100,100,-100,100);
ofBox(300,300,-300,100);
depth.end();

glDisable(GL_DEPTH_TEST);
```

then in draw

```
   depth.getDepthTexture().draw(0,0);
```

i've added some comments in allocate for things i've changed for openGL ES if someone can try iOS and verify it's working?
