### PR TITLE
removing a now un-neccessary getPocoElement() that called itself

### DIFF
--- a/libs/openFrameworks/types/ofXml.cpp
+++ b/libs/openFrameworks/types/ofXml.cpp
@@ -579,11 +579,6 @@ Poco::XML::Element* ofXml::getPocoElement(const string& path) const
     
 }
 
-Poco::XML::Element* ofXml::getPocoElement(const string& path) {
-	return getPocoElement(path);
-}
-
-
 string ofXml::getName() const
 {
     if(element)


### PR DESCRIPTION
To fix https://github.com/openframeworks/openFrameworks/issues/2217
