### PR TITLE
fixes to compile on windows vs2012

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -521,7 +521,7 @@ int ofSerial::readBytes(unsigned char * buffer, int length){
 	#ifdef TARGET_WIN32
 		DWORD nRead = 0;
 		if (!ReadFile(hComm,buffer,length,&nRead,0)){
-			ofLogError("ofSerial") << "readBytes(): couldn't read from port");
+			ofLogError("ofSerial") << "readBytes(): couldn't read from port";
 			return OF_SERIAL_ERROR;
 		}
 		return (int)nRead;
@@ -567,7 +567,7 @@ bool ofSerial::writeByte(unsigned char singleByte){
 			 return false;
 		}
 
-		ofLogVerbose("ofSerial") << "wrote byte");
+		ofLogVerbose("ofSerial") << "wrote byte";
 
 		return ((int)written > 0 ? true : false);
 	#endif

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -6,7 +6,7 @@
 #include <set>
 
 static const double MICROS_TO_SEC = .000001;
-//static const double MICROS_TO_MILLIS = .001;
+static const double MICROS_TO_MILLIS = .001;
 
 static unsigned long long   timeThen = 0, oneSec = 0;
 static float    			targetRate = 0;

--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
@@ -124,7 +124,6 @@
     <ClInclude Include="..\..\..\openFrameworks\types\ofPoint.h" />
     <ClInclude Include="..\..\..\openFrameworks\types\ofRectangle.h" />
     <ClInclude Include="..\..\..\openFrameworks\types\ofTypes.h" />
-    <ClInclude Include="..\..\..\openFrameworks\types\ofXml.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofConstants.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofFileUtils.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofLog.h" />
@@ -134,6 +133,7 @@
     <ClInclude Include="..\..\..\openFrameworks\utils\ofThread.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofURLFileLoader.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofUtils.h" />
+    <ClInclude Include="..\..\..\openFrameworks\utils\ofXml.h" />
     <ClInclude Include="..\..\..\openFrameworks\video\ofDirectShowGrabber.h" />
     <ClInclude Include="..\..\..\openFrameworks\video\ofQtUtils.h" />
     <ClInclude Include="..\..\..\openFrameworks\video\ofQuickTimeGrabber.h" />
@@ -193,7 +193,6 @@
     <ClCompile Include="..\..\..\openFrameworks\types\ofParameter.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\types\ofParameterGroup.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\types\ofRectangle.cpp" />
-    <ClCompile Include="..\..\..\openFrameworks\types\ofXml.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\utils\ofFileUtils.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\utils\ofLog.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\utils\ofMatrixStack.cpp" />
@@ -201,6 +200,7 @@
     <ClCompile Include="..\..\..\openFrameworks\utils\ofThread.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\utils\ofURLFileLoader.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\utils\ofUtils.cpp" />
+    <ClCompile Include="..\..\..\openFrameworks\utils\ofXml.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\video\ofDirectShowGrabber.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\video\ofQtUtils.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\video\ofQuickTimeGrabber.cpp" />

--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
@@ -264,8 +264,8 @@
     <ClInclude Include="..\..\..\openFrameworks\app\ofAppNoWindow.h">
       <Filter>libs\openFrameworks\app</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\..\openFrameworks\types\ofXml.h">
-      <Filter>libs\openFrameworks\types</Filter>
+    <ClInclude Include="..\..\..\openFrameworks\utils\ofXml.h">
+      <Filter>libs\openFrameworks\utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -455,8 +455,8 @@
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppNoWindow.cpp">
       <Filter>libs\openFrameworks\app</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\openFrameworks\types\ofXml.cpp">
-      <Filter>libs\openFrameworks\types</Filter>
+    <ClCompile Include="..\..\..\openFrameworks\utils\ofXml.cpp">
+      <Filter>libs\openFrameworks\utils</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
this moves ofXML from /types to /utils in the VS2012 project and fixes some of the new logging code for TARGET_WIN32. 
