### PR TITLE
ofEvents: remove OF_USING_POCO conditionals

### DIFF
--- a/libs/openFrameworks/events/ofEventUtils.h
+++ b/libs/openFrameworks/events/ofEventUtils.h
@@ -1,10 +1,6 @@
-#ifndef _OF_EVENTS
-#error "ofEventUtils shouldn't be included directly, include ofEvents.h or ofMain.h"
-#endif
+#pragma once
 
 #include "ofConstants.h"
-
-#ifdef OF_USING_POCO
 
 #include "Poco/FIFOEvent.h"
 #include "Poco/Delegate.h"
@@ -110,4 +106,3 @@ static void ofNotifyEvent(EventType & event, const ArgumentsType & args){
 	event.notify(NULL,args);
 }
 
-#endif

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -6,14 +6,12 @@
 #include <set>
 
 // core events instance & arguments
-#ifdef OF_USING_POCO
-	ofCoreEvents & ofEvents(){
-		static ofCoreEvents * events = new ofCoreEvents;
-		return *events;
-	}
+ofCoreEvents & ofEvents(){
+	static ofCoreEvents * events = new ofCoreEvents;
+	return *events;
+}
 
-	ofEventArgs voidEventArgs;
-#endif
+ofEventArgs voidEventArgs;
 
 
 static int	currentMouseX=0, currentMouseY=0;
@@ -76,9 +74,7 @@ void ofNotifySetup(){
 	if(ofAppPtr){
 		ofAppPtr->setup();
 	}
-	#ifdef OF_USING_POCO
-		ofNotifyEvent( ofEvents().setup, voidEventArgs );
-	#endif
+	ofNotifyEvent( ofEvents().setup, voidEventArgs );
 }
 
 //------------------------------------------
@@ -90,9 +86,7 @@ void ofNotifyUpdate(){
 	if(ofAppPtr){
 		ofAppPtr->update();
 	}
-	#ifdef OF_USING_POCO
-		ofNotifyEvent( ofEvents().update, voidEventArgs );
-	#endif
+	ofNotifyEvent( ofEvents().update, voidEventArgs );
 }
 
 //------------------------------------------
@@ -102,9 +96,7 @@ void ofNotifyDraw(){
 	if(ofAppPtr){
 		ofAppPtr->draw();
 	}
-	#ifdef OF_USING_POCO
-		ofNotifyEvent( ofEvents().draw, voidEventArgs );
-	#endif
+	ofNotifyEvent( ofEvents().draw, voidEventArgs );
 }
 
 //------------------------------------------
@@ -118,10 +110,8 @@ void ofNotifyKeyPressed(int key){
 		ofAppPtr->keyPressed(key);
 	}
 	
-	#ifdef OF_USING_POCO
-		keyEventArgs.key = key;
-		ofNotifyEvent( ofEvents().keyPressed, keyEventArgs );
-	#endif
+	keyEventArgs.key = key;
+	ofNotifyEvent( ofEvents().keyPressed, keyEventArgs );
 	
 	
 	if (key == OF_KEY_ESC && bEscQuits == true){				// "escape"
@@ -142,10 +132,8 @@ void ofNotifyKeyReleased(int key){
 		ofAppPtr->keyReleased(key);
 	}
 	
-	#ifdef OF_USING_POCO
-		keyEventArgs.key = key;
-		ofNotifyEvent( ofEvents().keyReleased, keyEventArgs );
-	#endif
+	keyEventArgs.key = key;
+	ofNotifyEvent( ofEvents().keyReleased, keyEventArgs );
 }
 
 //------------------------------------------
@@ -171,12 +159,10 @@ void ofNotifyMousePressed(int x, int y, int button){
 		ofAppPtr->mouseY = y;
 	}
 
-	#ifdef OF_USING_POCO
-		mouseEventArgs.x = x;
-		mouseEventArgs.y = y;
-		mouseEventArgs.button = button;
-		ofNotifyEvent( ofEvents().mousePressed, mouseEventArgs );
-	#endif
+	mouseEventArgs.x = x;
+	mouseEventArgs.y = y;
+	mouseEventArgs.button = button;
+	ofNotifyEvent( ofEvents().mousePressed, mouseEventArgs );
 }
 
 //------------------------------------------
@@ -204,12 +190,10 @@ void ofNotifyMouseReleased(int x, int y, int button){
 		ofAppPtr->mouseY = y;
 	}
 
-	#ifdef OF_USING_POCO
-		mouseEventArgs.x = x;
-		mouseEventArgs.y = y;
-		mouseEventArgs.button = button;
-		ofNotifyEvent( ofEvents().mouseReleased, mouseEventArgs );
-	#endif
+	mouseEventArgs.x = x;
+	mouseEventArgs.y = y;
+	mouseEventArgs.button = button;
+	ofNotifyEvent( ofEvents().mouseReleased, mouseEventArgs );
 }
 
 //------------------------------------------
@@ -235,12 +219,10 @@ void ofNotifyMouseDragged(int x, int y, int button){
 		ofAppPtr->mouseY = y;
 	}
 
-	#ifdef OF_USING_POCO
-		mouseEventArgs.x = x;
-		mouseEventArgs.y = y;
-		mouseEventArgs.button = button;
-		ofNotifyEvent( ofEvents().mouseDragged, mouseEventArgs );
-	#endif
+	mouseEventArgs.x = x;
+	mouseEventArgs.y = y;
+	mouseEventArgs.button = button;
+	ofNotifyEvent( ofEvents().mouseDragged, mouseEventArgs );
 }
 
 //------------------------------------------
@@ -265,11 +247,9 @@ void ofNotifyMouseMoved(int x, int y){
 		ofAppPtr->mouseY = y;
 	}
 
-	#ifdef OF_USING_POCO
-		mouseEventArgs.x = x;
-		mouseEventArgs.y = y;
-		ofNotifyEvent( ofEvents().mouseMoved, mouseEventArgs );
-	#endif
+	mouseEventArgs.x = x;
+	mouseEventArgs.y = y;
+	ofNotifyEvent( ofEvents().mouseMoved, mouseEventArgs );
 }
 
 //------------------------------------------
@@ -278,9 +258,7 @@ void ofNotifyExit(){
 	if(ofAppPtr){
 		ofAppPtr->exit();
 	}
-	#ifdef OF_USING_POCO
-		ofNotifyEvent( ofEvents().exit, voidEventArgs );
-	#endif
+	ofNotifyEvent( ofEvents().exit, voidEventArgs );
 }
 
 //------------------------------------------
@@ -292,11 +270,9 @@ void ofNotifyWindowResized(int width, int height){
 		ofAppPtr->windowResized(width, height);
 	}
 	
-	#ifdef OF_USING_POCO
-		resizeEventArgs.width	= width;
-		resizeEventArgs.height	= height;
-		ofNotifyEvent( ofEvents().windowResized, resizeEventArgs );
-	#endif
+	resizeEventArgs.width	= width;
+	resizeEventArgs.height	= height;
+	ofNotifyEvent( ofEvents().windowResized, resizeEventArgs );
 }
 
 //------------------------------------------
@@ -306,9 +282,7 @@ void ofNotifyDragEvent(ofDragInfo info){
 		ofAppPtr->dragEvent(info);
 	}
 	
-	#ifdef OF_USING_POCO
-		ofNotifyEvent(ofEvents().fileDragEvent, info);
-	#endif
+	ofNotifyEvent(ofEvents().fileDragEvent, info);
 }
 
 //------------------------------------------
@@ -318,9 +292,7 @@ void ofSendMessage(ofMessage msg){
 		ofAppPtr->gotMessage(msg);
 	}
 	
-	#ifdef OF_USING_POCO
-		ofNotifyEvent(ofEvents().messageEvent, msg);
-	#endif
+	ofNotifyEvent(ofEvents().messageEvent, msg);
 }
 
 //------------------------------------------
@@ -338,9 +310,7 @@ void ofNotifyWindowEntry( int state ) {
 		ofAppPtr->windowEntry(state);
 	}
 	
-#ifdef OF_USING_POCO
 	entryArgs.state = state;
 	ofNotifyEvent(ofEvents().windowEntered, entryArgs);
-#endif
 	
 }

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -2,6 +2,7 @@
 
 #include "ofConstants.h"
 #include "ofPoint.h"
+#include "ofEventUtils.h"
 
 //-------------------------- mouse/key query
 bool		ofGetMousePressed(int button=-1); //by default any button
@@ -24,230 +25,219 @@ class ofDragInfo{
 		ofPoint position;
 };
 
+
 //-----------------------------------------------
+// event arguments, this are used in oF to pass
+// the data when notifying events
 
-#ifdef OF_USING_POCO
-	#define _OF_EVENTS
-	#ifndef OF_EVENTS_ADDON
-		#include "ofEventUtils.h"
+class ofEventArgs{};
 
-		//-----------------------------------------------
-		// event arguments, this are used in oF to pass
-		// the data when notifying events
+class ofEntryEventArgs : public ofEventArgs {
+public:
+	int state;
+};
 
-		class ofEventArgs{};
+class ofKeyEventArgs : public ofEventArgs {
+  public:
+	int key;
+};
 
-		class ofEntryEventArgs : public ofEventArgs {
-		public:
-			int state;
-		};
+class ofMouseEventArgs : public ofEventArgs {
+  public:
+	int x;
+	int y;
+	int button;
+};
 
-		class ofKeyEventArgs : public ofEventArgs {
-		  public:
-			int key;
-		};
+class ofTouchEventArgs : public ofEventArgs {
+  public:
+	enum Type{
+		down,
+		up,
+		move,
+		doubleTap,
+		cancel
+	} type;
 
-		class ofMouseEventArgs : public ofEventArgs {
-		  public:
-			int x;
-			int y;
-			int button;
-		};
+	int id;
+	int time;
+	float x, y;
+	int numTouches;
+	float width, height;
+	float angle;
+	float minoraxis, majoraxis;
+	float pressure;
+	float xspeed, yspeed;
+	float xaccel, yaccel;
+};
 
-		class ofTouchEventArgs : public ofEventArgs {
-		  public:
-			enum Type{
-				down,
-				up,
-				move,
-				doubleTap,
-				cancel
-			} type;
+class ofAudioEventArgs : public ofEventArgs {
+  public:
+	float* buffer;
+	int bufferSize;
+	int nChannels;
+};
 
-			int id;
-			int time;
-			float x, y;
-			int numTouches;
-			float width, height;
-			float angle;
-			float minoraxis, majoraxis;
-			float pressure;
-			float xspeed, yspeed;
-			float xaccel, yaccel;
-		};
+class ofResizeEventArgs : public ofEventArgs {
+  public:
+	int width;
+	int height;
+};
 
-		class ofAudioEventArgs : public ofEventArgs {
-		  public:
-			float* buffer;
-			int bufferSize;
-			int nChannels;
-		};
-
-		class ofResizeEventArgs : public ofEventArgs {
-		  public:
-			int width;
-			int height;
-		};
-		
-		class ofMessage : public ofEventArgs{
-			public:
-				ofMessage( string msg ){
-					message = msg;
-				}
-				string message;
-		};
-		
-	#else
-		#include "ofxEventUtils.h"
-	#endif
-
-	class ofCoreEvents {
-	  public:
-		ofEvent<ofEventArgs> 		setup;
-		ofEvent<ofEventArgs> 		update;
-		ofEvent<ofEventArgs> 		draw;
-		ofEvent<ofEventArgs> 		exit;
-		
-		ofEvent<ofEntryEventArgs>	windowEntered;
-		ofEvent<ofResizeEventArgs> 	windowResized;
-
-		ofEvent<ofKeyEventArgs> 	keyPressed;
-		ofEvent<ofKeyEventArgs> 	keyReleased;
-
-		ofEvent<ofMouseEventArgs> 	mouseMoved;
-		ofEvent<ofMouseEventArgs> 	mouseDragged;
-		ofEvent<ofMouseEventArgs> 	mousePressed;
-		ofEvent<ofMouseEventArgs> 	mouseReleased;
-
-		ofEvent<ofAudioEventArgs> 	audioReceived;
-		ofEvent<ofAudioEventArgs> 	audioRequested;
-
-		ofEvent<ofTouchEventArgs>	touchDown;
-		ofEvent<ofTouchEventArgs>	touchUp;
-		ofEvent<ofTouchEventArgs>	touchMoved;
-		ofEvent<ofTouchEventArgs>	touchDoubleTap;
-		ofEvent<ofTouchEventArgs>	touchCancelled;
-
-		ofEvent<ofMessage>			messageEvent;
-		ofEvent<ofDragInfo>			fileDragEvent;
-
-		void disable(){
-			setup.disable();
-			draw.disable();
-			update.disable();
-			exit.disable();
-			keyPressed.disable();
-			keyReleased.disable();
-			mouseDragged.disable();
-			mouseReleased.disable();
-			mousePressed.disable();
-			mouseMoved.disable();
-			audioReceived.disable();
-			audioRequested.disable();
-			touchDown.disable();
-			touchUp.disable();
-			touchMoved.disable();
-			touchDoubleTap.disable();
-			touchCancelled.disable();
-			messageEvent.disable();
-			fileDragEvent.disable();
+class ofMessage : public ofEventArgs{
+	public:
+		ofMessage( string msg ){
+			message = msg;
 		}
+		string message;
+};
+		
 
-		void enable(){
-			setup.enable();
-			draw.enable();
-			update.enable();
-			exit.enable();
-			keyPressed.enable();
-			keyReleased.enable();
-			mouseDragged.enable();
-			mouseReleased.enable();
-			mousePressed.enable();
-			mouseMoved.enable();
-			audioReceived.enable();
-			audioRequested.enable();
-			touchDown.enable();
-			touchUp.enable();
-			touchMoved.enable();
-			touchDoubleTap.enable();
-			touchCancelled.enable();
-			messageEvent.enable();
-			fileDragEvent.enable();
-		}
-	};
+class ofCoreEvents {
+  public:
+	ofEvent<ofEventArgs> 		setup;
+	ofEvent<ofEventArgs> 		update;
+	ofEvent<ofEventArgs> 		draw;
+	ofEvent<ofEventArgs> 		exit;
 
-	void ofSendMessage(ofMessage msg);
-	void ofSendMessage(string messageString);
+	ofEvent<ofEntryEventArgs>	windowEntered;
+	ofEvent<ofResizeEventArgs> 	windowResized;
 
-	ofCoreEvents & ofEvents();
+	ofEvent<ofKeyEventArgs> 	keyPressed;
+	ofEvent<ofKeyEventArgs> 	keyReleased;
 
-	template<class ListenerClass>
-	void ofRegisterMouseEvents(ListenerClass * listener){
-		ofAddListener(ofEvents().mouseDragged,listener,&ListenerClass::mouseDragged);
-		ofAddListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved);
-		ofAddListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed);
-		ofAddListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased);
+	ofEvent<ofMouseEventArgs> 	mouseMoved;
+	ofEvent<ofMouseEventArgs> 	mouseDragged;
+	ofEvent<ofMouseEventArgs> 	mousePressed;
+	ofEvent<ofMouseEventArgs> 	mouseReleased;
+
+	ofEvent<ofAudioEventArgs> 	audioReceived;
+	ofEvent<ofAudioEventArgs> 	audioRequested;
+
+	ofEvent<ofTouchEventArgs>	touchDown;
+	ofEvent<ofTouchEventArgs>	touchUp;
+	ofEvent<ofTouchEventArgs>	touchMoved;
+	ofEvent<ofTouchEventArgs>	touchDoubleTap;
+	ofEvent<ofTouchEventArgs>	touchCancelled;
+
+	ofEvent<ofMessage>			messageEvent;
+	ofEvent<ofDragInfo>			fileDragEvent;
+
+	void disable(){
+		setup.disable();
+		draw.disable();
+		update.disable();
+		exit.disable();
+		keyPressed.disable();
+		keyReleased.disable();
+		mouseDragged.disable();
+		mouseReleased.disable();
+		mousePressed.disable();
+		mouseMoved.disable();
+		audioReceived.disable();
+		audioRequested.disable();
+		touchDown.disable();
+		touchUp.disable();
+		touchMoved.disable();
+		touchDoubleTap.disable();
+		touchCancelled.disable();
+		messageEvent.disable();
+		fileDragEvent.disable();
 	}
 
-	template<class ListenerClass>
-	void ofRegisterKeyEvents(ListenerClass * listener){
-		ofAddListener(ofEvents().keyPressed, listener, &ListenerClass::keyPressed);
-		ofAddListener(ofEvents().keyReleased, listener, &ListenerClass::keyReleased);
+	void enable(){
+		setup.enable();
+		draw.enable();
+		update.enable();
+		exit.enable();
+		keyPressed.enable();
+		keyReleased.enable();
+		mouseDragged.enable();
+		mouseReleased.enable();
+		mousePressed.enable();
+		mouseMoved.enable();
+		audioReceived.enable();
+		audioRequested.enable();
+		touchDown.enable();
+		touchUp.enable();
+		touchMoved.enable();
+		touchDoubleTap.enable();
+		touchCancelled.enable();
+		messageEvent.enable();
+		fileDragEvent.enable();
 	}
+};
 
-	template<class ListenerClass>
-	void ofRegisterTouchEvents(ListenerClass * listener){
-		ofAddListener(ofEvents().touchDoubleTap, listener, &ListenerClass::touchDoubleTap);
-		ofAddListener(ofEvents().touchDown, listener, &ListenerClass::touchDown);
-		ofAddListener(ofEvents().touchMoved, listener, &ListenerClass::touchMoved);
-		ofAddListener(ofEvents().touchUp, listener, &ListenerClass::touchUp);
-		ofAddListener(ofEvents().touchCancelled, listener, &ListenerClass::touchCancelled);
-	}
+void ofSendMessage(ofMessage msg);
+void ofSendMessage(string messageString);
 
-	template<class ListenerClass>
-	void ofRegisterGetMessages(ListenerClass * listener){
-		ofAddListener(ofEvents().messageEvent, listener, &ListenerClass::gotMessage);
-	}
+ofCoreEvents & ofEvents();
 
-	template<class ListenerClass>
-	void ofRegisterDragEvents(ListenerClass * listener){
-		ofAddListener(ofEvents().fileDragEvent, listener, &ListenerClass::dragEvent);
-	}
+template<class ListenerClass>
+void ofRegisterMouseEvents(ListenerClass * listener){
+	ofAddListener(ofEvents().mouseDragged,listener,&ListenerClass::mouseDragged);
+	ofAddListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved);
+	ofAddListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed);
+	ofAddListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased);
+}
 
-	template<class ListenerClass>
-	void ofUnregisterMouseEvents(ListenerClass * listener){
-		ofRemoveListener(ofEvents().mouseDragged,listener,&ListenerClass::mouseDragged);
-		ofRemoveListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved);
-		ofRemoveListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed);
-		ofRemoveListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased);
-	}
+template<class ListenerClass>
+void ofRegisterKeyEvents(ListenerClass * listener){
+	ofAddListener(ofEvents().keyPressed, listener, &ListenerClass::keyPressed);
+	ofAddListener(ofEvents().keyReleased, listener, &ListenerClass::keyReleased);
+}
 
-	template<class ListenerClass>
-	void ofUnregisterKeyEvents(ListenerClass * listener){
-		ofRemoveListener(ofEvents().keyPressed, listener, &ListenerClass::keyPressed);
-		ofRemoveListener(ofEvents().keyReleased, listener, &ListenerClass::keyReleased);
-	}
+template<class ListenerClass>
+void ofRegisterTouchEvents(ListenerClass * listener){
+	ofAddListener(ofEvents().touchDoubleTap, listener, &ListenerClass::touchDoubleTap);
+	ofAddListener(ofEvents().touchDown, listener, &ListenerClass::touchDown);
+	ofAddListener(ofEvents().touchMoved, listener, &ListenerClass::touchMoved);
+	ofAddListener(ofEvents().touchUp, listener, &ListenerClass::touchUp);
+	ofAddListener(ofEvents().touchCancelled, listener, &ListenerClass::touchCancelled);
+}
 
-	template<class ListenerClass>
-	void ofUnregisterTouchEvents(ListenerClass * listener){
-		ofRemoveListener(ofEvents().touchDoubleTap, listener, &ListenerClass::touchDoubleTap);
-		ofRemoveListener(ofEvents().touchDown, listener, &ListenerClass::touchDown);
-		ofRemoveListener(ofEvents().touchMoved, listener, &ListenerClass::touchMoved);
-		ofRemoveListener(ofEvents().touchUp, listener, &ListenerClass::touchUp);
-		ofRemoveListener(ofEvents().touchCancelled, listener, &ListenerClass::touchCancelled);
-	}
+template<class ListenerClass>
+void ofRegisterGetMessages(ListenerClass * listener){
+	ofAddListener(ofEvents().messageEvent, listener, &ListenerClass::gotMessage);
+}
 
-	template<class ListenerClass>
-	void ofUnregisterGetMessages(ListenerClass * listener){
-		ofRemoveListener(ofEvents().messageEvent, listener, &ListenerClass::gotMessage);
-	}
-	
-	template<class ListenerClass>
-	void ofUnregisterDragEvents(ListenerClass * listener){
-		ofRemoveListener(ofEvents().fileDragEvent, listener, &ListenerClass::dragEvent);
-	}	
+template<class ListenerClass>
+void ofRegisterDragEvents(ListenerClass * listener){
+	ofAddListener(ofEvents().fileDragEvent, listener, &ListenerClass::dragEvent);
+}
 
-#endif
+template<class ListenerClass>
+void ofUnregisterMouseEvents(ListenerClass * listener){
+	ofRemoveListener(ofEvents().mouseDragged,listener,&ListenerClass::mouseDragged);
+	ofRemoveListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved);
+	ofRemoveListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed);
+	ofRemoveListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased);
+}
+
+template<class ListenerClass>
+void ofUnregisterKeyEvents(ListenerClass * listener){
+	ofRemoveListener(ofEvents().keyPressed, listener, &ListenerClass::keyPressed);
+	ofRemoveListener(ofEvents().keyReleased, listener, &ListenerClass::keyReleased);
+}
+
+template<class ListenerClass>
+void ofUnregisterTouchEvents(ListenerClass * listener){
+	ofRemoveListener(ofEvents().touchDoubleTap, listener, &ListenerClass::touchDoubleTap);
+	ofRemoveListener(ofEvents().touchDown, listener, &ListenerClass::touchDown);
+	ofRemoveListener(ofEvents().touchMoved, listener, &ListenerClass::touchMoved);
+	ofRemoveListener(ofEvents().touchUp, listener, &ListenerClass::touchUp);
+	ofRemoveListener(ofEvents().touchCancelled, listener, &ListenerClass::touchCancelled);
+}
+
+template<class ListenerClass>
+void ofUnregisterGetMessages(ListenerClass * listener){
+	ofRemoveListener(ofEvents().messageEvent, listener, &ListenerClass::gotMessage);
+}
+
+template<class ListenerClass>
+void ofUnregisterDragEvents(ListenerClass * listener){
+	ofRemoveListener(ofEvents().fileDragEvent, listener, &ListenerClass::dragEvent);
+}
 
 //  event notification only for internal OF use
 void ofNotifySetup();


### PR DESCRIPTION
removes OF_USING_POCO conditionals from ofEvents and ofEventUtils.  Poco is used in other places in the core without ifdefs and is supported in all platforms.

having the ifdefs was avoiding doxygen to parse certain functions so they won't appear in the documentation
