### PR TITLE
Update and copy-edit readme.linux

### DIFF
--- a/readme.linux
+++ b/readme.linux
@@ -1,18 +1,18 @@
-OF linux CB: 
+OpenFrameworks on Linux (with Code::Blocks): 
 
-a) installation
+a) Installation
 ---------------
 
-inside the scripts folder you'll find under ubuntu, debian or fedora some
-scripts to install everything you need to use openframeworks. inside that
-folders there's a file called `install_codeblocks.sh` that will install
-Code::Blocks svn version, please use this script to install codeblocks as
-some libraries in the new project format used in 006 won't work with
-codeblocks 8.02, the last stable version present in most linux distributions.
-there's also a script called `install_dependencies.sh` that will install
-all the libraries needed to use openFrameworks under linux.
+Inside the scripts folder you'll find some scripts in the ubuntu, debian, fedora 
+and archlinux folders which will install everything you need to use openFrameworks.
+Inside those folders there's a file called `install_codeblocks.sh` that will install 
+a current Code::Blocks version. Please use this script to install Code::Blocks, 
+it will avoid problems with some old Code::Blocks versions, but typically your 
+distribution's current version will be installed.
+There's also a script called `install_dependencies.sh` that will install
+all the libraries needed to use openFrameworks under Linux.
 
-you will need to run it from a console:
+You will need to run from a console:
 
 for ubuntu:
 
@@ -49,124 +49,118 @@ for archlinux
     if you want to have support for mp3 and some video codecs:
     sudo ./install_codecs.sh
 
-that's all, now go to the apps folder where you will find the examples
-and have fun!
+That's all, now go to the your_oF_directory/examples folder, where you will find 
+the examples, and have fun!
 
 
-b) manual install
------------------
+b) Other distributions
+----------------------
 
-if you are using a different distribution than ubuntu, debian or fedora,
+If you are using a different distribution than ubuntu, debian, fedora or arch,
 please take a look at one of the `install_dependencies.sh` scripts from
 one of the supported distributions to know what libraries you need to install.
-Also if you have problems or manage to install oF in any other distribution
+Also, if you have problems or manage to install OF in any other distribution
 please post in the forums so we can add it to the next release.
 
 
 c) projectGenerator
---------------------
+-------------------
 
-this is an openFrameworks application that will make your life easier when 
+This is an openFrameworks application that will make your life easier when 
 creating projects or adding addons to existing ones.
 
-you'll need to compile it before being able to use it. in a terminal:
+You'll need to compile it before being able to use it. in a terminal:
 
     cd OF_ROOT/scripts/projectGenerator
     make
     
-then copy the application to /usr/bin so you can use it from anywhere:
+Then copy the application to /usr/bin so you can use it from anywhere:
 
     sudo cp bin/projectGenerator /usr/bin
 
-to create a new openFrameworks project, or update an already existing from a 
-console do:
+To create a new openFrameworks project, or update an already existing one from a 
+console, do:
 
     cd OF_ROOT/apps    (wherever you have uncompressed OF)
     projectGenerator myApps/projectName
 
-to add addons to a project just add the name of the addon to the addons.make 
-file in the root folder of the project and run the projectGenerator again passing
-the path to update the codeblocks project
+To add addons to a project just add the name of the addon to the addons.make 
+file in the root folder of the project and run the projectGenerator again, passing
+the path to update the Code::Blocks project.
 
 
-d) wizard
----------- 	  	
-you can also install a codeblocks wizard to create new projects, check the	
+d) Code::Blocks Wizard
+---------------------- 	  	
+You can also install a Code::Blocks wizard to create new projects, check the	
+instructions in scripts/linux/codeblocks_wizard.
 
-instructions in scripts/linux/codeblocks_wizard
 
+e) Code::Blocks projects
+------------------------
 
-e) codeblocks
--------------
+Code::Blocks projects are now using Makefiles to make the configuration easier.
+Take a look at the next section to see how it works, to add search paths or 
+libraries you need to edit config.make, if you want to add addons, edit addons.make.
 
-codeblocks projects are now using Makefiles to make the configuration easier
-take a look at the next step: d  to know how it works, the only difference is that
-now to add search paths, or libraries you need to edit config.make, if you want 
-to add addons use addons.make
-
-you can also run the createProjects.py script with a -n parameter to generate old 
-style codeblocks projects
 
 f) Makefile
 -----------
 
-every example has a Makefile you can configure it using the files: config.make
-and addons.make
+Every example has a Makefile you can configure using the files config.make
+and addons.make.
 
-config.make: has options to add search paths, libraries... the syntax is the 
-usual syntax in makefiles, there's help comments inside the file
+config.make: This file has options to add search paths, libraries, etc., the 
+syntax is the usual syntax in makefiles, there's help comments inside the file.
 
-addons.make: if you want to use an addon inside the addons folder, just add its
-name in a new line in this file.
+addons.make: if you want to use an addon which is inside the addons folder, just 
+add its name in a new line in this file.
 
 
-g) post build steps:
+g) Post build steps:
 --------------------
 	
 some folks have mentioned trouble with post-build step which copies the export
 directory into the bin folder. if you have issues, please let us know,
-and esp what linux you are running, what version of CB, etc...
+and especially what Linux you are running, what version of Code::Blocks, etc...
 (please read the readme in export to understand the post build step).
 
-We've modified in this release the script to use `$(PROJECT_DIR)bin` instead of
-`$(TARGET_OUTPUT_DIR)bin/` since this lead to `bin/bin` on some versions of CB.
+In a previous release, we've modified  the script to use `$(PROJECT_DIR)bin` instead of
+`$(TARGET_OUTPUT_DIR)bin/`, since this lead to `bin/bin` on some versions of CB.
 It should work now on all versions (fingers crossed).
 
-one problem occurs if you try to compile OF from a folder you got to in nautilus
+One problem occurs if you try to compile OF from a folder you reached in nautilus
 via a symbolic link:
 
-error will look like this:
+The error will look like this:
 
     cp -r ../../../export/libs /home/zach/Desktop/Link to openframeworks/0.05/0.05b_fat/apps/addonsExamples/allTestExample/bin/
     cp: target `openframeworks/0.05/0.05b_fat/apps/addonsExamples/allTestExample/bin/' is not a directory: No such file or directory
     Process terminated with status 1 (0 minutes, 1 seconds)
     0 errors, 0 warnings
 
-so don't open up the project via a symbolic link.
-we will report this to CB forum. 
+So, don't open up the project via a symbolic link. We will report this to CB forum. 
 
 
-h) scripts
-----------
+h) Other scripts
+----------------
 
-we've created a scripts directory to make everyone life easier, and to get a
+We've created a /scripts directory to make everyone life easier, and to get a
 hang of building / cleaning multiple projects at once.
-also, you can enable or diable running app from within CB via our hacked out
+Also, you can enable or diable running app from within CB via our hacked out
 build = build + run system.
-we are hoping that crafty folk will get into scripting, esp. as it relates to
-addons, etc.  please share any helpful scripts on the forum.
+We are hoping that crafty folk will get into scripting, esp. as it relates to
+addons, etc. Please share any helpful scripts on the forum.
 
 	
-i) linux info, advice, etc
+i) Linux info, advice, etc
 --------------------------
 
-linux version of openFrameworks is in some way different to windows and mac,
-mainly the video support provided by quicktime doesn-t exist here. in 0.06
+The linux version of openFrameworks is in some way different to Windows and MacOS,
+mainly the video support provided by quicktime doesn't exist here. From OF 0.06,
 this is provided with gStreamer for video files and unicap for cameras.
-although it has been tested, some cameras and video formats can pose some
+Although it has been tested, some cameras and video formats can pose some
 issues, if you have some problem please post in the forum as much info
-as posible.
-
+as possible.
 
 
 many thanks!! OFteam


### PR DESCRIPTION
This is work towards #1301. I did some copy-editing, and updated the new examples location. While working on it, it seemed that some info is pretty old, and probably needs to be updated/dropped.
I'm not up to date with the current C::B situation, @arturoc and/or someone else, could you take a look?
Most affected are section d), e), g) (are post-build steps even relevant anymore? also, the mentioned issue smells like a space-in-filename issue, not a symlink issue to me), h), i).

Also, and that's more of a btw, is that Code::blocks install script trickery still necessary? I think no linux distro is still on C::B 8. That's probably for another issue, though.
