### PR TITLE
frame support for ofiPhoneVideoPlayer

### DIFF
--- a/addons/ofxiPhone/src/video/AVFoundationVideoPlayer.h
+++ b/addons/ofxiPhone/src/video/AVFoundationVideoPlayer.h
@@ -74,6 +74,10 @@
 - (double)getCurrentTimeInSec;
 - (CMTime)getDuration;
 - (double)getDurationInSec;
+- (int)getDurationInFrames;
+- (int)getCurrentFrameNum;
+- (float)getFrameRate;
+- (void)setFrame:(int)frame;
 - (void)setPosition:(float)position;
 - (float)getPosition;
 - (void)setVolume:(float)volume;

--- a/addons/ofxiPhone/src/video/ofiPhoneVideoPlayer.mm
+++ b/addons/ofxiPhone/src/video/ofiPhoneVideoPlayer.mm
@@ -616,17 +616,23 @@ void ofiPhoneVideoPlayer::setFrame(int frame) {
         return;
     }
 
-    return; // not supported yet.
+    [((AVFoundationVideoPlayer *)videoPlayer) setFrame:frame];
 }
 
 //----------------------------------------
 int	ofiPhoneVideoPlayer::getCurrentFrame() {
-    return -1; // not supported yet.
+    if(videoPlayer == NULL){
+        return 0;
+    }
+    return [((AVFoundationVideoPlayer *)videoPlayer) getCurrentFrameNum];
 }
 
 //----------------------------------------
 int	ofiPhoneVideoPlayer::getTotalNumFrames() {
-    return -1; // not supported yet.
+    if(videoPlayer == NULL){
+        return 0;
+    }
+    return [((AVFoundationVideoPlayer *)videoPlayer) getDurationInFrames];
 }
 
 //----------------------------------------
@@ -653,12 +659,14 @@ void ofiPhoneVideoPlayer::firstFrame() {
 
 //----------------------------------------
 void ofiPhoneVideoPlayer::nextFrame() {
-    return; // not supported yet.
+    int nextFrameNum = ofClamp(getCurrentFrame() + 1, 0, getTotalNumFrames());
+    setFrame(nextFrameNum);
 }
 
 //----------------------------------------
 void ofiPhoneVideoPlayer::previousFrame() {
-    return; // not supported yet.
+    int prevFrameNum = ofClamp(getCurrentFrame() - 1, 0, getTotalNumFrames());
+    setFrame(prevFrameNum);
 }
 
 //----------------------------------------


### PR DESCRIPTION
ofiPhoneVideoPlayer  now supports the following functions,
`setFrame`
`getCurrentFrame()`
`getTotalNumFrames()`
`nextFrame()`
`previousFrame()`

previously submitted as PR #2027 and slightly reworked.
seeing as this PR has had 2 people work on it and is only a small change, id say its good to go.
