### PR TITLE
fixes ofGetElapsedTimef() and ofGetElapsedTimeMicros() wrapping after ~71 min

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -59,7 +59,7 @@ unsigned long ofGetElapsedTimeMicros(){
 
 //--------------------------------------
 float ofGetElapsedTimef(){
-	return ofGetElapsedTimeMicros() / 1000000.0f;
+	return ofGetElapsedTimeMillis() / 1000.0f;
 }
 
 //--------------------------------------


### PR DESCRIPTION
this branch fixes the bug by reverting to using milliseconds for ofGetElapsedTimef(), but leaves ofGetElapsedTimeMicros() "broken".
