### PR TITLE
fixes triangle winding direction for ofIcoSphere

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -1854,9 +1854,7 @@ ofMesh ofMesh::icosphere(float radius, int iterations) {
 	// makes things very, very complicated.
 	
 	for (int i = 0; i < faces.size(); i+=3) {
-		ofIndexType tmpI = faces[i+1];
-		faces[i+1] = faces[i+2];
-		faces[i+2] = tmpI;
+		std::swap(faces[i+1], faces[i+2]);
 	}
 
     ofMesh sphere;


### PR DESCRIPTION
triangles were wound the other way around, which resulted in backfaces to be rendered instead of front faces when glEnable(GL_CULL_FACE), glCullFace(GL_BACK) was applied.

This reverses the triangle winding mode - and so fixes it.

fixes #2263

![screen shot 2013-07-16 at 12 45 09](https://f.cloud.github.com/assets/423509/804413/31832956-ee0d-11e2-8d1d-7fa91fba0b4a.png)

(icosphere on the left, note that @nickhardeman's PR #2259 fixes the cone not being rendered correctly, too. =)

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
