### PR TITLE
Add ofSerial speed 230400.

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -350,6 +350,9 @@ bool ofSerial::setup(string portName, int baud){
 		   case 115200: cfsetispeed(&options,B115200);
 						cfsetospeed(&options,B115200);
 						break;
+		   case 230400: cfsetispeed(&options,B230400);
+						cfsetospeed(&options,B230400);
+						break;
 
 			default:	cfsetispeed(&options,B9600);
 						cfsetospeed(&options,B9600);


### PR DESCRIPTION
Could not test because I have no serial device. Original reporter has successfully tested, though.
Tried the SerialExample, this works (in that it can open a connection with that speed).

Closes #577
