### PR TITLE
fix for ofToDataPath - checks now for both backslash and forwardslash be...

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -278,15 +278,20 @@ string ofToDataPath(string path, bool makeAbsolute){
 	
 	if( enableDataPath ){
 
-        string enclosingFolder = path.substr(0,dataPathRoot().length());
+        //we create dataPath as a string for the check, on windows we modify it to check both types of slashes
+        //however we use the original value from dataPathRoot() to prepend the string if needed.  
+        string dataPath = dataPathRoot(); 
+        string enclosingFolder = path.substr(0,dataPath.length());
+        
         #ifdef TARGET_WIN32
             //this is so we can check both "data\" and "data/" on windows
             std::replace( enclosingFolder.begin(), enclosingFolder.end(), '\\', '/' );
+            std::replace( dataPath.begin(), dataPath.end(), '\\', '/' );
         #endif // TARGET_WIN32
 
 		//check if absolute path has been passed or if data path has already been applied
 		//do we want to check for C: D: etc ?? like  substr(1, 2) == ':' ??
-		if( path.length()==0 || (path.substr(0,1) != "/" &&  path.substr(1,1) != ":" && enclosingFolder != dataPathRoot())){
+		if( path.length()==0 || (path.substr(0,1) != "/" &&  path.substr(1,1) != ":" && enclosingFolder != dataPath)){
 			path = dataPathRoot()+path;
 		}
 


### PR DESCRIPTION
...fore prepending the data path. Closes #1867 

as we are listing the default data path as "data/" for windows .
this grabs the substr of the file path of the same length as the ofDataPathRoot and then converts any \ to / for the check. 

it doesn't modify the incoming path - just allows it to pass the check so that data\myFile.txt doesn't become data/data\myFile.txt 

would be good to test all windows examples to make sure this fix doesn't introduce any other bugs. 
