### PR TITLE
Windows compatibility patches

### DIFF
--- a/libs/openFrameworksCompiled/project/android/makefile
+++ b/libs/openFrameworksCompiled/project/android/makefile
@@ -21,6 +21,8 @@ ifeq ($(findstring Android,$(MAKECMDGOALS)),Android)
 	ARCH = android
 	ifeq ($(shell uname),Darwin)
 		HOST_PLATFORM = darwin-x86
+	else ifeq ($(shell uname),MINGW32_NT-6.1)
+		HOST_PLATFORM = windows
 	else
 		HOST_PLATFORM = linux-x86
 	endif
@@ -89,7 +91,7 @@ else
 	AR=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/$(ANDROID_PREFIX)ar
 	SYSROOT=$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/
 	CFLAGS += -nostdlib --sysroot=$(SYSROOT) -fno-short-enums -frtti -fexceptions
-	CFLAGS += -I"$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/usr/include/" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/include" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/libs/$(ABI)/include" -I"$(NDK_ROOT)/sources/crystax/include/"
+	CFLAGS += -I"$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/usr/include/" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/include" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/libs/$(ABI)/include" -I"$(NDK_ROOT)/sources/crystax/include/"
 	CFLAGS += -DANDROID
 endif
 

--- a/libs/openFrameworksCompiled/project/makefileCommon/Makefile.android
+++ b/libs/openFrameworksCompiled/project/makefileCommon/Makefile.android
@@ -24,14 +24,14 @@ CXX=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/$(ANDROID_
 AR=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/$(ANDROID_PREFIX)ar
 SYSROOT=$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/
 CFLAGS += -nostdlib --sysroot=$(SYSROOT) -fno-short-enums
-CFLAGS += -I"$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/usr/include/" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/include" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/libs/$(ABI)/include" -I"$(NDK_ROOT)/sources/crystax/include/" 
+CFLAGS += -I"$(NDK_ROOT)/platforms/$(NDK_PLATFORM)/arch-arm/usr/include/" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/include" -I"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/libs/$(ABI)/include" -I"$(NDK_ROOT)/sources/crystax/include/" 
 CFLAGS += -DANDROID
 
 INCLUDES_FLAGS += -I$(OF_ROOT)/libs/glu/include_android
 
 
-LDFLAGS = --sysroot=$(SYSROOT) -nostdlib -L"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/libs/$(ABI)"
-SYSTEMLIBS +=  -lsupc++ -lz -lGLESv1_CM -llog -ldl -lm -lc $(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/libs/$(ABI)/libgnustl_static.a -lgcc 
+LDFLAGS = --sysroot=$(SYSROOT) -nostdlib -L"$(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/libs/$(ABI)"
+SYSTEMLIBS +=  -lsupc++ -lz -lGLESv1_CM -llog -ldl -lm -lc $(NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/$(GCC_VERSION)/libs/$(ABI)/libgnustl_static.a -lgcc 
 LIB_STATIC += $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoNet.a $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoXML.a $(OF_ROOT)/libs/poco/lib/$(LIBSPATH)/libPocoFoundation.a
 
 
@@ -102,7 +102,7 @@ CleanAndroid:
 afterDebugAndroid:$(TARGET)
 	@if [ -d libs/armeabi-v7a ]; then rm -r libs/armeabi-v7a; fi
 	
-	@cp $(NDK_ROOT)/toolchains/arm-linux-androideabi-4.4.3/prebuilt/gdbserver libs/armeabi
+	@cp $(NDK_ROOT)/prebuilt/android-arm/gdbserver/gdbserver libs/armeabi
 	
 	#create gdb.setup for armeabi
 	@echo "set solib-search-path $(PWD)/obj/local/armeabi:$(PWD)/libs/armeabi" > libs/armeabi/gdb.setup
@@ -120,7 +120,7 @@ afterReleaseAndroid:$(TARGET)
 	@if [ -f obj/$(BIN_NAME) ]; then rm obj/$(BIN_NAME); fi
 	
 	@cp $(OF_ROOT)/libs/openFrameworksCompiled/project/android/libneondetection.so libs/armeabi-v7a/
-	@cp $(NDK_ROOT)/toolchains/arm-linux-androideabi-4.4.3/prebuilt/gdbserver libs/armeabi-v7a
+	@cp $(NDK_ROOT)/prebuilt/android-arm/gdbserver/gdbserver libs/armeabi-v7a
 	
 	#create gdb.setup for armeabi-v7a
 	@echo "set solib-search-path $(PWD)/obj/local/armeabi-v7a:$(PWD)/libs/armeabi-v7a" > libs/armeabi-v7a/gdb.setup
@@ -150,7 +150,11 @@ AndroidInstall:
 	fi 
 	if [ -f obj/$(BIN_NAME) ]; then rm obj/$(BIN_NAME); fi
 	#touch AndroidManifest.xml
-	$(SDK_ROOT)/tools/android update project --target $(NDK_PLATFORM) --path $(PROJECT_PATH)
+	if [ "$(shell uname)" = "MINGW32_NT-6.1" ]; then \
+	cmd //c $(SDK_ROOT)/tools/android.bat update project --target $(NDK_PLATFORM) --path $(PROJECT_PATH); \
+	else \
+	$(SDK_ROOT)/tools/android update project --target $(NDK_PLATFORM) --path $(PROJECT_PATH); \
+	fi
 	if [ -d bin/classes ]; then rm -r bin/classes; fi
 	if [ -d bin/res ]; then rm -r bin/res; fi
 	if [ -f bin/classes.dex ]; then rm bin/classes.dex; fi
@@ -163,7 +167,11 @@ AndroidInstall:
 	if [ -f bin/$(APPNAME).apk ]; then rm bin/$(APPNAME).apk; fi
 	if [ -f bin/build.prop ]; then rm bin/build.prop; fi
 	if [ -f bin/jarlist.cache ]; then rm bin/jarlist.cache; fi
-	ant debug
+	if [ "$(shell uname)" = "MINGW32_NT-6.1" ]; then \
+	$(ANT_BIN)/ant debug; \
+	else \
+	ant debug; \
+	fi
 	cp bin/OFActivity-debug.apk bin/$(APPNAME).apk
 	#if [ "$(shell $(SDK_ROOT)/platform-tools/adb get-state)" = "device" ]; then
 	$(SDK_ROOT)/platform-tools/adb uninstall $(PKGNAME)

--- a/libs/openFrameworksCompiled/project/makefileCommon/Makefile.examples
+++ b/libs/openFrameworksCompiled/project/makefileCommon/Makefile.examples
@@ -29,6 +29,8 @@ ifeq ($(findstring Android,$(MAKECMDGOALS)),Android)
 	ARCH = android
 	ifeq ($(shell uname),Darwin)
 		HOST_PLATFORM = darwin-x86
+	else ifeq ($(shell uname),MINGW32_NT-6.1)
+		HOST_PLATFORM = windows
 	else
 		HOST_PLATFORM = linux-x86
 	endif


### PR DESCRIPTION
As requested I redid my patches for MinGW to build openFrameworks Android projects on the Windows platform.

This replaces my previous pull request (https://github.com/openframeworks/openFrameworks/pull/922) and is based on the current develop branch (0071).

I have also updated the documentation on how to setup the build environment on Windows:
http://www.multigesture.net/articles/how-to-setup-openframeworks-for-android-on-windows/

This patch also makes openFrameworks compatible with the latest NDK: r8b.

Changelog:
- Fixed Makefiles for use with MinGW (To build the Android target on Windows)
- Updated Makefiles for NDK r8b (Compiler version + new gdbserver location)

Note: 
- The external storage location patch will be redone in a separate pull request later (see https://github.com/openframeworks/openFrameworks/commit/7a9cf0ba for more details).
- This is a serious issue in our app NodeBeat because either the application won't start because assets can not be found, be extracted or are placed at the wrong storage location.
