### PR TITLE
Fix fullscreen initialization of width and height variables

### DIFF
--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -250,7 +250,13 @@ void ofAppGlutWindow::setupOpenGL(int w, int h, int screenMode){
 	windowMode = screenMode;
 	bNewScreenMode = true;
 
-	if (windowMode != OF_GAME_MODE){
+	if (windowMode == OF_FULLSCREEN){
+		glutInitWindowSize(glutGet(GLUT_SCREEN_WIDTH), glutGet(GLUT_SCREEN_HEIGHT));
+		glutCreateWindow("");
+		
+		requestedWidth  = w;
+		requestedHeight = h;
+	} else if (windowMode != OF_GAME_MODE){
 		glutInitWindowSize(w, h);
 		glutCreateWindow("");
 


### PR DESCRIPTION
closes #2075 

tested with:

```
#include "ofAppGlutWindow.h"
#include "ofMain.h"

class ofApp : public ofBaseApp {
public:
    void setup(){
        if(ofGetWidth() != ofGetScreenWidth()){
            ofLogWarning() << "oh-oh... screen width doesn't equal window width in setup()";
        }
    }
    void update(){
        if(ofGetWidth() != ofGetScreenWidth()){
            ofLogWarning() << "oh-oh... screen width doesn't equal window width in update()";
        }
    }
    void draw() {
        if(ofGetWidth() != ofGetScreenWidth()){
            ofLogWarning() << "oh-oh... screen width doesn't equal window width in draw()";
        }
    }
};

int main() {
    ofAppGlutWindow window;
    ofSetupOpenGL(&window, 600, 400, OF_FULLSCREEN);
    ofRunApp(new ofApp());
}
```
