### PR TITLE
add support for a different default renderer

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -44,6 +44,10 @@ void ofSetupOpenGL(ofAppBaseWindow * windowPtr, int w, int h, int screenMode){
 	ofSetupOpenGL(ofPtr<ofAppBaseWindow>(windowPtr,std::ptr_fun(noopDeleter)),w,h,screenMode);
 }
 
+void ofSetupOpenGL(ofAppBaseWindow * windowPtr, int w, int h, int screenMode, ofBaseRenderer* renderer, bool initGlew){
+	ofSetupOpenGL(ofPtr<ofAppBaseWindow>(windowPtr,std::ptr_fun(noopDeleter)),w,h,screenMode, ofPtr<ofBaseRenderer>(renderer), initGlew);
+}
+
 
 void ofExitCallback();
 
@@ -83,23 +87,29 @@ void ofRunApp(ofBaseApp * OFSA){
 
 //--------------------------------------
 void ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode){
+	ofSetupOpenGL(windowPtr, w, h, screenMode, ofPtr<ofBaseRenderer>(new ofGLRenderer(false)));
+}
+
+//--------------------------------------
+void ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode, ofPtr<ofBaseRenderer> rendererPtr, bool initGlew){
 	window = windowPtr;
 	window->setupOpenGL(w, h, screenMode);
 	
 #ifndef TARGET_OPENGLES
-	glewExperimental = GL_TRUE;
-	GLenum err = glewInit();
-	if (GLEW_OK != err)
-	{
-		/* Problem: glewInit failed, something is seriously wrong. */
-		ofLog(OF_LOG_ERROR, "Error: %s\n", glewGetErrorString(err));
+	if(initGlew){
+		glewExperimental = GL_TRUE;
+		GLenum err = glewInit();
+		if (GLEW_OK != err)
+		{
+			/* Problem: glewInit failed, something is seriously wrong. */
+			ofLog(OF_LOG_ERROR, "Error: %s\n", glewGetErrorString(err));
+		}
 	}
 #endif
-	ofSetCurrentRenderer(ofPtr<ofBaseRenderer>(new ofGLRenderer(false)));
+	ofSetCurrentRenderer(rendererPtr);
 	//Default colors etc are now in ofGraphics - ofSetupGraphicDefaults
 	//ofSetupGraphicDefaults();
 }
-
 
 //--------------------------------------
 void ofSetupOpenGL(int w, int h, int screenMode){

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -7,9 +7,12 @@
 
 class ofAppBaseWindow;
 class ofBaseApp;
+class ofBaseRenderer;
 
+void 		ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode, ofPtr<ofBaseRenderer> rendererPtr, bool initGlew = true); //to pass a different renderer than opengl
 void 		ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode);	// sets up the opengl context!
 void 		ofSetupOpenGL(ofAppBaseWindow * windowPtr, int w, int h, int screenMode); // this is deprecated, use an ofPtr
+void 		ofSetupOpenGL(ofAppBaseWindow * windowPtr, int w, int h, int screenMode, ofBaseRenderer* renderer, bool initGlew = true); //this should also be deprecated but it is in here for the sake of completion
 void 		ofSetupOpenGL(int w, int h, int screenMode);	// sets up the opengl context!
 
 void 		ofRunApp(ofPtr<ofBaseApp> OFSA); // this is for deprecated, use an ofPtr


### PR DESCRIPTION
I recently wanted to use something else than OpenGL in OF and didn't see a way to not automatically initialize the opengl renderer and glew. This PR introduces different versions of ofSetupOpenGL so a default renderer can be passed and an optional bool whether to initialize glew or not. Personally I think this function is now a little bit too long. But ways how  an OF app could also be initialized is a completely different topic...
