### PR TITLE
fix a critical programmable GL renderer custom shader state leak

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -923,7 +923,7 @@ void ofGLProgrammableRenderer::beginDefaultShader(){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::endCustomShader(){
 	usingCustomShader = false;
-	if(uniqueShader) beginDefaultShader();
+	if(!uniqueShader) beginDefaultShader();
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
This addresses an issue where the programmableGL renderer would not return to default shaders after a custom shader had been applied, because of a typo in a conditional introduced to optimise shaders for Raspberry Pi.

This PR adds a crucial `!` to endCustomShader, returning control to default Shader once a custom shader is done with.

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
