### PR TITLE
Bugfix remove texture aligment

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -632,9 +632,9 @@ void ofTexture::loadData(void * data, int w, int h, int glFormat){
 	//  http://www.opengl.org/discussion_boards/ubb/ultimatebb.php?ubb=get_topic;f=3;t=014770#000001
 	
 	//------------------------ likely, we are uploading continuous data
-	GLint prevAlignment;
+	/*GLint prevAlignment;
 	glGetIntegerv(GL_UNPACK_ALIGNMENT, &prevAlignment);
-	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1);*/
 	
 	
 	//Sosolimited: texture compression
@@ -721,7 +721,7 @@ void ofTexture::loadData(void * data, int w, int h, int glFormat){
 		
 	}
 	//------------------------ back to normal.
-	glPixelStorei(GL_UNPACK_ALIGNMENT, prevAlignment);
+	//glPixelStorei(GL_UNPACK_ALIGNMENT, prevAlignment);
 	
 	texData.bFlipTexture = false;
 	


### PR DESCRIPTION
These lines seem to make texture uploading slower than if they are not there, but don't know why we are using them
