### PR TITLE
Fix ofURLFileLoader crash issue if removing while loading

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -117,10 +117,17 @@ void ofURLFileLoader::threadedFunction() {
 
 			if(response.status!=-1){
 				lock();
-		    	ofLog(OF_LOG_VERBOSE,"got request " + requests.front().name);
-				responses.push(response);
-				requests.pop_front();
-		    	ofAddListener(ofEvents().update,this,&ofURLFileLoader::update);
+				// double-check that the request hasn't been removed from the queue
+				if( (requests.size()==0) || (requests.front().getID()!=request.getID()) ){
+					// this request has been removed from the queue
+					ofLog(OF_LOG_VERBOSE,"request " + requests.front().name + " is missing from the queue, must have been removed/cancelled" );
+				}
+				else{
+					ofLog(OF_LOG_VERBOSE,"got response to request " + requests.front().name + " status "+ofToString(response.status) );
+					responses.push(response);
+					requests.pop_front();
+					ofAddListener(ofEvents().update,this,&ofURLFileLoader::update);
+				}
 				unlock();
 			}else{
 		    	ofLog(OF_LOG_VERBOSE,"failed getting request " + requests.front().name);


### PR DESCRIPTION
If a URL request issued by `ofURLGetAsync()` is currently in progress (downloading), and that request is removed by `ofRemoveURLRequest()`, `ofURLFileLoader`'s `threadedFunction` will crash or misbehave trying to `pop_front` on the request queue (because the request has already been removed).

This patch fixes that issue.
