### PR TITLE
fix multiLightExample ofLight::draw

### DIFF
--- a/examples/gl/multiLightExample/src/testApp.cpp
+++ b/examples/gl/multiLightExample/src/testApp.cpp
@@ -126,11 +126,11 @@ void testApp::draw(){
     ofDisableLighting();
     
 	ofSetColor( pointLight.getDiffuseColor() );
-	if(bPointLight) pointLight.customDraw();
+	if(bPointLight) pointLight.draw();
     
     ofSetColor(255, 255, 255);
 	ofSetColor( spotLight.getDiffuseColor() );
-	if(bSpotLight) spotLight.customDraw();
+	if(bSpotLight) spotLight.draw();
 	
 	ofSetColor(255, 255, 255);
 	ofDrawBitmapString("Point Light On (1) : "+ofToString(bPointLight) +"\n"+


### PR DESCRIPTION
Resolves an issue where the debug view of a light would not be drawn at the proper position in  multiLightExample.

When drawing a light, it's enough to call `ofLight::draw()` to draw it at the correct position, instead of     `ofLight::customDraw()`. [which should most probably be made a private method anyway].

ofLight inherits from ofNode, and ofNode takes care of the matrix transformations when ofNode::draw() gets called, and then calls customDraw() wrapped by the correct transformation matrices.

See also issue #1471
