### PR TITLE
add setter for OpenAL's distance model in ofxOpenALSoundPlayer

### DIFF
--- a/addons/ofxiPhone/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiPhone/src/sound/ofxOpenALSoundPlayer.cpp
@@ -609,3 +609,12 @@ void ofxOpenALSoundPlayer::ofxALSoundSetMaxDistance(float dist) {
 		SoundEngine_SetMaxDistance(dist);
 }
 
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetDistanceModel(ALenum model) {
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		alDistanceModel(model);
+}
+

--- a/addons/ofxiPhone/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiPhone/src/sound/ofxOpenALSoundPlayer.h
@@ -101,6 +101,11 @@ public:
 	static void	ofxALSoundSetReferenceDistance(float dist); // sets the distance after which attenuation is applied
 	static void	ofxALSoundSetMaxDistance(float dist); // sets the maximum distance for which attenuation is applied
 	
+	static void ofxALSoundSetDistanceModel(ALenum model); // sets the formula which determines how attenuation is applied.
+														  // Note: the default distance model is AL_INVERSE_DISTANCE_CLAMPED,
+														  // but you may find AL_LINEAR_DISTANCE_CLAMPED to be more intuitive
+														  // (all sounds beyond the max distance will be silent)
+	
 	void	setLocation(float x, float y, float z); // x -1..1 gets mapped to pan -1..1
 	
 	bool	update(); // can this be called at a different time? maybe should be a static function

--- a/examples/ios/OpenAlExample/src/testApp.mm
+++ b/examples/ios/OpenAlExample/src/testApp.mm
@@ -13,8 +13,10 @@ void testApp::setup(){
 	
 	ofxOpenALSoundPlayer::ofxALSoundSetListenerLocation(ofGetWidth()/2,0,ofGetHeight()/2);
 	ofxOpenALSoundPlayer::ofxALSoundSetReferenceDistance(10);
-	ofxOpenALSoundPlayer::ofxALSoundSetMaxDistance(500);
-	ofxOpenALSoundPlayer::ofxALSoundSetListenerGain(5.0);
+	ofxOpenALSoundPlayer::ofxALSoundSetMaxDistance(200);
+	ofxOpenALSoundPlayer::ofxALSoundSetListenerGain(1.0);
+	ofxOpenALSoundPlayer::ofxALSoundSetDistanceModel(AL_LINEAR_DISTANCE_CLAMPED);
+	
 	for(int i = 0; i < 5; i++){
 		audioLoc[i].set(-1,-1);
 		audioSize[i]=0;
@@ -37,6 +39,10 @@ void testApp::draw(){
 	ofNoFill();
 	ofSetColor(50,50,200);
 	ofCircle(ofGetWidth()/2, ofGetHeight()/2, 4);
+	
+	// draw a circle representing the max distance
+	ofSetColor(200, 50, 50);
+	ofCircle(ofGetWidth()/2, ofGetHeight()/2, 200);
 	
 	for(int i = 0; i < 5; i++){
 		ofSetColor(150+31*i,150+31*i,150+31*i);


### PR DESCRIPTION
This adds a simple feature to the ofxOpenALSoundPlayer on ios, requested in issue #1322 and added to the 0.8.0 milestone list.

This code just adds a wrapper for the `alDistanceModel` setter. In addition, there's a little note in the header explaining what the "distance model" means, what the default one is (as per the OpenAL spec), and calls attention to the AL_LINEAR_DISTANCE_CLAMPED which is _not_ the default, but is perhaps more intuitive (again, see #1322).

Also, I've added a minimal demonstration of the new functionality to the OpenAL example, similar to @armadillu's original demonstration. Let me know if you'd like that to be a separate PR.

I'm against making it the default, as suggested, but I _do_ personally think that AL_LINEAR_DISTANCE_CLAMPED acts more like what I'd expect.

Summoning @ofTheo and @julapy
