### PR TITLE
fix possible state change after ofDrawRotationAxes()

### DIFF
--- a/libs/openFrameworks/3d/of3dUtils.cpp
+++ b/libs/openFrameworks/3d/of3dUtils.cpp
@@ -159,12 +159,13 @@ void ofDrawRotationAxes(float radius, float stripWidth, int circleRes){
 		axisZMesh.addVertex(ofVec3f( stripWidth, x*radius, y*radius));
 	}
 	
-	glEnable(GL_DEPTH_TEST);
+	ofPushStyle();
+	ofEnableDepthTest();
 	axisXMesh.draw();
 	axisYMesh.draw();
 	axisZMesh.draw();
 	ofDrawAxis(radius);
-	glDisable(GL_DEPTH_TEST);
+	ofPopStyle();
 	
 }
 


### PR DESCRIPTION
ofDrawRotationAxes would set glDisable(GL_DEPTH_TEST) upon returning, which differs from how comparable methods behave. These use ofPushStyle and ofPopStyle to restore state.

This should bring ofDrawRotationAxes in line.

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
