### PR TITLE
ofParameter does not initialize min value correctly for floating point numbers. 

### DIFF
--- a/addons/ofxGui/src/ofParameter.h
+++ b/addons/ofxGui/src/ofParameter.h
@@ -63,13 +63,13 @@ private:
 
 		Value(ParameterType v)
 		:value(v)
-		,min(numeric_limits<ParameterType>::min())
+		,min(-numeric_limits<ParameterType>::max())
 		,max(numeric_limits<ParameterType>::max()){};
 
 		Value(string name, ParameterType v)
 		:name(name)
 		,value(v)
-		,min(numeric_limits<ParameterType>::min())
+		,min(-numeric_limits<ParameterType>::max())
 		,max(numeric_limits<ParameterType>::max()){};
 
 		Value(string name, ParameterType v, ParameterType min, ParameterType max)


### PR DESCRIPTION
`numeric_limits<ParameterType>::min()` behaves incorrectly when `ParameterType` is a floating point type.  In this case, `numeric_limits<ParameterType>::min()` yields the smallest number > 0 that it can represent, rather than the expected smallest possible value for the min bound that is being initialized.  The solution is to use the negative `max()` value.  This works for all valid types.

More here:

http://www.cplusplus.com/reference/std/limits/numeric_limits/
