### PR TITLE
fix ofAppGLFWWindow fullscreen on multimonitor systems

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -115,6 +115,8 @@ private:
 	int 			nFramesSinceWindowResized;
 	bool			bDoubleBuffered;
 
+	int				getCurrentMonitor();
+	
 	static ofAppGLFWWindow	* instance;
 	static ofBaseApp *	ofAppPtr;
 


### PR DESCRIPTION
## issue

Contrary to ofAppGLUTWindow, ofAppGLFWWindow would always only go fullscreen on the _primary_ monitor, regardless on which monitor the window was placed before going fullscreen.

This commit fixes this by replicating the behaviour of ofAppGLUTWindow, following the maxim of least surprise.
## fix
- in multi-monitor scenarios, windows will go fullscreen on the monitor they inhabited before they switched into fullscreen mode.

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
