### PR TITLE
Fixed bug in ofCairoRenderer where moveTo commands are interpreted wrong

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -415,6 +415,7 @@ void ofCairoRenderer::draw(ofPath::Command & command){
 	case ofPath::Command::moveTo:
 		curvePoints.clear();
 		cairo_new_sub_path(cr);
+		cairo_move_to(cr, command.to.x, command.to.y);
 		break;
 
 	case ofPath::Command::lineTo:


### PR DESCRIPTION
This results in cairo sub paths not starting from the supplied point of the moveTo command. Adding one lien of code fixes this.
