### PR TITLE
Windows microsecond timer overflow fix.

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -100,9 +100,9 @@ unsigned long long ofGetSystemTimeMicros( ) {
 			(unsigned long long) now.tv_sec*1000000;
 	#else
 		#if defined(_WIN32_WCE)
-			return GetTickCount()*1000;
+			return ((unsigned long long)GetTickCount()) * 1000;
 		#else
-			return timeGetTime()*1000;
+			return ((unsigned long long)timeGetTime()) * 1000;
 		#endif
 	#endif
 }


### PR DESCRIPTION
I've fixed an overflow in ofGetSystemTimeMicros() on Windows. I first noticed the bug when ofAppGlutWindow::getLastFrameTime() started constantly returning 0, freezing animations etc that relied on frame timings. This is the first time I've used github, and I apologise for any mistakes made submitting this fix.

Hope you find this useful.
-Jason
