### PR TITLE
Fixed onTouchMoved historical event handling

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -977,14 +977,10 @@ class OFGestureListener extends SimpleOnGestureListener implements OnClickListen
                 case MotionEvent.ACTION_MOVE:
                 {
             		for(int i=0; i<event.getHistorySize(); i++)
-            		{
-            			try{
-		                	for(int j=0; j<event.getPointerCount(); j++)
-		                	{
-	                			int ptr = event.getPointerId(j);
-	                			OFAndroid.onTouchMoved(ptr, event.getHistoricalX(ptr, i), event.getHistoricalY(ptr, i), event.getHistoricalPressure(ptr, i));                		
-	                		}
-            			}catch(IllegalArgumentException e){}
+            		{            			
+		                for(int j=0; j<event.getPointerCount(); j++){	                			
+	                		OFAndroid.onTouchMoved(event.getPointerId(j), event.getHistoricalX(j, i), event.getHistoricalY(j, i), event.getHistoricalPressure(j, i));
+	                	}            			
                 	}
 	            	for(int i=0; i<event.getPointerCount(); i++){
 	            		OFAndroid.onTouchMoved(event.getPointerId(i), event.getX(i), event.getY(i), event.getPressure(i));


### PR DESCRIPTION
This one is found by Jeff Brown (Google), I'm just passing on the bugfix.

"In OFAndroid.java, line 1011, there's a bug in the way the historical events are handled.  The clue here is the exception handler which shouldn't be needed.

int ptr = event.getPointerId(j);
OFAndroid.onTouchMoved(ptr, event.getHistoricalX(ptr, i), event.getHistoricalY(ptr, i), event.getHistoricalPressure(ptr, i));

In the above code, the calls to getHistoricalX(), getHistoricalY() and getHistoricalPressure() should be passing "j" as the argument, not "ptr".  The first argument is intended to be the pointer index, not the pointer id.  Once you do that, you'll find you can remove the try/catch for IllegalArgumentException."

Reference: http://developer.android.com/reference/android/view/MotionEvent.html
