### PR TITLE
added ofPixels::setColor(ofColor) and ofImage::setColor(ofColor)

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -836,13 +836,19 @@ ofColor_<PixelType> ofImage_<PixelType>::getColor(int x, int y) const {
 
 //------------------------------------
 template<typename PixelType>
-void ofImage_<PixelType>::setColor(int x, int y, ofColor_<PixelType> color) {
+void ofImage_<PixelType>::setColor(int x, int y, const ofColor_<PixelType>& color) {
 	pixels.setColor(x, y, color);
 }
 
 //------------------------------------
 template<typename PixelType>
-void ofImage_<PixelType>::setColor(ofColor_<PixelType> color) {
+void ofImage_<PixelType>::setColor(int index, const ofColor_<PixelType>& color) {
+	pixels.setColor(index, color);
+}
+
+//------------------------------------
+template<typename PixelType>
+void ofImage_<PixelType>::setColor(const ofColor_<PixelType>& color) {
 	pixels.setColor(color);
 }
 

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -142,8 +142,9 @@ class ofImage_ : public ofBaseImage_<PixelType>{
 		ofColor_<PixelType> getColor(int x, int y) const;
 
 		// alter the image
-		void				setColor(int x, int y, ofColor_<PixelType> color);
-		void				setColor(ofColor_<PixelType> color);
+		void				setColor(int x, int y, const ofColor_<PixelType>& color);
+		void				setColor(int index, const ofColor_<PixelType>& color);
+		void				setColor(const ofColor_<PixelType>& color);
 		void 				setFromPixels(const PixelType * pixels, int w, int h, ofImageType type, bool bOrderIsRGB = true);
 		void				setFromPixels(const ofPixels_<PixelType> & pixels);
 		void 				setImageType(ofImageType type);

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -271,9 +271,7 @@ ofColor_<PixelType> ofPixels_<PixelType>::getColor(int x, int y) const {
 }
 
 template<typename PixelType>
-void ofPixels_<PixelType>::setColor(int x, int y, ofColor_<PixelType> color) {
-	int index = getPixelIndex(x, y);
-
+void ofPixels_<PixelType>::setColor(int index, const ofColor_<PixelType>& color) {
 	if( channels == 1 ){
 		pixels[index] = color.getBrightness();
 	}else if( channels == 3 ){
@@ -289,10 +287,16 @@ void ofPixels_<PixelType>::setColor(int x, int y, ofColor_<PixelType> color) {
 }
 
 template<typename PixelType>
-void ofPixels_<PixelType>::setColor(ofColor_<PixelType> color) {
-	for(int y = 0; y < height; y++) {
-		for(int x = 0; x < width; x++) {
-			setColor(x, y, color);
+void ofPixels_<PixelType>::setColor(int x, int y, const ofColor_<PixelType>& color) {
+	setColor(getPixelIndex(x, y), color);
+}
+
+template<typename PixelType>
+void ofPixels_<PixelType>::setColor(const ofColor_<PixelType>& color) {
+	int i = 0;
+	while(i < size()) {
+		for(int j = 0; j < channels; j++) {
+			pixels[i++] = color[j];
 		}
 	}
 }

--- a/libs/openFrameworks/graphics/ofPixels.h
+++ b/libs/openFrameworks/graphics/ofPixels.h
@@ -68,8 +68,9 @@ public:
 
 	int getPixelIndex(int x, int y) const;
 	ofColor_<PixelType> getColor(int x, int y) const;
-	void setColor(int x, int y, ofColor_<PixelType> color);
-	void setColor(ofColor_<PixelType> color);
+	void setColor(int x, int y, const ofColor_<PixelType>& color);
+	void setColor(int index, const ofColor_<PixelType>& color);
+	void setColor(const ofColor_<PixelType>& color);
 
 	const PixelType& operator[](int pos) const;
 	PixelType& operator[](int pos);


### PR DESCRIPTION
example:

``` c++
#include "ofAppGlutWindow.h"
#include "ofMain.h"

class ofApp : public ofBaseApp {
public:
    ofImage img;

    void setup() {
        img.allocate(ofGetWidth(), ofGetHeight(), OF_IMAGE_COLOR);
        img.update();
    }

    void update() {
        img.setColor(ofColor::fromHsb(mouseX % 256, mouseY % 256, 255));
        img.update();
    }

    void draw() {
        img.draw(0, 0);
    }
};

int main() {
    ofAppGlutWindow window;
    ofSetupOpenGL(&window, 1280, 720, OF_WINDOW);
    ofRunApp(new ofApp());
}
```
