### PR TITLE
Contribution/documents path support

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -384,6 +384,18 @@ string ofToDocumentsPath(string path, bool makeAbsolute){
 }
 
 //----------------------------------------
+string ofToPath(string path, bool useDocuments, bool absolute)
+{
+    if ( useDocuments )
+    {
+        return ofToDocumentsPath( path, absolute );
+    } else
+    {
+        return ofToDataPath( path, absolute );
+    }
+}
+
+//----------------------------------------
 template <>
 string ofToHex(const string& value) {
 	ostringstream out;

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -48,6 +48,8 @@ void	ofEnableDocumentsPath();
 void	ofDisableDocumentsPath();
 string 	ofToDocumentsPath(string path, bool absolute=false);
 
+string ofToPath(string path, bool useDocuments=false, bool absolute=false);
+
 template<class T>
 void ofRandomize(vector<T>& values) {
 	random_shuffle(values.begin(), values.end());


### PR DESCRIPTION
Currently openFrameworks supports a Data path in many of its operations. This is the source of anything that can come implicitly with a release, things like media and configuration data. 

This PR includes work towards formalizing a Documents path. The Documents path is often used to store information relavant to a specific user's running the software.
