### PR TITLE
Fix for #1732.

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -312,6 +312,7 @@ typedef ofBaseApp ofSimpleApp;
 #include <iomanip>  //for setprecision
 #include <fstream>
 #include <algorithm>
+#include <cfloat>
 using namespace std;
 
 #ifndef PI


### PR DESCRIPTION
Include cfloat globally so we have access to FLT_EPSILON. Closes #1732.
