### PR TITLE
Fixed bug in ofxSvg that ignored transform attribute

### DIFF
--- a/addons/ofxSvg/libs/svgTiny/src/svgtiny.cpp
+++ b/addons/ofxSvg/libs/svgTiny/src/svgtiny.cpp
@@ -1174,7 +1174,7 @@ void svgtiny_parse_transform_attributes(Poco::XML::Element *node,
 	/* parse transform */
 	//transform = (char *) xmlGetProp(node, (const xmlChar *) "transform");
     
-    transform = (char *) node->getChildElement("transform");
+    transform = (char *) node->getAttribute("transform").c_str();
     
 	if (transform) {
 		svgtiny_parse_transform(transform, &state->ctm.a, &state->ctm.b,


### PR DESCRIPTION
Just a minor glitch in svgtiny.cpp
