### PR TITLE
Feature dynamic_pointer_cast for ofPtr

### DIFF
--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -141,6 +141,12 @@ public:
 		ofPtr(const std::tr1::weak_ptr<Tp1>& __r)
 	: std::tr1::shared_ptr<T>(__r) { }
 
+	// tgfrerer: extends ofPtr facade to allow dynamic_pointer_cast, pt.1
+	template<typename Tp1>
+	ofPtr(const ofPtr<Tp1>& __r, std::tr1::__dynamic_cast_tag)
+	: std::tr1::shared_ptr<T>(__r, std::tr1::__dynamic_cast_tag()) { }
+
+	
 	  /*template<typename Tp1, typename Del>
 		explicit
 		ofPtr(const std::tr1::unique_ptr<Tp1, Del>&) = delete;
@@ -150,3 +156,11 @@ public:
 		ofPtr(std::tr1::unique_ptr<Tp1, Del>&& __r)
 	: std::tr1::shared_ptr<T>(std::move(__r)) { }*/
 };
+
+
+// tgfrerer: extends ofPtr facade to allow dynamic_pointer_cast, pt. 2
+template<typename _Tp, typename _Tp1>
+ofPtr<_Tp>
+dynamic_pointer_cast(const ofPtr<_Tp1>& __r)
+{ return ofPtr<_Tp>(__r, std::tr1::__dynamic_cast_tag()); }
+


### PR DESCRIPTION
I propose to add dynamic_pointer_cast to the ofPtr<T> facade.

dynamic_pointer_cast allows you to downcast from ofPtr, similar to dynamic_cast with 'dumb' pointers.

A simple dynamic_cast would eventually break ofPtr.
