### PR TITLE
fix - ofMesh.load() resolves an issue where Normals wouldn't be loaded

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -898,9 +898,9 @@ void ofMesh::load(string path){
 			currentFace++;
 			if(currentFace==data.getNumIndices()/3){
 				if(orderVertices<orderIndices){
-					state = Faces;
-				}else{
 					state = Vertices;
+				}else{
+					state = Faces;
 				}
 			}
 			continue;


### PR DESCRIPTION
## issue

When saving a .ply file using ofMesh::save(), Normals are stored as vertex element properties. This is in line with the .ply file format specs. 

In ofMesh.load() Normals are, however, not imported back in again, since ofMesh.load() expects normals to be in a separate element list. 
## test case

See test case here:

http://github.com/tgfrerer/testMeshLoader
## fix proposed

Attached fix brings ofMesh::load() in line with ofMesh::save() and the .ply file format specs. It loads normals as vertex element attributes, if normals are declared & stored in the .ply file.
