### PR TITLE
setMultiDisplayFullscreen(true) working better on OSX (2)

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -680,7 +680,7 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 			//calc the sum Rect of all the monitors
 			for(int i = 0; i < monitorCount; i++){
 				const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[i]);
-				int x, y, w, h;
+				int x, y;
 				glfwGetMonitorPos(monitors[i], &x, &y);
 				ofRectangle screen = ofRectangle( x, y, desktopMode->width, desktopMode->height );
 				allScreensSpace = allScreensSpace.getUnion(screen);


### PR DESCRIPTION
It now creates a window that spans across all available monitors, (potentially wasting lots of pixel space too)
http://cl.ly/image/0x313h0G3R21. Now without unused vars.
