### PR TITLE
fixed ofMaterial for opengl ES1

### DIFF
--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -58,6 +58,7 @@ ofFloatColor ofMaterial::getEmissiveColor() {
 }
 
 void ofMaterial::begin() {
+#ifndef TARGET_OPENGLES
     // save previous values, opengl es cannot use push/pop attrib
 	glGetMaterialfv(GL_FRONT,GL_DIFFUSE,&prev_diffuse.r);
 	glGetMaterialfv(GL_FRONT,GL_SPECULAR,&prev_specular.r);
@@ -83,9 +84,25 @@ void ofMaterial::begin() {
 	glMaterialfv(GL_BACK, GL_AMBIENT, &ambient.r);
 	glMaterialfv(GL_BACK, GL_EMISSION, &emissive.r);
 	glMaterialfv(GL_BACK, GL_SHININESS, &shininess);
+#else
+    // opengl es 1.1 implementation must use GL_FRONT_AND_BACK.
+    
+	glGetMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, &prev_diffuse.r);
+	glGetMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, &prev_specular.r);
+	glGetMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, &prev_ambient.r);
+	glGetMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, &prev_emissive.r);
+	glGetMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &prev_shininess);
+    
+	glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, &diffuse.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, &specular.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, &ambient.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, &emissive.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &shininess);
+#endif
 }
 
 void ofMaterial::end() {
+#ifndef TARGET_OPENGLES
     // Set previous material colors and properties
 	glMaterialfv(GL_FRONT, GL_DIFFUSE, &prev_diffuse.r);
 	glMaterialfv(GL_FRONT, GL_SPECULAR, &prev_specular.r);
@@ -98,5 +115,14 @@ void ofMaterial::end() {
 	glMaterialfv(GL_BACK, GL_AMBIENT, &prev_ambient_back.r);
 	glMaterialfv(GL_BACK, GL_EMISSION, &prev_emissive_back.r);
 	glMaterialfv(GL_BACK, GL_SHININESS, &prev_shininess_back);
+#else
+    // opengl es 1.1 implementation must use GL_FRONT_AND_BACK.
+    
+	glMaterialfv(GL_FRONT_AND_BACK, GL_DIFFUSE, &prev_diffuse.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, &prev_specular.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT, &prev_ambient.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, &prev_emissive.r);
+	glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &prev_shininess);
+#endif
 }
 


### PR DESCRIPTION
glGetMaterialfv on ES1 must only use GL_FRONT_AND_BACK,
so i've added a TARGET_OPENGLES guard that handles ES1.
