### PR TITLE
fix std namespace for shared_ptr, weak_ptr, ...

### DIFF
--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -9,7 +9,7 @@
 #include <tr1/memory>
 // import smart pointers utils into std
 namespace std {
-#if __cplusplus <= 199711L
+#if __cplusplus<201103L
 	using std::tr1::shared_ptr;
 	using std::tr1::weak_ptr;
 	using std::tr1::enable_shared_from_this;


### PR DESCRIPTION
I tried to use c++11 in an OF project but ofTypes.h redefines variable that are now part of the std namespace. This PR is a quick fix for that.

I only did a quick test and ofPtr still works. I wonder though if this is safe? is the std::shared_ptr of c++11 the same as the former std::tr1::shared_ptr?
