### PR TITLE
android: add unloadTextures method to ofxAndroidApp

### DIFF
--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -307,6 +307,9 @@ Java_cc_openframeworks_OFAndroid_onSurfaceDestroyed( JNIEnv*  env, jclass  thiz 
 	ofLog(OF_LOG_NOTICE,"onSurfaceDestroyed");
 	ofUnloadAllFontTextures();
 	ofPauseVideoGrabbers();
+	if(androidApp){
+		androidApp->unloadTextures();
+	}
 }
 
 void
@@ -315,6 +318,9 @@ Java_cc_openframeworks_OFAndroid_onSurfaceCreated( JNIEnv*  env, jclass  thiz ){
 	if(!surfaceDestroyed){
 		ofUnloadAllFontTextures();
 		ofPauseVideoGrabbers();
+		if(androidApp){
+			androidApp->unloadTextures();
+		}
 	}
 	reloadTextures();
 	if(androidApp){
@@ -577,8 +583,8 @@ Java_cc_openframeworks_OFAndroid_cancelPressed( JNIEnv*  env, jobject  thiz ){
 
 void
 Java_cc_openframeworks_OFAndroid_networkConnected( JNIEnv*  env, jobject  thiz, jboolean connected){
-	if(androidApp) androidApp->networkConnected(connected);
 	bool bConnected = (bool)connected;
+	if(androidApp) androidApp->networkConnected(bConnected);
 	ofNotifyEvent(ofxAndroidEvents().networkConnected,bConnected);
 }
 }

--- a/addons/ofxAndroid/src/ofxAndroidApp.h
+++ b/addons/ofxAndroid/src/ofxAndroidApp.h
@@ -26,6 +26,7 @@ public:
 	virtual void stop(){};
 	virtual void resume(){};
 	virtual void reloadTextures(){}
+	virtual void unloadTextures(){}
 
 	virtual void touchDown(int x, int y, int id) {};
 	virtual void touchMoved(int x, int y, int id) {};


### PR DESCRIPTION
called when the application goes to pause or stop on the gl thread
to be able to manually unload textures that are not taken care
automatically by the core
