### PR TITLE
Fixing accelerometer code to work with devices with a default landscape orientation (ie, tablets)

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidAccelerometer.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidAccelerometer.java
@@ -2,18 +2,21 @@ package cc.openframeworks;
 
 import java.util.List;
 
+import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
+import android.view.WindowManager;
 
 public class OFAndroidAccelerometer extends OFAndroidObject {
 	private SensorManager sensorManager;
     private Sensor accelerometer;
     
     OFAndroidAccelerometer(SensorManager sensorManager){
-
         this.sensorManager = sensorManager;
         List<Sensor> sensors = sensorManager.getSensorList(Sensor.TYPE_ACCELEROMETER);
         if(sensors.size() > 0)
@@ -45,8 +48,31 @@ public class OFAndroidAccelerometer extends OFAndroidObject {
 	
 	private final SensorEventListener sensorListener = new SensorEventListener() {
 		public void onSensorChanged(SensorEvent event) {
-			updateAccelerometer(event.values[0],
-			          event.values[1],
+	    	WindowManager windowManager = (WindowManager)OFAndroid.getContext().getSystemService(Context.WINDOW_SERVICE);
+	    	Display display = windowManager.getDefaultDisplay();
+	    	
+	    	float x, y;
+	    	switch (display.getRotation()) {
+	    	case Surface.ROTATION_90:
+	    		x = -event.values[1];
+	    		y = event.values[0];
+	    		break;
+	    	case Surface.ROTATION_180:
+	    		x = event.values[0];
+	    		y = -event.values[1];
+	    		break;
+	    	case Surface.ROTATION_270:
+	    		x = event.values[1];
+	    		y = -event.values[0];
+	    		break;
+	    	case Surface.ROTATION_0:
+	    	default:
+	    		x = event.values[0];
+	    		y = event.values[1];
+	    		break;
+	    	}
+	    	
+			updateAccelerometer(x, y,
 			          event.values[2]);
 		}
 		 


### PR DESCRIPTION
The acceleration coordinates are always relative to the default orientation of a device, not the current orientation. I added some code to translate the coordinates so that they work with the androidTouchExample
