### PR TITLE
ios-bugfix-ios6-armv7s

### DIFF
--- a/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 				<string>ofxiphone-Info.plist</string>
 				<key>PRODUCT_NAME</key>
 				<string>${TARGET_NAME}</string>
+                <key>VALID_ARCHS</key>
+				<string>armv6 armv7</string>
 			</dict>
 			<key>isa</key>
 			<string>XCBuildConfiguration</string>
@@ -166,6 +168,8 @@
 				<string>ofxiphone-Info.plist</string>
 				<key>PRODUCT_NAME</key>
 				<string>${TARGET_NAME}</string>
+                <key>VALID_ARCHS</key>
+				<string>armv6 armv7</string>
 			</dict>
 			<key>isa</key>
 			<string>XCBuildConfiguration</string>


### PR DESCRIPTION
ios xcode project valid architecture is now set to armv6 armv7 by default.
this fixes issue #1615
