### PR TITLE
guard cwd restore to win32-only (from "not android")

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -279,7 +279,7 @@ string ofToDataPath(string path, bool makeAbsolute){
 		return path;
 	
 	// if our Current Working Directory has changed (e.g. file open dialog)
-#ifndef TARGET_ANDROID
+#ifdef TARGET_WIN32
 	if (defaultWorkingDirectory().toString() != getWorkingDir().toString()) {
 		// change our cwd back to where it was on app load
 		int ret = chdir(defaultWorkingDirectory().toString().c_str());


### PR DESCRIPTION
closes #2337

This just implements the #ifdef change mentioned by @arturoc in #2337. So:

```
#ifndef TARGET_ANDROID -> #ifdef TARGET_WIN32
```

I'm not really sure how to fully test it, but I ran an ios app with some ofToDataPath() calls, and the file dialog example on OSX. 
