### PR TITLE
fix to ofNotifyMousePressed. It wasn't updating currentMouseX and curren...

### DIFF
--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -152,7 +152,17 @@ void ofNotifyKeyReleased(int key){
 void ofNotifyMousePressed(int x, int y, int button){
 	ofBaseApp * ofAppPtr = ofGetAppPtr();
 	static ofMouseEventArgs mouseEventArgs;
-	
+    if( bPreMouseNotSet ){
+		previousMouseX	= x;
+		previousMouseY	= y;
+		bPreMouseNotSet	= false;
+	}else{
+		previousMouseX = currentMouseX;
+		previousMouseY = currentMouseY;
+	}
+    
+	currentMouseX = x;
+	currentMouseY = y;
 	pressedMouseButtons.insert(button);
 
 	if(ofAppPtr){


### PR DESCRIPTION
...tMouseY. The update to these happened in ofNotyfyMouseDragged. So when requesting either getMouseX() or getMouseY()  on iOS the correct values were only retrieved after dragging. I found this when testing ofEasyCam in iOS, yet it might fix other problems.
