### PR TITLE
remove deprecated functions for 0.8.0, closes #1428

### DIFF
--- a/addons/ofxiPhone/src/app/ofAppiPhoneWindow.h
+++ b/addons/ofxiPhone/src/app/ofAppiPhoneWindow.h
@@ -91,11 +91,6 @@ public:
     bool                disableAntiAliasing();
     bool                isAntiAliasingEnabled();
     int					getAntiAliasingSampleCount();
-    
-    //---------------------------------------------- deprecation messages. to be removed in OF 0073.
-    OF_DEPRECATED_MSG("Use enableRetina() instead", void enableRetinaSupport());
-    OF_DEPRECATED_MSG("Use isRetinaSupportedOnDevice() instead", bool isRetinaSupported());
-    OF_DEPRECATED_MSG("Use isDepthBufferEnabled() instead", bool isDepthEnabled());
 	
 	void timerLoop();
 	int					windowMode;

--- a/addons/ofxiPhone/src/app/ofAppiPhoneWindow.mm
+++ b/addons/ofxiPhone/src/app/ofAppiPhoneWindow.mm
@@ -315,19 +315,6 @@ int	ofAppiPhoneWindow::getAntiAliasingSampleCount() {
     return antiAliasingSamples;
 }
 
-//-------------------------------------------------------- deprecated.
-void ofAppiPhoneWindow::enableRetinaSupport() {
-	enableRetina();
-}
-
-bool ofAppiPhoneWindow::isRetinaSupported() {
-	return isRetinaEnabled();
-}
-
-bool ofAppiPhoneWindow::isDepthEnabled() {
-	return isDepthBufferEnabled();
-}
-
 //-------------------------------------------------------- timer loop.
 void ofAppiPhoneWindow::timerLoop() {
     // all the timerLoop logic has been moved into [ofxiOSEAGLView drawView]

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -885,11 +885,6 @@ void ofVertices( const vector <ofPoint> & polyPoints ){
 	}
 }
 
-//----------------------------------------------------------
-void ofVertexes( const vector <ofPoint> & polyPoints ){
-	ofVertices(polyPoints);
-}
-
 //---------------------------------------------------
 void ofCurveVertex(float x, float y){
     shape.setCurveResolution(currentStyle.curveResolution);
@@ -907,11 +902,6 @@ void ofCurveVertices( const vector <ofPoint> & curvePoints){
 	for( int k = 0; k < (int)curvePoints.size(); k++){
 		shape.curveTo(curvePoints[k]);
 	}
-}
-
-//----------------------------------------------------------
-void ofCurveVertexes( const vector <ofPoint> & curvePoints){
-	ofCurveVertices(curvePoints);
 }
 
 //---------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -212,14 +212,11 @@ void ofVertex(float x, float y);
 void ofVertex(float x, float y, float z);
 void ofVertex(ofPoint & p);
 void ofVertices(const vector <ofPoint> & polyPoints);
-OF_DEPRECATED_MSG("Use ofVertices instead.", void ofVertexes(const vector <ofPoint> & polyPoints));
-
 
 void ofCurveVertex(float x, float y);
 void ofCurveVertex(float x, float y, float z);
 void ofCurveVertex(ofPoint & p);
 void ofCurveVertices(const vector <ofPoint> & curvePoints);
-OF_DEPRECATED_MSG("Use ofCurveVertices instead.", void ofCurveVertexes(const vector <ofPoint> & curvePoints));
 
 void ofBezierVertex(float x1, float y1, float x2, float y2, float x3, float y3);
 void ofBezierVertex(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3);

--- a/libs/openFrameworks/graphics/ofPolyline.cpp
+++ b/libs/openFrameworks/graphics/ofPolyline.cpp
@@ -55,20 +55,10 @@ void ofPolyline::addVertices(const vector<ofPoint>& verts) {
 }
 
 //----------------------------------------------------------
-void ofPolyline::addVertexes(const vector<ofPoint>& verts) {
-	addVertices(verts);
-}
-
-//----------------------------------------------------------
 void ofPolyline::addVertices(const ofPoint* verts, int numverts) {
 	curveVertices.clear();
 	points.insert( points.end(), verts, verts + numverts );
     flagHasChanged();
-}
-
-//----------------------------------------------------------
-void ofPolyline::addVertexes(const ofPoint* verts, int numverts) {
-	addVertices(verts, numverts);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -23,9 +23,7 @@ public:
 	void addVertex( const ofPoint& p );
 	void addVertex( float x, float y, float z=0 );
 	void addVertices( const vector<ofPoint>& verts );
-	OF_DEPRECATED_MSG("Use ofPolyline::addVertices instead", void addVertexes( const vector<ofPoint>& verts ));
 	void addVertices(const ofPoint* verts, int numverts);
-	OF_DEPRECATED_MSG("Use ofPolyline::addVertices instead",void addVertexes(const ofPoint* verts, int numverts));
 
 	// adds a straight line to the polyline
 	void lineTo(const ofPoint & to ){ addVertex(to); }

--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -154,7 +154,6 @@ public:
     //
     float length() const;
     float lengthSquared() const;
-	OF_DEPRECATED_MSG("Use ofVec2f::lengthSquared() instead.", float squareLength() const);
 	
 	
     /**
@@ -712,11 +711,6 @@ inline float ofVec2f::length() const {
 inline float ofVec2f::lengthSquared() const {
 	return (float)(x*x + y*y);
 }
-
-inline float ofVec2f::squareLength() const {
-	return lengthSquared();
-}
-
 
 
 /**

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -168,7 +168,7 @@ public:
     //
     float length() const;
     float lengthSquared() const;
-	OF_DEPRECATED_MSG("Use ofVec3f::lengthSquared() instead.", float squareLength() const);
+
     /**
 	 * Angle (deg) between two vectors.
 	 * This is an unsigned relative angle from 0 to 180.
@@ -1015,10 +1015,6 @@ inline float ofVec3f::length() const {
 
 inline float ofVec3f::lengthSquared() const {
 	return (float)(x*x + y*y + z*z);
-}
-
-inline float ofVec3f::squareLength() const {
-	return lengthSquared();
 }
 
 

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -112,7 +112,7 @@ public:
     //
     float length() const;
     float lengthSquared() const;
-	OF_DEPRECATED_MSG("Use ofVec4f::lengthSquared() instead.", float squareLength() const);
+
     /**
 	 * Dot Product.
 	 */
@@ -545,9 +545,6 @@ inline float ofVec4f::lengthSquared() const {
 	return (float)(x*x + y*y + z*z + w*w);
 }
 
-inline float ofVec4f::squareLength() const {
-	return lengthSquared();
-}
 
 
 

--- a/libs/openFrameworks/video/ofQTKitPlayer.h
+++ b/libs/openFrameworks/video/ofQTKitPlayer.h
@@ -48,9 +48,6 @@ class ofQTKitPlayer  : public ofBaseVideoPlayer {
 		void                play();
 		void                stop();
 
-        OF_DEPRECATED_MSG("Use getTexture()->bind() instead. Ensure decodeMode != OF_QTKIT_DECODE_PIXELS_ONLY.", void bind());
-        OF_DEPRECATED_MSG("Use getTexture()->unbind() instead. Ensure decodeMode != OF_QTKIT_DECODE_PIXELS_ONLY.", void unbind());
-
 		bool                isFrameNew(); //returns true if the frame has changed in this update cycle
 
 		// Returns openFrameworks compatible RGBA pixels.

--- a/libs/openFrameworks/video/ofQTKitPlayer.mm
+++ b/libs/openFrameworks/video/ofQTKitPlayer.mm
@@ -218,19 +218,6 @@ void ofQTKitPlayer::update() {
 bool ofQTKitPlayer::isFrameNew() {
 	return bNewFrame;
 }
-		
-//--------------------------------------------------------------------
-void ofQTKitPlayer::bind() {
-	if(!isLoaded() || !moviePlayer.useTexture) return;
-	updateTexture();
-	tex.bind();
-}
-
-//--------------------------------------------------------------------
-void ofQTKitPlayer::unbind(){
-	if(!isLoaded() || !moviePlayer.useTexture) return;
-	tex.unbind();
-}
 
 //--------------------------------------------------------------------
 void ofQTKitPlayer::draw(float x, float y) {

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -198,11 +198,6 @@ void ofVideoGrabber::update(){
 }
 
 //--------------------------------------------------------------------
-void ofVideoGrabber::grabFrame(){
-	update();
-}
-
-//--------------------------------------------------------------------
 void ofVideoGrabber::close(){
 	if(	grabber != NULL ){
 		grabber->close();

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -50,7 +50,6 @@ class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
 		void				listDevices();
 		bool				isFrameNew();
 		void				update();
-		OF_DEPRECATED_MSG("Use ofVideoGrabber::update() instead.", void grabFrame());
 		void				close();	
 		bool				initGrabber(int w, int h){return initGrabber(w,h,true);}
 		bool				initGrabber(int w, int h, bool bTexture);

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -169,11 +169,6 @@ void ofVideoPlayer::update(){
 }
 
 //---------------------------------------------------------------------------
-void ofVideoPlayer::idleMovie(){
-	update();
-}
-
-//---------------------------------------------------------------------------
 void ofVideoPlayer::closeMovie(){
 	close();
 }

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -45,7 +45,6 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		void 				close();		
 
 		void				update();
-		OF_DEPRECATED_MSG("Use ofVideoPlayer::update() instead.", void idleMovie());
 		void 				play();
 		void 				stop();
 


### PR DESCRIPTION
This PR removes functions which have been deprecated since 0072.

The removed functions are:

`ofVec*f::squareLength()`
`ofVideoGrabber::grabFrame()`
`ofVideoPlayer::idleMovie()`
`ofPolyline::addVertexes` 
`ofGraphics: ofVertexes` and `ofGraphics: ofCurveVertexes` 
`ofQTKitPlayer::bind() and ofQTKitPlayer::unbind()`
`ofAppiPhoneWindow::enableRetinaSupport()`, `ofAppiPhoneWindow::isRetinaSupported()` and `ofAppiPhoneWindow::isDepthEnabled()`
