### PR TITLE
update deprecated ofSphere / ofBox calls in examples

### DIFF
--- a/examples/3d/advanced3dExample/src/Swarm.cpp
+++ b/examples/3d/advanced3dExample/src/Swarm.cpp
@@ -67,7 +67,7 @@ void swarm::customDraw(){
 		ofPushStyle();
 		ofSetColor(particles[i].color);
 
-		ofSphere(particles[i].position, 1.0);
+		ofDrawSphere(particles[i].position, 1.0);
 
 		ofPopStyle();
 	}
@@ -82,7 +82,7 @@ void swarm::customDraw(){
 
 	// Render light as white sphere
 	ofSetColor(255, 255, 255);
-	ofSphere(light.getPosition(), 2.0);
+	ofDrawSphere(light.getPosition(), 2.0);
 	ofSetDrawBitmapMode(OF_BITMAPMODE_MODEL);
 	ofDrawBitmapString(" light", particles[0].position);
 	ofPopStyle();

--- a/examples/3d/advanced3dExample/src/testApp.cpp
+++ b/examples/3d/advanced3dExample/src/testApp.cpp
@@ -305,7 +305,7 @@ void testApp::drawScene(int iCameraDraw){
 
 		ofNoFill();
 		// i.e. a box -1, -1, -1 to +1, +1, +1
-		ofBox(0, 0, 0, 2.0f);
+		ofDrawBox(0, 0, 0, 2.0f);
 		//
 		//--
 

--- a/examples/3d/quaternionArcballExample/src/testApp.cpp
+++ b/examples/3d/quaternionArcballExample/src/testApp.cpp
@@ -37,7 +37,7 @@ void testApp::draw(){
 	
 	//apply the quaternion's rotation to the viewport and draw the sphere
 	ofRotate(angle, axis.x, axis.y, axis.z);  
-	ofSphere(0, 0, 0, 200);
+	ofDrawSphere(0, 0, 0, 200);
 	
 	ofPopMatrix();  
 }

--- a/examples/3d/quaternionLatLongExample/src/testApp.cpp
+++ b/examples/3d/quaternionLatLongExample/src/testApp.cpp
@@ -60,7 +60,7 @@ void testApp::draw(){
 	ofPushMatrix();
 	//add an extra spin at the rate of 1 degree per frame
 	ofRotate(ofGetFrameNum(), 0, 1, 0);
-	ofSphere(0, 0, 0, 300);
+	ofDrawSphere(0, 0, 0, 300);
 	ofPopMatrix();
 	
 	ofSetColor(255);	

--- a/examples/android/androidAdvanced3DExample/src/Swarm.cpp
+++ b/examples/android/androidAdvanced3DExample/src/Swarm.cpp
@@ -100,7 +100,7 @@ void Swarm::customDraw()
 		ofPushStyle();
 		ofSetColor(colors[i]);
 		
-		ofSphere(positions[i], 1.0);
+		ofDrawSphere(positions[i], 1.0);
 		
 		ofPopStyle();
 	}
@@ -112,7 +112,7 @@ void Swarm::customDraw()
 	
 	//render light as white sphere
 	ofSetColor(255, 255, 255);
-	ofSphere(positions[0], 2.0);
+	ofDrawSphere(positions[0], 2.0);
 	ofSetDrawBitmapMode(OF_BITMAPMODE_MODEL);
 	ofDrawBitmapString(" light", (ofPoint)positions[0]);
 	ofPopStyle();

--- a/examples/gl/multiLightExample/src/testApp.cpp
+++ b/examples/gl/multiLightExample/src/testApp.cpp
@@ -99,20 +99,20 @@ void testApp::draw(){
     ofPushMatrix();
     ofTranslate(center.x, center.y, center.z-300);
     ofRotate(ofGetElapsedTimef() * .8 * RAD_TO_DEG, 0, 1, 0);
-	ofSphere( 0,0,0, radius);
+	ofDrawSphere( 0,0,0, radius);
     ofPopMatrix();
 	
 	ofPushMatrix();
 	ofTranslate(300, 300, cos(ofGetElapsedTimef()*1.4) * 300.f);
 	ofRotate(ofGetElapsedTimef()*.6 * RAD_TO_DEG, 1, 0, 0);
 	ofRotate(ofGetElapsedTimef()*.8 * RAD_TO_DEG, 0, 1, 0);
-	ofBox(0, 0, 0, 60);
+	ofDrawBox(0, 0, 0, 60);
 	ofPopMatrix();
 	
 	ofPushMatrix();
 	ofTranslate(center.x, center.y, -900);
 	ofRotate(ofGetElapsedTimef() * .2 * RAD_TO_DEG, 0, 1, 0);
-	ofBox( 0, 0, 0, 850);
+	ofDrawBox( 0, 0, 0, 850);
 	ofPopMatrix();
     
     if(bUseTexture) ofLogoImage.getTextureReference().unbind();

--- a/examples/gl/singleLightExample/src/testApp.cpp
+++ b/examples/gl/singleLightExample/src/testApp.cpp
@@ -66,7 +66,7 @@ void testApp::update() {
 void testApp::draw() {
     
     ofSetColor(pointLight.getDiffuseColor());
-    ofSphere(pointLight.getPosition(), 20.f);
+    ofDrawSphere(pointLight.getPosition(), 20.f);
     
     // enable lighting //
     ofEnableLighting();
@@ -85,7 +85,7 @@ void testApp::draw() {
         float angle = TWO_PI / (float)numSpheres * i;
         float x = cos(angle) * radius;
         float y = sin(angle) * radius;
-        ofSphere(x, y, -200, sphereRadius);
+        ofDrawSphere(x, y, -200, sphereRadius);
     }
     ofPopMatrix();
 	material.end();


### PR DESCRIPTION
A few of the examples still use the deprecated `ofSphere` and `ofBox` functions, which throws accompanying warnings in the examples. This fixes that :+1: 
