### PR TITLE
Restore ofxOpenALSoundPlayer for iOS

### DIFF
--- a/addons/ofxiOS/src/sound/SoundEngine.cpp
+++ b/addons/ofxiOS/src/sound/SoundEngine.cpp
@@ -1,0 +1,1462 @@
+/***********************************************************************
+ 
+ Copyright (C) 2011 by Zach Gage
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+ This is based on code from:
+ 
+ http://stormyprods.com/SoundEngine
+ 
+ 
+ and apple:
+ 
+ Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple Inc.
+ ("Apple") in consideration of your agreement to the following terms, and your
+ use, installation, modification or redistribution of this Apple software
+ constitutes acceptance of these terms.  If you do not agree with these terms,
+ please do not use, install, modify or redistribute this Apple software.
+ 
+ In consideration of your agreement to abide by the following terms, and subject
+ to these terms, Apple grants you a personal, non-exclusive license, under
+ Apple's copyrights in this original Apple software (the "Apple Software"), to
+ use, reproduce, modify and redistribute the Apple Software, with or without
+ modifications, in source and/or binary forms; provided that if you redistribute
+ the Apple Software in its entirety and without modifications, you must retain
+ this notice and the following text and disclaimers in all such redistributions
+ of the Apple Software.
+ Neither the name, trademarks, service marks or logos of Apple Inc. may be used
+ to endorse or promote products derived from the Apple Software without specific
+ prior written permission from Apple.  Except as expressly stated in this notice,
+ no other rights or licenses, express or implied, are granted by Apple herein,
+ including but not limited to any patent rights that may be infringed by your
+ derivative works or by other works in which the Apple Software may be
+ incorporated.
+ 
+ The Apple Software is provided by Apple on an "AS IS" basis.  APPLE MAKES NO
+ WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED
+ WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND OPERATION ALONE OR IN
+ COMBINATION WITH YOUR PRODUCTS.
+ 
+ IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION, MODIFICATION AND/OR
+ DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY OF
+ CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
+ APPLE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ 
+ */
+
+#if !TARGET_IPHONE_SIMULATOR
+/*==================================================================================================
+	SoundEngine.cpp
+==================================================================================================*/
+#if !defined(__SoundEngine_cpp__)
+#define __SoundEngine_cpp__
+
+//==================================================================================================
+//	Includes
+//==================================================================================================
+
+//	System Includes
+#include <AudioToolbox/AudioToolbox.h>
+#include <CoreFoundation/CFURL.h>
+#include <map>
+#include <vector>
+#include <pthread.h>
+#include <mach/mach.h>
+#include <iostream>
+using namespace std;
+
+// Local Includes
+#include "SoundEngine.h"
+
+#define	AssertNoError(inMessage, inHandler)						\
+			if(result != noErr)									\
+			{													\
+				printf("%s: %d\n", inMessage, (int)result);		\
+				goto inHandler;									\
+			}
+			
+#define AssertNoOALError(inMessage, inHandler)					\
+			if((result = alGetError()) != AL_NO_ERROR)			\
+			{													\
+				printf("%s: %x\n", inMessage, (int)result);		\
+				goto inHandler;									\
+			}
+
+#define kNumberBuffers 3    // Used for the bgMusic audio queue
+#define MAX_SOURCES 32
+
+class OpenALObject;
+class BackgroundTrackMgr;
+
+static OpenALObject			*sOpenALObject = NULL;
+static BackgroundTrackMgr	*sBackgroundTrackMgr = NULL;
+static Float32				gMasterVolumeGain = 1.0;
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+typedef ALvoid	AL_APIENTRY	(*alBufferDataStaticProcPtr) (const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq);
+ALvoid  alBufferDataStaticProc(const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq)
+{
+	static	alBufferDataStaticProcPtr	proc = NULL;
+    
+    if (proc == NULL) {
+        proc = (alBufferDataStaticProcPtr) alcGetProcAddress(NULL, (const ALCchar*) "alBufferDataStatic");
+    }
+    
+    if (proc)
+        proc(bid, format, data, size, freq);
+
+    return;
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+typedef ALvoid	AL_APIENTRY	(*alcMacOSXMixerOutputRateProcPtr) (const ALdouble value);
+ALvoid  alcMacOSXMixerOutputRateProc(const ALdouble value)
+{
+	static	alcMacOSXMixerOutputRateProcPtr	proc = NULL;
+    
+    if (proc == NULL) {
+        proc = (alcMacOSXMixerOutputRateProcPtr) alcGetProcAddress(NULL, (const ALCchar*) "alcMacOSXMixerOutputRate");
+    }
+    
+    if (proc)
+        proc(value);
+
+    return;
+}
+
+
+//==================================================================================================
+//	Helper functions
+//==================================================================================================
+OSStatus OpenFile(const char *inFilePath, AudioFileID &outAFID)
+{
+	
+	CFURLRef theURL = CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (UInt8*)inFilePath, strlen(inFilePath), false);
+	if (theURL == NULL)
+		return kSoundEngineErrFileNotFound;
+
+#if TARGET_OS_IPHONE
+	OSStatus result = AudioFileOpenURL(theURL, kAudioFileReadPermission, 0, &outAFID);
+#else
+	OSStatus result = AudioFileOpenURL(theURL, fsRdPerm, 0, &outAFID);
+#endif
+	CFRelease(theURL);
+		//cout<<inFilePath<<endl;
+		AssertNoError("Error opening file", end);
+	end:
+		return result;
+}
+
+OSStatus LoadFileDataInfo(const char *inFilePath, AudioFileID &outAFID, AudioStreamBasicDescription &outFormat, UInt64 &outDataSize)
+{
+	UInt32 thePropSize = sizeof(outFormat);				
+	OSStatus result = OpenFile(inFilePath, outAFID);
+		//cout<<inFilePath<<endl;
+		AssertNoError("Error opening file", end);
+
+	result = AudioFileGetProperty(outAFID, kAudioFilePropertyDataFormat, &thePropSize, &outFormat);
+		AssertNoError("Error getting file format", end);
+	
+	thePropSize = sizeof(UInt64);
+	result = AudioFileGetProperty(outAFID, kAudioFilePropertyAudioDataByteCount, &thePropSize, &outDataSize);
+		AssertNoError("Error getting file data size", end);
+
+end:
+	return result;
+}
+
+void CalculateBytesForTime (AudioStreamBasicDescription & inDesc, UInt32 inMaxPacketSize, Float64 inSeconds, UInt32 *outBufferSize, UInt32 *outNumPackets)
+{
+	static const UInt32 maxBufferSize = 0x10000; // limit size to 64K
+	static const UInt32 minBufferSize = 0x4000; // limit size to 16K
+
+	if (inDesc.mFramesPerPacket) {
+		Float64 numPacketsForTime = inDesc.mSampleRate / inDesc.mFramesPerPacket * inSeconds;
+		*outBufferSize = numPacketsForTime * inMaxPacketSize;
+	} else {
+		// if frames per packet is zero, then the codec has no predictable packet == time
+		// so we can't tailor this (we don't know how many Packets represent a time period
+		// we'll just return a default buffer size
+		*outBufferSize = maxBufferSize > inMaxPacketSize ? maxBufferSize : inMaxPacketSize;
+	}
+	
+		// we're going to limit our size to our default
+	if (*outBufferSize > maxBufferSize && *outBufferSize > inMaxPacketSize)
+		*outBufferSize = maxBufferSize;
+	else {
+		// also make sure we're not too small - we don't want to go the disk for too small chunks
+		if (*outBufferSize < minBufferSize)
+			*outBufferSize = minBufferSize;
+	}
+	*outNumPackets = *outBufferSize / inMaxPacketSize;
+}
+
+static Boolean MatchFormatFlags(const AudioStreamBasicDescription& x, const AudioStreamBasicDescription& y)
+{
+	UInt32 xFlags = x.mFormatFlags;
+	UInt32 yFlags = y.mFormatFlags;
+	
+	// match wildcards
+	if (x.mFormatID == 0 || y.mFormatID == 0 || xFlags == 0 || yFlags == 0) 
+		return true;
+	
+	if (x.mFormatID == kAudioFormatLinearPCM)
+	{		 		
+		// knock off the all clear flag
+		xFlags = xFlags & ~kAudioFormatFlagsAreAllClear;
+		yFlags = yFlags & ~kAudioFormatFlagsAreAllClear;
+	
+		// if both kAudioFormatFlagIsPacked bits are set, then we don't care about the kAudioFormatFlagIsAlignedHigh bit.
+		if (xFlags & yFlags & kAudioFormatFlagIsPacked) {
+			xFlags = xFlags & ~kAudioFormatFlagIsAlignedHigh;
+			yFlags = yFlags & ~kAudioFormatFlagIsAlignedHigh;
+		}
+		
+		// if both kAudioFormatFlagIsFloat bits are set, then we don't care about the kAudioFormatFlagIsSignedInteger bit.
+		if (xFlags & yFlags & kAudioFormatFlagIsFloat) {
+			xFlags = xFlags & ~kAudioFormatFlagIsSignedInteger;
+			yFlags = yFlags & ~kAudioFormatFlagIsSignedInteger;
+		}
+		
+		//	if the bit depth is 8 bits or less and the format is packed, we don't care about endianness
+		if((x.mBitsPerChannel <= 8) && ((xFlags & kAudioFormatFlagIsPacked) == kAudioFormatFlagIsPacked))
+		{
+			xFlags = xFlags & ~kAudioFormatFlagIsBigEndian;
+		}
+		if((y.mBitsPerChannel <= 8) && ((yFlags & kAudioFormatFlagIsPacked) == kAudioFormatFlagIsPacked))
+		{
+			yFlags = yFlags & ~kAudioFormatFlagIsBigEndian;
+		}
+		
+		//	if the number of channels is 0 or 1, we don't care about non-interleavedness
+		if (x.mChannelsPerFrame <= 1 && y.mChannelsPerFrame <= 1) {
+			xFlags &= ~kLinearPCMFormatFlagIsNonInterleaved;
+			yFlags &= ~kLinearPCMFormatFlagIsNonInterleaved;
+		}
+	}
+	return xFlags == yFlags;
+}
+
+Boolean FormatIsEqual(AudioStreamBasicDescription x, AudioStreamBasicDescription y)
+{
+	//	the semantics for equality are:
+	//		1) Values must match exactly
+	//		2) wildcard's are ignored in the comparison
+	
+#define MATCH(name) ((x.name) == 0 || (y.name) == 0 || (x.name) == (y.name))
+	
+	return 
+		((x.mSampleRate==0.) || (y.mSampleRate==0.) || (x.mSampleRate==y.mSampleRate)) 
+		&& MATCH(mFormatID)
+		&& MatchFormatFlags(x, y)  
+		&& MATCH(mBytesPerPacket) 
+		&& MATCH(mFramesPerPacket) 
+		&& MATCH(mBytesPerFrame) 
+		&& MATCH(mChannelsPerFrame) 		
+		&& MATCH(mBitsPerChannel) ;
+}
+
+#pragma mark ***** BackgroundTrackMgr *****
+//==================================================================================================
+//	BackgroundTrackMgr class
+//==================================================================================================
+class BackgroundTrackMgr
+{	
+	#define CurFileInfo THIS->mBGFileInfo[THIS->mCurrentFileIndex]
+	public:
+		typedef struct BG_FileInfo {
+			char*						mFilePath;
+			AudioFileID						mAFID;
+			AudioStreamBasicDescription		mFileFormat;
+			UInt64							mFileDataSize;
+			//UInt64							mFileNumPackets; // this is only used if loading file to memory
+			Boolean							mLoadAtOnce;
+			Boolean							mFileDataInQueue;
+		} BackgroundMusicFileInfo;
+		
+		BackgroundTrackMgr() 
+			:	mQueue(0),
+				mBufferByteSize(0),
+				mCurrentPacket(0),
+				mNumPacketsToRead(0),
+				mVolume(1.0),
+				mPacketDescs(NULL),
+				mCurrentFileIndex(0),
+				mMakeNewQueueWhenStopped(false),
+				mStopAtEnd(false),
+				mStopped(false){ }
+		
+		~BackgroundTrackMgr() { Teardown(); }
+
+		void Teardown()
+		{
+			if (mQueue)
+				AudioQueueDispose(mQueue, true);
+			for (UInt32 i=0; i < mBGFileInfo.size(); i++)
+				if (mBGFileInfo[i]->mAFID)
+					AudioFileClose(mBGFileInfo[i]->mAFID);
+
+			if (mPacketDescs)
+				delete mPacketDescs;
+		}
+		
+		AudioStreamPacketDescription *GetPacketDescsPtr() { return mPacketDescs; }
+		
+		UInt32 GetNumPacketsToRead(BackgroundTrackMgr::BG_FileInfo *inFileInfo) 
+		{ 
+			return mNumPacketsToRead; 
+		}
+
+		static OSStatus AttachNewCookie(AudioQueueRef inQueue, BackgroundTrackMgr::BG_FileInfo *inFileInfo)
+		{
+			OSStatus result = noErr;
+			UInt32 size = sizeof(UInt32);
+			result = AudioFileGetPropertyInfo (inFileInfo->mAFID, kAudioFilePropertyMagicCookieData, &size, NULL);
+			if (!result && size) 
+			{
+				char* cookie = new char [size];		
+				result = AudioFileGetProperty (inFileInfo->mAFID, kAudioFilePropertyMagicCookieData, &size, cookie);
+					AssertNoError("Error getting cookie data", end);
+				result = AudioQueueSetProperty(inQueue, kAudioQueueProperty_MagicCookie, cookie, size);
+				delete [] cookie;
+					AssertNoError("Error setting cookie data for queue", end);
+			}
+			return noErr;
+		
+		end:
+			return noErr;
+		}
+
+		static void QueueStoppedProc(	void *                  inUserData,
+										AudioQueueRef           inAQ,
+										AudioQueuePropertyID    inID)
+		{
+			UInt32 isRunning;
+			UInt32 propSize = sizeof(isRunning);
+
+			BackgroundTrackMgr *THIS = (BackgroundTrackMgr*)inUserData;
+			OSStatus result = AudioQueueGetProperty(inAQ, kAudioQueueProperty_IsRunning, &isRunning, &propSize);
+				
+			if ((!isRunning) && (THIS->mMakeNewQueueWhenStopped))
+			{
+				result = AudioQueueDispose(inAQ, true);
+					AssertNoError("Error disposing queue", end);
+				result = THIS->SetupQueue(CurFileInfo);
+					AssertNoError("Error setting up new queue", end);
+				result = THIS->SetupBuffers(CurFileInfo);
+					AssertNoError("Error setting up new queue buffers", end);
+				result = THIS->Start();
+					AssertNoError("Error starting queue", end);
+			}
+		end:
+			return;
+		}
+		
+		static Boolean DisposeBuffer(AudioQueueRef inAQ, std::vector<AudioQueueBufferRef> inDisposeBufferList, AudioQueueBufferRef inBufferToDispose)
+		{
+			for (unsigned int i=0; i < inDisposeBufferList.size(); i++)
+			{
+				if (inBufferToDispose == inDisposeBufferList[i])
+				{
+					OSStatus result = AudioQueueFreeBuffer(inAQ, inBufferToDispose);
+					if (result == noErr)
+						inDisposeBufferList.pop_back();
+					return true;
+				}
+			}
+			return false;
+		}
+		
+		enum {
+			kQueueState_DoNothing		= 0,
+			kQueueState_ResizeBuffer	= 1,
+			kQueueState_NeedNewCookie	= 2,
+			kQueueState_NeedNewBuffers	= 3,
+			kQueueState_NeedNewQueue	= 4,
+		};
+		
+		static SInt8 GetQueueStateForNextBuffer(BackgroundTrackMgr::BG_FileInfo *inFileInfo, BackgroundTrackMgr::BG_FileInfo *inNextFileInfo)
+		{
+			inFileInfo->mFileDataInQueue = false;
+			
+			// unless the data formats are the same, we need a new queue
+			if (!FormatIsEqual(inFileInfo->mFileFormat, inNextFileInfo->mFileFormat))
+				return kQueueState_NeedNewQueue;
+				
+			// if going from a load-at-once file to streaming or vice versa, we need new buffers
+			if (inFileInfo->mLoadAtOnce != inNextFileInfo->mLoadAtOnce)
+				return kQueueState_NeedNewBuffers;
+			
+			// if the next file is smaller than the current, we just need to resize
+			if (inNextFileInfo->mLoadAtOnce)
+				return (inFileInfo->mFileDataSize >= inNextFileInfo->mFileDataSize) ? kQueueState_ResizeBuffer : kQueueState_NeedNewBuffers;
+						
+			return kQueueState_NeedNewCookie;
+		}
+		
+		static void QueueCallback(	void *					inUserData,
+									AudioQueueRef			inAQ,
+									AudioQueueBufferRef		inCompleteAQBuffer) 
+		{
+			// dispose of the buffer if no longer in use
+			OSStatus result = noErr;
+			BackgroundTrackMgr *THIS = (BackgroundTrackMgr*)inUserData;
+			if (DisposeBuffer(inAQ, THIS->mBuffersToDispose, inCompleteAQBuffer))
+				return;
+			
+			if (THIS->mStopped){
+				return;
+			}
+			
+			UInt32 nPackets = 0;
+			// loop the current buffer if the following:
+			// 1. file was loaded into the buffer previously
+			// 2. only one file in the queue
+			// 3. we have not been told to stop at playlist completion
+			if ((CurFileInfo->mFileDataInQueue) && (THIS->mBGFileInfo.size() == 1) && (!THIS->mStopAtEnd))
+				nPackets = THIS->GetNumPacketsToRead(CurFileInfo);
+
+			else
+			{
+				UInt32 numBytes;
+				while (nPackets == 0)
+				{
+					// if loadAtOnce, get all packets in the file, otherwise ~.5 seconds of data
+					nPackets = THIS->GetNumPacketsToRead(CurFileInfo);					
+					result = AudioFileReadPackets(CurFileInfo->mAFID, false, &numBytes, THIS->mPacketDescs, THIS->mCurrentPacket, &nPackets, 
+											inCompleteAQBuffer->mAudioData);
+						AssertNoError("Error reading file data", end);
+					
+					inCompleteAQBuffer->mAudioDataByteSize = numBytes;	
+											
+					if (nPackets == 0) // no packets were read, this file has ended.
+					{
+						if (CurFileInfo->mLoadAtOnce)
+							CurFileInfo->mFileDataInQueue = true;
+						
+						THIS->mCurrentPacket = 0;
+						UInt32 theNextFileIndex = (THIS->mCurrentFileIndex < THIS->mBGFileInfo.size()-1) ? THIS->mCurrentFileIndex+1 : 0;
+						
+						// we have gone through the playlist. if mStopAtEnd, stop the queue here
+						if (theNextFileIndex == 0 && THIS->mStopAtEnd)
+						{
+							THIS->mStopped = true;
+							result = AudioQueueStop(inAQ, false);
+								AssertNoError("Error stopping queue", end);
+							return;
+						}
+						
+						SInt8 theQueueState = GetQueueStateForNextBuffer(CurFileInfo, THIS->mBGFileInfo[theNextFileIndex]);
+						if (theNextFileIndex != THIS->mCurrentFileIndex)
+						{
+							// if were are not looping the same file. Close the old one and open the new
+							result = AudioFileClose(CurFileInfo->mAFID);
+								AssertNoError("Error closing file", end);
+							THIS->mCurrentFileIndex = theNextFileIndex;
+
+							result = LoadFileDataInfo(CurFileInfo->mFilePath, CurFileInfo->mAFID, CurFileInfo->mFileFormat, CurFileInfo->mFileDataSize);
+								AssertNoError("Error opening file", end);
+						}
+						
+						switch (theQueueState) 
+						{							
+							// if we need to resize the buffer, set the buffer's audio data size to the new file's size
+							// we will also need to get the new file cookie
+							case kQueueState_ResizeBuffer:
+								inCompleteAQBuffer->mAudioDataByteSize = CurFileInfo->mFileDataSize;							
+							// if the data format is the same but we just need a new cookie, attach a new cookie
+							case kQueueState_NeedNewCookie:
+								result = AttachNewCookie(inAQ, CurFileInfo);
+									AssertNoError("Error attaching new file cookie data to queue", end);
+								break;
+							
+							// we can keep the same queue, but not the same buffer(s)
+							case kQueueState_NeedNewBuffers:
+								THIS->mBuffersToDispose.push_back(inCompleteAQBuffer);
+								THIS->SetupBuffers(CurFileInfo);
+								break;
+							
+							// if the data formats are not the same, we need to dispose the current queue and create a new one
+							case kQueueState_NeedNewQueue:
+								THIS->mMakeNewQueueWhenStopped = true;
+								result = AudioQueueStop(inAQ, false);
+									AssertNoError("Error stopping queue", end);
+								return;
+								
+							default:
+								break;
+						}
+					}
+				}
+			}
+			
+			result = AudioQueueEnqueueBuffer(inAQ, inCompleteAQBuffer, (THIS->mPacketDescs ? nPackets : 0), THIS->mPacketDescs);
+				AssertNoError("Error enqueuing new buffer", end);
+			if (CurFileInfo->mLoadAtOnce)
+				CurFileInfo->mFileDataInQueue = true;
+				
+			THIS->mCurrentPacket += nPackets;
+		
+		end:
+			return;
+		}
+		
+		OSStatus SetupQueue(BG_FileInfo *inFileInfo)
+		{
+			UInt32 size = 0;
+			OSStatus result = AudioQueueNewOutput(&inFileInfo->mFileFormat, QueueCallback, this, CFRunLoopGetCurrent(), kCFRunLoopCommonModes, 0, &mQueue);
+					//AssertNoError("Error creating queue", end);
+
+			// (2) If the file has a cookie, we should get it and set it on the AQ
+			size = sizeof(UInt32);
+			result = AudioFileGetPropertyInfo (inFileInfo->mAFID, kAudioFilePropertyMagicCookieData, &size, NULL);
+
+			if (!result && size) {
+				char* cookie = new char [size];		
+				result = AudioFileGetProperty (inFileInfo->mAFID, kAudioFilePropertyMagicCookieData, &size, cookie);
+					//AssertNoError("Error getting magic cookie", end);
+				result = AudioQueueSetProperty(mQueue, kAudioQueueProperty_MagicCookie, cookie, size);
+				delete [] cookie;
+					//AssertNoError("Error setting magic cookie", end);
+			}
+
+			// channel layout
+			OSStatus err = AudioFileGetPropertyInfo(inFileInfo->mAFID, kAudioFilePropertyChannelLayout, &size, NULL);
+			if (err == noErr && size > 0) {
+				AudioChannelLayout *acl = (AudioChannelLayout *)malloc(size);
+				result = AudioFileGetProperty(inFileInfo->mAFID, kAudioFilePropertyChannelLayout, &size, acl);
+					//AssertNoError("Error getting channel layout from file", end);
+				result = AudioQueueSetProperty(mQueue, kAudioQueueProperty_ChannelLayout, acl, size);
+				free(acl);
+					//AssertNoError("Error setting channel layout on queue", end);
+			}
+			
+			// add a notification proc for when the queue stops
+			result = AudioQueueAddPropertyListener(mQueue, kAudioQueueProperty_IsRunning, QueueStoppedProc, this);
+				//AssertNoError("Error adding isRunning property listener to queue", end);
+				
+			// we need to reset this variable so that if the queue is stopped mid buffer we don't dispose it 
+			mMakeNewQueueWhenStopped = false;
+			
+			// volume
+			result = SetVolume(mVolume);
+			
+		//end:
+			return result;
+		}
+
+		OSStatus SetupBuffers(BG_FileInfo *inFileInfo)
+		{
+			int numBuffersToQueue = kNumberBuffers;
+			UInt32 maxPacketSize;
+			UInt32 size = sizeof(maxPacketSize);
+			// we need to calculate how many packets we read at a time, and how big a buffer we need
+			// we base this on the size of the packets in the file and an approximate duration for each buffer
+				
+			// first check to see what the max size of a packet is - if it is bigger
+			// than our allocation default size, that needs to become larger
+			OSStatus result = AudioFileGetProperty(inFileInfo->mAFID, kAudioFilePropertyPacketSizeUpperBound, &size, &maxPacketSize);
+				//AssertNoError("Error getting packet upper bound size", end);
+			bool isFormatVBR = (inFileInfo->mFileFormat.mBytesPerPacket == 0 || inFileInfo->mFileFormat.mFramesPerPacket == 0);
+
+			CalculateBytesForTime(inFileInfo->mFileFormat, maxPacketSize, 0.5/*seconds*/, &mBufferByteSize, &mNumPacketsToRead);
+			
+			// if the file is smaller than the capacity of all the buffer queues, always load it at once
+			if ((mBufferByteSize * numBuffersToQueue) > inFileInfo->mFileDataSize)
+				inFileInfo->mLoadAtOnce = true;
+				
+			if (inFileInfo->mLoadAtOnce)
+			{
+				UInt64 theFileNumPackets;
+				size = sizeof(UInt64);
+				result = AudioFileGetProperty(inFileInfo->mAFID, kAudioFilePropertyAudioDataPacketCount, &size, &theFileNumPackets);
+					//AssertNoError("Error getting packet count for file", end);
+				
+				mNumPacketsToRead = (UInt32)theFileNumPackets;
+				mBufferByteSize = inFileInfo->mFileDataSize;
+				numBuffersToQueue = 1;
+			}	
+			else
+			{
+				mNumPacketsToRead = mBufferByteSize / maxPacketSize;
+			}
+			
+			if (isFormatVBR)
+				mPacketDescs = new AudioStreamPacketDescription [mNumPacketsToRead];
+			else
+				mPacketDescs = NULL; // we don't provide packet descriptions for constant bit rate formats (like linear PCM)	
+				
+			// allocate the queue's buffers
+			for (int i = 0; i < numBuffersToQueue; ++i) 
+			{
+				result = AudioQueueAllocateBuffer(mQueue, mBufferByteSize, &mBuffers[i]);
+					//AssertNoError("Error allocating buffer for queue", end);
+				QueueCallback (this, mQueue, mBuffers[i]);
+				if (inFileInfo->mLoadAtOnce)
+					inFileInfo->mFileDataInQueue = true;
+			}
+		
+		//end:
+			return result;
+		}
+		
+		OSStatus LoadTrack(const char* inFilePath, Boolean inAddToQueue, Boolean inLoadAtOnce)
+		{
+			BG_FileInfo *fileInfo = new BG_FileInfo;
+			fileInfo->mFilePath = (char *)malloc(strlen(inFilePath)+1);
+			strcpy(fileInfo->mFilePath, inFilePath);
+			
+			OSStatus result = LoadFileDataInfo(fileInfo->mFilePath, fileInfo->mAFID, fileInfo->mFileFormat, fileInfo->mFileDataSize);
+				AssertNoError("Error getting file data info", fail);
+			fileInfo->mLoadAtOnce = inLoadAtOnce;
+			fileInfo->mFileDataInQueue = false;
+			
+			mFileTotalDataSize = fileInfo->mFileDataSize;
+			// if not adding to the queue, clear the current file vector
+			if (!inAddToQueue)
+				mBGFileInfo.clear();
+				
+			mBGFileInfo.push_back(fileInfo);
+			
+			// setup the queue if this is the first (or only) file
+			if (mBGFileInfo.size() == 1)
+			{
+				result = SetupQueue(fileInfo);
+					AssertNoError("Error setting up queue", fail);
+				result = SetupBuffers(fileInfo);
+					AssertNoError("Error setting up queue buffers", fail);					
+			}
+			// if this is just part of the playlist, close the file for now
+			else
+			{
+				result = AudioFileClose(fileInfo->mAFID);
+					AssertNoError("Error closing file", fail);
+			}	
+			return result;
+		
+		fail:
+			if (fileInfo)
+				delete fileInfo;
+			return result;
+		}
+		
+		OSStatus UpdateGain()
+		{
+			return SetVolume(mVolume);
+		}
+		
+		OSStatus SetVolume(Float32 inVolume)
+		{
+			mVolume = inVolume;
+			return AudioQueueSetParameter(mQueue, kAudioQueueParam_Volume, mVolume * gMasterVolumeGain);
+		}
+		
+		OSStatus Start()
+		{
+			
+			OSStatus result = AudioQueuePrime(mQueue, 1, NULL);	
+			if (result)
+			{
+				mStopped = true;
+				printf("Error priming queue");
+				return result;
+			}
+			mStopped = false;
+			return AudioQueueStart(mQueue, NULL);
+		}
+	
+		void setLooping(Boolean inStopAtEnd)
+		{
+			mStopAtEnd = !inStopAtEnd;
+		}
+	
+		void setPosition(SInt64 packetNum)
+		{
+			mCurrentPacket = packetNum;
+		}
+	
+		UInt64 getLength()
+		{
+			return mFileTotalDataSize;
+		}
+	
+		bool getStopped()
+		{
+			return mStopped;
+		}
+	
+		OSStatus Stop(Boolean inStopAtEnd)
+		{
+			if (inStopAtEnd)
+			{
+				mStopAtEnd = true;
+				return noErr;
+			}
+			else{
+				mStopped = true;
+				return AudioQueueStop(mQueue, true);
+			}
+		}
+	
+	private:
+		AudioQueueRef						mQueue;
+		AudioQueueBufferRef					mBuffers[kNumberBuffers];
+		UInt32								mBufferByteSize;
+		UInt64								mFileTotalDataSize;
+		SInt64								mCurrentPacket;
+		UInt32								mNumPacketsToRead;
+		Float32								mVolume;
+		AudioStreamPacketDescription *		mPacketDescs;
+		std::vector<BG_FileInfo*>			mBGFileInfo;
+		UInt32								mCurrentFileIndex;
+		Boolean								mMakeNewQueueWhenStopped;
+		Boolean								mStopAtEnd;
+		Boolean								mStopped;
+		std::vector<AudioQueueBufferRef>	mBuffersToDispose;
+};
+
+#pragma mark ***** SoundEngineEffect *****
+//==================================================================================================
+//	SoundEngineEffect class
+//==================================================================================================
+class SoundEngineEffect
+{
+	public:	
+		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		SoundEngineEffect(const char* inPath) 
+			:	
+				mBufferID(0),
+				mPath(inPath),
+				mData(NULL),
+				mDataSize(0)
+	{ mIsLoopingEffect=false;}
+		
+		SoundEngineEffect(const char* inPath, bool inDoLoop) 
+		:	
+		mBufferID(0),
+		mPath(inPath),
+		mData(NULL),
+		mDataSize(0),
+		mIsLoopingEffect(inDoLoop)
+		{
+		}
+		
+		~SoundEngineEffect()
+		{			
+			if (mData)
+				free(mData);
+		}
+		
+		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		// Accessors
+		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		UInt32	GetEffectID() { return mBufferID; }		
+
+		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		// Helper Functions
+		// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+		ALenum GetALFormat(AudioStreamBasicDescription inFileFormat)
+		{
+			if (inFileFormat.mFormatID != kAudioFormatLinearPCM)
+				return kSoundEngineErrInvalidFileFormat;
+				
+			if ((inFileFormat.mChannelsPerFrame > 2) || (inFileFormat.mChannelsPerFrame < 1))
+				return kSoundEngineErrInvalidFileFormat;
+			
+			if(inFileFormat.mBitsPerChannel == 8)
+				return (inFileFormat.mChannelsPerFrame == 1) ? AL_FORMAT_MONO8 : AL_FORMAT_STEREO8;
+			else if(inFileFormat.mBitsPerChannel == 16)
+				return (inFileFormat.mChannelsPerFrame == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
+
+			return kSoundEngineErrInvalidFileFormat;
+		}
+
+		OSStatus LoadFileData(const char *inFilePath, void* &outData, UInt32 &outDataSize, ALuint &outBufferID)
+		{
+			AudioFileID theAFID = 0;
+			OSStatus result = noErr;
+			UInt64 theFileSize = 0;
+			AudioStreamBasicDescription theFileFormat;
+			
+			result = LoadFileDataInfo(inFilePath, theAFID, theFileFormat, theFileSize);
+			outDataSize = (UInt32)theFileSize;
+				AssertNoError("Error loading file info", fail)
+
+			outData = malloc(outDataSize);
+
+			result = AudioFileReadBytes(theAFID, false, 0, &outDataSize, outData);
+				AssertNoError("Error reading file data", fail)
+				
+			if (!TestAudioFormatNativeEndian(theFileFormat) && (theFileFormat.mBitsPerChannel > 8)) 
+				return kSoundEngineErrInvalidFileFormat;
+		
+			alGenBuffers(1, &outBufferID); // ZACH
+			/*ALenum			error;
+			if((error = alGetError()) != AL_NO_ERROR) {
+				printf("Error Generating Buffers: %x", error);
+				exit(1);
+			}*/
+				AssertNoOALError("Error generating buffer\n", fail);
+			
+			alBufferDataStaticProc(outBufferID, GetALFormat(theFileFormat), outData, outDataSize, theFileFormat.mSampleRate);
+				AssertNoOALError("Error attaching data to buffer\n", fail);
+
+			AudioFileClose(theAFID);
+			return result;
+			
+		fail:			
+			if (theAFID)
+				AudioFileClose(theAFID);
+			if (outData)
+			{
+				free(outData);
+				outData = NULL;
+			}
+			return result;
+		}
+		
+		OSStatus initialize()
+		{
+			OSStatus result = AL_NO_ERROR;			
+
+			result = LoadFileData(mPath, mData, mDataSize, mBufferID);
+				AssertNoError("Error loading sound file info", end)
+
+		end:
+			return result;
+		}
+	
+	UInt32 getDataSize()
+	{
+		return mDataSize;
+	}
+
+	private:
+		ALuint					mBufferID;
+		const char*				mPath;
+		void*					mData;
+		UInt32					mDataSize;
+		Boolean					mIsLoopingEffect;
+};
+
+#pragma mark ***** SoundEngineEffectMap *****
+//==================================================================================================
+//	SoundEngineEffectMap class
+//==================================================================================================
+class SoundEngineEffectMap 
+	: std::multimap<UInt32, SoundEngineEffect*, std::less<ALuint> > 
+{
+	public:
+    // add a new context to the map
+    void Add (const	ALuint	inEffectToken, SoundEngineEffect **inEffect)
+	{
+		iterator	it = upper_bound(inEffectToken);
+		insert(it, value_type (inEffectToken, *inEffect));
+	}
+
+    SoundEngineEffect* Get(ALuint	inEffectToken) 
+	{
+        iterator	it = find(inEffectToken);
+        if (it != end())
+            return ((*it).second);
+		return (NULL);
+    }
+
+    void Remove (const	ALuint	inSourceToken) {
+        iterator 	it = find(inSourceToken);
+        if (it != end())
+            erase(it);
+    }
+	
+    SoundEngineEffect* GetEffectByIndex(UInt32	inIndex) {
+        iterator	it = begin();
+
+		for (UInt32 i = 0; i < inIndex; i++) {
+            if (it != end())
+                ++it;
+            else
+                i = inIndex;
+        }
+        
+        if (it != end())
+            return ((*it).second);		
+		return (NULL);
+    }
+
+	iterator GetIterator() { return begin(); }
+	
+    UInt32 Size () const { return size(); }
+    bool Empty () const { return empty(); }
+};
+
+#pragma mark ***** OpenALObject *****
+//==================================================================================================
+//	OpenALObject class
+//==================================================================================================
+class OpenALObject
+{	
+	public:	
+		OpenALObject(Float32 inMixerOutputRate)
+			:	mOutputRate(inMixerOutputRate),
+				mGain(1.0),
+				mContext(NULL),
+				mDevice(NULL),
+				mEffectsMap(NULL) 
+		{
+			mEffectsMap = new SoundEngineEffectMap();
+		}
+		
+		~OpenALObject() { Teardown(); }
+
+		OSStatus Initialize()
+		{
+			OSStatus result = noErr;
+			mDevice = alcOpenDevice(NULL);
+				AssertNoOALError("Error opening output device", end)
+			if(mDevice == NULL) { return kSoundEngineErrDeviceNotFound; }
+			
+			// if a mixer output rate was specified, set it here
+			// must be done before the alcCreateContext() call
+			if (mOutputRate)
+				alcMacOSXMixerOutputRateProc(mOutputRate);
+			
+			// Create an OpenAL Context
+			mContext = alcCreateContext(mDevice, NULL);
+				AssertNoOALError("Error creating OpenAL context", end)
+			
+			alcMakeContextCurrent(mContext);
+				AssertNoOALError("Error setting current OpenAL context", end)
+			
+			alGenSources(MAX_SOURCES, mSourceID); 
+				AssertNoOALError("Error generating sources", end)
+			
+			for (int i = 0; i < MAX_SOURCES; ++i){
+				mSourcePrimed[i] = FALSE;
+			}
+			 
+		end:
+			return result;
+		}
+	
+		void clearSources()
+		{
+			for (int i = 0; i < MAX_SOURCES; ++i){
+				mSourcePrimed[i] = FALSE;
+			}
+		}
+		
+		void Teardown()
+		{
+			if (mEffectsMap) {
+				// [FIXED] In old FOR loop, Remove() will decrease Size(), but variable i will increase whenever
+				while (mEffectsMap->Size()){
+					SoundEngineEffect *theEffect = mEffectsMap->GetEffectByIndex(0);
+					if (theEffect){
+						mEffectsMap->Remove(theEffect->GetEffectID());
+						delete theEffect;
+					}
+				}
+				delete mEffectsMap;
+			}
+			
+			// [FIXED] alGenSources() created sources should be deleted.
+			alDeleteSources(MAX_SOURCES, mSourceID);
+			
+			if (mContext){
+				alcMakeContextCurrent(NULL);
+				alcDestroyContext(mContext);
+			}
+			
+			if (mDevice) alcCloseDevice(mDevice);
+		}
+
+		OSStatus SetListenerVelocity(Float32 inX, Float32 inY, Float32 inZ)
+		{
+			alListener3f(AL_VELOCITY, inX, inY, inZ);
+			return alGetError();
+		}
+	
+		OSStatus SetListenerPosition(Float32 inX, Float32 inY, Float32 inZ)
+		{
+			alListener3f(AL_POSITION, inX, inY, inZ);
+			return alGetError();
+		}
+
+		OSStatus SetListenerGain(Float32 inValue)
+		{
+			alListenerf(AL_GAIN, inValue);
+			return alGetError();
+		}
+		
+		OSStatus SetMaxDistance(Float32 inValue)
+		{
+			OSStatus result = 0;
+			for (UInt32 i=0; i < MAX_SOURCES; i++)
+			{
+				alSourcef(mSourceID[i], AL_MAX_DISTANCE, inValue);
+
+				if ((result = alGetError()) != AL_NO_ERROR)
+					return result;
+			}
+			return result;			
+		}
+	
+		OSStatus SetLooping(bool looping, ALint _id)
+		{
+			ALint doLoop = looping ? 1 : 0;
+			alSourcei(_id, AL_LOOPING, doLoop);
+			return alGetError();
+		}
+
+	
+		OSStatus SetReferenceDistance(Float32 inValue)
+		{
+			OSStatus result = 0;
+			for (UInt32 i=0; i < MAX_SOURCES; i++)
+			{
+				alSourcef(mSourceID[i], AL_REFERENCE_DISTANCE, inValue);
+				
+				if ((result = alGetError()) != AL_NO_ERROR)
+					return result;
+			}
+			return result;		
+		}
+
+	
+		OSStatus SetEffectsVolume(Float32 inValue)
+		{
+			OSStatus result = 0;
+			for (UInt32 i=0; i < MAX_SOURCES; i++)
+			{
+				alSourcef(mSourceID[i], AL_GAIN, inValue * gMasterVolumeGain);
+				
+				if ((result = alGetError()) != AL_NO_ERROR)
+					return result;
+			}
+			return result;		
+		}
+	
+		int getEffectLength(UInt32 effectID)
+		{
+			return mEffectsMap->Get(effectID)->getDataSize();
+		}
+	
+		OSStatus UpdateGain()
+		{
+			return SetEffectsVolume(mGain);
+		}
+						
+		OSStatus LoadEffect(const char *inFilePath, UInt32 *outEffectID)
+		{
+			SoundEngineEffect *theEffect = new SoundEngineEffect(inFilePath);
+			OSStatus result = theEffect->initialize();
+			if (result == noErr)
+			{
+				*outEffectID = theEffect->GetEffectID();
+				mEffectsMap->Add(*outEffectID, &theEffect);
+			}
+			return result;
+		}
+				
+		OSStatus UnloadEffect(UInt32 inEffectID)
+		{
+			mEffectsMap->Remove(inEffectID); //remove pointer from structure first
+			SoundEngineEffect *theEffect = mEffectsMap->Get(inEffectID); //then delete
+			if (theEffect){
+				delete theEffect;
+			}
+			return 0;
+		}
+
+		bool checkToRelease(ALuint sourceID, int mSource)
+		{
+			ALint state;
+			alGetSourcei(sourceID, AL_SOURCE_STATE, &state);
+
+			if(state==AL_STOPPED)
+			{
+				mSourcePrimed[mSource] = FALSE;
+				return true;
+			}
+			else
+				return false;
+			
+		}
+	
+		int PrimeEffect(UInt32 inEffectID, ALuint *sourceID)
+		{
+			// Locate an available source.  We consider a source available if it is either not primed or is in the stoppped state
+			for (int i = 0; i < MAX_SOURCES; ++i){
+				if (! mSourcePrimed[i]){
+					mSourcePrimed[i] = TRUE;
+					
+					alSourcei(mSourceID[i], AL_BUFFER, inEffectID);
+					
+					
+					if(mSourceID[i] < 10000)
+					{
+						*sourceID = mSourceID[i];
+						return i;
+					}
+					else
+					{
+						mSourcePrimed[i] = FALSE;
+						cout<<"priming error"<<endl;
+					}
+				}
+				
+				ALint sourceState;
+				alGetSourcei(mSourceID[i], AL_SOURCE_STATE, &sourceState);
+				if (sourceState != AL_PLAYING){
+					alSourcei(mSourceID[i], AL_BUFFER, inEffectID);
+					
+					if(mSourceID[i] < 10000)
+					{
+						*sourceID = mSourceID[i];
+						return i;
+					}
+					else
+						cout<<"priming error"<<endl;
+				}
+			}
+			cout<<"no sources!"<<endl;
+			// If we fell through the loop, then no available sources
+			return -1;
+		}
+	
+
+		OSStatus PauseEffect(ALuint sourceID)
+		{
+			alSourcePause(sourceID);
+			return alGetError();
+		}
+	
+		OSStatus StartEffect(ALuint sourceID)
+		{
+			alSourcePlay(sourceID);
+			return alGetError();
+		}
+	
+		void SetEffectPosition(ALuint sourceID, float position)
+		{
+			alSourcef(sourceID, AL_BYTE_OFFSET, position);
+		}
+	
+		float GetEffectPosition(ALuint sourceID)
+		{
+			float p;
+			alGetSourcef(sourceID, AL_BYTE_OFFSET, &p);
+			return p;
+		}
+	
+	
+		OSStatus StopEffect(ALuint sourceID)
+		{
+			alSourceStop(sourceID);
+			return alGetError();
+		}
+		
+		OSStatus SetEffectPitch(ALuint sourceID, Float32 inValue)
+		{
+			alSourcef(sourceID, AL_PITCH, inValue);
+			return alGetError();
+		}
+
+		OSStatus SetEffectVolume(ALuint sourceID, Float32 inValue)
+		{
+			alSourcef(sourceID, AL_GAIN, inValue * gMasterVolumeGain);
+			return alGetError();
+		}
+				
+		OSStatus	SetEffectLocation(ALuint sourceID, Float32 inX, Float32 inY, Float32 inZ)	
+		{
+			alSource3f(sourceID, AL_POSITION, inX, inY, inZ);
+			return alGetError();
+		}
+				
+	private:
+		Float32									mOutputRate;
+		Float32									mGain;
+		ALCcontext*								mContext;
+		ALCdevice*								mDevice;
+		SoundEngineEffectMap*					mEffectsMap;
+		ALuint									mSourceID[MAX_SOURCES];
+		bool									mSourcePrimed[MAX_SOURCES];
+};
+
+#pragma mark ***** API *****
+//==================================================================================================
+//	Sound Engine
+//==================================================================================================
+
+extern "C"
+OSStatus  SoundEngine_Initialize(Float32 inMixerOutputRate)
+{
+	if (sOpenALObject)
+		delete sOpenALObject;
+
+	if (sBackgroundTrackMgr)
+		delete sBackgroundTrackMgr;
+
+	sOpenALObject = new OpenALObject(inMixerOutputRate);	
+	sBackgroundTrackMgr = new BackgroundTrackMgr();
+	
+	return sOpenALObject->Initialize();
+	
+}
+
+extern "C"
+void SoundEngine_ClearSources()
+{
+	if (sOpenALObject)
+		sOpenALObject->clearSources();
+}
+
+extern "C"
+OSStatus  SoundEngine_Teardown()
+{
+	if (sOpenALObject)
+	{
+		delete sOpenALObject;
+		sOpenALObject = NULL;
+	}
+	
+	if (sBackgroundTrackMgr)
+	{
+		delete sBackgroundTrackMgr;
+		sBackgroundTrackMgr = NULL;	
+	}
+	
+	return 0; 
+}
+
+extern "C"
+OSStatus  SoundEngine_SetMasterVolume(Float32 inValue)
+{
+	OSStatus result = noErr;
+	gMasterVolumeGain = inValue;
+	if (sBackgroundTrackMgr)
+		result = sBackgroundTrackMgr->UpdateGain();
+	
+	if (result) return result;
+		
+	if (sOpenALObject) 
+		return sOpenALObject->UpdateGain();
+	
+	return result;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetListenerVelocity(Float32 inX, Float32 inY, Float32 inZ)
+{	
+	return (sOpenALObject) ? sOpenALObject->SetListenerVelocity(inX, inY, inZ) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetListenerPosition(Float32 inX, Float32 inY, Float32 inZ)
+{	
+	return (sOpenALObject) ? sOpenALObject->SetListenerPosition(inX, inY, inZ) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetListenerGain(Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetListenerGain(inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_LoadBackgroundMusicTrack(const char* inPath, Boolean inAddToQueue, Boolean inLoadAtOnce)
+{
+	if (sBackgroundTrackMgr == NULL)
+		sBackgroundTrackMgr = new BackgroundTrackMgr();
+	return sBackgroundTrackMgr->LoadTrack(inPath, inAddToQueue, inLoadAtOnce);
+}
+
+extern "C"
+OSStatus  SoundEngine_UnloadBackgroundMusicTrack()
+{
+	if (sBackgroundTrackMgr)
+	{
+		delete sBackgroundTrackMgr;
+		sBackgroundTrackMgr = NULL;
+	}
+		
+	return 0;
+}
+
+extern "C"
+OSStatus  SoundEngine_StartBackgroundMusic()
+{
+	return (sBackgroundTrackMgr) ? sBackgroundTrackMgr->Start() : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_StopBackgroundMusic(Boolean stopAtEnd)
+{
+	return (sBackgroundTrackMgr) ?  sBackgroundTrackMgr->Stop(stopAtEnd) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+void  SoundEngine_SetBackgroundMusicLooping(Boolean loop)
+{
+	sBackgroundTrackMgr->setLooping(loop);
+}
+
+extern "C"
+UInt64  SoundEngine_getBackgroundMusicLength()
+{
+	return sBackgroundTrackMgr->getLength();
+}
+
+extern "C"
+bool  SoundEngine_getBackgroundMusicStopped()
+{
+	return sBackgroundTrackMgr->getStopped();
+}
+
+extern "C"
+void SoundEngine_setBackgroundMusicPosition(UInt64 pos)
+{
+	sBackgroundTrackMgr->setPosition(pos);
+}
+
+extern "C"
+OSStatus  SoundEngine_SetBackgroundMusicVolume(Float32 inValue)
+{
+	return (sBackgroundTrackMgr) ? sBackgroundTrackMgr->SetVolume(inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_LoadEffect(const char* inPath, UInt32* outEffectID)
+{
+	OSStatus result = noErr;
+	if (sOpenALObject == NULL)
+	{
+		sOpenALObject = new OpenALObject(0.0);
+		result = sOpenALObject->Initialize();
+	}	
+	return (result) ? result : sOpenALObject->LoadEffect(inPath, outEffectID);
+}
+
+extern "C"
+OSStatus  SoundEngine_UnloadEffect(UInt32 inEffectID)
+{
+	return (sOpenALObject) ? sOpenALObject->UnloadEffect(inEffectID) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+int  SoundEngine_PrimeEffect(UInt32 inEffectID, ALuint *sourceID)
+{
+	return (sOpenALObject) ? sOpenALObject->PrimeEffect(inEffectID, sourceID) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+
+bool  SoundEngine_Update(ALuint sourceID, int mSource)
+{
+	return (sOpenALObject) ? sOpenALObject->checkToRelease(sourceID, mSource) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+void SoundEngine_SetEffectPosition(ALuint sourceID, float position)
+{
+	sOpenALObject->SetEffectPosition(sourceID, position);
+}
+
+extern "C"
+float SoundEngine_GetEffectPosition(ALuint sourceID)
+{
+	return sOpenALObject->GetEffectPosition(sourceID);
+}
+
+extern "C"
+OSStatus  SoundEngine_StartEffect(ALuint sourceID)
+{
+	return (sOpenALObject) ? sOpenALObject->StartEffect(sourceID) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_PauseEffect(ALuint sourceID)
+{
+	return (sOpenALObject) ? sOpenALObject->PauseEffect(sourceID) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_StopEffect(ALuint sourceID)
+{	
+	return (sOpenALObject) ?  sOpenALObject->StopEffect(sourceID) : kSoundEngineErrUnitialized;
+}
+		
+extern "C"
+OSStatus  SoundEngine_SetEffectPitch(ALuint sourceID, Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetEffectPitch(sourceID, inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetEffectLevel(ALuint sourceID, Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetEffectVolume(sourceID, inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus	SoundEngine_SetEffectLocation(ALuint sourceID, Float32 inX, Float32 inY, Float32 inZ)
+{
+	return (sOpenALObject) ? sOpenALObject->SetEffectLocation(sourceID, inX, inY, inZ) : kSoundEngineErrUnitialized;	
+}
+
+extern "C"
+OSStatus  SoundEngine_SetEffectsVolume(Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetEffectsVolume(inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetMaxDistance(Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetMaxDistance(inValue) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+OSStatus  SoundEngine_SetLooping(bool looping, ALint _id)
+{
+	return (sOpenALObject) ? sOpenALObject->SetLooping(looping, _id) : kSoundEngineErrUnitialized;
+}
+
+extern "C"
+unsigned long SoundEngine_GetEffectLength(ALint _id)
+{
+	return sOpenALObject->getEffectLength(_id);
+}
+
+extern "C"
+OSStatus  SoundEngine_SetReferenceDistance(Float32 inValue)
+{
+	return (sOpenALObject) ? sOpenALObject->SetReferenceDistance(inValue) : kSoundEngineErrUnitialized;
+}
+
+#endif
+#endif

--- a/addons/ofxiOS/src/sound/SoundEngine.h
+++ b/addons/ofxiOS/src/sound/SoundEngine.h
@@ -1,0 +1,393 @@
+/***********************************************************************
+ 
+ Copyright (C) 2011 by Zach Gage
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+This is based on code from:
+ 
+http://stormyprods.com/SoundEngine
+
+ 
+and apple:
+ 
+Disclaimer: IMPORTANT:  This Apple software is supplied to you by Apple Inc.
+("Apple") in consideration of your agreement to the following terms, and your
+use, installation, modification or redistribution of this Apple software
+constitutes acceptance of these terms.  If you do not agree with these terms,
+please do not use, install, modify or redistribute this Apple software.
+
+In consideration of your agreement to abide by the following terms, and subject
+to these terms, Apple grants you a personal, non-exclusive license, under
+Apple's copyrights in this original Apple software (the "Apple Software"), to
+use, reproduce, modify and redistribute the Apple Software, with or without
+modifications, in source and/or binary forms; provided that if you redistribute
+the Apple Software in its entirety and without modifications, you must retain
+this notice and the following text and disclaimers in all such redistributions
+of the Apple Software.
+Neither the name, trademarks, service marks or logos of Apple Inc. may be used
+to endorse or promote products derived from the Apple Software without specific
+prior written permission from Apple.  Except as expressly stated in this notice,
+no other rights or licenses, express or implied, are granted by Apple herein,
+including but not limited to any patent rights that may be infringed by your
+derivative works or by other works in which the Apple Software may be
+incorporated.
+
+The Apple Software is provided by Apple on an "AS IS" basis.  APPLE MAKES NO
+WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED
+WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE, REGARDING THE APPLE SOFTWARE OR ITS USE AND OPERATION ALONE OR IN
+COMBINATION WITH YOUR PRODUCTS.
+
+IN NO EVENT SHALL APPLE BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ARISING IN ANY WAY OUT OF THE USE, REPRODUCTION, MODIFICATION AND/OR
+DISTRIBUTION OF THE APPLE SOFTWARE, HOWEVER CAUSED AND WHETHER UNDER THEORY OF
+CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHERWISE, EVEN IF
+APPLE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright (C) 2008 Apple Inc. All Rights Reserved.
+
+*/
+
+/*==================================================================================================
+	SoundEngine.h
+==================================================================================================*/
+#if !defined(__SoundEngine_h__)
+#define __SoundEngine_h__
+
+//==================================================================================================
+//	Includes
+//==================================================================================================
+
+//	System Includes
+#include <CoreAudio/CoreAudioTypes.h>
+#include <AudioToolbox/AudioToolbox.h>
+#include <OpenAL/al.h>
+#include <OpenAL/alc.h>
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+//==================================================================================================
+//	Sound Engine
+//==================================================================================================
+/*!
+    @enum SoundEngine error codes
+    @abstract   These are the error codes returned from the SoundEngine API.
+    @constant   kSoundEngineErrUnitialized 
+		The SoundEngine has not been initialized. Use SoundEngine_Initialize().
+    @constant   kSoundEngineErrInvalidID 
+		The specified EffectID was not found. This can occur if the effect has not been loaded, or
+		if an unloaded is trying to be accessed.
+    @constant   kSoundEngineErrFileNotFound 
+		The specified file was not found.
+    @constant   kSoundEngineErrInvalidFileFormat 
+		The format of the file is invalid. Effect data must be little-endian 8 or 16 bit LPCM.
+    @constant   kSoundEngineErrDeviceNotFound 
+		The output device was not found.
+
+*/
+enum {
+		kSoundEngineErrUnitialized			= 1,
+		kSoundEngineErrInvalidID			= 2,
+		kSoundEngineErrFileNotFound			= 3,
+		kSoundEngineErrInvalidFileFormat	= 4,
+		kSoundEngineErrDeviceNotFound		= 5,
+		kSoundEngineErrNoSourcesAvailable   = 6,
+};
+
+
+/*!
+    @function       SoundEngine_Initialize
+    @abstract       Initializes and sets up the sound engine. Calling after a previous initialize will
+						reset the state of the SoundEngine, with all previous effects and music tracks
+						erased. Note: This is not required, loading an effect or background track will 
+						initialize as necessary.
+    @param          inMixerOutputRate
+                        A Float32 that represents the output sample rate of the mixer unit. Setting this to 
+						0 will use the default rate (the sample rate of the device)
+	@result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_Initialize(Float32 inMixerOutputRate);
+
+/*!
+    @function       SoundEngine_Teardown
+    @abstract       Tearsdown the sound engine.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_Teardown();
+
+/*!
+    @function       SoundEngine_SetMasterVolume
+    @abstract       Sets the overall volume of all sounds coming from the process
+    @param          inValue
+                        A Float32 that represents the level. The range is between 0.0 and 1.0 (inclusive).
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetMasterVolume(Float32 inValue);
+
+/*!
+    @function       SoundEngine_SetListenerPosition
+    @abstract       Sets the position of the listener in the 3D space
+    @param          inX
+                        A Float32 that represents the listener's position along the X axis.
+    @param          inY
+                        A Float32 that represents the listener's position along the Y axis.
+    @param          inZ
+                        A Float32 that represents the listener's position along the Z axis.
+    @result         A OSStatus indicating success or failure.
+*/
+	OSStatus  SoundEngine_SetListenerVelocity(Float32 inX, Float32 inY, Float32 inZ);
+
+	OSStatus  SoundEngine_SetListenerPosition(Float32 inX, Float32 inY, Float32 inZ);
+
+/*!
+    @function       SoundEngine_SetListenerGain
+    @abstract       Sets the gain of the listener. Must be >= 0.0
+    @param          inValue
+                        A Float32 that represents the listener's gain
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetListenerGain(Float32 inValue);
+
+/*!
+    @function       SoundEngine_LoadBackgroundMusicTrack
+    @abstract       Tells the background music player which file to play
+    @param          inPath
+                        The absolute path to the file to play.
+    @param          inAddToQueue
+                        If true, file will be added to the current background music queue. If
+						false, queue will be cleared and only loop the specified file.
+    @param          inLoadAtOnce
+                        If true, file will be loaded completely into memory. If false, data will be 
+						streamed from the file as needed. For games without large memory pressure and/or
+						small background music files, this can save memory access and improve power efficiency
+	@result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_LoadBackgroundMusicTrack(const char* inPath, Boolean inAddToQueue, Boolean inLoadAtOnce);
+
+/*!
+    @function       SoundEngine_UnloadBackgroundMusicTrack
+    @abstract       Tells the background music player to release all resources and stop playing.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_UnloadBackgroundMusicTrack();
+
+/*!
+    @function       SoundEngine_StartBackgroundMusic
+    @abstract       Tells the background music player to start playing.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_StartBackgroundMusic();
+
+/*!
+    @function       SoundEngine_StopBackgroundMusic
+    @abstract       Tells the background music player to stop playing.
+    @param          inAddToQueue
+                        If true, playback will stop when all tracks have completed. If false, playback
+						will stop immediately.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_StopBackgroundMusic(Boolean inStopAtEnd);
+	
+void  SoundEngine_SetBackgroundMusicLooping(Boolean loop);
+/*!
+    @function       SoundEngine_SetBackgroundMusicVolume
+    @abstract       Sets the volume for the background music player
+    @param          inValue
+                        A Float32 that represents the level. The range is between 0.0 and 1.0 (inclusive).
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetBackgroundMusicVolume(Float32 inValue);
+	
+void	  SoundEngine_ClearSources();
+
+
+/*!
+    @function       SoundEngine_LoadEffect
+    @abstract       Loads a sound effect from a file and return an ID to refer to that effect.
+    @param          inPath
+                        The absolute path to the file to load.
+	@param			outEffectID
+						A UInt32 ID that refers to the effect.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_LoadEffect(const char* inPath, UInt32* outEffectID);
+
+/*!
+    @function       SoundEngine_UnloadEffect
+    @abstract       Releases all resources associated with the given effect ID
+    @param          inEffectID
+                        The ID of the effect to unload.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_UnloadEffect(UInt32 inEffectID);
+
+	
+/*!
+ @function       SoundEngine_StartEffect
+ @abstract       Binds the sound effect buffer to a source
+ @param          inEffectID
+					The ID of the effect to prime.
+ @param			outSourceID
+					A ALuint ID that refers to the OpenAL source.
+ @result         The index of the primed effect in the map for unpriming later
+ */
+int  SoundEngine_PrimeEffect(UInt32 inEffectID, ALuint *outSourceID); 
+
+void SoundEngine_SetEffectPosition(ALuint sourceID, float position);
+
+float SoundEngine_GetEffectPosition(ALuint sourceID);
+	
+unsigned long SoundEngine_GetEffectLength(ALint _id);
+
+/*!
+ @function       SoundEngine_Update
+ @abstract       Checks to see if the sound as finished playing. if it has, releases the source
+ @param          sourceID
+ The ID of the effect to check.
+ @param			mSource
+the id of the buffer that has been used.
+ @result         weather the sound is finished and the buffer has been released
+ */
+bool  SoundEngine_Update(ALuint sourceID, int mSource); 
+	
+	
+/*!
+    @function       SoundEngine_StartEffect
+    @abstract       Starts playback of a source
+    @param          sourceID
+                        The ID of the source to start.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_StartEffect(ALuint sourceID);
+	
+OSStatus  SoundEngine_PauseEffect(ALuint sourceID);
+
+/*!
+    @function       SoundEngine_StopEffect
+    @abstract       Stops playback of a source
+	@param          sourceID
+						The ID of the source to stop.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_StopEffect(ALuint sourceID);
+
+/*!
+    @function       SoundEngine_Vibrate
+    @abstract       Tells the device to vibrate
+*/
+#if TARGET_OS_IPHONE
+	#define SoundEngine_Vibrate() AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+#endif
+
+/*!
+    @function       SoundEngine_SetEffectPitch
+    @abstract       Applies pitch shifting to an effect
+	@param          sourceID
+						The ID of the source to adjust.
+    @param          inValue
+                        A Float32 that represents the pitch scalar, with 1.0 being unchanged. Must 
+						be greater than 0.
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetEffectPitch(ALuint sourceID, Float32 inValue);
+
+/*!
+    @function       SoundEngine_SetEffectVolume
+    @abstract       Sets the volume for an effect
+	@param          sourceID
+						The ID of the source to adjust.
+    @param          inValue
+                        A Float32 that represents the level. The range is between 0.0 and 1.0 (inclusive).
+    @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetEffectLevel(ALuint sourceID, Float32 inValue);
+
+/*!
+    @function       SoundEngine_SetEffectLocation
+    @abstract       Tells the engine whether a given effect should loop when played or if it should
+					play through just once and stop.
+	@param          sourceID
+						The ID of the source to adjust.
+    @param          inX
+                        A Float32 that represents the effect's position along the X axis. Maximum distance
+						is 100000.0 (absolute, not per axis), reference distance (distance from which gain 
+						begins to attenuate) is 1.0
+    @param          inY
+                        A Float32 that represents the effect's position along the Y axis. Maximum distance
+						is 100000.0 (absolute, not per axis), reference distance (distance from which gain 
+						begins to attenuate) is 1.0
+	@param          inZ
+                        A Float32 that represents the effect's position along the Z axis. Maximum distance
+						is 100000.0 by default (absolute, not per axis), reference distance (distance from 
+						which gain begins to attenuate) is 1.0
+	@result         A OSStatus indicating success or failure.
+*/
+OSStatus	SoundEngine_SetEffectLocation(ALuint sourceID, Float32 inX, Float32 inY, Float32 inZ);
+
+/*!
+   @function       SoundEngine_SetEffectsVolume
+   @abstract       Sets the overall volume for the effects
+   @param          inValue
+                       A Float32 that represents the level. The range is between 0.0 and 1.0 (inclusive).
+   @result         A OSStatus indicating success or failure.
+*/
+OSStatus  SoundEngine_SetEffectsVolume(Float32 inValue);
+
+/*!
+   @function       SoundEngine_SetMaxDistance
+   @abstract       Sets the maximum distance for effect attenuation. Gain will attenuate between the
+				   reference distance and the maximum distance, after which gain will be 0.0
+   @param          inValue
+                       A Float32 that represents the level. Must be greater than 0.0.
+   @result         A OSStatus indicating success or failure.
+*/
+OSStatus	SoundEngine_SetMaxDistance(Float32 inValue);
+	
+UInt64  SoundEngine_getBackgroundMusicLength();
+	
+bool  SoundEngine_getBackgroundMusicStopped();
+	
+void SoundEngine_setBackgroundMusicPosition(UInt64 pos);
+
+
+OSStatus	SoundEngine_SetLooping(bool looping, ALint _id);
+
+/*!
+   @function       SoundEngine_SetReferenceDistance
+   @abstract       Sets the distance at which effect gain attenuation begins. It will attenuate between
+				   the reference distance and the maximum distance. Sounds closer than the reference
+				   distance will have no attenuation applied
+   @param          inValue
+                       A Float32 that represents the level. Must be greater than 0.0.
+   @result         A OSStatus indicating success or failure.
+*/
+OSStatus	SoundEngine_SetReferenceDistance(Float32 inValue);
+	
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -1,0 +1,620 @@
+/***********************************************************************
+ 
+ Copyright (C) 2011 by Zach Gage
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+ ************************************************************************/ 
+
+#import "ofxOpenALSoundPlayer.h"
+
+bool SoundEngineInitialized = false;
+
+UInt32	numSounds;
+bool	mp3Loaded;
+
+
+static ofMutex& soundPlayerLock() {
+    static ofMutex* m = new ofMutex;
+    return *m;
+}
+
+vector<ofxOpenALSoundPlayer *> soundPlayers;
+
+//--------------------------------------------------------------
+
+ofxOpenALSoundPlayer::ofxOpenALSoundPlayer() {
+
+	volume = 1.0f;
+	pitch = 1.0f;
+	pan = 0.0f;
+	stopped=true;
+	bPaused=false;
+	
+	myPrimedId=-1;
+	
+	myId = 0;
+	bLoadedOk=false;
+	bLoop = false;
+	bMultiPlay=false;
+	iAmAnMp3=false;
+	
+	numSounds++;
+}
+
+//--------------------------------------------------------------
+
+ofxOpenALSoundPlayer::~ofxOpenALSoundPlayer() { 
+	
+	unloadSound();
+	numSounds--;
+	
+	soundPlayerLock().lock();
+	for(int i=0;i<soundPlayers.size();i++)
+	{
+		if(soundPlayers[i] == this)
+		{
+			soundPlayers.erase(soundPlayers.begin()+i);
+			break;
+		}
+	}
+	soundPlayerLock().unlock();
+	
+	if(numSounds==0) {
+		closeSoundEngine();
+		soundPlayers.clear();
+	}
+}
+
+//--------------------------------------------------------------
+
+bool ofxOpenALSoundPlayer::loadSound(string fileName, bool stream) {
+	
+	if(!SoundEngineInitialized) {
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	}
+	
+	if( fileName.length()-3 == fileName.rfind("mp3") )
+		iAmAnMp3=true;
+	
+	if(iAmAnMp3) {
+		bLoadedOk = loadBackgroundMusic(fileName, false, true);
+		setLoop(bLoop);
+		isStreaming=true;
+	}
+	else {
+		isStreaming=false;
+		myId = 0; //assigned by AL
+		
+		bLoadedOk=true;
+		
+		if(SoundEngine_LoadEffect(ofToDataPath(fileName).c_str(), &myId) == noErr) {
+			length = SoundEngine_GetEffectLength(myId);
+		}
+		else {
+			cerr<<"faied to load sound "<<fileName<<endl;
+			bLoadedOk=false;
+		}
+		
+		soundPlayerLock().lock();
+		soundPlayers.push_back(this);
+		soundPlayerLock().unlock();
+	}
+	
+	return bLoadedOk;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::unloadSound() {
+	if(bLoadedOk)
+	{
+		if ( getIsPlaying() )
+			stop();
+		
+		bLoadedOk=false;
+		if(iAmAnMp3)
+			unloadAllBackgroundMusic();
+		else
+			SoundEngine_UnloadEffect(myId);
+	}
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::play() {
+	
+	if ( !bLoadedOk ) 
+		return;
+	
+	if(iAmAnMp3)
+		SoundEngine_StartBackgroundMusic();
+	else
+	{
+		if(myPrimedId==-1 || bMultiPlay)
+			prime();
+		SoundEngine_StartEffect(myPrimedId);
+	}
+	
+	stopped = false;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::stop() {
+
+	if ( !bLoadedOk )
+		return;
+	
+	if(iAmAnMp3)
+		SoundEngine_StopBackgroundMusic(false);
+	else
+		SoundEngine_StopEffect(myPrimedId);
+	
+	stopped = true;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setVolume(float _vol) {
+	if ( !bLoadedOk )
+		return;
+
+	volume = _vol;
+	
+	if(iAmAnMp3)
+		SoundEngine_SetBackgroundMusicVolume(volume);
+	else
+		SoundEngine_SetEffectLevel(myPrimedId, (Float32)volume);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setPan(float _pan) {
+	
+	if ( !bLoadedOk )
+		return;
+	
+	if(iAmAnMp3)
+		cerr<<"error, cannot set pan on mp3s in openAL"<<endl;
+	else {
+		float locX = ofClamp(_pan, -1, 1);
+		setLocation(locX, location.y, location.z);
+	}
+	pan = _pan;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setPitch(float _pitch) {
+	
+	if ( !bLoadedOk ) 
+		return;
+
+	if(iAmAnMp3)
+		cerr<<"error, cannot set pitch on mp3s in openAL"<<endl;
+	else {
+		pitch = _pitch;
+		SoundEngine_SetEffectPitch(myPrimedId, (Float32)pitch);
+	}
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setPaused(bool bP) {
+	
+	if ( !bLoadedOk )
+		return;
+	
+	if(iAmAnMp3)
+		cerr<<"error, cannot set pause on mp3s in openAL"<<endl; // TODO
+	else {
+		bool isPlaying = getIsPlaying();
+		bPaused = bP;
+		
+		if(bPaused && isPlaying)
+			SoundEngine_PauseEffect(myPrimedId);
+		else if(!bPaused && !isPlaying)
+			play();
+	}
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setLoop(bool bLp) {
+	if ( !bLoadedOk )
+		return;
+	
+	bLoop = bLp;
+	
+	if(iAmAnMp3)
+		SoundEngine_SetBackgroundMusicLooping(bLoop);
+	else
+		SoundEngine_SetLooping(bLoop, myPrimedId);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setMultiPlay(bool bMp) { 
+	if ( !bLoadedOk )
+		return;
+	
+	if(iAmAnMp3)
+		cerr<<"error, cannot set multiplay on mp3s in openAL"<<endl;
+	else
+		bMultiPlay = bMp;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setPosition(float pct) {
+	if ( !bLoadedOk ) 
+		return;
+
+	if(iAmAnMp3)
+		cerr<<"error, cannot set position on mp3s in openAL"<<endl;
+	else
+		SoundEngine_SetEffectPosition(myPrimedId, pct*length);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setPositionMS(int ms){
+	if ( !bLoadedOk ) 
+		return;
+
+	if(iAmAnMp3)
+		cerr<<"error, cannot set position on mp3s in openAL"<<endl;
+	else
+		SoundEngine_SetEffectPosition(myPrimedId, float(ms)/1000.f);
+}
+
+//--------------------------------------------------------------
+
+float ofxOpenALSoundPlayer::getPosition() {
+	if ( !bLoadedOk ) 
+		return 0;
+
+	if(iAmAnMp3)
+	{
+		cerr<<"error, cannot get position on mp3s in openAL"<<endl;
+	}
+	else
+		return (float)SoundEngine_GetEffectPosition(myPrimedId)/length;
+	
+	return 0;
+}
+
+//--------------------------------------------------------------
+
+int ofxOpenALSoundPlayer::getPositionMS() {
+	if ( !bLoadedOk ) 
+		return 0;
+
+	if(iAmAnMp3)
+	{
+		cerr<<"error, cannot get position on mp3s in openAL"<<endl;
+	}
+	else
+		return SoundEngine_GetEffectPosition(myPrimedId)*1000.f;
+
+	return 0;
+}
+
+//--------------------------------------------------------------
+
+bool ofxOpenALSoundPlayer::getIsPlaying() {
+	if ( !bLoadedOk ) 
+		return false;
+
+	if(iAmAnMp3)
+		stopped = SoundEngine_getBackgroundMusicStopped();
+	
+	if(!stopped) // if not stopped, run the update to see if maybe we should be...
+		update();
+	
+	if(stopped || bPaused)
+		return false;
+	else
+		return true;
+}
+
+//--------------------------------------------------------------
+
+float ofxOpenALSoundPlayer::getPitch() {
+	return pitch;
+}
+
+//--------------------------------------------------------------
+
+float ofxOpenALSoundPlayer::getPan() {
+	return pan;
+}
+
+//--------------------------------------------------------------
+
+float ofxOpenALSoundPlayer::getVolume() {
+    return volume;
+}
+
+//--------------------------------------------------------------
+bool ofxOpenALSoundPlayer::isLoaded() {
+    return bLoadedOk;
+}
+
+//--------------------------------------------------------------
+
+
+//static calls ---------------------------------------------------------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::initializeSoundEngine() {
+	if(!SoundEngineInitialized){
+		
+		OSStatus err = SoundEngine_Initialize(44100);
+				
+		if(err)
+			cerr<<"ERROR failed to initialize soundEngine."<<endl;
+		else {
+			numSounds=1;
+			mp3Loaded=false;
+			
+			SoundEngineInitialized = true;
+			OSStatus err = SoundEngine_SetListenerPosition(0.0f, 0.0f, 0.0f);
+			if(err)
+				cerr<<"ERROR failed to set listener position in init..\n (if you are running in the simulator, this is normal, sounds won't work.)"<<endl;
+		}
+	}
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::closeSoundEngine(){
+	if(SoundEngineInitialized){
+		
+		SoundEngine_Teardown();
+
+		SoundEngineInitialized = false;
+	}
+}
+
+//--------------------------------------------------------------
+
+void ofxALSoundStopAll(){
+	soundPlayerLock().lock();
+	for(int i=0;i<soundPlayers.size();i++)
+			soundPlayers[i]->stop();
+	soundPlayerLock().unlock();
+}
+
+//--------------------------------------------------------------
+
+float * ofxALSoundGetSpectrum(){
+	cerr<<"unfortunately there is no way to get the sound spectrum out of openAL"<<endl;
+	return NULL;
+}
+
+//--------------------------------------------------------------
+
+void ofxALSoundSetVolume(float vol){
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetMasterVolume((Float32)vol);
+}
+
+//--------------------------------------------------------------
+
+
+
+// internal ------------------------------------------------------------------------------------------------------------------
+
+bool ofxOpenALSoundPlayer::update() {
+
+	bool deletedAnything= false;
+	for(int i=retainedBuffers.size()-1;i>=0;i--) {
+		if(SoundEngine_Update(retainedBuffers[i]->primedID, retainedBuffers[i]->buffer)) {
+			delete retainedBuffers[i];
+			retainedBuffers.erase(retainedBuffers.begin()+i);
+			deletedAnything = true;
+		}
+	}
+	
+	if(retainedBuffers.size()==0)
+	{
+		myPrimedId=-1;
+		stopped=true;
+	}
+	
+	return deletedAnything;
+}
+
+//--------------------------------------------------------------
+
+bool ofxOpenALSoundPlayer::prime() {
+
+	soundPlayerLock().lock();
+	for(int i=0;i<soundPlayers.size();i++)
+		soundPlayers[i]->update();
+	soundPlayerLock().unlock();
+	
+	multiPlaySource * m;
+	m = new multiPlaySource();
+	ALuint newPrimedId;
+	m->buffer = SoundEngine_PrimeEffect(myId, &newPrimedId);
+
+	if(m->buffer != -1) {
+		m->primedID = newPrimedId;
+		myPrimedId = newPrimedId;
+		retainedBuffers.push_back(m);
+		updateInternalsForNewPrime();
+		return true;
+	}
+	else
+		delete m;
+	
+	return false;
+}
+
+//--------------------------------------------------------------
+
+bool ofxOpenALSoundPlayer::loadBackgroundMusic(string fileName, bool queue, bool loadAtOnce) {
+	myId = 0;
+	
+	if(!mp3Loaded) {
+		if(SoundEngine_LoadBackgroundMusicTrack(ofToDataPath(fileName).c_str(), queue, loadAtOnce) == noErr )
+		{
+			length = SoundEngine_getBackgroundMusicLength();
+			bLoadedOk=true;
+			mp3Loaded=true;
+			
+			soundPlayerLock().lock();
+				soundPlayers.push_back(this);
+			soundPlayerLock().unlock();
+		}
+		else
+		{
+			bLoadedOk=false;
+			cerr<<"faied to load sound "<<fileName<<endl;
+		}
+	}
+	else {
+		cerr<<"more than one mp3 cannot be loaded at the same time"<<endl;
+	}
+	
+	return bLoadedOk;
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::updateInternalsForNewPrime() {
+	setPitch(pitch);
+	setLocation(location.x, location.y, location.z);
+	setPan(pan);
+	setVolume(volume);
+	setLoop(bLoop);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::unloadAllBackgroundMusic() {
+	SoundEngine_UnloadBackgroundMusicTrack();
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::startBackgroundMusic() {
+	SoundEngine_StartBackgroundMusic();
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::stopBackgroundMusic(bool stopNow) {
+	SoundEngine_StopBackgroundMusic(!stopNow); //this is confusing but i think stopNow makes more sense than stopAtEnd in terms of how people will likely be calling this
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setBackgroundMusicVolume(float bgVol) {
+	SoundEngine_SetBackgroundMusicVolume((Float32)bgVol);
+}
+
+//--------------------------------------------------------------
+
+
+
+// beyond ofSoundPlayer ------------------------------------------------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::vibrate() { 
+	SoundEngine_Vibrate();
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::setLocation(float x, float y, float z) { 
+	
+	if ( !bLoadedOk )
+		return;
+
+	if(iAmAnMp3)
+		cerr<<"error, cannot set location on mp3s in openAL"<<endl;
+	else
+	{
+		location.set(x,y,z);
+		pan = ofClamp(x,-1,1); // assuming x clamp pan to -1..1
+		SoundEngine_SetEffectLocation(myPrimedId, x, y, z);
+	}
+}
+
+//--------------------------------------------------------------
+
+
+
+// beyond ofSoundPlayer static -----------------------------------------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetListenerLocation(float x, float y, float z){	
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetListenerPosition(x, y, z);
+}
+
+//--------------------------------------------------------------
+void ofxOpenALSoundPlayer::ofxALSoundSetListenerVelocity(float x, float y, float z){
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetListenerVelocity(x, y, z); //deprecated
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetListenerGain(float gain) {
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetListenerGain(gain);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetReferenceDistance(float dist) {
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetReferenceDistance(dist);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetMaxDistance(float dist) {
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		SoundEngine_SetMaxDistance(dist);
+}
+
+//--------------------------------------------------------------
+
+void ofxOpenALSoundPlayer::ofxALSoundSetDistanceModel(ALenum model) {
+	if(!SoundEngineInitialized)
+		ofxOpenALSoundPlayer::initializeSoundEngine();
+	if ( SoundEngineInitialized )
+		alDistanceModel(model);
+}
+

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
@@ -1,0 +1,143 @@
+/***********************************************************************
+ 
+ Copyright (C) 2011 by Zach Gage
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ 
+ ************************************************************************/ 
+
+
+#ifndef OFX_OPEN_AL_SOUND_PLAYER_H
+#define OFX_OPEN_AL_SOUND_PLAYER_H
+
+/* convert your sounds to caf for them to work best:
+ 
+ afconvert -f caff -d LEI16 FILEIN
+ 
+ where FILEIN is the name of your file.
+ 
+ mp3's can be played but only load and play one at a time.
+ 
+ */
+
+
+#include "SoundEngine.h"
+#include <CoreAudio/CoreAudioTypes.h>
+#include "ofBaseSoundPlayer.h"
+#include "ofUtils.h"
+#include "ofPoint.h"
+#include "ofTypes.h"
+
+//globals
+
+void ofxALSoundStopAll();
+void ofxALSoundSetVolume(float vol);
+float * ofxALSoundGetSpectrum(int nBands);
+
+struct multiPlaySource {
+	ALuint primedID;
+	int buffer;
+};
+
+class ofxOpenALSoundPlayer : public ofBaseSoundPlayer{
+public:
+	
+	static void initializeSoundEngine();				
+	static void closeSoundEngine();	
+	
+	ofxOpenALSoundPlayer();
+	~ofxOpenALSoundPlayer();
+	
+	bool	loadSound(string fileName, bool stream=false);
+	void	unloadSound();
+
+	void	play();
+	void	stop();
+	void	setVolume(float _vol);
+	void	setPan(float _pan);
+	void	setPitch(float _pitch);
+	void	setSpeed(float _speed){setPitch(_speed);};// same as pitch. mapped for ofSoundPlayer compatibility
+	
+	void	setPaused(bool bP);
+	void	setLoop(bool bLp);
+	void	setMultiPlay(bool bMp);
+	void	setPosition(float pct);
+	void    setPositionMS(int ms);
+
+	float	getPosition();
+	int		getPositionMS();
+	bool	getIsPlaying();
+	float	getPitch();
+	float	getSpeed(){return getPitch();}; // same as pitch. mapped for ofSoundPlayer compatibility
+	float   getVolume();
+    
+	float	getPan();
+
+    bool    isLoaded();
+	
+	// IPHONE EXTRA FUNCTIONS
+	static void	vibrate();
+	
+	static void	ofxALSoundSetListenerLocation(float x, float y, float z);
+	static void	ofxALSoundSetListenerGain(float gain);
+	static void	ofxALSoundSetListenerVelocity(float x, float y, float z);
+	
+	static void	ofxALSoundSetReferenceDistance(float dist); // sets the distance after which attenuation is applied
+	static void	ofxALSoundSetMaxDistance(float dist); // sets the maximum distance for which attenuation is applied
+	
+	static void ofxALSoundSetDistanceModel(ALenum model); // sets the formula which determines how attenuation is applied.
+														  // Note: the default distance model is AL_INVERSE_DISTANCE_CLAMPED,
+														  // but you may find AL_LINEAR_DISTANCE_CLAMPED to be more intuitive
+														  // (all sounds beyond the max distance will be silent)
+	
+	void	setLocation(float x, float y, float z); // x -1..1 gets mapped to pan -1..1
+	
+	bool	update(); // can this be called at a different time? maybe should be a static function
+
+	bool isStreaming; //always false for openAL
+	bool bMultiPlay;
+	bool bLoop;
+	bool bLoadedOk;
+	
+	bool bPaused;
+
+	float	pan;
+	float	pitch;
+	float	volume;
+	unsigned int length;
+	ofPoint location;
+	
+protected: //internal
+	
+	bool    prime();
+	void	updateInternalsForNewPrime();
+	bool	loadBackgroundMusic(string fileName, bool queue, bool loadAtOnce);
+	void	unloadAllBackgroundMusic();
+	void	startBackgroundMusic();
+	void	stopBackgroundMusic(bool stopNow);
+	void	setBackgroundMusicVolume(float bgVol);
+	
+	UInt32 myId;
+	ALuint  myPrimedId;
+	bool	stopped; 	
+	bool	iAmAnMp3;
+	vector <multiPlaySource *> retainedBuffers;
+};
+
+#endif

--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -56,6 +56,10 @@
 		53DA339012DF8F5000C622CE /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA338F12DF8F5000C622CE /* CoreMedia.framework */; };
 		53DA339212DF8F5000C622CE /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA339112DF8F5000C622CE /* CoreVideo.framework */; };
 		5E2E99DD10ED147800587639 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E2E99DC10ED147800587639 /* MapKit.framework */; };
+		66EA462B17A6D396009BB12A /* ofxOpenALSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */; };
+		66EA462C17A6D396009BB12A /* ofxOpenALSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */; };
+		66EA462D17A6D396009BB12A /* SoundEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66EA462917A6D396009BB12A /* SoundEngine.cpp */; };
+		66EA462E17A6D396009BB12A /* SoundEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EA462A17A6D396009BB12A /* SoundEngine.h */; };
 		671C0AF41770246200DF03B3 /* AVSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 671C0AF01770246200DF03B3 /* AVSoundPlayer.h */; };
 		671C0AF51770246200DF03B3 /* AVSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 671C0AF11770246200DF03B3 /* AVSoundPlayer.m */; };
 		671C0AF61770246200DF03B3 /* ofxiOSSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 671C0AF21770246200DF03B3 /* ofxiOSSoundPlayer.h */; };
@@ -255,6 +259,10 @@
 		53DA339112DF8F5000C622CE /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		53F323EA10A20EDB00E0DAE4 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
 		5E2E99DC10ED147800587639 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxOpenALSoundPlayer.cpp; sourceTree = "<group>"; };
+		66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxOpenALSoundPlayer.h; sourceTree = "<group>"; };
+		66EA462917A6D396009BB12A /* SoundEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SoundEngine.cpp; sourceTree = "<group>"; };
+		66EA462A17A6D396009BB12A /* SoundEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundEngine.h; sourceTree = "<group>"; };
 		671C0AF01770246200DF03B3 /* AVSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSoundPlayer.h; sourceTree = "<group>"; };
 		671C0AF11770246200DF03B3 /* AVSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSoundPlayer.m; sourceTree = "<group>"; };
 		671C0AF21770246200DF03B3 /* ofxiOSSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundPlayer.h; sourceTree = "<group>"; };
@@ -463,6 +471,10 @@
 		15594F0115C55A5700727FF2 /* sound */ = {
 			isa = PBXGroup;
 			children = (
+				66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */,
+				66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */,
+				66EA462917A6D396009BB12A /* SoundEngine.cpp */,
+				66EA462A17A6D396009BB12A /* SoundEngine.h */,
 				678C3D19176F04F800D1CC68 /* ofxiOSSoundStream.h */,
 				678C3D1A176F04F800D1CC68 /* ofxiOSSoundStream.mm */,
 				678C3D1B176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h */,
@@ -980,6 +992,8 @@
 				671C0AF41770246200DF03B3 /* AVSoundPlayer.h in Headers */,
 				671C0AF61770246200DF03B3 /* ofxiOSSoundPlayer.h in Headers */,
 				67509ABD17979781003A3A29 /* ofXml.h in Headers */,
+				66EA462C17A6D396009BB12A /* ofxOpenALSoundPlayer.h in Headers */,
+				66EA462E17A6D396009BB12A /* SoundEngine.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,6 +1129,8 @@
 				671C0AF51770246200DF03B3 /* AVSoundPlayer.m in Sources */,
 				671C0AF71770246200DF03B3 /* ofxiOSSoundPlayer.mm in Sources */,
 				67509ABC17979781003A3A29 /* ofXml.cpp in Sources */,
+				66EA462B17A6D396009BB12A /* ofxOpenALSoundPlayer.cpp in Sources */,
+				66EA462D17A6D396009BB12A /* SoundEngine.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR restores the ofxOpenALSoundPlayer and SoundEngine files for iOS. This is to provide a fallback sound player for the regression documented in issue #2336

The files are added to the iOS+OFLib project, but they aren't pulled in by any of the headers. So, you'd have to explicitly `#include "ofxOpenALSoundPlayer.h"` and also create it like `ofxOpenALSoundPlayer myPlayer`.

Tested by replacing the "beats" sound player in the soundPlayerExample with an explicit ofxOpenALSoundPlayer, and didn't notice any conflicts.

For the future (as in 0.8.1) I think it'd be a good idea to remove these again, but provide a solid "low level" sound player which sacrifices a bit of the automatic niceness of the AVFoundation player, but allows you to have tighter control over your playback. Initial testing with an AUFilePlayer-based sound player went very well, but it failed the

> works perfectly

test, due to not having a total 1:1 coverage of the features in the OpenAL player (like playback at different pitches). It did cover the use case of high-speed seeking within a file, though.

Pinging @ofTheo @julapy @edburton
