### PR TITLE
fix out-of-bounds access in string display functions. close #1675.

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -631,7 +631,7 @@ vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(string str){
 		  }else if (str[index] == ' ') {
 				 int cy = (int)'p' - NUM_CHARACTER_TO_START;
 				 X += cps[cy].setWidth * letterSpacing * spaceSize;
-		  } else {
+		  } else if(cy > -1){
 			  	shapes.push_back(getCharacterAsPoints(str[index]));
 			  	shapes.back().translate(ofPoint(X,Y));
 
@@ -702,7 +702,7 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(string c, float x, float y){
 	     		int cy = (int)'p' - NUM_CHARACTER_TO_START;
 				 xoffset += cps[cy].setWidth * letterSpacing * spaceSize;
 				 // zach - this is a bug to fix -- for now, we don't currently deal with ' ' in calculating string bounding box
-		  } else {
+		  } else if(cy > -1){
                 GLint height	= cps[cy].height;
             	GLint bwidth	= cps[cy].width * letterSpacing;
             	GLint top		= cps[cy].topExtent - cps[cy].height;
@@ -779,7 +779,7 @@ void ofTrueTypeFont::drawString(string c, float x, float y) {
 		  }else if (c[index] == ' ') {
 				 int cy = (int)'p' - NUM_CHARACTER_TO_START;
 				 X += cps[cy].setWidth * letterSpacing * spaceSize;
-		  } else {
+		  } else if(cy > -1){
 				drawChar(cy, X, Y);
 				X += cps[cy].setWidth * letterSpacing;
 		  }
@@ -879,7 +879,7 @@ void ofTrueTypeFont::drawStringAsShapes(string c, float x, float y) {
 				 int cy = (int)'p' - NUM_CHARACTER_TO_START;
 				 X += cps[cy].setWidth;
 				 //glTranslated(cps[cy].width, 0, 0);
-		  } else {
+		  } else if(cy > -1){
 				drawCharAsShape(cy, X, Y);
 				X += cps[cy].setWidth;
 				//glTranslated(cps[cy].setWidth, 0, 0);


### PR DESCRIPTION
Fix for #1675.

It doesn't handle \t or \r, but at least it doesn't crash.
