### PR TITLE
Make whitespace and printable character width the same in font rendering

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -630,7 +630,7 @@ vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(string str){
 
 		  }else if (str[index] == ' ') {
 				 int cy = (int)'p' - NUM_CHARACTER_TO_START;
-				 X += cps[cy].width * letterSpacing * spaceSize;
+				 X += cps[cy].setWidth * letterSpacing * spaceSize;
 		  } else {
 			  	shapes.push_back(getCharacterAsPoints(str[index]));
 			  	shapes.back().translate(ofPoint(X,Y));


### PR DESCRIPTION
`ofTrueTypeFont::drawString` [calculates](https://github.com/openframeworks/openFrameworks/blob/develop/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L779-L785) x offsets differently for the whitespace character than for other characters. Namely, the whitespace character uses the `width` property of the character, while everything else uses the `setWidth` property.

This becomes very noticeable when trying to use monospace fonts.

![Incorrect](http://f.cl.ly/items/1p303L0o260l0W3p1C3y/Screen%20Shot%202012-09-24%20at%2012.17.32%20AM.png)

The whitespace is clearly too small. This patch fixes this by using `setWidth` to calculate whitespace offsets in `ofTrueTypeFont::drawString`

![Correct](http://f.cl.ly/items/0u2m3m0f3P03093E1z0N/Screen%20Shot%202012-09-24%20at%2012.17.56%20AM.png)

Test code used:

``` cpp
void testApp::draw(){
    ofSetColor(0, 0, 0);

    ofTrueTypeFont andale;
    andale.loadFont("/Library/Fonts/Andale Mono.ttf", 12, false, true, true);
    andale.drawString("Hello World!", 10, 100);
    andale.drawString("Hello_World!", 10, 113);
}
```
