### PR TITLE
fixed broken hole detection in CV contour finder

### DIFF
--- a/examples/addons/opencvExample/src/testApp.cpp
+++ b/examples/addons/opencvExample/src/testApp.cpp
@@ -79,18 +79,28 @@ void testApp::draw(){
 	// we could draw the whole contour finder
 	//contourFinder.draw(360,540);
 
-	// or, instead we can draw each blob individually,
+	// or, instead we can draw each blob individually from the blobs vector,
 	// this is how to get access to them:
     for (int i = 0; i < contourFinder.nBlobs; i++){
         contourFinder.blobs[i].draw(360,540);
+		
+		// draw over the centroid if the blob is a hole
+		ofSetColor(255);
+		if(contourFinder.blobs[i].hole){
+			ofDrawBitmapString("hole",
+				contourFinder.blobs[i].boundingRect.getCenter().x + 360,
+				contourFinder.blobs[i].boundingRect.getCenter().y + 540);
+		}
     }
 
 	// finally, a report:
-
 	ofSetHexColor(0xffffff);
-	char reportStr[1024];
-	sprintf(reportStr, "bg subtraction and blob detection\npress ' ' to capture bg\nthreshold %i (press: +/-)\nnum blobs found %i, fps: %f", threshold, contourFinder.nBlobs, ofGetFrameRate());
-	ofDrawBitmapString(reportStr, 20, 600);
+	stringstream reportStr;
+	reportStr << "bg subtraction and blob detection" << endl
+			  << "press ' ' to capture bg" << endl
+			  << "threshold " << threshold << " (press: +/-)" << endl
+			  << "num blobs found " << contourFinder.nBlobs << ", fps: " << ofGetFrameRate();
+	ofDrawBitmapString(reportStr.str(), 20, 600);
 
 }
 


### PR DESCRIPTION
ofxCvBlob.hole bool now works correctly; updated openCVExample to denote detected holes with some text to make checking this easier in the future; also updated sprintf in example to use a stringstream

This is related to #784 which I thought I fixed, but Chris found I hadn't: http://forum.openframeworks.cc/index.php/topic,11675.msg51514.html
