### PR TITLE
bind defaultShader in setup() for RPi/GLProgrammable

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1681,7 +1681,7 @@ void ofGLProgrammableRenderer::setup(){
 		defaultUniqueShader().setupShaderFromSource(GL_FRAGMENT_SHADER,uniqueFragmentShader);
 		defaultUniqueShader().bindDefaults();
 		defaultUniqueShader().linkProgram();
-
+		beginDefaultShader();
 	}else{
 		defaultTexColor().setupShaderFromSource(GL_VERTEX_SHADER,defaultVertexShader);
 		defaultTex2DColor().setupShaderFromSource(GL_VERTEX_SHADER,defaultVertexShader);


### PR DESCRIPTION
This fixes an issue in the Programmable GL Renderer where RPi would not have the default shader bound when a drawing call was issued in update().

Fixes issue #2593

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
