### PR TITLE
Deprecate ofVec*::squareLength() in favour of ofVec*::lengthSquared(). 

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,7 +1,7 @@
 + Deprecation mechanism: Compile-time warnings tell you if you are using legacy/old functions. Alternatives are mentioned where appropriate.
 
 Deprecations (will be removed in a future release):
-/ ofVec*f::lengthSquared() has been deprecated. Use ofVec*f::squareLength() instead.
+/ ofVec*f::squareLength() has been deprecated. Use ofVec*f::lengthSquared() instead.
 / ofVideoGrabber::grabFrame() has been deprecated. Use ofVideoGrabber::update() instead.
 / ofVideoPlayer::idleMovie() has been deprecated. Use ofVideoPlayer::update() instead.
 / ofPolyline::addVertexes has been deprecated. Use ofPolyline::addVertices instead.

--- a/libs/openFrameworks/math/ofQuaternion.cpp
+++ b/libs/openFrameworks/math/ofQuaternion.cpp
@@ -77,7 +77,7 @@ void ofQuaternion::makeRotate( const ofVec3f& from, const ofVec3f& to ) {
 	ofVec3f sourceVector = from;
 	ofVec3f targetVector = to;
 
-	float fromLen2 = from.squareLength();
+	float fromLen2 = from.lengthSquared();
 	float fromLen;
 	// normalize only when necessary, epsilon test
 	if ((fromLen2 < 1.0 - 1e-7) || (fromLen2 > 1.0 + 1e-7)) {
@@ -85,7 +85,7 @@ void ofQuaternion::makeRotate( const ofVec3f& from, const ofVec3f& to ) {
 		sourceVector /= fromLen;
 	} else fromLen = 1.0;
 
-	float toLen2 = to.squareLength();
+	float toLen2 = to.lengthSquared();
 	// normalize only when necessary, epsilon test
 	if ((toLen2 < 1.0 - 1e-7) || (toLen2 > 1.0 + 1e-7)) {
 		float toLen;

--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -153,7 +153,8 @@ public:
     // Length
     //
     float length() const;
-    float squareLength() const;
+    float lengthSquared() const;
+	OF_DEPRECATED_MSG("Use ofVec2f::lengthSquared() instead.", float squareLength() const);
 	
 	
     /**
@@ -191,9 +192,6 @@ public:
 	
     // getPerpendicular
     ofVec2f perpendiculared() const;
-	
-    // squareLength
-    OF_DEPRECATED_MSG("Use ofVec2f::squareLength() instead.", float lengthSquared() const);
 	
     // getInterpolated
     ofVec2f interpolated( const ofVec2f& pnt, float p ) const;
@@ -712,11 +710,11 @@ inline float ofVec2f::length() const {
 }
 
 inline float ofVec2f::lengthSquared() const {
-	return squareLength();
+	return (float)(x*x + y*y);
 }
 
 inline float ofVec2f::squareLength() const {
-	return (float)(x*x + y*y);
+	return lengthSquared();
 }
 
 

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -167,7 +167,8 @@ public:
     // Length
     //
     float length() const;
-    float squareLength() const;
+    float lengthSquared() const;
+	OF_DEPRECATED_MSG("Use ofVec3f::lengthSquared() instead.", float squareLength() const);
     /**
 	 * Angle (deg) between two vectors.
 	 * This is an unsigned relative angle from 0 to 180.
@@ -209,9 +210,6 @@ public:
 	
     // getPerpendicular
     ofVec3f perpendiculared( const ofVec3f& vec ) const;
-	
-    // squareLength
-    OF_DEPRECATED_MSG("Use ofVec3f::squareLength() instead.", float lengthSquared() const);
     
     // use getMapped
     ofVec3f  mapped( const ofVec3f& origin,
@@ -1016,11 +1014,11 @@ inline float ofVec3f::length() const {
 }
 
 inline float ofVec3f::lengthSquared() const {
-	return squareLength();
+	return (float)(x*x + y*y + z*z);
 }
 
 inline float ofVec3f::squareLength() const {
-	return (float)(x*x + y*y + z*z);
+	return lengthSquared();
 }
 
 

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -111,7 +111,8 @@ public:
     // Length
     //
     float length() const;
-    float squareLength() const;
+    float lengthSquared() const;
+	OF_DEPRECATED_MSG("Use ofVec4f::lengthSquared() instead.", float squareLength() const);
     /**
 	 * Dot Product.
 	 */
@@ -134,9 +135,6 @@ public:
 	
     // getLimited
     ofVec4f limited(float max) const;
-	
-    // squareLength
-    OF_DEPRECATED_MSG("Use ofVec4f::squareLength() instead.", float lengthSquared() const);
 	
     // use squareDistance
     float  distanceSquared( const ofVec4f& pnt ) const;
@@ -544,11 +542,11 @@ inline float ofVec4f::length() const {
 }
 
 inline float ofVec4f::lengthSquared() const {
-	return squareLength();
+	return (float)(x*x + y*y + z*z + w*w);
 }
 
 inline float ofVec4f::squareLength() const {
-	return (float)(x*x + y*y + z*z + w*w);
+	return lengthSquared();
 }
 
 


### PR DESCRIPTION
Effectively undoes/refactors 5b89bbd2fb5049f29aa67db2b4e5f57b03859d7f. Closes #1611.
