### PR TITLE
Add logging output when example generation for a target is finished.

### DIFF
--- a/apps/devApps/projectGenerator/src/testApp.cpp
+++ b/apps/devApps/projectGenerator/src/testApp.cpp
@@ -195,6 +195,8 @@ void testApp::generateExamples(){
 
         }
     }
+    ofLogNotice() << " ";
+    ofLogNotice() << "Finished generating examples for " << target;
 }
 
 ofFileDialogResult testApp::makeNewProjectViaDialog(){


### PR DESCRIPTION
Add logging output when example generation for a target is finished. Closes #1291.

I didn't add additional output when example generation for _all_ selected targets is completed. This gets done in PG in three different ways (depending on command line usage, keypress, or button selection), and I didn't want to bloat the code too much. Reports on individual targets should be enough to show you when it's finished.
