### PR TITLE
Update to ofParameter.h to fix build errors on Windows 8. 

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -183,7 +183,7 @@ protected:
 
 	void setSerializable(bool serializable);
 
-#ifdef TARGET_OSX
+#if defined(TARGET_OSX) || (_MSC_VER)
 	friend typename FriendMaker<Friend>::Type;
 #else
 	friend class FriendMaker<Friend>::Type;


### PR DESCRIPTION
Fixes build errors on Windows 8 using VS2010.  Needs to be tested on other Windows systems. 
