### PR TITLE
uncomment box drawing in ofNode's default customDraw()

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -2,6 +2,7 @@
 #include "ofNode.h"
 #include "ofMath.h"
 #include "ofLog.h"
+#include "of3dGraphics.h"
 
 ofNode::ofNode() : 
 	parent(NULL) {
@@ -350,6 +351,12 @@ void ofNode::draw() {
 	transformGL();
 	customDraw();
 	restoreTransformGL();
+}
+
+//----------------------------------------
+void ofNode::customDraw() {
+	ofDrawBox(10);
+	ofDrawAxis(20);
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -137,10 +137,7 @@ public:
 	
 
 	// if you extend ofNode and wish to change the way it draws, extend this
-	virtual void customDraw() {
-		//ofBox(10);
-		ofDrawAxis(20);
-	}
+	virtual void customDraw();
 
 	
 	// draw function. do NOT override this


### PR DESCRIPTION
the `ofBox` call in ofNode's `customDraw()` was commented out, to avoid a bit of a dependency problem. This PR moves the `customDraw` implementation into ofNode.cpp, which avoids the issue.

fixes #2388
