### PR TITLE
update gstreamer version to 1.0 in archlinux install scripts

### DIFF
--- a/scripts/linux/archlinux/install_codecs.sh
+++ b/scripts/linux/archlinux/install_codecs.sh
@@ -1,2 +1,2 @@
-pacman -Sy --needed mpg123 gstreamer0.10-ugly-plugins gstreamer0.10-ffmpeg
+pacman -Sy --needed mpg123 gst-plugins-ugly
 

--- a/scripts/linux/archlinux/install_dependencies.sh
+++ b/scripts/linux/archlinux/install_dependencies.sh
@@ -10,7 +10,7 @@ if [ $EUID != 0 ]; then
    exit 1
 fi
 
-pacman -Sy --needed make pkg-config gcc openal python-lxml glew freeglut freeimage jack gstreamer0.10-good-plugins gstreamer0.10-bad-plugins portaudio
+pacman -Sy --needed make pkg-config gcc openal python-lxml glew freeglut freeimage jack gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav portaudio
 
 exit_code=$?
 if [ $exit_code != 0 ]; then


### PR DESCRIPTION
What I've done with the Archlinux install scripts:
- updated GStreamer to 1.0
- moved gstreamer-ffmpeg to install_deps script to make it more like the ubuntu scripts (the ffmpeg package is called gst-libav on arch)
- added gstreamer gst-plugins-base explicitly to install_deps script

Tested this on Archlinux 64bit with all old gstreamer packages removed beforehand.

this refs 56caffc011ac2d8ed8c7b30d628aaf0429d704c3
