### PR TITLE
remove freeing of non-allocated memory in svgtiny_parse_poly(...)

### DIFF
--- a/addons/ofxSvg/libs/svgTiny/src/svgtiny.cpp
+++ b/addons/ofxSvg/libs/svgTiny/src/svgtiny.cpp
@@ -805,7 +805,6 @@ svgtiny_code svgtiny_parse_poly(Poco::XML::Element *poly,
 	p = (float*) malloc(sizeof p[0] * strlen(s));
 	if (!p) {
         //xmlFree(points);
-        //free(points);
 		return svgtiny_OUT_OF_MEMORY;
 	}
 
@@ -834,7 +833,6 @@ svgtiny_code svgtiny_parse_poly(Poco::XML::Element *poly,
 		p[i++] = svgtiny_PATH_CLOSE;
 
 	//xmlFree(points);
-    //free(points);
 
 	return svgtiny_add_path(p, i, &state);
 }


### PR DESCRIPTION
just commented it out.

it could probably be removed to prevent confusion... let me know what's preferred.

closes #1725 .
