### PR TITLE
Wrappers for Mult and Load matrix, lessened need for GLU in ofGLRenderer

### DIFF
--- a/examples/3d/advanced3dExample/src/testApp.cpp
+++ b/examples/3d/advanced3dExample/src/testApp.cpp
@@ -292,7 +292,7 @@ void testApp::drawScene(int iCameraDraw){
 		//  from the inverseCameraMatrix object
 		//  to OpenGL, and apply that matrix to
 		//  the current OpenGL transform
-		glMultMatrixf(inverseCameraMatrix.getPtr());
+		ofMultMatrix( inverseCameraMatrix );
 
 		//
 		//--

--- a/examples/3d/normalsExample/src/testApp.cpp
+++ b/examples/3d/normalsExample/src/testApp.cpp
@@ -99,7 +99,7 @@ void testApp::draw(){
 
     mesh.drawFaces();
     ofSetColor(255,255,255);
-    light.customDraw();
+    light.draw();
     
     
     // draw our normals, and show that they are perpendicular to the vector from the center to the vertex

--- a/libs/openFrameworks/3d/of3dUtils.cpp
+++ b/libs/openFrameworks/3d/of3dUtils.cpp
@@ -122,7 +122,7 @@ void ofDrawArrow(const ofVec3f& start, const ofVec3f& end, float headSize) {
 	mat.makeRotationMatrix(ofVec3f(0,0,1), end - start);
 	ofPushMatrix();
 	ofTranslate(end);
-	glMultMatrixf(mat.getPtr());
+	ofMultMatrix(mat.getPtr());
 	ofTranslate(0,0,-headSize);
 	ofCone(headSize, headSize);	
 	ofPopMatrix();

--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -97,7 +97,8 @@ void ofCamera::begin(ofRectangle viewport) {
 	calcClipPlanes(viewport);
 
 	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
+	ofLoadIdentityMatrix();
+	
 	if(isOrtho) {
 		//			if(vFlip) glOrtho(0, width, height, 0, nearDist, farDist);
 		//			else
@@ -106,14 +107,18 @@ void ofCamera::begin(ofRectangle viewport) {
 #else
 		ofMatrix4x4 ortho;
 		ortho.makeOrthoMatrix(0, viewport.width, 0, viewport.height, nearClip, farClip);
-		glLoadMatrixf(ortho.getPtr());
+		ofLoadMatrix( ortho );
 #endif
 	} else {
-		gluPerspective(fov, viewport.width/viewport.height, nearClip, farClip);
+		
+		ofMatrix4x4 persp;
+		persp.makePerspectiveMatrix( fov, viewport.width/viewport.height, nearClip, farClip );
+		ofLoadMatrix( persp );
+		//gluPerspective(fov, viewport.width/viewport.height, nearClip, farClip);
 	}
 
 	glMatrixMode(GL_MODELVIEW);
-	glLoadMatrixf(ofMatrix4x4::getInverseOf(getGlobalTransformMatrix()).getPtr());
+	ofLoadMatrix( ofMatrix4x4::getInverseOf(getGlobalTransformMatrix()) );
 	ofViewport(viewport);
 }
 

--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -341,13 +341,14 @@ void ofNode::draw() {
 
 //----------------------------------------
 void ofNode::transformGL() const {
-	glPushMatrix();
-	glMultMatrixf(getGlobalTransformMatrix().getPtr());
+	ofPushMatrix();
+	ofMultMatrix( getGlobalTransformMatrix() );
+	//glMultMatrixf( getGlobalTransformMatrix().getPtr() );
 }
 
 //----------------------------------------
 void ofNode::restoreTransformGL() const {
-	glPopMatrix();
+	ofPopMatrix();
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -363,7 +363,7 @@ void ofGLRenderer::setupScreenPerspective(float width, float height, ofOrientati
 		
 	ofMatrix4x4 persp;
 	persp.makePerspectiveMatrix(fov, aspect, nearDist, farDist);
-	ofLoadMatrix( &persp );
+	loadMatrix( persp );
 	//gluPerspective(fov, aspect, nearDist, farDist);
 
 
@@ -372,7 +372,7 @@ void ofGLRenderer::setupScreenPerspective(float width, float height, ofOrientati
 	
 	ofMatrix4x4 lookAt;
 	lookAt.makeLookAtViewMatrix( ofVec3f(eyeX, eyeY, dist),  ofVec3f(eyeX, eyeY, 0),  ofVec3f(0, 1, 0) );
-	ofLoadMatrix( &lookAt );
+	loadMatrix( lookAt );
 	//gluLookAt(eyeX, eyeY, dist, eyeX, eyeY, 0, 0, 1, 0);
 
 	//note - theo checked this on iPhone and Desktop for both vFlip = false and true
@@ -693,8 +693,8 @@ void ofGLRenderer::loadIdentityMatrix (void){
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::loadMatrix (const ofMatrix4x4 *m){
-	loadMatrix( m->getPtr() );
+void ofGLRenderer::loadMatrix (const ofMatrix4x4 & m){
+	loadMatrix( m.getPtr() );
 }
 
 //----------------------------------------------------------
@@ -703,8 +703,8 @@ void ofGLRenderer::loadMatrix (const float *m){
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::multMatrix (const ofMatrix4x4 *m){
-	multMatrix( m->getPtr() );
+void ofGLRenderer::multMatrix (const ofMatrix4x4 & m){
+	multMatrix( m.getPtr() );
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -65,10 +65,10 @@ public:
 	void rotateZ(float degrees);
 	void rotate(float degrees);
 	void loadIdentityMatrix (void);
-	void loadMatrix (const ofMatrix4x4 *m);
-	void loadMatrix (const float *m);
-	void multMatrix (const ofMatrix4x4 *m);
-	void multMatrix (const float *m);
+	void loadMatrix (const ofMatrix4x4 & m);
+	void loadMatrix (const float * m);
+	void multMatrix (const ofMatrix4x4 & m);
+	void multMatrix (const float * m);
 	
 	// screen coordinate things / default gl values
 	void setupGraphicDefaults();

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -276,7 +276,7 @@ void ofLoadIdentityMatrix (void){
 }
 
 //----------------------------------------------------------
-void ofLoadMatrix (const ofMatrix4x4 *m){
+void ofLoadMatrix (const ofMatrix4x4 & m){
 	renderer->loadMatrix(m);
 }
 
@@ -286,7 +286,7 @@ void ofLoadMatrix (const float *m){
 }
 
 //----------------------------------------------------------
-void ofMultMatrix (const ofMatrix4x4 *m){
+void ofMultMatrix (const ofMatrix4x4 & m){
 	renderer->multMatrix(m);
 }
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -53,9 +53,9 @@ void ofRotateY(float degrees);
 void ofRotateZ(float degrees);
 void ofRotate(float degrees);
 void ofLoadIdentityMatrix (void);
-void ofLoadMatrix (const ofMatrix4x4 *m);   // Andreas: I've included both a ofMatrix4x4* and a float* version here,
-void ofLoadMatrix (const float *m);			// ideally we would always use ofMatrix4x4, but in a lot of temporary 
-void ofMultMatrix (const ofMatrix4x4 *m);	// ofMatrix4x4 objects when interacting with non-OF code
+void ofLoadMatrix (const ofMatrix4x4 & m);   // Andreas: I've included both a ofMatrix4x4* and a float* version here,
+void ofLoadMatrix (const float *m);			// ideally we would always use ofMatrix4x4, but in a lot of temporary
+void ofMultMatrix (const ofMatrix4x4 & m);	// ofMatrix4x4 objects when interacting with non-OF code
 void ofMultMatrix (const float *m);
 
 // screen coordinate things / default gl values

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -320,9 +320,9 @@ public:
 	virtual void rotateZ(float degrees){};
 	virtual void rotate(float degrees){};
 	virtual void loadIdentityMatrix (void){};
-	virtual void loadMatrix (const ofMatrix4x4 *m){};
+	virtual void loadMatrix (const ofMatrix4x4 & m){};
 	virtual void loadMatrix (const float *m){};
-	virtual void multMatrix (const ofMatrix4x4 *m){};
+	virtual void multMatrix (const ofMatrix4x4 & m){};
 	virtual void multMatrix (const float *m){};
 	
 	// screen coordinate things / default gl values


### PR DESCRIPTION
- Added OF functions that wrap glLoadMatrix, glMultMatrix and glLoadIdentity so that these get passed on the the renderer.
- Lessened the need for GLU in ofGLRenderer by replacing gluLookAt and gluPerspective with ofMatrix4x4 functions. There is still a gluProject call in there, after that ofGLRenderer does not need GLU.
