### PR TITLE
revert "multisampling by default"

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -65,9 +65,7 @@ ofAppGLFWWindow::ofAppGLFWWindow():ofAppBaseWindow(){
 
 	glVersionMinor=glVersionMajor=-1;
 	nFramesSinceWindowResized = 0;
-    
-    //default to 4 times antialiasing. 
-    setNumSamples(4);
+	
 	iconSet = false;
 
 }


### PR DESCRIPTION
- It's good to be consistent in how openFrameworks renders things from version to version.
- OF users often use Processing and expect it to behave similarly (e.g., smooth() turns on smoothing, otherwise things are aliased)
- The definition of a "center of a pixel" varies, which means a white outlined rectangle (or any other 1 px shape aligned to the pixel grid) can appear gray/semitransparent instead of white.
- It's not easy enough to turn off the multisampling yet. I would concede "multisampling by default" if the meaning of "ofEnableSmoothing()" changed to be something about multisampling, or if there's another function that's added that can be used in `main()` to set the samples in a way that works with RPi.
