### PR TITLE
ios es2 fixes.

### DIFF
--- a/addons/ofxiOS/src/gl/ES2Renderer.h
+++ b/addons/ofxiOS/src/gl/ES2Renderer.h
@@ -14,7 +14,8 @@
     GLint backingHeight;
 
     // The OpenGL ES names for the framebuffer and renderbuffer used to render to this view
-    GLuint defaultFramebuffer, colorRenderbuffer;
+    GLuint defaultFramebuffer, colorRenderbuffer, depthRenderbuffer;
+	GLuint fsaaFrameBuffer, fsaaColorRenderBuffer;
 
 	//settings
 	bool fsaaEnabled;
@@ -24,8 +25,8 @@
 }
 
 - (id)initWithDepth:(bool)depth andAA:(bool)fsaa andFSAASamples:(int)samples andRetina:(bool)retina;
-- (void) startRender;
-- (void) finishRender;
+- (void)startRender;
+- (void)finishRender;
 - (BOOL)resizeFromLayer:(CAEAGLLayer *)layer;
 - (BOOL)createFramebuffer:(CAEAGLLayer *)layer;
 - (void)destroyFramebuffer;

--- a/examples/ios/advancedGraphics/src/testApp.mm
+++ b/examples/ios/advancedGraphics/src/testApp.mm
@@ -87,7 +87,7 @@ void testApp::draw(){
 	ofDisableAlphaBlending();
 
 	if(ofGetWidth() > 480){ // then we are running retina
-		glScalef(2, 2, 0);
+		ofScale(2, 2, 0);
     }
 
 	//---------------------------
@@ -113,12 +113,12 @@ void testApp::draw(){
 	//We only want to rotate the circles
 	//So we use push and pop matrix to
 	//make sure the rotation is contained
-	glPushMatrix();
+	ofPushMatrix();
 		//we position the rotation point
 		//at the location we want it to
 		//spin around .
-		glTranslatef(750, 320, 0);
-		glRotatef(spin, 0, 0, 1);
+		ofTranslate(750, 320, 0);
+		ofRotate(spin, 0, 0, 1);
 
 		//draw a red circle
 		ofSetColor(255,0, 0);
@@ -131,7 +131,7 @@ void testApp::draw(){
 		//draw a blue circle
 		ofSetColor(0, 0, 255);
 		ofCircle(0, 57, 100);
-	glPopMatrix();
+	ofPopMatrix();
 
 
 	//---------------------------------

--- a/examples/ios/polygonExample/src/testApp.mm
+++ b/examples/ios/polygonExample/src/testApp.mm
@@ -149,8 +149,8 @@ void testApp::draw(){
 	// 
 	// 		use sin cos and time to make some spirally shape
 	//
-	glPushMatrix();
-		glTranslatef(100,300,0);
+	ofPushMatrix();
+		ofTranslate(100,300,0);
 		ofSetHexColor(0xff2220);
 		ofFill();
 		ofSetPolyMode(OF_POLY_WINDING_ODD);
@@ -166,7 +166,7 @@ void testApp::draw(){
 			radius 	+= radiusAdder; 
 		}
 		ofEndShape(OF_CLOSE);
-	glPopMatrix();
+	ofPopMatrix();
 	//-------------------------------------
 	
 	//------(f)--------------------------------------
@@ -312,7 +312,7 @@ void testApp::draw(){
 	ofNoFill();
 	
 	
-	glPushMatrix();
+	ofPushMatrix();
 	
 	ofSetPolyMode(OF_POLY_WINDING_ODD);
 	
@@ -335,7 +335,7 @@ void testApp::draw(){
 
 	ofEndShape(true);
 	
-	glTranslatef(100,0,0);
+	ofTranslate(100,0,0);
 	
 	ofSetPolyMode(OF_POLY_WINDING_NONZERO);	
 	ofBeginShape();
@@ -356,7 +356,7 @@ void testApp::draw(){
 		
 	ofEndShape(true);
 	
-	glTranslatef(100,0,0);
+	ofTranslate(100,0,0);
 	ofSetPolyMode(OF_POLY_WINDING_ABS_GEQ_TWO);
 	ofBeginShape();
 		ofVertex(300,500);
@@ -375,7 +375,7 @@ void testApp::draw(){
 		
 	ofEndShape(true);
 	
-	glPopMatrix();
+	ofPopMatrix();
 	//-------------------------------------
 	
 	


### PR DESCRIPTION
- added depth buffer to ES2 renderer.
- added fsaa buffer to ES2 renderer.
- ES2 renderer now supports the same features as ES1 renderer
- tested that both ES2 and ES1 renderers behave the same.
- updated a couple examples so they use ofPushMatrix instead of glPushMatrix (etc) which is not supported in ES2.
