### PR TITLE
Fix misuse of readlink() buffer causing an uninitialized string ending

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1332,10 +1332,14 @@ string ofFilePath::join(string path1, string path2){
 string ofFilePath::getCurrentExePath(){
 	#if defined(TARGET_LINUX) || defined(TARGET_ANDROID)
 		char buff[FILENAME_MAX];
-		if (readlink("/proc/self/exe", buff, FILENAME_MAX) == -1){
+		ssize_t size = readlink("/proc/self/exe", buff, sizeof(buff) - 1);
+		if (size == -1){
 			ofLogError("ofFilePath") << "readlink failed with error " << errno;
 		}
-		return buff;
+		else{
+			buff[size] = '\0';
+			return buff;
+		}
 	#elif defined(TARGET_OSX)
 		char path[FILENAME_MAX];
 		uint32_t size = sizeof(path);


### PR DESCRIPTION
This patch should fix #1366
This change affects only Linux.

`readlink()` puts the result in a buffer given as an argument but the null-ending character is not automatically set. This patch add the null character preventing access to uninitialized memory.

Also, even in case of failure of `readlink()` the buffer was returned, an empty string is returned now.

The manpage of `readlink()` says:

> readlink() places the contents of the symbolic link path in the buffer buf, which has size bufsiz. readlink() does not append a null byte to buf. It will truncate the contents (to a length of bufsiz characters), in case the buffer is too small to hold all of the contents.

I do not have a Mac to test but I have the feeling the same kind of errors can occur. Looking at the documentation ([here](https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/dyld.3.html)) it says:

> This function returns 0 if the path was successfully copied...

But the actual code is:

``` C++
char path[FILENAME_MAX];
uint32_t size = sizeof(path);
if(_NSGetExecutablePath(path, &size) == 0){
    ofLogError() << "buffer too small; need size " <<  size;
}
return path;
```
