### PR TITLE
bugfix-ios-video-texture-cache

### DIFF
--- a/libs/openFrameworks/video/ofiPhoneVideoPlayer.h
+++ b/libs/openFrameworks/video/ofiPhoneVideoPlayer.h
@@ -57,8 +57,6 @@ public:
     
 	void * getAVFoundationVideoPlayer();
     
-    void setTextureCache(bool bOn);
-    
 protected:
     
     void updatePixelsToRGB();

--- a/libs/openFrameworks/video/ofiPhoneVideoPlayer.mm
+++ b/libs/openFrameworks/video/ofiPhoneVideoPlayer.mm
@@ -21,21 +21,9 @@ ofiPhoneVideoPlayer::ofiPhoneVideoPlayer() {
     bUpdateTexture = false;
     bTextureHack = false;
     bTextureCacheSupported = false;
-    /**
-     *  texture cache is disabled for now.
-     *  it does work for ios5 and up,
-     *  but crashes on io4 and down.
-     *  i've made CoreVideo.framework optional which is supposed to weak-link the framework,
-     *  but still no cigar.
-     *
-     *  the below is supposed to check if CVOpenGLESTextureCache is supported,
-     *  but for some reason, its always returning true on ios4
-     *
 #ifdef __IPHONE_5_0    
     bTextureCacheSupported = (CVOpenGLESTextureCacheCreate != NULL);
-#endif
-     *
-     */
+#endif    
 }
 
 //----------------------------------------
@@ -666,11 +654,4 @@ void ofiPhoneVideoPlayer::setPixelFormat(ofPixelFormat _internalPixelFormat) {
 //----------------------------------------
 void * ofiPhoneVideoPlayer::getAVFoundationVideoPlayer() {
     return videoPlayer;
-}
-
-//----------------------------------------
-void ofiPhoneVideoPlayer::setTextureCache(bool bOn) {
-#ifdef __IPHONE_5_0    
-    bTextureCacheSupported = bOn;
-#endif
 }


### PR DESCRIPTION
texture cache is now automatically enabled if its available.
