### PR TITLE
feature: added ofEnableAntiAliasing / ofDisableAntiAliasing

### DIFF
--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -2,6 +2,7 @@
 
 #include "ofPoint.h"
 #include "ofTypes.h"
+#include "ofLog.h"
 
 class ofBaseApp;
 
@@ -15,6 +16,14 @@ public:
 	virtual void setupOpenGL(int w, int h, int screenMode) {}
 	virtual void initializeWindow() {}
 	virtual void runAppViaInfiniteLoop(ofBaseApp * appPtr) {}
+    
+    virtual void enableAntiAliasing(int requestedNumSamples){
+        ofLogWarning("ofAppBaseWindow") << " enableAntiAliasing is not implemented for your window " << endl; 
+    }
+    
+    virtual void disableAntiAliasing(){
+        ofLogWarning("ofAppBaseWindow") << " disableAntiAliasing is not implemented for your window " << endl; 
+    }
 
 	virtual void hideCursor() {}
 	virtual void showCursor() {}

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -74,7 +74,17 @@ ofAppGLFWWindow::ofAppGLFWWindow():ofAppBaseWindow(){
 
 }
 
+//------------------------------------------------------------
+void ofAppGLFWWindow::enableAntiAliasing(int requestedNumSamples){
+    //for glfw we just pass this through. 
+    setNumSamples(requestedNumSamples);
+}
 
+//------------------------------------------------------------
+void ofAppGLFWWindow::disableAntiAliasing(){
+    setNumSamples(0);
+}
+    
 //------------------------------------------------------------
 void ofAppGLFWWindow::setNumSamples(int _samples){
 	samples=_samples;

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -32,6 +32,11 @@ public:
 	void setWindowIcon(const string & path);
 	void setWindowIcon(const ofPixels & iconPixels);
 #endif
+
+    //call before ofSetupOpenGL
+    void        enableAntiAliasing(int requestedNumSamples);
+    void        disableAntiAliasing();
+
 	void 		setNumSamples(int samples);
 	void 		setDoubleBuffering(bool doubleBuff);
 	void 		setColorBits(int r, int g, int b);

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -200,6 +200,24 @@ ofAppGlutWindow::ofAppGlutWindow(){
 //lets you enable alpha blending using a display string like:
 // "rgba double samples>=4 depth" ( mac )
 // "rgb double depth alpha samples>=4" ( some pcs )
+
+//------------------------------------------------------------
+void ofAppGlutWindow::enableAntiAliasing(int requestedNumSamples){
+    string displayStr = "rgba";
+    #ifndef TARGET_OSX
+        displayStr = "rgb"
+    #endif
+    
+    displayStr += " double depth samples>=" + ofToString(requestedNumSamples);
+     
+    setGlutDisplayString(displayStr);
+}
+
+//------------------------------------------------------------
+void ofAppGlutWindow::disableAntiAliasing(){
+    setGlutDisplayString("");
+}
+
 //------------------------------------------------------------
  void ofAppGlutWindow::setGlutDisplayString(string displayStr){
 	displayString = displayStr;

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -26,6 +26,10 @@ public:
 	void initializeWindow();
 	void runAppViaInfiniteLoop(ofBaseApp * appPtr);
 	
+    //call before ofSetupOpenGL
+    void enableAntiAliasing(int requestedNumSamples);
+    void disableAntiAliasing();
+    
 	//note if you fail to set a compatible string the app will not launch
 	void setGlutDisplayString(string str);
 

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -32,6 +32,10 @@
 static ofPtr<ofBaseApp>				OFSAptr;
 static ofPtr<ofAppBaseWindow> 		window;
 
+static bool bAntiAliasingRequestSet = false; 
+static bool bAntiAliasingEnabled = false;
+static int  numSamplesAntiAliasing = 2; 
+
 //#define USE_PROGRAMMABLE_GL
 
 //========================================================================
@@ -138,6 +142,19 @@ void ofRunApp(ofBaseApp * OFSA){
 }
 
 //--------------------------------------
+void  ofEnableAntiAliasing(int requestedSamples){
+    bAntiAliasingRequestSet = true; 
+    bAntiAliasingEnabled = true; 
+    numSamplesAntiAliasing = requestedSamples;  
+}
+
+//--------------------------------------
+void  ofDisableAntiAliasing(){
+    bAntiAliasingRequestSet = true; 
+    bAntiAliasingEnabled = false; 
+}
+
+//--------------------------------------
 void ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode){
     if(!ofGetCurrentRenderer()) {
 	#ifdef USE_PROGRAMMABLE_GL
@@ -149,6 +166,14 @@ void ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMod
     }
 
 	window = windowPtr;
+    
+    if( bAntiAliasingRequestSet ){
+        if( bAntiAliasingEnabled ){
+            window->enableAntiAliasing(numSamplesAntiAliasing); 
+        }else{
+            window->disableAntiAliasing(); 
+        }
+    }
 
 	if(ofIsGLProgrammableRenderer()){
         #if defined(TARGET_RASPBERRY_PI)

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -9,6 +9,11 @@ class ofAppBaseWindow;
 class ofBaseApp;
 class ofBaseRenderer;
 
+
+//call before window is setup. requestedSamples will be set if supported, otherwise default AA sampling will occur. 
+void        ofEnableAntiAliasing(int requestedSamples);
+void        ofDisableAntiAliasing(); 
+
 void 		ofSetupOpenGL(ofPtr<ofAppBaseWindow> windowPtr, int w, int h, int screenMode);	// sets up the opengl context!
 void 		ofSetupOpenGL(int w, int h, int screenMode);	// sets up the opengl context!
 void 		ofSetupOpenGL(ofAppBaseWindow * windowPtr, int w, int h, int screenMode);  // will be deprecated


### PR DESCRIPTION
Allows you to set anti-aliasing on or off without the window handle in main.cpp. 
Implemented for GLUT and GLFW window. 

If people are okay with this, I can add it to ofxiOS too. 

The reason we need this is that we currently can't have AA disable for some core examples because it requires us to expose the type of window we are using Raspberry PI / other devices need a different window handle. 

Tested for OS X GLFW and GLUT - AA on and off with different sampling ( 0, 2, 4, 8, 16 ) 
Works great. Might need nix / win testing. 

Example disabling AA which is on with default GLFW window:

```
#include "ofMain.h"
#include "testApp.h"

//========================================================================
int main( ){

    ofDisableAntiAliasing(); 
    ofSetupOpenGL(1024,768, OF_WINDOW);         // <-------- setup the GL context

    // this kicks off the running of my app
    // can be OF_WINDOW or OF_FULLSCREEN
    // pass in width and height too:
    ofRunApp( new testApp());

}

```

Example using Glut window ( non default ) and enabling AA for both mac / nix / pc:

```
#include "ofMain.h"
#include "testApp.h"
#include "ofAppGlutWindow.h"

//========================================================================
int main( ){

     ofAppGlutWindow * window = new ofAppGlutWindow(); 

     ofEnableAntiAliasing(4); 
    ofSetupOpenGL(window, 1024,768, OF_WINDOW);         // <-------- setup the GL context

    // this kicks off the running of my app
    // can be OF_WINDOW or OF_FULLSCREEN
    // pass in width and height too:
    ofRunApp( new testApp());

}
```
