### PR TITLE
Added the ofXml unit to the win_cb project

### DIFF
--- a/libs/openFrameworksCompiled/project/win_cb/openFrameworksLib.cbp
+++ b/libs/openFrameworksCompiled/project/win_cb/openFrameworksLib.cbp
@@ -387,6 +387,12 @@
 		<Unit filename="..\..\..\openFrameworks\utils\ofUtils.h">
 			<Option virtualFolder="openframeworks\utils\" />
 		</Unit>
+		<Unit filename="..\..\..\openFrameworks\utils\ofXml.cpp">
+			<Option virtualFolder="openframeworks\utils\" />
+		</Unit>
+		<Unit filename="..\..\..\openFrameworks\utils\ofXml.h">
+			<Option virtualFolder="openframeworks\utils\" />
+		</Unit>
 		<Unit filename="..\..\..\openFrameworks\video\ofDirectShowGrabber.cpp">
 			<Option virtualFolder="openframeworks\video\" />
 		</Unit>


### PR DESCRIPTION
Bugfix <strong>#2370</strong>
Added the ofXml unit paths (for .h and .cpp) in the .cbp which were missing earlier causing build errors in gui and xml examples.
