### PR TITLE
fixes drawStringAsShapes() and getStringAsPoints() 

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -898,7 +898,7 @@ vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(string str){
 				int cy = (int)'p' - NUM_CHARACTER_TO_START;
 				X += cps[cy].setWidth * letterSpacing * spaceSize;
 			} else if(cy > -1){
-				shapes.push_back(getCharacterAsPoints(str[index]));
+				shapes.push_back(getCharacterAsPoints((unsigned char)str[index]));
 				shapes.back().translate(ofPoint(X,Y));
 
 				X += cps[cy].setWidth * letterSpacing;
@@ -1159,7 +1159,7 @@ void ofTrueTypeFont::drawStringAsShapes(string c, float x, float y) {
 				 X += cps[cy].setWidth * letterSpacing * spaceSize;
 				 //glTranslated(cps[cy].width, 0, 0);
 		  } else if(cy > -1){
-				drawCharAsShape(c[index], X, Y);
+				drawCharAsShape((unsigned char)c[index], X, Y);
 				X += cps[cy].setWidth * letterSpacing;
 				//glTranslated(cps[cy].setWidth, 0, 0);
 		  }


### PR DESCRIPTION
for extended utf-8 characters.

closes #2093
