### PR TITLE
bugfix-proposed-ofLight::customDraw()

### DIFF
--- a/libs/openFrameworks/gl/ofLight.cpp
+++ b/libs/openFrameworks/gl/ofLight.cpp
@@ -369,8 +369,6 @@ ofFloatColor ofLight::getSpecularColor() const {
 
 //----------------------------------------
 void ofLight::customDraw() {
-    ofPushMatrix();
-    glMultMatrixf(getGlobalTransformMatrix().getPtr());
     if(getIsPointLight()) {
         ofSphere( 0,0,0, 10);
     } else if (getIsSpotlight()) {
@@ -381,7 +379,6 @@ void ofLight::customDraw() {
         ofBox(10);
     }
     ofDrawAxis(20);
-    ofPopMatrix();
 }
 
 


### PR DESCRIPTION
Suspected bug:

ofLight::customDraw(), when called through its wrapper ofNode::draw(), will apply the ofNode's global transformation matrix _within the customDraw() call_.

This is not desirable, since ofNode::draw() will have applied the transformation matrix already, and the matrix will thus be twice applied.

(would close issue #1471)
