### PR TITLE
added Windows driver install info to kinectExample header

### DIFF
--- a/addons/ofxKinect/README.md
+++ b/addons/ofxKinect/README.md
@@ -94,11 +94,11 @@ Also, you can add a set of udev rules which allow you to run a kinect app withou
 
 ### Windows
 
-Precompiled libfreenect Kinect drivers and libusb-win32 libs are included for Windows.
+Precompiled libfreenect drivers and libusb-win32 libs are included for Windows.
 
 Make sure to install or update the libfreenect Kinect camera, motor, and audio drivers through Windows Device Manager by pointing it to the driver folder:
 <pre>
-libs/libfreenect/platform/windows/inf
+ofxKinect/libs/libfreenect/platform/windows/inf
 </pre>
 
 You may need to manually update each driver individually if you've plugged it in before. ofxKinect will not work if the drivers are not installed.

--- a/examples/addons/kinectExample/src/testApp.h
+++ b/examples/addons/kinectExample/src/testApp.h
@@ -4,6 +4,21 @@
 #include "ofxOpenCv.h"
 #include "ofxKinect.h"
 
+// Windows users:
+// You MUST install the libfreenect kinect drivers in order to be able to use
+// ofxKinect. Plug in the kinect and point your Windows Device Manager to the
+// driver folder in:
+//
+//     ofxKinect/libs/libfreenect/platform/windows/inf
+//
+// This should install the Kinect camera, motor, & audio drivers.
+//
+// You CANNOT use this driver and the OpenNI driver with the same device. You
+// will have to manually update the kinect device to use the libfreenect drivers
+// and/or uninstall/reinstall it in Device Manager.
+//
+// No way around the Windows driver dance, sorry.
+
 // uncomment this to read from two kinects simultaneously
 //#define USE_TWO_KINECTS
 


### PR DESCRIPTION
This should mitigate new windows users from trying to run the kinectExample without the freenect drivers, see #2452
