### PR TITLE
deprecating ofxiPhoneSetOrientation and ofxiPhoneGetOrientation

### DIFF
--- a/addons/ofxiPhone/src/utils/ofxiPhoneExtras.h
+++ b/addons/ofxiPhone/src/utils/ofxiPhoneExtras.h
@@ -72,10 +72,10 @@ enum ofxiPhoneDeviceType {
 
 
 // possible values for iPhoneSetOrientation or iPhoneGetOrientation
-#define  OFXIPHONE_ORIENTATION_PORTRAIT      OF_ORIENTATION_DEFAULT  // UIDeviceOrientationPortrait
-#define OFXIPHONE_ORIENTATION_UPSIDEDOWN    OF_ORIENTATION_180      // UIDeviceOrientationPortraitUpsideDown
-#define OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT  OF_ORIENTATION_90_RIGHT // UIDeviceOrientationLandscapeRight
-#define OFXIPHONE_ORIENTATION_LANDSCAPE_LEFT  OF_ORIENTATION_90_LEFT  // UIDeviceOrientationLandscapeLeft
+#define OFXIPHONE_ORIENTATION_PORTRAIT          OF_ORIENTATION_DEFAULT  // UIDeviceOrientationPortrait
+#define OFXIPHONE_ORIENTATION_UPSIDEDOWN        OF_ORIENTATION_180      // UIDeviceOrientationPortraitUpsideDown
+#define OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT   OF_ORIENTATION_90_RIGHT // UIDeviceOrientationLandscapeRight
+#define OFXIPHONE_ORIENTATION_LANDSCAPE_LEFT    OF_ORIENTATION_90_LEFT  // UIDeviceOrientationLandscapeLeft
  
 // whether device has audio in
 bool ofxiPhoneHasAudioIn();
@@ -150,10 +150,8 @@ void ofxiPhoneUnlockGLContext();
 void ofxiPhoneEnableLoopInThread();
 
 
-// set orientation of device (affects statusbar, opengl viewport, touch positions)
-void ofxiPhoneSetOrientation(ofOrientation orientation);
-UIDeviceOrientation ofxiPhoneGetOrientation();
-
+OF_DEPRECATED_MSG("ofxiPhoneSetOrientation is deprecated, use ofSetOrientation instead.", void ofxiPhoneSetOrientation(ofOrientation orientation));
+OF_DEPRECATED_MSG("ofxiPhoneGetOrientation is deprecated, use ofGetOrientation instead.", UIDeviceOrientation ofxiPhoneGetOrientation());
 
 //void iPhoneEnableMultitouch();
 

--- a/addons/ofxiPhone/src/utils/ofxiPhoneKeyboard.mm
+++ b/addons/ofxiPhone/src/utils/ofxiPhoneKeyboard.mm
@@ -202,25 +202,25 @@ void ofxiPhoneKeyboard::updateOrientation()
 		_xOriginal = x;
 		_yOriginal = y;
 		
-		switch (ofxiPhoneGetOrientation()) 
+		switch (ofGetOrientation())
 		{
             // TODO: Move all these positions transformations to setFrame
-			case OFXIPHONE_ORIENTATION_LANDSCAPE_LEFT:
+			case OF_ORIENTATION_90_LEFT:
 				_x = ofGetWidth() - _xOriginal - _w; 
 				_y = ofGetHeight() - _yOriginal;
 				break;
 				
-			case OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT:
+			case OF_ORIENTATION_90_RIGHT:
 				_x = ofGetWidth() - _xOriginal - _w; 
 				_y = ofGetHeight() - _yOriginal;
 				break;
 				
-			case OFXIPHONE_ORIENTATION_UPSIDEDOWN:
+			case OF_ORIENTATION_180:
 				 _x = ofGetWidth() - _xOriginal - _w; 
 				 _y = ofGetHeight() - _yOriginal;
 				 break;
 				
-			case OFXIPHONE_ORIENTATION_PORTRAIT:
+			case OF_ORIENTATION_DEFAULT:
                 _x = _xOriginal;
 				_y = _h;
 				break;
@@ -243,25 +243,25 @@ void ofxiPhoneKeyboard::updateOrientation()
 {
 	_textField.transform = CGAffineTransformMakeRotation(0.0f);
 	
-	switch (ofxiPhoneGetOrientation()) 
+	switch (ofGetOrientation())
 	{
         // TODO: Move all these positions transformations to setFrame
-		case OFXIPHONE_ORIENTATION_LANDSCAPE_LEFT:
+		case OF_ORIENTATION_90_LEFT:
 			_x = ofGetWidth() - _xOriginal - _w; 
 			_y = ofGetHeight() - _yOriginal;
 			break;
 			
-		case OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT:
+		case OF_ORIENTATION_90_RIGHT:
 			_x = ofGetWidth() - _xOriginal - _w; 
 			_y = ofGetHeight() - _yOriginal;
 			break;
 			
-		case OFXIPHONE_ORIENTATION_UPSIDEDOWN:
+		case OF_ORIENTATION_180:
 			_x = ofGetWidth() - _xOriginal - _w; 
 			_y = ofGetHeight() - _yOriginal;
 			break;
 			
-		case OFXIPHONE_ORIENTATION_PORTRAIT:
+		case OF_ORIENTATION_DEFAULT:
             _x = _xOriginal;
 			_y = _h;
 			break;
@@ -363,9 +363,9 @@ void ofxiPhoneKeyboard::updateOrientation()
 	
     int x, y, w, h;
     
-	switch (ofxiPhoneGetOrientation()) 
+	switch (ofGetOrientation()) 
 	{
-		case OFXIPHONE_ORIENTATION_LANDSCAPE_LEFT:
+		case OF_ORIENTATION_90_LEFT:
             _textField.transform = CGAffineTransformMakeRotation(M_PI_2);
             x = rect.origin.y-rect.size.height;
             y = s.height-rect.size.width-rect.origin.x;
@@ -373,7 +373,7 @@ void ofxiPhoneKeyboard::updateOrientation()
             h = rect.size.width;
 			break;
 			
-		case OFXIPHONE_ORIENTATION_LANDSCAPE_RIGHT:
+		case OF_ORIENTATION_90_RIGHT:
             _textField.transform = CGAffineTransformMakeRotation(-M_PI_2);
             x = s.width-rect.origin.y;
             y = rect.origin.x;
@@ -381,7 +381,7 @@ void ofxiPhoneKeyboard::updateOrientation()
             h = rect.size.width;
 			break;
 			
-		case OFXIPHONE_ORIENTATION_UPSIDEDOWN:
+		case OF_ORIENTATION_180:
 			_textField.transform = CGAffineTransformMakeRotation(M_PI);
             x = rect.origin.x;
             y = rect.origin.y-rect.size.height;
@@ -389,7 +389,7 @@ void ofxiPhoneKeyboard::updateOrientation()
             h = rect.size.height;
             break;
 			
-		case OFXIPHONE_ORIENTATION_PORTRAIT:
+		case OF_ORIENTATION_DEFAULT:
             x = rect.origin.x;
             y = rect.origin.y-rect.size.height;
             w = rect.size.width;

--- a/addons/ofxiPhone/src/video/AVFoundationVideoGrabber.mm
+++ b/addons/ofxiPhone/src/video/AVFoundationVideoGrabber.mm
@@ -276,7 +276,7 @@ bool AVFoundationVideoGrabber::initGrabber(int w, int h){
 	if( [grabber initCapture:fps capWidth:w capHeight:h] ) {
 		grabber->grabberPtr = this;
 		
-		if(ofxiPhoneGetOrientation() == UIDeviceOrientationPortrait || ofxiPhoneGetOrientation() == UIDeviceOrientationPortraitUpsideDown) {
+		if(ofGetOrientation() == OF_ORIENTATION_DEFAULT || ofGetOrientation() == OF_ORIENTATION_180) {
 			width = grabber->height;
 			height = grabber->width;
 		}
@@ -323,21 +323,21 @@ void AVFoundationVideoGrabber::updatePixelsCB( CGImageRef & ref ){
 	// Uses the bitmap creation function provided by the Core Graphics framework. 
 	spriteContext = CGBitmapContextCreate(pixelsTmp, width, height, CGImageGetBitsPerComponent(ref), width * 4, CGImageGetColorSpace(ref), kCGImageAlphaPremultipliedLast);
 	
-	if(ofxiPhoneGetOrientation() == UIDeviceOrientationPortrait) {
+	if(ofGetOrientation() == OF_ORIENTATION_DEFAULT) {
         transform = CGAffineTransformMakeTranslation(0.0, height);
         transform = CGAffineTransformRotate(transform, 3.0 * M_PI / 2.0);
 			
         CGContextConcatCTM(spriteContext, transform);
         CGContextDrawImage(spriteContext, CGRectMake(0.0, 0.0, (CGFloat)height, (CGFloat)width), ref);
 	}
-	else if(ofxiPhoneGetOrientation() == UIDeviceOrientationPortraitUpsideDown) {
+	else if(ofGetOrientation() == OF_ORIENTATION_180) {
         transform = CGAffineTransformMakeTranslation(width, 0.0);
         transform = CGAffineTransformRotate(transform, M_PI / 2.0);
         
         CGContextConcatCTM(spriteContext, transform);
         CGContextDrawImage(spriteContext, CGRectMake(0.0, 0.0, (CGFloat)height, (CGFloat)width), ref);
 	}
-	else if(ofxiPhoneGetOrientation() == UIDeviceOrientationLandscapeLeft) {
+	else if(ofGetOrientation() == OF_ORIENTATION_90_LEFT) {
 		CGContextDrawImage(spriteContext, CGRectMake(0.0, 0.0, (CGFloat)width, (CGFloat)height), ref);
 	}
 	else { // landscape RIGHT


### PR DESCRIPTION
the new renderer now handles orientation,
old orientation functions, `ofxiPhoneSetOrientation` and `ofxiPhoneGetOrientation` have been deprecated.
