### PR TITLE
Added optional z param to ofVec3f( ofVec2f ) constructor, and swizzles

### DIFF
--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -281,7 +281,7 @@ ofVec3f operator/( float f, const ofVec3f& vec );
 /////////////////
 
 
-inline ofVec3f::ofVec3f( const ofVec2f& vec, float _z=0 ):x(vec.x), y(vec.y), z(_z) {}
+inline ofVec3f::ofVec3f( const ofVec2f& vec, float _z ):x(vec.x), y(vec.y), z(_z) {}
 inline ofVec3f::ofVec3f( const ofVec4f& vec ):x(vec.x), y(vec.y), z(vec.z) {}
 inline ofVec3f::ofVec3f(): x(0), y(0), z(0) {};
 inline ofVec3f::ofVec3f( float _all ): x(_all), y(_all), z(_all) {};


### PR DESCRIPTION
Useful accessors for 3D <-> 2D vector conversion.
The ofVec2f constructor for ofVec3f now takes a Z too so we can construct a little more simply
 ofVec3f World3( GetWorld2(), 100.f );
