### PR TITLE
texture cache fix for ofxiOSVideoPlayer

### DIFF
--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -70,7 +70,6 @@ protected:
     bool bUpdatePixelsToRgb;
     bool bUpdateTexture;
     bool bTextureCacheSupported;
-    bool bTextureHack;
 	
 	GLubyte * pixelsRGB;
     GLubyte * pixelsRGBA;


### PR DESCRIPTION
ofTexture now supports using external texture IDs with this method, setUseExternalTextureID.
this PR updates ofxiOSVideoPlayer to work with this new method.
