### PR TITLE
more matrices utils + ofCamera independent from openGL

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -96,28 +96,20 @@ void ofCamera::begin(ofRectangle viewport) {
 	// autocalculate near/far clip planes if not set by user
 	calcClipPlanes(viewport);
 
-	glMatrixMode(GL_PROJECTION);
+	ofMatrixMode(OF_MATRIX_PROJECTION);
 	ofLoadIdentityMatrix();
 	
 	if(isOrtho) {
-		//			if(vFlip) glOrtho(0, width, height, 0, nearDist, farDist);
-		//			else
-#ifndef TARGET_OPENGLES
-		glOrtho(0, viewport.width, 0, viewport.height, nearClip, farClip);
-#else
 		ofMatrix4x4 ortho;
 		ortho.makeOrthoMatrix(0, viewport.width, 0, viewport.height, nearClip, farClip);
 		ofLoadMatrix( ortho );
-#endif
 	} else {
-		
 		ofMatrix4x4 persp;
 		persp.makePerspectiveMatrix( fov, viewport.width/viewport.height, nearClip, farClip );
 		ofLoadMatrix( persp );
-		//gluPerspective(fov, viewport.width/viewport.height, nearClip, farClip);
 	}
 
-	glMatrixMode(GL_MODELVIEW);
+	ofMatrixMode(OF_MATRIX_MODELVIEW);
 	ofLoadMatrix( ofMatrix4x4::getInverseOf(getGlobalTransformMatrix()) );
 	ofViewport(viewport);
 }

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -440,17 +440,6 @@ void ofGLRenderer::setupScreenOrtho(float width, float height, ofOrientation ori
 	glLoadIdentity();
 
 	ofSetCoordHandedness(OF_RIGHT_HANDED);
-#ifndef TARGET_OPENGLES
-	if(vFlip) {
-		ofSetCoordHandedness(OF_LEFT_HANDED);
-	}
-
-	if(nearDist == -1) nearDist = 0;
-	if(farDist == -1) farDist = 10000;
-	
-	glOrtho(0, viewW, 0, viewH, nearDist, farDist);
-
-#else
 	if(vFlip) {
 		ofMatrix4x4 ortho = ofMatrix4x4::newOrthoMatrix(0, width, height, 0, nearDist, farDist);
 		ofSetCoordHandedness(OF_LEFT_HANDED);
@@ -458,7 +447,6 @@ void ofGLRenderer::setupScreenOrtho(float width, float height, ofOrientation ori
 	
 	ofMatrix4x4 ortho = ofMatrix4x4::newOrthoMatrix(0, viewW, 0, viewH, nearDist, farDist);
 	glMultMatrixf(ortho.getPtr());	
-#endif
 
 	glMatrixMode(GL_MODELVIEW);
 	glLoadIdentity();
@@ -686,6 +674,10 @@ void ofGLRenderer::rotate(float degrees){
 	glRotatef(degrees, 0, 0, 1);
 }
 
+//----------------------------------------------------------
+void ofGLRenderer::matrixMode(ofMatrixMode mode){
+	glMatrixMode(GL_MODELVIEW+mode);
+}
 
 //----------------------------------------------------------
 void ofGLRenderer::loadIdentityMatrix (void){

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -64,6 +64,7 @@ public:
 	void rotateY(float degrees);
 	void rotateZ(float degrees);
 	void rotate(float degrees);
+	void matrixMode(ofMatrixMode mode);
 	void loadIdentityMatrix (void);
 	void loadMatrix (const ofMatrix4x4 & m);
 	void loadMatrix (const float * m);

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -37,6 +37,7 @@ ofCairoRenderer::ofCairoRenderer(){
 	multiPage = false;
 	bFilled = OF_FILLED;
 	b3D = false;
+	currentMatrixMode=OF_MATRIX_MODELVIEW;
 }
 
 ofCairoRenderer::~ofCairoRenderer(){
@@ -720,6 +721,67 @@ void ofCairoRenderer::rotateZ(float degrees){
 
 void ofCairoRenderer::rotate(float degrees){
 	rotateZ(degrees);
+}
+
+void ofCairoRenderer::matrixMode(ofMatrixMode mode){
+	currentMatrixMode = mode;
+}
+
+void ofCairoRenderer::loadIdentityMatrix (void){
+	if(!surface || !cr) return;
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		cairo_matrix_init_identity(getCairoMatrix());
+		setCairoMatrix();
+	}
+
+	if(!b3D) return;
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		modelView.makeIdentityMatrix();
+	}else if(currentMatrixMode==OF_MATRIX_PROJECTION){
+		projection.makeIdentityMatrix();
+	}
+}
+
+void ofCairoRenderer::loadMatrix (const ofMatrix4x4 & m){
+	if(!surface || !cr) return;
+	if(!b3D) return;
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		modelView = m;
+	}else if(currentMatrixMode==OF_MATRIX_PROJECTION){
+		projection = m;
+	}
+}
+
+void ofCairoRenderer::loadMatrix (const float * m){
+	if(!surface || !cr) return;
+	if(!b3D) return;
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		modelView.set(m);
+	}else if(currentMatrixMode==OF_MATRIX_PROJECTION){
+		projection.set(m);
+	}
+
+}
+
+void ofCairoRenderer::multMatrix (const ofMatrix4x4 & m){
+	if(!surface || !cr) return;
+	if(!b3D) return;
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		modelView *= m;
+	}else if(currentMatrixMode==OF_MATRIX_PROJECTION){
+		projection *= m;
+	}
+}
+
+void ofCairoRenderer::multMatrix (const float * m){
+	if(!surface || !cr) return;
+	if(!b3D) return;
+	ofMatrix4x4 mat(m);
+	if(currentMatrixMode==OF_MATRIX_MODELVIEW){
+		modelView *= mat;
+	}else if(currentMatrixMode==OF_MATRIX_PROJECTION){
+		projection *= mat;
+	}
 }
 
 void ofCairoRenderer::rotate(float degrees, float vecX, float vecY, float vecZ){

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -85,6 +85,12 @@ public:
 	void rotateY(float degrees);
 	void rotateZ(float degrees);
 	void rotate(float degrees);
+	void matrixMode(ofMatrixMode mode);
+	void loadIdentityMatrix (void);
+	void loadMatrix (const ofMatrix4x4 & m);
+	void loadMatrix (const float * m);
+	void multMatrix (const ofMatrix4x4 & m);
+	void multMatrix (const float * m);
 
 	// screen coordinate things / default gl values
 	void setupGraphicDefaults();
@@ -157,6 +163,8 @@ private:
 	stack<ofMatrix4x4> modelViewStack;
 	stack<ofRectangle> viewportStack;
 	
+	ofMatrixMode currentMatrixMode;
+
 	vector<ofPoint> sphereVerts;
 	vector<ofPoint> spherePoints;
 

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -319,6 +319,7 @@ public:
 	virtual void rotateY(float degrees){};
 	virtual void rotateZ(float degrees){};
 	virtual void rotate(float degrees){};
+	virtual void matrixMode(ofMatrixMode mode){};
 	virtual void loadIdentityMatrix (void){};
 	virtual void loadMatrix (const ofMatrix4x4 & m){};
 	virtual void loadMatrix (const float *m){};

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -489,6 +489,7 @@ enum ofPolyWindingMode{
 
 enum ofHandednessType {OF_LEFT_HANDED, OF_RIGHT_HANDED};
 
+enum ofMatrixMode {OF_MATRIX_MODELVIEW=0, OF_MATRIX_PROJECTION, OF_MATRIX_TEXTURE};
 
 //--------------------------------------------
 //


### PR DESCRIPTION
This complements @andreasmuller PR for matrices:

adds load/mult methods to cairo
adds ofMatrixMode (only thing missing to make ofCamera independent from openGL)
ofCamera now independent from openGL, working on cairo with 3d activated
