### PR TITLE
fixed ofxOsc for vs2010 by removing redclared int type

### DIFF
--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -71,11 +71,6 @@ subclasses for each possible argument type
 
 */
 
-#if defined TARGET_WIN32 && defined _MSC_VER
-	// required because MSVC isn't ANSI-C compliant
-	typedef long int32_t;
-#endif
-
 class ofxOscArgInt32 : public ofxOscArg
 {
 public:


### PR DESCRIPTION
ofxOsc wasn't compiling in vs2010 for me, and this fixed it. unless someone sees something wrong with this approach i'll merge it.
