### PR TITLE
ofReadOnlyParameter operators should be public

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -91,7 +91,6 @@ public:
 
 	void makeReferenceTo(ofReadOnlyParameter<ParameterType,Friend> mom);
 
-protected:
 	virtual ofReadOnlyParameter<ParameterType,Friend> & operator=(const ofReadOnlyParameter<ParameterType,Friend> & v);
 	virtual const ParameterType & operator=(const ParameterType & v);
 
@@ -122,7 +121,7 @@ protected:
 	template<typename OtherType>
 	ofReadOnlyParameter<ParameterType,Friend> & operator>>=(const OtherType & v);
 
-
+protected:
 	virtual ofReadOnlyParameter<ParameterType,Friend> & set(ParameterType v);
 	virtual ofReadOnlyParameter<ParameterType,Friend> & set(string name, ParameterType value);
 	virtual ofReadOnlyParameter<ParameterType,Friend> & set(string name, ParameterType value, ParameterType min, ParameterType max);


### PR DESCRIPTION
Error [here](https://github.com/openframeworks/openFrameworks/blob/develop/examples/gui/parameterEdgeCasesExample/src/testApp.cpp#L30), because [*= operator](https://github.com/openframeworks/openFrameworks/commit/03ae024b3ced03fbca2d7212c3b009c9e9ac664a#L2R125) is protected, and unaccessible.

This fix it, by make operators public. Please **double** check if that follow that you want about `ofParameter`, @arturoc.
