### PR TITLE
project generator simple/linux:  compile in release mode instead of debug

### DIFF
--- a/scripts/linux/compilePG.sh
+++ b/scripts/linux/compilePG.sh
@@ -6,7 +6,7 @@ WHO=`who am i`;ID=`echo ${WHO%% *}`
 GROUP_ID=`id --group -n ${ID}`
 
 cd ../../apps/projectGenerator/projectGeneratorSimple
-make Debug 
+make Release
 ret=$?
 if [ $ret -ne 0 ]; then
   echo "there has been a problem compiling the projectGenerator"


### PR DESCRIPTION
Closes #2535.

This change was an accident. @arturoc could you give the final go-ahead?
