### PR TITLE
ios external display mirror mode is now default

### DIFF
--- a/addons/ofxiPhone/src/core/ofxiPhoneAppDelegate.h
+++ b/addons/ofxiPhone/src/core/ofxiPhoneAppDelegate.h
@@ -32,27 +32,28 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
-#import "ofxiPhoneViewController.h"
+
+@class ofxiPhoneViewController;
 
 @interface ofxiPhoneAppDelegate : NSObject <UIApplicationDelegate> {
     NSInteger currentScreenIndex;
 }
 
-@property (nonatomic, retain) UIWindow *window;
-@property (nonatomic, retain) UIWindow *externalWindow;
-@property (nonatomic, retain) ofxiPhoneViewController *glViewController;
+@property (nonatomic, retain) UIWindow * window;
+@property (nonatomic, retain) UIWindow * externalWindow;
+@property (nonatomic, retain) ofxiPhoneViewController * glViewController;
 @property (readonly,  assign) NSInteger currentScreenIndex;
 
--(BOOL) application:(UIApplication*)application 
+- (BOOL)application:(UIApplication*)application
       handleOpenURL:(NSURL*)url;
 
--(void) receivedRotate:(NSNotification*)notification;
+- (void)receivedRotate:(NSNotification*)notification;
 
 #ifdef __IPHONE_4_3
--(BOOL) createExternalWindowWithPreferredMode;
--(BOOL) createExternalWindowWithScreenModeIndex:(NSInteger)screenModeIndex;
--(BOOL) destroyExternalWindow;
--(BOOL) displayOnScreenWithIndex:(NSInteger)screenIndex 
+- (BOOL)createExternalWindowWithPreferredMode;
+- (BOOL)createExternalWindowWithScreenModeIndex:(NSInteger)screenModeIndex;
+- (BOOL)destroyExternalWindow;
+- (BOOL)displayOnScreenWithIndex:(NSInteger)screenIndex
               andScreenModeIndex:(NSInteger)screenModeIndex;
 #endif
 

--- a/examples/ios/iosCustomSizeExample/src/UI/MyAppViewController.mm
+++ b/examples/ios/iosCustomSizeExample/src/UI/MyAppViewController.mm
@@ -4,6 +4,7 @@
 //
 
 #import "MyAppViewController.h"
+#import "ofxiPhoneViewController.h"
 #import "testApp.h"
 
 @implementation MyAppViewController


### PR DESCRIPTION
- external display mirror mode is now default
- also cleaned up ofxiPhoneAppDelegate up a little bit,
  - cleaned up formatting.
  - including ofxiPhoneViewController class reference in the ofxiPhoneAppDelegate implementation file.
  - adjusted iosCustomSizeExample to include a reference to ofxiPhoneViewController
