### PR TITLE
bugfix-ios6-videoplayer

### DIFF
--- a/addons/ofxiPhone/src/video/ofiPhoneVideoPlayer.mm
+++ b/addons/ofxiPhone/src/video/ofiPhoneVideoPlayer.mm
@@ -54,7 +54,7 @@ bool ofiPhoneVideoPlayer::loadMovie(string name) {
         if(_videoTextureCache == NULL) {
             CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, 
                                                         NULL, 
-                                                        (__bridge void *)ofxiPhoneGetGLView().context,
+                                                        ofxiPhoneGetGLView().context,
                                                         NULL, 
                                                         &_videoTextureCache);
             if(err) {


### PR DESCRIPTION
latest Xcode 4.5 and LLVM 4.1 don't like the (__bridge void *) syntax.
__bridge syntax is used to let the function know NOT to take ownership of an object.
i was worried that removing (__bridge void *) would cause leaks but the iOS moviePlayerExample is running fine and leak free.

fixes issue #1607
