### PR TITLE
Fix ofColor overflow/underflow

### DIFF
--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -151,6 +151,23 @@ template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::whit
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::yellowGreen(0.603922*limit(),0.803922*limit(),0.196078*limit());
 
 
+template<typename A, typename B>
+A clampedSubtract(const A& a, const B& b) {
+	return CLAMP((float) a - (float) b, 0, ofColor_<A>::limit());
+}
+template<typename A, typename B>
+A clampedAdd(const A& a, const B& b) {
+	return CLAMP((float) a + (float) b, 0, ofColor_<A>::limit());
+}
+template<typename A, typename B>
+A clampedDivide(const A& a, const B& b) {
+	return CLAMP((float) a / (float) b, 0, ofColor_<A>::limit());
+}
+template<typename A, typename B>
+A clampedMultiply(const A& a, const B& b) {
+	return CLAMP((float) a * (float) b, 0, ofColor_<A>::limit());
+}
+
 template<typename PixelType>
 float ofColor_<PixelType>::limit() {
 	return numeric_limits<PixelType>::max();

--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -149,15 +149,6 @@ class ofColor_{
 	private:
 		template<typename SrcType>
 		void copyFrom(const ofColor_<SrcType> & mom);
-	
-		template<typename SrcType>
-		PixelType clampedSubtract(const PixelType& a, const SrcType& b);
-		template<typename SrcType>
-		PixelType clampedAdd(const PixelType& a, const SrcType& b);
-		template<typename SrcType>
-		PixelType clampedMultiply(const PixelType& a, const SrcType& b);
-		template<typename SrcType>
-		PixelType clampedDivide(const PixelType& a, const SrcType& b);
 };
 
 
@@ -196,29 +187,5 @@ void ofColor_<PixelType>::copyFrom(const ofColor_<SrcType> & mom){
 			v[i] = mom[i] * factor;
 		}
 	}
-}
-
-template<typename PixelType>
-template<typename SrcType>
-PixelType ofColor_<PixelType>::clampedSubtract(const PixelType& a, const SrcType& b) {
-	return CLAMP((float) a - (float) b, 0, limit());
-}
-
-template<typename PixelType>
-template<typename SrcType>
-PixelType ofColor_<PixelType>::clampedAdd(const PixelType& a, const SrcType& b) {
-	return CLAMP((float) a + (float) b, 0, limit());
-}
-
-template<typename PixelType>
-template<typename SrcType>
-PixelType ofColor_<PixelType>::clampedMultiply(const PixelType& a, const SrcType& b) {
-	return CLAMP((float) a * (float) b, 0, limit());
-}
-
-template<typename PixelType>
-template<typename SrcType>
-PixelType ofColor_<PixelType>::clampedDivide(const PixelType& a, const SrcType& b) {
-	return CLAMP((float) a / (float) b, 0, limit());
 }
 


### PR DESCRIPTION
This fix replaces all arithmetic operations (add, subtract, multiply, divide) with functions that use floating point math internally and clamp the values to the color range before casting to the original type. This has been tested on ofShortColor, ofFloatColor and ofColor. Closes #1144.
