### PR TITLE
Fixed an issue related to retrieving the external storage location.

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -50,6 +50,38 @@ import android.widget.Toast;
 
 public class OFAndroid {
 	
+	// List based on http://bit.ly/NpkL4Q
+	private final String[] mExternalStorageDirectories = new String[] { 
+			"/mnt/sdcard-ext", 
+			"/mnt/sdcard/external_sd", 
+			"/sdcard/sd", 
+			"/mnt/external_sd", 
+			"/emmc",  
+			"/mnt/sdcard/bpemmctest", 
+			"/mnt/sdcard/_ExternalSD",  
+			"/mnt/Removable/MicroSD", 
+			"/Removable/MicroSD" };
+	
+	private String getRealExternalStorageDirectory()
+	{				
+		// Standard way to get the external storage directory
+		String externalPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+		
+		// This checks if any of the directories from mExternalStorageDirectories exist, if it does, it uses that one instead
+		for(int i = 0; i < mExternalStorageDirectories.length; i++)
+		{
+			//Log.i("OF", "Checking: " + mExternalStorageDirectories[i]);	
+			File SDCardDir = new File(mExternalStorageDirectories[i]);		
+	    	if(SDCardDir.exists() && SDCardDir.canWrite()) {				
+	    		externalPath = mExternalStorageDirectories[i];	// Found writable location
+				break;
+	    	}	    	
+		}
+		
+		Log.i("OF", "Using storage location: " + externalPath);
+		return externalPath;		
+	}
+	
 	public OFAndroid(String packageName, Activity ofActivity){
 		ofActivity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
 		//Log.i("OF","external files dir: "+ ofActivity.getApplicationContext().getExternalFilesDir(null));
@@ -84,7 +116,8 @@ public class OFAndroid {
 
 	        dataPath="";
     		try{
-    			dataPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+    			//dataPath = Environment.getExternalStorageDirectory().getAbsolutePath();
+    			dataPath = getRealExternalStorageDirectory();
     			dataPath += "/"+packageName;
     			Log.i("OF","creating app directory: " + dataPath);
 				try{


### PR DESCRIPTION
This replaces a part of the previous pull request for the Android platform ( https://github.com/openframeworks/openFrameworks/pull/922 )

Normally you would use the method "Environment.getExternalStorageDirectory()" to find the location to the SD card. However on some phones or tablets, this returns the wrong location (it will probably return /mnt/sdcard), and most likely it will point to the internal storage. On some phones, the SD card is actually mounted on /mnt/sdcard-ext (Motorola) or /mnt/sdcard/external_sd (Samsung). This commit solves the issue by manually checking the possible storage locations (as reported on Stackoverflow) and will return this location if it is writable. If none of the predefined storage locations exist (or aren't writable) it will return the default path by using "Environment.getExternalStorageDirectory()"

More information about this Android related issue can be found here:
- http://stackoverflow.com/questions/5694933/find-an-external-sd-card-location
- http://stackoverflow.com/questions/5524105/how-could-i-get-the-correct-external-storage-on-samsung-and-all-other-devices
- http://beyondpod.com/support/index.php?/Knowledgebase/Article/View/30/0/how-to-change-the-location-of-downloaded-podcasts
