### PR TITLE
Add ofGetVersionMajor(), ofGetVersionMinor() to ofUtils

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -661,6 +661,10 @@ unsigned int ofGetVersionMinor() {
 	return OF_VERSION_MINOR;
 }
 
+unsigned int ofGetVersionPatch() {
+	return OF_VERSION_PATCH;
+}
+
 //---- new to 006
 //from the forums http://www.openframeworks.cc/forum/viewtopic.php?t=1413
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -176,6 +176,7 @@ string ofBinaryToString(const string& value);
 string 	ofGetVersionInfo();
 unsigned int ofGetVersionMajor();
 unsigned int ofGetVersionMinor();
+unsigned int ofGetVersionPatch();
 
 void	ofSaveScreen(string filename);
 void	ofSaveFrame(bool bUseViewport = false);


### PR DESCRIPTION
They return `OF_VERSION` and `OF_VERSION_MINOR` respectively. I wrote them because [Zajal](https://github.com/nasser/zajal) uses openFrameworks as [a shared library](https://github.com/nasser/zajal/tree/amsterdam/lib/core/lib), and can only see functions, not `#define`s. 

Although you can use the `#define`s from normal openFrameworks C++ projects, this patch brings internal version information under the more standard syntax.
