### PR TITLE
bugfix-ios-antialiasing

### DIFF
--- a/addons/ofxiPhone/src/ES1Renderer.mm
+++ b/addons/ofxiPhone/src/ES1Renderer.mm
@@ -51,13 +51,8 @@
 }
 
 - (void)finishRender {
-	glBindRenderbufferOES(GL_RENDERBUFFER_OES, colorRenderbuffer);
 	
 	if(fsaaEnabled) {
-		glBindFramebufferOES(GL_READ_FRAMEBUFFER_APPLE, fsaaFrameBuffer);
-		glBindFramebufferOES(GL_DRAW_FRAMEBUFFER_APPLE, defaultFramebuffer);
-		glResolveMultisampleFramebufferAPPLE();
-		
 		if(depthEnabled) {
 			GLenum attachments[] = {GL_COLOR_ATTACHMENT0_OES, GL_DEPTH_ATTACHMENT_OES};
 			glDiscardFramebufferEXT(GL_READ_FRAMEBUFFER_APPLE, 2, attachments);
@@ -65,8 +60,13 @@
 			GLenum attachments[] = {GL_COLOR_ATTACHMENT0_OES};
 			glDiscardFramebufferEXT(GL_READ_FRAMEBUFFER_APPLE, 1, attachments);
 		}
+        
+		glBindFramebufferOES(GL_READ_FRAMEBUFFER_APPLE, fsaaFrameBuffer);
+		glBindFramebufferOES(GL_DRAW_FRAMEBUFFER_APPLE, defaultFramebuffer);
+		glResolveMultisampleFramebufferAPPLE();
 	}
 	
+    glBindRenderbufferOES(GL_RENDERBUFFER_OES, colorRenderbuffer);
     [context presentRenderbuffer:GL_RENDERBUFFER_OES];
 	
 	if(fsaaEnabled) {


### PR DESCRIPTION
when antialiasing was turned on, ofSetBackgroundAuto(false) stopped working,
and screen was always being redrawn.

this was a problem with the order in which the opengl buffers were being attached.
following the blog post below i was able to get it running,
http://www.gandogames.com/2010/07/tutorial-using-anti-aliasing-msaa-in-the-iphone/

tested on all ios graphics examples.
tested on ios 5.1 & 4.0

closes #1330
