### PR TITLE
Tiny fix on ofRectangle ostream operator

### DIFF
--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -689,7 +689,7 @@ bool ofRectangle::operator == (const ofRectangle& rect) const {
 
 //----------------------------------------------------------
 ostream& operator<<(ostream& os, const ofRectangle& rect){
-	os << rect.x << ", " << rect.x << ", " << rect.width << ", " << rect.height;
+	os << rect.x << ", " << rect.y << ", " << rect.width << ", " << rect.height;
 	return os;
 }
 


### PR DESCRIPTION
It was printing 5 components (position.x, position.y, position.z, width, height) making it very confusing to read
