### PR TITLE
expose inner vbo in ofVboMesh

### DIFF
--- a/libs/openFrameworks/gl/ofVboMesh.cpp
+++ b/libs/openFrameworks/gl/ofVboMesh.cpp
@@ -72,6 +72,9 @@ bool ofVboMesh::usingIndices() const {
 	return vbo.getUsingIndices();
 }
 
+ofVbo & ofVboMesh::getVbo() {
+	return vbo;
+};
 
 void ofVboMesh::drawInstanced(ofPolyRenderMode drawMode, int primCount){
 	if(getNumVertices()==0) return;

--- a/libs/openFrameworks/gl/ofVboMesh.h
+++ b/libs/openFrameworks/gl/ofVboMesh.h
@@ -28,6 +28,8 @@ public:
 	void draw(ofPolyRenderMode drawMode);
 	void drawInstanced(ofPolyRenderMode drawMode, int primCount);
 	
+	ofVbo & getVbo();
+	
 private:
 	void updateVbo();
 	ofVbo vbo;


### PR DESCRIPTION
this ideally allows the wrapper to be a bit more flexible, especially by giving access to ofVbo::setAttributeData()

this is a proposal for issue #2228

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
