### PR TITLE
Fixed non ARB_RECT depth and stencil textures coords and power-of-two.......

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -2,14 +2,6 @@
 
 #include "ofTexture.h"
 
-#ifdef TARGET_OPENGLES
-
-	#define GL_DEPTH24_STENCIL8								GL_DEPTH24_STENCIL8_OES
-	#define GL_DEPTH_COMPONENT16							GL_DEPTH_COMPONENT16_OES
-	#define GL_DEPTH_COMPONENT24							GL_DEPTH_COMPONENT24_OES
-	#define GL_DEPTH_COMPONENT32							GL_DEPTH_COMPONENT32_OES
-#endif
-
 class ofFbo : public ofBaseDraws, public ofBaseHasTexture {
 public:
 	struct Settings;


### PR DESCRIPTION
Fixed iOS depth component type. Added iOS depth needs stencil. Disabled depth as tex for iOS as it doesn't work. Added retain for the the depth and stencil buffers.

Tested both with and without texture depth on osx and iOS.
Also tested with ARB and non ARB.
iOS depth as texture doesn't work afaikt, so I disabled it.
iOS also needs stencil enabled for depth to work - so its handled now automatically in allocate.

One issue still remains - is because retain(int id) is a static function in ofTexture.cpp we can't retain the depthStencilTexture - this produces an error at the end of the app.

```
    OF: OF_LOG_ERROR: trying to delete a non indexed texture, something weird is happening. Deleting anyway
```
