### PR TITLE
bugfix-ios-retina

### DIFF
--- a/addons/ofxiPhone/src/app/ofAppiPhoneWindow.h
+++ b/addons/ofxiPhone/src/app/ofAppiPhoneWindow.h
@@ -78,14 +78,24 @@ public:
 	ofOrientation		getOrientation();
 	void				rotateXY(float &x, float &y);		// updates
 	
-	void				enableRetinaSupport();
-	void				enableDepthBuffer();
-	void				enableAntiAliasing(int samples);
-	
-	bool				isDepthEnabled();
-	bool				isAntiAliasingEnabled();
-	int					getAntiAliasingSampleCount();
-	bool				isRetinaSupported();
+    bool                enableRetina();
+    bool                disableRetina();
+    bool                isRetinaEnabled();
+    bool                isRetinaSupportedOnDevice();
+    
+    bool                enableDepthBuffer();
+    bool                disableDepthBuffer();
+    bool                isDepthBufferEnabled();
+    
+    bool                enableAntiAliasing(int samples);
+    bool                disableAntiAliasing();
+    bool                isAntiAliasingEnabled();
+    int					getAntiAliasingSampleCount();
+    
+    //---------------------------------------------- deprecation messages. to be removed in OF 0073.
+    OF_DEPRECATED_MSG("Use enableRetina() instead", void enableRetinaSupport());
+    OF_DEPRECATED_MSG("Use isRetinaSupportedOnDevice() instead", bool isRetinaSupported());
+    OF_DEPRECATED_MSG("Use isDepthBufferEnabled() instead", bool isDepthEnabled());
 	
 	void timerLoop();
 	int					windowMode;
@@ -97,9 +107,11 @@ protected:
 	bool bEnableSetupScreen;
 	ofOrientation orientation;
 	
-	bool depthEnabled;
-	bool antiAliasingEnabled;
-	bool retinaEnabled;
+    bool bRetinaEnabled;
+    bool bRetinaSupportedOnDevice;
+    bool bRetinaSupportedOnDeviceChecked;
+	bool bDepthEnabled;
+	bool bAntiAliasingEnabled;
 	int antiAliasingSamples;
 };
 

--- a/addons/ofxiPhone/src/app/ofAppiPhoneWindow.mm
+++ b/addons/ofxiPhone/src/app/ofAppiPhoneWindow.mm
@@ -58,10 +58,13 @@ ofAppiPhoneWindow::ofAppiPhoneWindow() {
 	bEnableSetupScreen = true;
     
     orientation = OF_ORIENTATION_DEFAULT;
-	
-	depthEnabled=false;
-	antiAliasingEnabled=false;
-	retinaEnabled=false;
+
+	bRetinaEnabled = false;
+    bRetinaSupportedOnDevice = false;
+    bRetinaSupportedOnDeviceChecked = false;
+	bDepthEnabled = false;
+	bAntiAliasingEnabled = false;
+    antiAliasingSamples = 0;
 }
 
 /******** Initialization methods ************/
@@ -247,42 +250,85 @@ void ofAppiPhoneWindow::rotateXY(float &x, float &y) {
 	}
 }
 
-void ofAppiPhoneWindow::enableRetinaSupport()
-{
-	retinaEnabled = true;
+//-------------------------------------------------------- retina.
+bool ofAppiPhoneWindow::enableRetina() {
+    if(isRetinaSupportedOnDevice()) {
+        bRetinaEnabled = true;
+    }
+    return bRetinaEnabled;
 }
 
-void ofAppiPhoneWindow::enableDepthBuffer()
-{
-	depthEnabled = true;
+bool ofAppiPhoneWindow::disableRetina() {
+    return (bRetinaEnabled = false);
 }
 
-void ofAppiPhoneWindow::enableAntiAliasing(int samples)
-{
-	antiAliasingEnabled = true;
+bool ofAppiPhoneWindow::isRetinaEnabled() {
+    return bRetinaEnabled;
+}
+
+bool ofAppiPhoneWindow::isRetinaSupportedOnDevice() {
+    if(bRetinaSupportedOnDeviceChecked) {
+        return bRetinaSupportedOnDevice;
+    }
+    
+    bRetinaSupportedOnDeviceChecked = true;
+    
+    NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
+    if([[UIScreen mainScreen] respondsToSelector:@selector(scale)]){
+        if ([[UIScreen mainScreen] scale] > 1){
+            bRetinaSupportedOnDevice = true;
+        }
+    }
+    [pool release];
+    
+    return bRetinaSupportedOnDevice;
+}
+
+//-------------------------------------------------------- depth buffer.
+bool ofAppiPhoneWindow::enableDepthBuffer() {
+    return (bDepthEnabled = true);
+}
+
+bool ofAppiPhoneWindow::disableDepthBuffer() {
+    return (bDepthEnabled = false);
+}
+
+bool ofAppiPhoneWindow::isDepthBufferEnabled() {
+    return bDepthEnabled;
+}
+
+//-------------------------------------------------------- anti aliasing.
+bool ofAppiPhoneWindow::enableAntiAliasing(int samples) {
 	antiAliasingSamples = samples;
+    return (bAntiAliasingEnabled = true);
 }
 
-bool ofAppiPhoneWindow::isDepthEnabled()
-{
-	return depthEnabled;
+bool ofAppiPhoneWindow::disableAntiAliasing() {
+    return (bAntiAliasingEnabled = false);
 }
 
-bool ofAppiPhoneWindow::isAntiAliasingEnabled()
-{
-	return antiAliasingEnabled;
+bool ofAppiPhoneWindow::isAntiAliasingEnabled() {
+    return bAntiAliasingEnabled;
 }
 
-int ofAppiPhoneWindow::getAntiAliasingSampleCount()
-{
-	return antiAliasingSamples;
+int	ofAppiPhoneWindow::getAntiAliasingSampleCount() {
+    return antiAliasingSamples;
 }
 
-bool ofAppiPhoneWindow::isRetinaSupported()
-{
-	return retinaEnabled;
+//-------------------------------------------------------- deprecated.
+void ofAppiPhoneWindow::enableRetinaSupport() {
+	enableRetina();
 }
 
+bool ofAppiPhoneWindow::isRetinaSupported() {
+	return isRetinaEnabled();
+}
+
+bool ofAppiPhoneWindow::isDepthEnabled() {
+	return isDepthBufferEnabled();
+}
+
+//-------------------------------------------------------- timer loop.
 void ofAppiPhoneWindow::timerLoop() {
     // all the timerLoop logic has been moved into [ofxiOSEAGLView drawView]
 }

--- a/addons/ofxiPhone/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiPhone/src/core/ofxiOSEAGLView.mm
@@ -35,10 +35,10 @@ static ofxiOSEAGLView * _instanceRef = nil;
 
 - (id)initWithFrame:(CGRect)frame andApp:(ofxiPhoneApp *)appPtr {
     self = [self initWithFrame:frame 
-                      andDepth:ofAppiPhoneWindow::getInstance()->isDepthEnabled()
+                      andDepth:ofAppiPhoneWindow::getInstance()->isDepthBufferEnabled()
                          andAA:ofAppiPhoneWindow::getInstance()->isAntiAliasingEnabled()
                  andNumSamples:ofAppiPhoneWindow::getInstance()->getAntiAliasingSampleCount()
-                     andRetina:ofAppiPhoneWindow::getInstance()->isRetinaSupported()];
+                     andRetina:ofAppiPhoneWindow::getInstance()->isRetinaEnabled()];
     
     if(self) {
         

--- a/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
+++ b/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
@@ -463,12 +463,10 @@ void ofxiPhoneScreenGrab(id delegate) {
 	
 	//fix from: http://forum.openframeworks.cc/index.php/topic,6092.15.html
 	//TODO: look and see if we need to take rotation into account 
-    if(ofxiPhoneGetOFWindow()->isRetinaSupported()) {
-        if([[UIScreen mainScreen] respondsToSelector:@selector(scale)] == YES){
-            float f_scale = [[UIScreen mainScreen] scale];
-            rect.size.width *= f_scale;
-            rect.size.height *= f_scale;
-        }
+    if(ofxiPhoneGetOFWindow()->isRetinaEnabled()) {
+        float f_scale = [[UIScreen mainScreen] scale];
+        rect.size.width *= f_scale;
+        rect.size.height *= f_scale;
     }
 
 	int width  = rect.size.width;


### PR DESCRIPTION
methods for enabling retina in ofAppiPhoneWindow were ambiguous.
have now been made more concise.

added isRetinaSupportedOnDevice() to check if retina is supported on the hardware.
added methods for disabling retina, depth, anti aliasing if needed.
added deprecation messages for old methods which should be removed in a couple releases.

closes #1315
