### PR TITLE
Install scripts: Replace libglew1.5-dev by general package libglew-dev.

### DIFF
--- a/scripts/linux/debian/install_dependencies.sh
+++ b/scripts/linux/debian/install_dependencies.sh
@@ -1,5 +1,5 @@
 apt-get update
-apt-get install libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev freeglut3-dev libasound2-dev libxmu-dev libxxf86vm-dev g++ libgl1-mesa-dev libglu1-mesa-dev libraw1394-dev libudev-dev libdrm-dev gstreamer0.10-ffmpeg libglew1.5-dev libopenal-dev libsndfile-dev libfreeimage-dev libcairo2-dev libgtk2.0-dev libjack-dev python-lxml python-argparse
+apt-get install libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev freeglut3-dev libasound2-dev libxmu-dev libxxf86vm-dev g++ libgl1-mesa-dev libglu1-mesa-dev libraw1394-dev libudev-dev libdrm-dev gstreamer0.10-ffmpeg libglew-dev libopenal-dev libsndfile-dev libfreeimage-dev libcairo2-dev libgtk2.0-dev libjack-dev python-lxml python-argparse
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then
         LIBSPATH=linux64

--- a/scripts/linux/ubuntu/install_dependencies.sh
+++ b/scripts/linux/ubuntu/install_dependencies.sh
@@ -1,5 +1,5 @@
 apt-get update
-apt-get install libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev freeglut3-dev libasound2-dev libxmu-dev libxxf86vm-dev g++ libgl1-mesa-dev libglu1-mesa-dev libraw1394-dev libudev-dev libdrm-dev gstreamer0.10-ffmpeg libglew1.5-dev libopenal-dev libsndfile-dev libfreeimage-dev libcairo2-dev libgtk2.0-dev libjack0 libjack-dev python-lxml python-argparse
+apt-get install libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libavcodec-dev libavformat-dev libavutil-dev libswscale-dev freeglut3-dev libasound2-dev libxmu-dev libxxf86vm-dev g++ libgl1-mesa-dev libglu1-mesa-dev libraw1394-dev libudev-dev libdrm-dev gstreamer0.10-ffmpeg libglew-dev libopenal-dev libsndfile-dev libfreeimage-dev libcairo2-dev libgtk2.0-dev libjack0 libjack-dev python-lxml python-argparse
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then
 	LIBSPATH=linux64


### PR DESCRIPTION
This avoids compilation errors when libglew1.6 is already installed on the system, cause it selects the latest -dev version available.
Done for Ubuntu and Debian, rest of the linux distros are fine as far as I can see.
Closes #1449

@arturoc: found a general package after all. :-)
