### PR TITLE
bugfix GLFW delete/backspace/return keys were not coming in. also ctrl-click alt-click were not coming in as left right click. closes #2197

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -957,7 +957,7 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int key, int scancode, i
 			key = OF_KEY_INSERT;
 			break;
 		case GLFW_KEY_LEFT_SHIFT:
-			key = OF_KEY_SHIFT;
+			key = OF_KEY_LEFT_SHIFT;
 			break;
 		case GLFW_KEY_LEFT_CONTROL:
 			key = OF_KEY_LEFT_CONTROL;
@@ -979,6 +979,7 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int key, int scancode, i
 			break;
 		case GLFW_KEY_RIGHT_SUPER:
 			key = OF_KEY_RIGHT_SUPER;
+            break;
 		case GLFW_KEY_BACKSPACE:
 			key = OF_KEY_BACKSPACE;
 			break;

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -179,15 +179,22 @@ void ofNotifyKeyPressed(int key){
 	static ofKeyEventArgs keyEventArgs;
 
     if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
-        pressedKeys.insert(OF_KEY_CTRL);
+        pressedKeys.insert(key);
+        key = OF_KEY_CTRL;
     }
-    if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
-        pressedKeys.insert(OF_KEY_SHIFT);
+    else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
+        pressedKeys.insert(key);
+        key = OF_KEY_SHIFT;
     }
-    if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT ){
-        pressedKeys.insert(OF_KEY_ALT);
+    else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
+        pressedKeys.insert(key);
+        key = OF_KEY_ALT; 
     }
-        
+    else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
+        pressedKeys.insert(key);
+        key = OF_KEY_SUPER; 
+    }
+            
 	pressedKeys.insert(key);
 	keyEventArgs.key = key;
 	ofNotifyEvent( ofEvents().keyPressed, keyEventArgs );
@@ -205,15 +212,22 @@ void ofNotifyKeyReleased(int key){
 	static ofKeyEventArgs keyEventArgs;
 
     if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
-        pressedKeys.erase(OF_KEY_CTRL);
+        pressedKeys.erase(key);
+        key = OF_KEY_CTRL;
     }
-    if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
-        pressedKeys.erase(OF_KEY_SHIFT);
+    else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
+        pressedKeys.erase(key);
+        key = OF_KEY_SHIFT;
     }
-    if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT ){
-        pressedKeys.erase(OF_KEY_ALT);
+    else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
+        pressedKeys.erase(key);
+        key = OF_KEY_ALT; 
     }
-
+    else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
+        pressedKeys.erase(key);
+        key = OF_KEY_SUPER; 
+    }
+    
 	pressedKeys.erase(key);
 	
 	keyEventArgs.key = key;

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -545,7 +545,9 @@ enum ofMatrixMode {OF_MATRIX_MODELVIEW=0, OF_MATRIX_PROJECTION, OF_MATRIX_TEXTUR
 	#define OF_KEY_CTRL			0x0200
 	#define OF_KEY_ALT			0x0300
 	#define OF_KEY_SHIFT		0x0400
-
+	#define OF_KEY_SUPER		0x0500
+    #define OF_KEY_COMMAND      OF_KEY_SUPER
+    
 	// http://www.openframeworks.cc/forum/viewtopic.php?t=494
 	// some issues with keys across platforms:
 


### PR DESCRIPTION
Note that for the key presses I translate:

```
GLFW_KEY_RIGHT_SHIFT to OF_KEY_SHIFT  
GLFW_KEY_RIGHT_ALT to OF_KEY_ALT
GLFW_KEY_LEFT_CONTROL to OF_KEY_CTRL 
```

so we get an event for OF_KEY_SHIFT / OF_KEY_ALT / OF_KEY_CTRL

I'm curious what you think about this @arturoc 

we could also fire two events? 
ie: 

ofNotifyKeyPressed(OF_KEY_RIGHT_ALT);
ofNotifyKeyPressed(OF_KEY_ALT);
