### PR TITLE
ofNode::setParent and clearParent have flags to maintain global transfor...

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -11,13 +11,25 @@ ofNode::ofNode() :
 }
 
 //----------------------------------------
-void ofNode::setParent(ofNode& parent) {
-	this->parent = &parent;
+void ofNode::setParent(ofNode& parent, bool bMaintainGlobalTransform) {
+    if(bMaintainGlobalTransform) {
+        ofMatrix4x4 globalTransform(getGlobalTransformMatrix());
+        this->parent = &parent;
+        setTransformMatrix(globalTransform);
+    } else {
+        this->parent = &parent;
+    }
 }
 
 //----------------------------------------
-void ofNode::clearParent() {
-	this->parent = NULL;
+void ofNode::clearParent(bool bMaintainGlobalTransform) {
+    if(bMaintainGlobalTransform) {
+        ofMatrix4x4 globalTransform(getGlobalTransformMatrix());
+        this->parent = NULL;
+        setTransformMatrix(globalTransform);
+    } else {
+        this->parent = NULL;
+    }
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -27,8 +27,8 @@ public:
 	// set parent to link nodes
 	// transformations are inherited from parent node
 	// set to NULL if not needed (default)
-	void setParent(ofNode& parent);
-	void clearParent();
+	void setParent(ofNode& parent, bool bMaintainGlobalTransform = false);
+	void clearParent(bool bMaintainGlobalTransform = false);
 	ofNode* getParent() const;
 
 	


### PR DESCRIPTION
...m

if you change parent of a node (e.g. clear the parent, or give it a
parent), the node's world transformation would snap to a new position.
This is understandable because all of a sudden the node's local
transformation is relative to a new matrix. Sometimes however, the
desired behaviour is that the node stays where it is in the world,
while it's place in the heirarchy changes. This is very simple to
implement. The ofNode::setParent and clearParent methods now have a
flag (default set to false for backwards compatibilty) to do exactly
this.
