### PR TITLE
removes ofFmodSoundPlayer files from iOS+OF project. Was causing compile...

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -64,8 +64,6 @@
 		5E2E99DD10ED147800587639 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E2E99DC10ED147800587639 /* MapKit.framework */; };
 		772C25181469274B00DDAAE6 /* ofOpenALSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 772C25161469274B00DDAAE6 /* ofOpenALSoundPlayer.cpp */; };
 		772C25191469274B00DDAAE6 /* ofOpenALSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 772C25171469274B00DDAAE6 /* ofOpenALSoundPlayer.h */; };
-		772C251C146927A500DDAAE6 /* ofFmodSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 772C251A146927A400DDAAE6 /* ofFmodSoundPlayer.cpp */; };
-		772C251D146927A500DDAAE6 /* ofFmodSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 772C251B146927A400DDAAE6 /* ofFmodSoundPlayer.h */; };
 		BB24DECA10DA7A3F00E9C588 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBE5EAB70F49AD8400F28951 /* AudioToolbox.framework */; };
 		BB24DECB10DA7A3F00E9C588 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB16EBD10F2B2A9500518274 /* OpenGLES.framework */; };
 		BB24DECC10DA7A3F00E9C588 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
@@ -246,8 +244,6 @@
 		5E2E99DC10ED147800587639 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		772C25161469274B00DDAAE6 /* ofOpenALSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofOpenALSoundPlayer.cpp; sourceTree = "<group>"; };
 		772C25171469274B00DDAAE6 /* ofOpenALSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofOpenALSoundPlayer.h; sourceTree = "<group>"; };
-		772C251A146927A400DDAAE6 /* ofFmodSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofFmodSoundPlayer.cpp; sourceTree = "<group>"; };
-		772C251B146927A400DDAAE6 /* ofFmodSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFmodSoundPlayer.h; sourceTree = "<group>"; };
 		BB16EBD10F2B2A9500518274 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		BB16EBD80F2B2AB500518274 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		BB24DED610DA7A3F00E9C588 /* libofxiPhone_iphoneos_Debug.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libofxiPhone_iphoneos_Debug.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -739,8 +735,6 @@
 		E485F6CE1360A90000E939D3 /* sound */ = {
 			isa = PBXGroup;
 			children = (
-				772C251A146927A400DDAAE6 /* ofFmodSoundPlayer.cpp */,
-				772C251B146927A400DDAAE6 /* ofFmodSoundPlayer.h */,
 				772C25161469274B00DDAAE6 /* ofOpenALSoundPlayer.cpp */,
 				772C25171469274B00DDAAE6 /* ofOpenALSoundPlayer.h */,
 				E485F6CF1360A90000E939D3 /* ofBaseSoundPlayer.cpp */,
@@ -894,7 +888,6 @@
 				E485F81A1363242200E939D3 /* ofxMultiTouch.h in Headers */,
 				E485F81B1363242200E939D3 /* ofxMultiTouchListener.h in Headers */,
 				772C25191469274B00DDAAE6 /* ofOpenALSoundPlayer.h in Headers */,
-				772C251D146927A500DDAAE6 /* ofFmodSoundPlayer.h in Headers */,
 				15594F0F15C55AC900727FF2 /* EAGLView.h in Headers */,
 				15594F1015C55AC900727FF2 /* ES1Renderer.h in Headers */,
 				15594F1115C55AC900727FF2 /* ES2Renderer.h in Headers */,
@@ -1022,7 +1015,6 @@
 				E485F7941360A90000E939D3 /* ofVideoPlayer.cpp in Sources */,
 				E485F8191363242200E939D3 /* ofxMultiTouch.cpp in Sources */,
 				772C25181469274B00DDAAE6 /* ofOpenALSoundPlayer.cpp in Sources */,
-				772C251C146927A500DDAAE6 /* ofFmodSoundPlayer.cpp in Sources */,
 				15594F0C15C55AC900727FF2 /* EAGLView.m in Sources */,
 				15594F0D15C55AC900727FF2 /* ES1Renderer.m in Sources */,
 				15594F0E15C55AC900727FF2 /* ES2Renderer.m in Sources */,


### PR DESCRIPTION
... issues with nightly builds.

When testing nightly builds having the ofFmodSoundPlayer files in the OF xcode project was causing compile errors with some examples. 

Pointed out in #1629 

This PR removes the .cpp and .h from the OF project. 
