### PR TITLE
fix log level for ofFBO allocation message

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -324,7 +324,7 @@ bool ofFbo::checkGLSupport() {
 	glGetIntegerv(GL_MAX_DRAW_BUFFERS, &_maxDrawBuffers);
 	glGetIntegerv(GL_MAX_SAMPLES, &_maxSamples);
 
-	ofLogNotice("ofFbo") << "checkGLSupport(): "
+	ofLogVerbose("ofFbo") << "checkGLSupport(): "
                           << "maxColorAttachments: " << _maxColorAttachments << ", "
                           << "maxDrawBuffers: " << _maxDrawBuffers << ", "
                           << "maxSamples: " << _maxSamples;


### PR DESCRIPTION
issues log message at log level OF_LOG_VERBOSE instead of OF_LOG_NOTICE in an effort to de-clutter log output.

Fixes issue #2583
