### PR TITLE
Fix for issue #2496 (ofColor == and != operators ignoring alpha)

### DIFF
--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -542,13 +542,13 @@ ofColor_<PixelType> & ofColor_<PixelType>::operator = (float const & val){
 
 template<typename PixelType>
 bool ofColor_<PixelType>::operator == (ofColor_<PixelType> const & color){
-	return (r == color.r) && (g == color.g) && (b == color.b);
+	return (r == color.r) && (g == color.g) && (b == color.b) && (a == color.a);
 }
 
 
 template<typename PixelType>
 bool ofColor_<PixelType>::operator != (ofColor_<PixelType> const & color){
-	return (r != color.r) || (g != color.g) || (b != color.b);
+	return (r != color.r) || (g != color.g) || (b != color.b) || (a != color.a);
 }
 
 


### PR DESCRIPTION
Update ofColor == and != operators to also test alpha channel. This fixes #2496
