### PR TITLE
ios orientation tweak

### DIFF
--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -173,8 +173,13 @@ void ofAppiOSWindow::setOrientation(ofOrientation toOrientation) {
             break;
     }
 
-    ofxiOSAppDelegate * appDelegate = (ofxiOSAppDelegate *)[UIApplication sharedApplication].delegate;
-    ofxiOSViewController * glViewController = appDelegate.glViewController;
+    id<UIApplicationDelegate> appDelegate = [UIApplication sharedApplication].delegate;
+    if([appDelegate respondsToSelector:@selector(glViewController)] == NO) {
+        // check app delegate has glViewController,
+        // otherwise calling glViewController will cause a crash.
+        return;
+    }
+    ofxiOSViewController * glViewController = ((ofxiOSAppDelegate *)appDelegate).glViewController;
     ofxiOSEAGLView * glView = glViewController.glView;
     
     if(bHardwareOrientation == true) {


### PR DESCRIPTION
i was getting crashes in my ios projects where im only using ofxiOSEAGLView without ofxiOSViewController.
sometime i have to create custom view controllers which do not subclass from ofxiOSViewController.

this fix prevents that crash from occurring by first checking if the glViewController exists in the app delegate class.
