### PR TITLE
ES3 + xcode5 fix for missing GL_STENCIL_INDEX

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -151,7 +151,7 @@ bool ofIsGLProgrammableRenderer();
     // ES2 + ES3 - GL_STENCIL_INDEX has been removed from gl header, and now replaced with GL_STENCIL_INDEX8.
     #ifndef GL_STENCIL_INDEX
         #ifdef GL_STENCIL_INDEX8
-            #define GL_STENCIL_INDEX                        GL_STENCIL_INDEX8;
+            #define GL_STENCIL_INDEX                        GL_STENCIL_INDEX8
         #endif
     #endif
 


### PR DESCRIPTION
ES2 and ES3 gl header files no longer include GL_STENCIL_INDEX.
it has now been replaced with GL_STENCIL_INDEX8.
