### PR TITLE
fixes ofDrawBitmapStringHighlight issues

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -1047,7 +1047,6 @@ void ofDrawBitmapStringHighlight(string text, int x, int y, const ofColor& backg
 	ofSetColor(background);
 	ofFill();
 	ofPushMatrix();
-	ofMatrix4x4 m;
 	ofTranslate(x,y,0);
 	if(currentStyle.drawBitmapMode == OF_BITMAPMODE_MODEL) {
 		ofScale(1,-1,0);


### PR DESCRIPTION
fixes an issue wherein the background rectangle would not be drawn at the correct position.

Note that the programmableGL renderer is more faithful in drawing the bitmap String since it uses the new internal ofMatrixStack to calculate the on-screen positions.

Closes issue #2212

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
