### PR TITLE
ofFbo: convenience draw functions from ofBaseDraws

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -16,6 +16,7 @@ public:
 	void allocate(Settings settings = Settings());
 	bool isAllocated();
 
+	using ofBaseDraws::draw;
 	void draw(float x, float y);
 	void draw(float x, float y, float width, float height);
 


### PR DESCRIPTION
Hi. I came across a small detail while trying to call _draw_ on an FBO object. Passing an ofRectangle or ofPoint as the argument does not work like in ofImage, ofTexture and others.

The ofBaseDraws interface specifies the _draw_ function with the following signatures:

```
void draw(float x, float y)
void draw(float x, float y, float w, float h)
void draw(const ofPoint & point)
void draw(const ofRectangle & rect)
void draw(const ofPoint & point, float w, float h)
```

The last three are implemented in the abstract class ofBaseDraws, but are hidden by the _draw_ implementations (first two in the list) in ofFbo. Simply adding 

```
using ofBaseDraws::draw;
```

will correct this.
