### PR TITLE
Fixed sound not restarting after an interupttion (phone call or alarm clock)

### DIFF
--- a/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.h
+++ b/addons/ofxiPhone/src/sound/ofxiPhoneSoundStream.h
@@ -4,6 +4,7 @@
 
 #include "ofBaseSoundStream.h"
 #include "ofTypes.h"
+#import <AudioToolbox/AudioToolbox.h>
 
 
 class ofxiPhoneSoundStream : public ofBaseSoundStream{
@@ -32,7 +33,9 @@ class ofxiPhoneSoundStream : public ofBaseSoundStream{
 	
 		int getNumInputChannels();
 		int getNumOutputChannels();
-		
+    
+        static AudioUnit audioUnit;
+
 	private:
 		long unsigned long	tickCount;
 		int					nInputChannels;


### PR DESCRIPTION
Made the audioUnit static so it's more accessible and fixed audio not restarting after an iOS interruption.
