### PR TITLE
remove early, unnecessary ESC check

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1011,9 +1011,6 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int key, int scancode, i
 
 	if(action == GLFW_PRESS || action == GLFW_REPEAT){
 		ofNotifyKeyPressed(key);
-		if (key == OF_KEY_ESC){				// "escape"
-			exitApp();
-		}
 	}else if (action == GLFW_RELEASE){
 		ofNotifyKeyReleased(key);
 	}


### PR DESCRIPTION
ofAppGLFWWindow has a specific ESC check for app quitting, which didn't respect whether the user had called `ofSetEscapeQuitsApp(false);`. It's an unnecessary check as far as I can tell, since it calls `ofNotifyKeyPressed(key)` right before that, which _does_ perform the check [see here](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/events/ofEvents.cpp#L209)

fixes #2549
