### PR TITLE
ofRectangle and ofPolyline: Added additional utility methods, setters, getters, etc.

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.cpp
+++ b/libs/openFrameworks/graphics/ofPolyline.cpp
@@ -380,17 +380,16 @@ ofPoint ofPolyline::getCentroid2D() const{
 }
 
 //----------------------------------------------------------
-ofRectangle ofPolyline::getBoundingBox(){
-	ofPolyline & polyline = *this;
+ofRectangle ofPolyline::getBoundingBox() const {
 
 	ofRectangle box;
-	int n = polyline.size();
+	int n = size();
 	if(n > 0) {
-		const ofPoint& first = polyline[0];
+		const ofPoint& first = (*this)[0];
 		// inititally, use width and height as max x and max y
 		box.set(first.x, first.y, first.x, first.y);
 		for(int i = 0; i < n; i++) {
-			const ofPoint& cur = polyline[i];
+			const ofPoint& cur = (*this)[i];
 			if(cur.x < box.x) {
 				box.x = cur.x;
 			}

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -7,6 +7,8 @@
 // ofPolyline
 // A line composed of straight line segments.
 
+class ofRectangle;
+
 class ofPolyline {
 public:
 	ofPolyline();
@@ -87,7 +89,7 @@ public:
 	ofPolyline getResampledByCount(int count);
 
 	// get the bounding box of a polyline
-	ofRectangle getBoundingBox();
+	ofRectangle getBoundingBox() const;
 	
 	// find the closest point 'target' on a polyline
 	// optionally pass a pointer to/address of an unsigned int to get the index of the closest vertex

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -1,99 +1,336 @@
 #include "ofRectangle.h"
 
-ofRectangle::ofRectangle (){ 
+//----------------------------------------------------------
+ofRectangle::ofRectangle(){ 
 	x = y = width = height = 0.0f; 
 }
 
-ofRectangle::~ ofRectangle (){}
+//----------------------------------------------------------
+ofRectangle::~ ofRectangle(){}
 
-ofRectangle::ofRectangle (float _x, float _y, float _w, float _h){
-	x = _x;
-	y = _y;
-	width = _w;
-	height = _h;
+//----------------------------------------------------------
+ofRectangle::ofRectangle(float px, float py, float w, float h){
+	x      = px;
+	y      = py;
+	width  = w;
+	height = h;
 }
 
-ofRectangle::ofRectangle (ofPoint pos, float _w, float _h){
-	x = pos.x;
-	y = pos.y;
-	width = _w;
-	height = _h;
+//----------------------------------------------------------
+ofRectangle::ofRectangle(const ofPoint& p, float w, float h){
+	x      = p.x;
+	y      = p.y;
+	width  = w;
+	height = h;
 }
 
-
-ofRectangle::ofRectangle (ofRectangle const & r){
-	x = r.x;
-	y = r.y;
-	width = r.width;
-	height = r.height;
+//----------------------------------------------------------
+ofRectangle::ofRectangle(const ofRectangle& rect){
+	x      = rect.x;
+	y      = rect.y;
+	width  = rect.width;
+	height = rect.height;
 }
 
-void ofRectangle::set (float px, float py, float w, float h){
+//----------------------------------------------------------
+void ofRectangle::set(float px, float py, float w, float h){
 	x		= px;
 	y		= py;
 	width	= w;
 	height	= h;
 }
 
-void ofRectangle::set (ofPoint pos, float w, float h){
-	x		= pos.x;
-	y		= pos.y;
-	width	= w;
-	height	= h;
+//----------------------------------------------------------
+void ofRectangle::set(const ofPoint& p, float w, float h){
+    set(p.x, p.y, w, h);
 }
 
-void ofRectangle::set (ofRectangle const & rect){
-	x		= rect.x;
-	y		= rect.y;
-	width	= rect.width;
-	height	= rect.height;
+//----------------------------------------------------------
+void ofRectangle::set(const ofRectangle& rect){
+    set(rect.x, rect.y, rect.width, rect.height);
 }
 
-void ofRectangle::setFromCenter (float px, float py, float w, float h){
+//----------------------------------------------------------
+void ofRectangle::setFromCenter(float px, float py, float w, float h){
 	x		= px - w*0.5f;
 	y		= py - h*0.5f;
 	width	= w;
 	height	= h;
 }
 
-void ofRectangle::setFromCenter (ofPoint pos, float w, float h){
-	x		= pos.x - w*0.5f;
-	y		= pos.y - h*0.5f;
-	width	= w;
-	height	= h;
+//----------------------------------------------------------
+void ofRectangle::setFromCenter(const ofPoint& p, float w, float h){
+    setFromCenter(p.x, p.y, w, h);
 }
 
-ofPoint ofRectangle::getCenter (){
+//----------------------------------------------------------
+ofPoint ofRectangle::getCenter() const {
 	return ofPoint(x + width * 0.5f, y + height * 0.5f, 0);
 }
 
-bool ofRectangle::inside (ofPoint p){
-	return inside(p.x, p.y);
+//----------------------------------------------------------
+void ofRectangle::translate(float px, float py) {
+    x += px;
+    y += py;
 }
 
-bool ofRectangle::inside (float px, float py){
-	return px > x && py > y && px < x + width && py < y + height;
+//----------------------------------------------------------
+void ofRectangle::translate(const ofPoint& p) {
+    translate(p.x,p.y);
 }
 
-ofRectangle & ofRectangle::operator = (ofRectangle const & rect){
-	x = rect.x;
-	y = rect.y;
-	width = rect.width;
-	height = rect.height;
+//----------------------------------------------------------
+void ofRectangle::scale(float sX, float sY) {
+    width  *= sX;
+    height *= sY;
+}
+
+//----------------------------------------------------------
+void ofRectangle::scale(const ofPoint& s) {
+    scale(s.x,s.y);
+}
+
+//----------------------------------------------------------
+bool ofRectangle::inside(float px, float py) const {
+	return inside(ofPoint(px,py));
+}
+
+//----------------------------------------------------------
+bool ofRectangle::inside(const ofPoint& p) const {
+    return p.x > getMinX() && p.y > getMinY() && 
+           p.x < getMaxX() && p.y < getMaxY();
+}
+
+//----------------------------------------------------------
+bool ofRectangle::inside(float px, float py, float w, float h) const {
+    return inside(ofRectangle(px,py,w,h));
+}
+
+//----------------------------------------------------------
+bool ofRectangle::inside(const ofPoint& p, float w, float h) const  {
+    return inside(ofRectangle(p,w,h));
+}
+
+//----------------------------------------------------------
+bool ofRectangle::inside(const ofRectangle& rect) const {
+    return inside(rect.getMinX(),rect.getMinY()) &&
+           inside(rect.getMaxX(),rect.getMaxY());
+}
+
+//----------------------------------------------------------
+bool ofRectangle::intersects(float px, float py, float w, float h) const  {
+    return intersects(ofRectangle(px, py, w, h));
+}
+
+//----------------------------------------------------------
+bool ofRectangle::intersects(const ofPoint& p, float w, float h) const {
+    return intersects(ofRectangle(p, w, h));
+}
+
+//----------------------------------------------------------
+bool ofRectangle::intersects(const ofRectangle& rect) const {
+    return (getMinX() < rect.getMaxX() && getMaxX() > rect.getMinX() &&
+            getMinY() < rect.getMaxY() && getMaxY() > rect.getMinY());
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(float px, float py){
+    add(ofPoint(px,py));
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(const ofPoint& p){
+    float x0 = MIN(getMinX(),p.x);
+    float x1 = MAX(getMaxX(),p.y);
+    float y0 = MIN(getMinY(),p.y);
+    float y1 = MAX(getMaxY(),p.y);
+    float w = x1 - x0;
+    float h = y1 - y0;
+    set(x0,y0,w,h);
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(float px, float py, float w, float h) {
+    add(ofRectangle(px,py,w,h));
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(const ofPoint& p, float w, float h) {
+    add(ofRectangle(p, w, h));
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(const ofRectangle& rect){
+    float x0 = MIN(getMinX(),rect.getMinX());
+    float x1 = MAX(getMaxX(),rect.getMaxX());
+    float y0 = MIN(getMinY(),rect.getMinY());
+    float y1 = MAX(getMaxY(),rect.getMaxY());
+    float w = x1 - x0;
+    float h = y1 - y0;
+    set(x0,y0,w,h);
+}
+
+//----------------------------------------------------------
+void ofRectangle::add(const ofPolyline& poly) {
+    add(poly.getBoundingBox());
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getIntersection(float px, float py, float w, float h) const {
+    return getIntersection(ofRectangle(px,py,w,h));
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getIntersection(const ofPoint& p, float w, float h) const {
+    return getIntersection(ofRectangle(p,w,h));
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getIntersection(const ofRectangle& rect) const {
+
+    float x0 = MAX(getMinX(),rect.getMinX());
+    float x1 = MIN(getMaxX(),rect.getMaxX());
+    
+    float w = x1 - x0;
+    if(w < 0) return ofRectangle(0,0,0,0); // short circuit if needed
+    
+    float y0 = MAX(getMinY(),rect.getMinY());
+    float y1 = MIN(getMaxY(),rect.getMaxY());
+    
+    float h = y1 - y0;
+    if(h < 0) return ofRectangle(0,0,0,0);  // short circuit if needed
+    
+    return ofRectangle(x0,y0,w,h);
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getUnion(float px, float py, float w, float h) const {
+    return getUnion(ofRectangle(px,py,w,h));
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getUnion(const ofPoint& p, float w, float h) const {
+    return getUnion(ofRectangle(p,w,h));
+}
+
+//----------------------------------------------------------
+ofRectangle ofRectangle::getUnion(const ofRectangle& rect) const {
+    ofRectangle united = *this;
+    united.add(rect);
+    return united;
+}
+
+//----------------------------------------------------------
+ofPolyline ofRectangle::getAsPolyline() const {
+    ofPolyline polyline;
+    polyline.addVertex(getMin());
+    polyline.addVertex(getMaxX(),getMinY());
+    polyline.addVertex(getMax());
+    polyline.addVertex(getMinX(),getMaxY());
+    polyline.close();
+    return polyline;
+}
+
+//----------------------------------------------------------
+float ofRectangle::getArea() const {
+    // negative areas imply a negative width or height
+    return width * height;
+}
+
+//----------------------------------------------------------
+bool ofRectangle::isEmpty() const {
+    return width == 0.0f && height == 0.0f;
+}
+
+//----------------------------------------------------------
+bool ofRectangle::isPositive() const {
+    return width >= 0.0f && height >= 0.0f;
+}
+
+//----------------------------------------------------------
+ofPoint ofRectangle::getMin() const {
+    return ofPoint(getMinX(),getMinY());
+}
+
+//----------------------------------------------------------
+ofPoint ofRectangle::getMax() const {
+    return ofPoint(getMaxX(),getMaxY());
+}
+
+//----------------------------------------------------------
+float ofRectangle::getMinX() const {
+    return MIN(x, x + width);  // - width
+}
+
+//----------------------------------------------------------
+float ofRectangle::getMaxX() const {
+    return MAX(x, x + width);  // - width
+}
+
+//----------------------------------------------------------
+float ofRectangle::getMinY() const{
+    return MIN(y, y + height);  // - height
+}
+
+//----------------------------------------------------------
+float ofRectangle::getMaxY() const {
+    return MAX(y, y + height);  // - height
+}
+
+//----------------------------------------------------------
+ofRectangle& ofRectangle::operator = (const ofRectangle& rect) {
+    x = rect.x;
+    y = rect.y;
+    width = rect.width;
+    height = rect.height;
 	return *this;
 }
 
-ofRectangle & ofRectangle::operator + (const ofPoint & point){
-	x += point.x;
-	y += point.y;
+
+//----------------------------------------------------------
+ofRectangle& ofRectangle::operator + (const ofPoint& point){
+    add(point);
 	return *this;
 }
 
-bool ofRectangle::operator == (ofRectangle const & r){
-	return (x == r.x) && (y == r.y) && (width == r.width) && (height == r.height);
+//----------------------------------------------------------
+ofRectangle& ofRectangle::operator + (const ofRectangle& rect) {
+    add(rect);
+	return *this;
 }
 
-bool ofRectangle::operator != (ofRectangle const & r){
-	return (x != r.x) || (y != r.y) || (width != r.width) || (height != r.height);
+//----------------------------------------------------------
+ofRectangle& ofRectangle::operator + (const ofPolyline& poly) {
+    add(poly);
+	return *this;
 }
 
+//----------------------------------------------------------
+bool ofRectangle::operator == (const ofRectangle& rect) const {
+	return (x == rect.x) && (y == rect.y) && (width == rect.width) && (height == rect.height);
+}
+
+//----------------------------------------------------------
+bool ofRectangle::operator != (const ofRectangle& rect) const {
+	return (x != rect.x) || (y != rect.y) || (width != rect.width) || (height != rect.height);
+}
+
+//----------------------------------------------------------
+float ofRectangle::getX() const {
+    return x;
+}
+
+//----------------------------------------------------------
+float ofRectangle::getY() const {
+    return y;
+}
+
+//----------------------------------------------------------
+float ofRectangle::getWidth() const {
+    return width;
+}
+
+//----------------------------------------------------------
+float ofRectangle::getHeight() const {
+    return height;
+}

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -7,11 +7,12 @@
  *
  */
 
-
-
 #pragma once
-#include "ofPoint.h"
 
+#include "ofPoint.h"
+#include "ofPolyline.h"
+
+class ofPolyline;
 
 //----------------------------------------------------------
 // ofRectangle
@@ -19,32 +20,83 @@
 
 class ofRectangle {
 	
-	public:
-		
-		ofRectangle ();
-		virtual ~ ofRectangle ();
-		ofRectangle (float _x, float _y, float _w, float _h);
-		ofRectangle (ofPoint pos, float w, float h);
-		ofRectangle (ofRectangle const & r);
-		
-		void set (float px, float py, float w, float h);
-		void set (ofPoint pos, float w, float h);
-		void set (ofRectangle const & rect);
-		void setFromCenter (float px, float py, float w, float h);
-		void setFromCenter (ofPoint pos, float w, float h);
-		
-		ofPoint getCenter ();
-		bool inside (ofPoint p);
-		bool inside (float px, float py);
-		
-		ofRectangle & operator = (const ofRectangle & rect);
-		bool operator == (ofRectangle const & r);
-		bool operator != (ofRectangle const & r);
-		ofRectangle & operator + (const ofPoint & point);
-		
-		float x;
-		float y;
-		float width;
-		float height;
+public:
+
+    ofRectangle ();
+    virtual ~ ofRectangle ();
+    ofRectangle(float px, float py, float w, float h);
+    ofRectangle(const ofPoint& p, float w, float h);
+    ofRectangle(const ofRectangle & rect);
+
+    void set(float px, float py, float w, float h);
+    void set(const ofPoint& p, float w, float h);
+    void set(const ofRectangle& rect);
+    void setFromCenter(float px, float py, float w, float h);
+    void setFromCenter(const ofPoint& p, float w, float h);
+
+    ofPoint getCenter() const;
+
+    void translate(float px, float py);
+    void translate(const ofPoint& p);
+    void scale(float sX, float sY);
+    void scale(const ofPoint& s);
+    
+    bool inside(float px, float py) const;
+    bool inside(const ofPoint& p) const;
+    bool inside(float px, float py, float w, float h) const;
+    bool inside(const ofPoint& p, float w, float h) const;
+    bool inside(const ofRectangle & rect) const;
+
+    bool intersects(float px, float py, float w, float h) const;
+    bool intersects(const ofPoint& p, float w, float h) const;
+    bool intersects(const ofRectangle & rect) const;
+    
+    void add(float px, float py);
+    void add(const ofPoint& p);
+    void add(float px, float py, float w, float h);
+    void add(const ofPoint&, float w, float h);
+    void add(const ofRectangle& rect);
+    void add(const ofPolyline& poly);
+
+    ofRectangle getIntersection(float px, float py, float w, float h) const;
+    ofRectangle getIntersection(const ofPoint& p, float w, float h) const;
+    ofRectangle getIntersection(const ofRectangle& rect) const;
+
+    ofRectangle getUnion(float px, float py, float w, float h) const;
+    ofRectangle getUnion(const ofPoint& p, float w, float h) const;
+    ofRectangle getUnion(const ofRectangle& rect) const;
+    
+    ofPolyline getAsPolyline() const;
+    
+    float getArea() const;  
+    
+    bool isEmpty() const;     // are width/height == 0.0f
+    bool isPositive() const;  // are width/height >= 0.0f
+    
+    ofPoint getMin() const;
+    ofPoint getMax() const;
+        
+    float getMinX() const;
+    float getMaxX() const;
+    float getMinY() const;
+    float getMaxY() const;
+    
+    ofRectangle & operator = (const ofRectangle& rect);
+    ofRectangle & operator + (const ofPoint& p);
+    ofRectangle & operator + (const ofRectangle& rect);
+    ofRectangle & operator + (const ofPolyline& poly);
+
+    bool operator == (const ofRectangle& rect) const;
+    bool operator != (const ofRectangle& rect) const;
+    
+    float getX() const;
+    float getY() const;
+    float getWidth() const;
+    float getHeight() const;
+
+    float x;
+    float y;
+    float width;
+    float height;
 };
 


### PR DESCRIPTION
In ofRectangle, I added a bunch of utility methods to help with typographic layout.

There is one CRITICAL change with ofRectangle's operator+.  Previously, the +operator preformed a translate operation.  This is better implemented via a call to translate(x,y) in order to be consistent with other platforms and ofPath, etc. 

I also did some code cleanup, adjusted const ordering for consistency with other oF classes..

In ofPolyline, I made the getBoundingBox() method const to allow it to play more nicely with ofRectangle.
