### PR TITLE
check for non-zero NSGetExecutablePath return, fixes #2394

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1411,7 +1411,7 @@ string ofFilePath::getCurrentExePath(){
 	#elif defined(TARGET_OSX)
 		char path[FILENAME_MAX];
 		uint32_t size = sizeof(path);
-		if(_NSGetExecutablePath(path, &size) == 0){
+		if(_NSGetExecutablePath(path, &size) != 0){
 			ofLogError("ofFilePath") << "getCurrentExePath(): path buffer too small, need size " <<  size;
 		}
 		return path;


### PR DESCRIPTION
TIny fix for checking wrong return value.
