### PR TITLE
Feature tcpmanager connect timeout

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -180,17 +180,13 @@ bool ofxTCPManager::Connect(char *pAddrStr, unsigned short usPort)
             socklen_t len = sizeof so_error;
             getsockopt(m_hSocket, SOL_SOCKET, SO_ERROR, &so_error, &len);
             if (so_error == 0) {
-                ofLog() << "OK! tcp";;
                 return true;
             } 
         }
     }
     
-    if(!ret) ofxNetworkCheckError();
-    
+    if(!ret) ofxNetworkCheckError();    
 	return ret;
-    //ofLog() << "FAILED! tcp";
-    //return false;
 }
 
 //--------------------------------------------------------------------------------

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -142,10 +142,7 @@ bool ofxTCPManager::Accept(ofxTCPManager& sConnect)
   return ret;
 }
 
-/*
-    Trent: adding a timeout for connection.
-    - based on http://stackoverflow.com/questions/2597608/c-socket-connection-timeout
- */
+
 //--------------------------------------------------------------------------------
 bool ofxTCPManager::Connect(char *pAddrStr, unsigned short usPort)
 {

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -29,6 +29,7 @@ ofxTCPManager::ofxTCPManager()
   m_dwTimeoutSend= OF_TCP_DEFAULT_TIMEOUT;
   m_dwTimeoutReceive= OF_TCP_DEFAULT_TIMEOUT;
   m_dwTimeoutAccept= OF_TCP_DEFAULT_TIMEOUT;
+  m_dwTimeoutConnect= 5;//OF_TCP_DEFAULT_TIMEOUT;
   m_iListenPort= -1;
   m_closing = false;
   m_iMaxConnections = 100;
@@ -141,6 +142,10 @@ bool ofxTCPManager::Accept(ofxTCPManager& sConnect)
   return ret;
 }
 
+/*
+    Trent: adding a timeout for connection.
+    - based on http://stackoverflow.com/questions/2597608/c-socket-connection-timeout
+ */
 //--------------------------------------------------------------------------------
 bool ofxTCPManager::Connect(char *pAddrStr, unsigned short usPort)
 {
@@ -158,9 +163,34 @@ bool ofxTCPManager::Connect(char *pAddrStr, unsigned short usPort)
 	addr_in.sin_port  = htons(usPort); // short, network byte order
 	addr_in.sin_addr  = *((struct in_addr *)he->h_addr);
 
+    // set to non-blocking before connect
+    if (m_dwTimeoutConnect != NO_TIMEOUT) fcntl(m_hSocket, F_SETFL, O_NONBLOCK);
+    
 	bool ret = (connect(m_hSocket, (sockaddr *)&addr_in, sizeof(sockaddr)) != SOCKET_ERROR);
-	if(!ret) ofxNetworkCheckError();
+    
+    // set a timeout
+    if (m_dwTimeoutConnect != NO_TIMEOUT) {
+        fd_set fd;
+        FD_ZERO(&fd);
+        FD_SET(m_hSocket, &fd);
+        timeval	tv=	{m_dwTimeoutConnect, 0};
+        fd_set fdset;
+        if(select(m_hSocket+1,NULL,&fd,NULL,&tv)== 1) {
+            int so_error;
+            socklen_t len = sizeof so_error;
+            getsockopt(m_hSocket, SOL_SOCKET, SO_ERROR, &so_error, &len);
+            if (so_error == 0) {
+                ofLog() << "OK! tcp";;
+                return true;
+            } 
+        }
+    }
+    
+    if(!ret) ofxNetworkCheckError();
+    
 	return ret;
+    //ofLog() << "FAILED! tcp";
+    //return false;
 }
 
 //--------------------------------------------------------------------------------
@@ -403,6 +433,9 @@ bool ofxTCPManager::GetInetAddr(LPINETADDR pInetAddr)
 	return ret;
 }
 
+void ofxTCPManager::SetTimeoutConnect(int timeoutInSeconds) {
+	m_dwTimeoutConnect= timeoutInSeconds;
+}
 void ofxTCPManager::SetTimeoutSend(int timeoutInSeconds) {
 	m_dwTimeoutSend= timeoutInSeconds;
 }
@@ -411,6 +444,9 @@ void ofxTCPManager::SetTimeoutReceive(int timeoutInSeconds) {
 }
 void ofxTCPManager::SetTimeoutAccept(int timeoutInSeconds) {
 	m_dwTimeoutAccept= timeoutInSeconds;
+}
+int ofxTCPManager::GetTimeoutConnect() {
+	return m_dwTimeoutConnect;
 }
 int ofxTCPManager::GetTimeoutSend() {
 	return m_dwTimeoutSend;

--- a/addons/ofxNetwork/src/ofxTCPManager.h
+++ b/addons/ofxNetwork/src/ofxTCPManager.h
@@ -187,10 +187,12 @@ public:
 	int  Write(const char* pBuff, const int iSize);
 	bool GetRemoteAddr(LPINETADDR pIntAddr);
 	bool GetInetAddr(LPINETADDR pInetAddr);
-	void SetTimeoutSend(int timeoutInSeconds);
+	void SetTimeoutConnect(int timeoutInSeconds);
+    void SetTimeoutSend(int timeoutInSeconds);
 	void SetTimeoutReceive(int timeoutInSeconds);
 	void SetTimeoutAccept(int timeoutInSeconds);
-	int  GetTimeoutSend();
+	int  GetTimeoutConnect();
+    int  GetTimeoutSend();
 	int  GetTimeoutReceive();
 	int  GetTimeoutAccept();
 	bool SetReceiveBufferSize(int sizeInByte);
@@ -216,6 +218,7 @@ private:
 	int m_hSocket;
   #endif
 
+  unsigned long m_dwTimeoutConnect;
   unsigned long m_dwTimeoutSend;
   unsigned long m_dwTimeoutReceive;
   unsigned long m_dwTimeoutAccept;


### PR DESCRIPTION
Hi, I haven't submitted a PR before- so let me know when I'm off track, and if the coding style is wrong. I opened an issue here https://github.com/openframeworks/openFrameworks/issues/2515 which describes the problem.

I have set the connect timeout to 5 seconds by default. Not sure what the preferred time should be (and whether to use a #define for this)? But having no timeout, eg. OF_TCP_DEFAULT_TIMEOUT is not recommended as this would not solve the issue (blocking for 90 seconds then crashing when connecting to invalid ip). 

I have only tested on OSX.

Thanks OF,
Trent
