### PR TITLE
add more sophisticated openGL capability checks.

### DIFF
--- a/examples/gl/vboMeshDrawInstancedExample/src/main.cpp
+++ b/examples/gl/vboMeshDrawInstancedExample/src/main.cpp
@@ -15,17 +15,54 @@
 //========================================================================
 int main( ){
 	
-if( glDrawElementsInstanced == 0 ){
-    ofLogFatalError("App") << " glDrawElementsInstanced is needed for this example but it is not supported by your graphics card. Exiting App.";
-    return -1;  
-}
+
 	
+
 #ifdef USE_PROGRAMMABLE_GL
+	// we are using the programmable gl renderer.
+
 	ofPtr<ofBaseRenderer> renderer(new ofGLProgrammableRenderer(false));
 	ofSetCurrentRenderer(renderer, false);
-#endif
 	ofSetupOpenGL(1024,768,OF_WINDOW);			// <-------- setup the GL context
 
+#else
+	// we are not using the progammable gl renderer.
+	
+	// when we are not using the programmable gl renderer it is not safe to assume
+	// out current gl context provides us with the necessary openGL extensions to
+	// run this example.
+	
+	// let's check if the current openGL context provides us with glDrawElementsInstanced
+	// we do this after we have initialised our openGL context.
+
+	ofSetupOpenGL(1024,768,OF_WINDOW);			// <-------- setup the GL context
+	
+	ostringstream extStr;
+	extStr << (char*)glGetString(GL_EXTENSIONS);		// first get all available extensions.
+	string extensionsAvailable = extStr.str();
+	
+	
+	if (ofStringTimesInString(extensionsAvailable, "GL_ARB_draw_instanced") == 0)
+		{
+			ofLogFatalError("App") << " GL_ARB_draw_instanced is needed for this example but it is not supported by your graphics card. Exiting App.";
+			return -1;
+
+		} else {
+			
+			// GL_ARB_draw_instanced is available... so far so good.
+			
+			// either one of these is needed, too:
+			if (ofStringTimesInString(extensionsAvailable, "GL_EXT_gpu_shader4") == 0 &&
+				ofStringTimesInString(extensionsAvailable, "NV_vertex_program4") == 0 )
+			{
+				ofLogFatalError("App") << " GL_EXT_gpu_shader4 or NV_vertex_program4 is needed for this example but it is not supported by your graphics card. Exiting App.";
+				return -1;
+
+			}
+
+		}
+#endif
+	
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:


### PR DESCRIPTION
- if we are using the programmable gl renderer, it is safe to assume glDrawElementsInstanced is available (it is a GL core feature from 3.1)
- for legacy GL, we check against the extensions our hardware provides us with, namely:

`GL_ARB_draw_instanced`, which, in turn, depends on either `EXT_gpu_shader4` or `NV_vertex_program4` .

It's not super-pretty, but commented throughout.

addresses issue #2457

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
