### PR TITLE
ios orientation fix to work with develop

### DIFF
--- a/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
+++ b/addons/ofxiPhone/src/utils/ofxiPhoneExtras.mm
@@ -152,13 +152,13 @@ void ofxiPhoneEnableLoopInThread() {
 
 //--------------------------------------------------------------
 void ofxiPhoneSetOrientation(ofOrientation orientation) {
-	if (orientation != OF_ORIENTATION_UNKNOWN) ofxiPhoneGetOFWindow()->setOrientation(orientation);
+    ofSetOrientation(orientation);
 }
 
 
 //--------------------------------------------------------------
 UIDeviceOrientation ofxiPhoneGetOrientation() {
-	return (UIDeviceOrientation)ofxiPhoneGetOFWindow()->getOrientation();
+    return (UIDeviceOrientation)ofGetOrientation();
 }
 
 


### PR DESCRIPTION
ofxiPhoneSetOrientation now reroutes the call to ofSetOrientation
and ofxiPhoneGetOrientation now reroutes the call to ofGetOrientation.
