### PR TITLE
bugfix-ios-ofxiPhoneScreenGrab

### DIFF
--- a/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
+++ b/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
@@ -463,11 +463,13 @@ void ofxiPhoneScreenGrab(id delegate) {
 	
 	//fix from: http://forum.openframeworks.cc/index.php/topic,6092.15.html
 	//TODO: look and see if we need to take rotation into account 
-	if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] == YES){
-		float f_scale = [[UIScreen mainScreen] scale];
-		rect.size.width *= f_scale;
-		rect.size.height *= f_scale;
-	}
+    if(ofxiPhoneGetOFWindow()->isRetinaSupported()) {
+        if([[UIScreen mainScreen] respondsToSelector:@selector(scale)] == YES){
+            float f_scale = [[UIScreen mainScreen] scale];
+            rect.size.width *= f_scale;
+            rect.size.height *= f_scale;
+        }
+    }
 
 	int width  = rect.size.width;
 	int height = rect.size.height;	


### PR DESCRIPTION
ofxiPhoneScreenGrab was over releasing and causing a crash.
adjusted it to work with retina displays and now saves a lossless png rather then jpg.
closes #1051
