### PR TITLE
ofSoundStream: adds getters for samplerate, bufferSize and numChannels

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
@@ -188,6 +188,13 @@ int ofxAndroidSoundStream::getNumOutputChannels(){
 	return outChannels;
 }
 
+int ofxAndroidSoundStream::getSampleRate(){
+	return sampleRate;
+}
+
+int ofxAndroidSoundStream::getBufferSize(){
+	return inBufferSize;
+}
 
 void ofxAndroidSoundStream::pause(){
 	isPaused = true;

--- a/addons/ofxAndroid/src/ofxAndroidSoundStream.h
+++ b/addons/ofxAndroid/src/ofxAndroidSoundStream.h
@@ -25,9 +25,11 @@ class ofxAndroidSoundStream : public ofBaseSoundStream{
 		void close();
 		
 		long unsigned long getTickCount();		
-				
+
 		int getNumInputChannels();
 		int getNumOutputChannels();
+		int getSampleRate();
+		int getBufferSize();
 
 		int androidInputAudioCallback(JNIEnv*  env, jobject  thiz,jshortArray array, jint numChannels, jint bufferSize);
 		int androidOutputAudioCallback(JNIEnv*  env, jobject  thiz,jshortArray array, jint numChannels, jint bufferSize);

--- a/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.h
+++ b/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.h
@@ -32,12 +32,15 @@ class ofxiPhoneSoundStream : public ofBaseSoundStream{
 	
 		int getNumInputChannels();
 		int getNumOutputChannels();
+		int getSampleRate();
+		int getBufferSize();
 		
 	private:
 		long unsigned long	tickCount;
 		int					nInputChannels;
 		int					nOutputChannels;
 		int					sampleRate;
+		int                 bufferSize;
 };
 
 

--- a/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.mm
+++ b/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.mm
@@ -171,12 +171,13 @@ void ofxiPhoneSoundStream::setOutput(ofBaseSoundOutput * soundOutput){
 }
 
 //------------------------------------------------------------------------------
-bool ofxiPhoneSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int bufferSize, int nBuffers){
+bool ofxiPhoneSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers){
 	
 	nInputChannels = inChannels;
 	nOutputChannels = outChannels;
 	tickCount = 0;
 	sampleRate = _sampleRate;
+	bufferSize = _bufferSize;
 	
 	// nBuffers is always 1  (see CoreAudio AudioBuffer struct)
 	// this may change in the future ...
@@ -405,6 +406,16 @@ int ofxiPhoneSoundStream::getNumOutputChannels(){
 //------------------------------------------------------------------------------
 int ofxiPhoneSoundStream::getNumInputChannels(){
 	return nInputChannels;
+}
+
+//------------------------------------------------------------------------------
+int ofxiPhoneSoundStream::getSampleRate(){
+    return sampleRate;
+}
+
+//------------------------------------------------------------------------------
+int ofxiPhoneSoundStream::getBufferSize(){
+    return bufferSize;
 }
 
 #endif

--- a/libs/openFrameworks/sound/ofBaseSoundStream.h
+++ b/libs/openFrameworks/sound/ofBaseSoundStream.h
@@ -20,4 +20,8 @@ class ofBaseSoundStream{
 		virtual void close() = 0;
 
 		virtual long unsigned long getTickCount() = 0;
+		virtual int getNumInputChannels() = 0;
+		virtual int getNumOutputChannels() = 0;
+		virtual int getSampleRate() = 0;
+		virtual int getBufferSize() = 0;
 };

--- a/libs/openFrameworks/sound/ofPASoundStream.cpp
+++ b/libs/openFrameworks/sound/ofPASoundStream.cpp
@@ -42,10 +42,10 @@ void ofPASoundStream::setOutput(ofBaseSoundOutput * soundOutput){
 	soundOutputPtr = soundOutput;
 }
 
-bool ofPASoundStream::setup(int outChannels, int inChannels, int _sampleRate, int bufferSize, int nBuffers){
+bool ofPASoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers){
 	nInputChannels 		=  inChannels;
 	nOutputChannels 	=  outChannels;
-	bufferSize = ofNextPow2(bufferSize);	// must be pow2
+	bufferSize = ofNextPow2(_bufferSize);	// must be pow2
 	sampleRate = _sampleRate;
 	tickCount			=  0;
 
@@ -223,4 +223,21 @@ void ofPASoundStream::setDeviceID(int _deviceID){
 long unsigned long ofPASoundStream::getTickCount(){
 	return tickCount;
 }
+
+int ofPASoundStream::getNumInputChannels(){
+	return nInputChannels;
+}
+
+int ofPASoundStream::getNumOutputChannels(){
+	return nOutputChannels;
+}
+
+int ofPASoundStream::getSampleRate(){
+	return sampleRate;
+}
+
+int ofPASoundStream::getBufferSize(){
+	return bufferSize;
+}
+
 #endif

--- a/libs/openFrameworks/sound/ofPASoundStream.h
+++ b/libs/openFrameworks/sound/ofPASoundStream.h
@@ -29,6 +29,8 @@ class ofPASoundStream : public ofBaseSoundStream{
 				
 		int getNumInputChannels();
 		int getNumOutputChannels();
+		int getSampleRate();
+		int getBufferSize();
 	
 		
 	private:
@@ -38,6 +40,7 @@ class ofPASoundStream : public ofBaseSoundStream{
 		int					deviceID;
 		int					nInputChannels;
 		int					nOutputChannels;
+		int					bufferSize;
 		ofBaseSoundInput *  soundInputPtr;
 		ofBaseSoundOutput * soundOutputPtr;
 		

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -78,7 +78,7 @@ void ofRtAudioSoundStream::setOutput(ofBaseSoundOutput * soundOutput){
 }
 
 //------------------------------------------------------------------------------
-bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int bufferSize, int nBuffers){
+bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers){
 	if( audio != NULL ){
 		close();
 	}
@@ -88,7 +88,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 
 	sampleRate			=  _sampleRate;
 	tickCount			=  0;
-	bufferSize			= ofNextPow2(bufferSize);	// must be pow2
+	bufferSize			= ofNextPow2(_bufferSize);	// must be pow2
 
 	try {
 		audio = ofPtr<RtAudio>(new RtAudio());
@@ -195,6 +195,16 @@ int ofRtAudioSoundStream::getNumInputChannels(){
 //------------------------------------------------------------------------------
 int ofRtAudioSoundStream::getNumOutputChannels(){
 	return nOutputChannels;		
+}
+
+//------------------------------------------------------------------------------
+int ofRtAudioSoundStream::getSampleRate(){
+	return sampleRate;
+}
+
+//------------------------------------------------------------------------------
+int ofRtAudioSoundStream::getBufferSize(){
+	return bufferSize;
 }
 
 //------------------------------------------------------------------------------

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.h
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.h
@@ -28,9 +28,11 @@ class ofRtAudioSoundStream : public ofBaseSoundStream{
 		void close();
 		
 		long unsigned long getTickCount();		
-				
+
 		int getNumInputChannels();
 		int getNumOutputChannels();
+		int getSampleRate();
+		int getBufferSize();
 	
 		
 	private:
@@ -38,7 +40,7 @@ class ofRtAudioSoundStream : public ofBaseSoundStream{
 		ofPtr<RtAudio>		audio;
 		int					sampleRate;
 		int					outDeviceID, inDeviceID;
-    
+		int					bufferSize;
 		int					nInputChannels;
 		int					nOutputChannels;
 		ofBaseSoundInput *  soundInputPtr;

--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -137,3 +137,34 @@ long unsigned long ofSoundStream::getTickCount(){
 	return 0;
 }
 
+//------------------------------------------------------------
+int ofSoundStream::getNumInputChannels(){
+	if( soundStream ){
+		return soundStream->getNumInputChannels();
+	}
+	return 0;
+}
+
+//------------------------------------------------------------
+int ofSoundStream::getNumOutputChannels(){
+	if( soundStream ){
+		return soundStream->getNumOutputChannels();
+	}
+	return 0;
+}
+
+//------------------------------------------------------------
+int ofSoundStream::getSampleRate(){
+	if( soundStream ){
+		return soundStream->getSampleRate();
+	}
+	return 0;
+}
+
+//------------------------------------------------------------
+int ofSoundStream::getBufferSize(){
+	if( soundStream ){
+		return soundStream->getBufferSize();
+	}
+	return 0;
+}

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -49,6 +49,10 @@ class ofSoundStream{
 		void close();
 		
 		long unsigned long getTickCount();
+		int getNumInputChannels();
+		int getNumOutputChannels();
+		int getSampleRate();
+		int getBufferSize();
 		
 	protected:
 		


### PR DESCRIPTION
these were missing and are useful when using an ofSoundStream from different classes to for example calculate timmings
