### PR TITLE
Add versioning system info to changelog.

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -28,6 +28,9 @@ For 0.7.4 we updated all core libraries to work against the new version of codeb
 System Libraries (linux):
 Linux now uses some system libraries instead of including them in the core.  Please ensure you have installed the system dependencies for your OS.  You can install the system dependencies by executing the install_dependencies.sh script in  $OF_ROOT/scripts/linux/DISTRO/install_dependencies.sh, where DISTRO is your running linux distribution.  Currently oF has install scripts for Debian, Ubuntu, ArchLinux, and Fedora.
 
+New versioning system:
+From now on, OF version are numbered Major.Minor.Patch (e.g. 0.7.4). See Utils section and readme.md for details.
+
 DEPRECATIONS & REMOVALS
 ========================
 - removed OF_USING_POCO conditionals
@@ -86,12 +89,14 @@ CORE
 ## Utils
     + added ofToDouble()
     + added Android and iOS functionality to ofLaunchBrowser
+    / ofGetVersionInfo() now returns only the version string.
 
     ofBuffer:
         + added append()
 
     ofConstants:
         + added #include <cfloat>
+        / The OF_VERSION* defines have been changed for the new version system.
         
 ## Video
     


### PR DESCRIPTION
Add missing info about the versioning system to the changelog. this could be important for people who check for OF version in addons etc.
