### PR TITLE
ofiPhoneVideoPlayer optimisations

### DIFF
--- a/libs/openFrameworks/video/ofiPhoneVideoPlayer.h
+++ b/libs/openFrameworks/video/ofiPhoneVideoPlayer.h
@@ -56,8 +56,12 @@ public:
     void setPixelFormat(ofPixelFormat pixelFormat);
     
 	void * getAVFoundationVideoPlayer();
-	
+    
+    void setTextureCache(bool bOn);
+    
 protected:
+    
+    void updatePixelsToRGB();
 	
 	void * videoPlayer; // super hack to forward declare an objective c class inside a header file that can only handle c classes.
 	
@@ -65,12 +69,13 @@ protected:
     bool bResetPixels;
     bool bResetTexture;
     bool bUpdatePixels;
+    bool bUpdatePixelsToRgb;
     bool bUpdateTexture;
     bool bTextureCacheSupported;
     bool bTextureHack;
 	
-	GLubyte * pixels;
-    GLubyte *pixelsTmp;
+	GLubyte * pixelsRGB;
+    GLubyte * pixelsRGBA;
     GLint internalGLFormat;
 	ofTexture videoTexture;
 };


### PR DESCRIPTION
optimisation for getTexture()
texture uses RGBA pixels, not RGB.
in which case, RGB pixels are not calculated unless needed.
this increases the performance by 2-5 fps.

also added a method for enabling texture cache - setTextureCache()
i still haven't been able to weak link the CoreVideo framework, so it still crashes when this in enabled on any devices below iOS5. it is up to the user to make sure they are only deploying for iOS5.
by default, texture cache is set to false.
