### PR TITLE
Fixed ofxTCPServer not close()ing properly when setup() fails due to bind()

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -50,21 +50,25 @@ void ofxTCPServer::setMessageDelimiter(string delim){
 //--------------------------
 bool ofxTCPServer::close(){
 
-	if(!connected) return true;
+	//	gr: if we created the TCP server, but didn't bind, we still want to close the TCPServer
+	//		the name "connected" is pretty misleading
+	if(connected) 
+	{
+		map<int,ofxTCPClient>::iterator it;
+		for(it=TCPConnections.begin(); it!=TCPConnections.end(); it++){
+			it->second.close();
+		}
+		TCPConnections.clear();
 
-	map<int,ofxTCPClient>::iterator it;
-	for(it=TCPConnections.begin(); it!=TCPConnections.end(); it++){
-		it->second.close();
+		stopThread(); //stop the thread
+		connected = false;
 	}
-	TCPConnections.clear();
-
-	stopThread(); //stop the thread
 
 	if( !TCPServer.Close() ){
 		ofLog(OF_LOG_WARNING, "ofxTCPServer: unable to close connection");
 		return false;
 	}else{
-		connected = false;
+		//connected = false;
 		return true;
 	}
 }


### PR DESCRIPTION
Previously if you called setup() to an already-bound port the TCPServer
would open a socket, but not bind and fail correctly.

A subsequent close() wouldn't actually close the TCPServer so you
couldn't re-use the ofxTCPServer; In my case to try and bind to another
port.

Now the TCPServer is cleaned up properly.
