### PR TITLE
fixes ofPtr

### DIFF
--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -140,7 +140,7 @@ public:
 	: std::shared_ptr<T>(__r) { }
 
 	  template<typename Tp1>
-		ofPtr(const std::tr1::shared_ptr<Tp1>& __r)
+		ofPtr(const std::shared_ptr<Tp1>& __r)
 	: std::shared_ptr<T>(__r) { }
 
 	  /*ofPtr(ofPtr&& __r)


### PR DESCRIPTION
adds non-explicit constructor  from shared_ptr so it can be used as one + imports everything related to smart pointers from std::tr1 into std:: so the syntax is clearer
