### PR TITLE
Add ofCurveVertex(x, y, z) overload

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -855,6 +855,11 @@ void ofCurveVertex(float x, float y){
 	shape.curveTo(x,y);
 }
 
+//---------------------------------------------------
+void ofCurveVertex(float x, float y, float z){
+	shape.curveTo(x,y,z);
+}
+
 //----------------------------------------------------------
 void ofCurveVertices( const vector <ofPoint> & curvePoints){
 	for( int k = 0; k < (int)curvePoints.size(); k++){

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -198,6 +198,7 @@ OF_DEPRECATED_MSG("Use ofVertices instead.", void ofVertexes(const vector <ofPoi
 
 
 void ofCurveVertex(float x, float y);
+void ofCurveVertex(float x, float y, float z);
 void ofCurveVertex(ofPoint & p);
 void ofCurveVertices(const vector <ofPoint> & curvePoints);
 OF_DEPRECATED_MSG("Use ofCurveVertices instead.", void ofCurveVertexes(const vector <ofPoint> & curvePoints));


### PR DESCRIPTION
For consistency with `ofVertex` and `ofBezierVertex`
