### PR TITLE
Rework/clean up paths.make process for user-specific changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Desktop.ini
 
 #Android
 .csettings
+/libs/openFrameworksCompiled/project/android/paths.make
 
 # Miscellaneous
 .mailmap

--- a/libs/openFrameworksCompiled/project/android/makefile
+++ b/libs/openFrameworksCompiled/project/android/makefile
@@ -13,7 +13,11 @@
 
 
 ifeq ($(findstring Android,$(MAKECMDGOALS)),Android)
-	include paths.make
+	ifeq ($(wildcard paths.make),)
+    $(error Android paths.make file does not exist. Create it from paths.make.default)
+	else
+		include paths.make
+	endif
 	ARCH = android
 	ifeq ($(shell uname),Darwin)
 		HOST_PLATFORM = darwin-x86

--- a/libs/openFrameworksCompiled/project/android/paths.make
+++ b/libs/openFrameworksCompiled/project/android/paths.make
@@ -1,4 +1,0 @@
-NDK_ROOT=/home/arturo/Downloads/android-ndk-r7b
-SDK_ROOT=/home/arturo/Downloads/android-sdk-linux
-ANT_HOME=/usr
-ANT_BIN=$(ANT_HOME)/bin/

--- a/libs/openFrameworksCompiled/project/android/paths.make.default
+++ b/libs/openFrameworksCompiled/project/android/paths.make.default
@@ -1,0 +1,7 @@
+# Default paths.make file.
+# Enter the correct paths for your system and save this file as paths.make
+
+NDK_ROOT=<path-to-NDK-location>
+SDK_ROOT=<path-to-SDK-location>
+ANT_HOME=/usr
+ANT_BIN=$(ANT_HOME)/bin/


### PR DESCRIPTION
Remove Android paths.make, put paths.make.default in place. Adapt makefile and .gitignore so that user-specific paths.make files won't pollute the repository.

Weird indentation in makefile is because a restriction about tabs and commands before a makefile target.
@arturo, could you see if this is ok with you?

Closes #1118
