### PR TITLE
PG fix wrong cli arguments

### DIFF
--- a/apps/devApps/projectGenerator/src/main.cpp
+++ b/apps/devApps/projectGenerator/src/main.cpp
@@ -18,6 +18,7 @@ int main(  int argc, char *argv[]  ){
 		ofSetupOpenGL(&window, 1024,768, OF_WINDOW);
 		testApp * app = new testApp;
 		app->buildAllExamples = false;
+		app->projectPath = "";
 		for(int i=1;i<argc;i++){
 			string arg = argv[i];
 			if(arg.find("--")==0){
@@ -73,6 +74,11 @@ int main(  int argc, char *argv[]  ){
 			}else{
 				app->projectPath = ofFilePath::removeTrailingSlash(ofFilePath::getPathForDirectory(ofFilePath::getAbsolutePath(arg,false)));
 			}
+		}
+
+		if (!(app->buildAllExamples) && app->projectPath.empty()){
+			cout << "Error: No target project given. Either run projectGenerator with the --allexamples option or supply a target project folder path. Run \'projectGenerator help\' for details." << endl;
+			std::exit(1);
 		}
 
 		if(app->targetsToMake.empty())


### PR DESCRIPTION
This elegantly captures wrong arguments, both unknown strings e.g. `--bla`, or wrongly formulated e.g. `-linux` (1 dash), and also a missing target. Closes issue #1273.

Tested on linux, project path as argument still works, since the second check sees if the arg starts with `-`, and I can't imagine a legal path starting with `-`.
This only affects command-line-only PG, so I don't see any significant impact beyond that. Furthermore, it's just 2 more else/if clauses in the argument parser, which abort the program elegantly, and I used only functions which were already in the code before (except for initializing `app->projectPath` to an empty string, and using `string.empty()`), so I can't imagine this having negative repercussions anywhere else in PG.
