### PR TITLE
Add basic modifier support to key and mouse events.

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -837,6 +837,13 @@ void ofAppGLFWWindow::mouse_cb(GLFWwindow* windowP_, int button, int state, int 
     }
 #endif
 
+    int modifiers = 0;
+
+    if(mods & GLFW_MOD_SHIFT)   modifiers |= OF_KEY_SHIFT;
+    if(mods & GLFW_MOD_CONTROL) modifiers |= OF_KEY_CONTROL;
+    if(mods & GLFW_MOD_ALT)     modifiers |= OF_KEY_ALT;
+    if(mods & GLFW_MOD_SUPER)   modifiers |= OF_KEY_SUPER;
+
 	switch(button){
 	case GLFW_MOUSE_BUTTON_LEFT:
 		button = OF_MOUSE_BUTTON_LEFT;
@@ -850,15 +857,13 @@ void ofAppGLFWWindow::mouse_cb(GLFWwindow* windowP_, int button, int state, int 
 	}
 
 	if (state == GLFW_PRESS) {
-		ofNotifyMousePressed(ofGetMouseX(), ofGetMouseY(), button);
+		ofNotifyMousePressed(ofGetMouseX(), ofGetMouseY(), button, modifiers);
 		instance->buttonPressed=true;
 	} else if (state == GLFW_RELEASE) {
-		ofNotifyMouseReleased(ofGetMouseX(), ofGetMouseY(), button);
+		ofNotifyMouseReleased(ofGetMouseX(), ofGetMouseY(), button,  modifiers);
 		instance->buttonPressed=false;
 	}
 	instance->buttonInUse = button;
-
-
 }
 
 //------------------------------------------------------------
@@ -1009,10 +1014,17 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int key, int scancode, i
 		key += 32;
 	}
 
+    int modifiers = 0;
+
+    if(mods & GLFW_MOD_SHIFT)   modifiers |= OF_KEY_SHIFT;
+    if(mods & GLFW_MOD_CONTROL) modifiers |= OF_KEY_CONTROL;
+    if(mods & GLFW_MOD_ALT)     modifiers |= OF_KEY_ALT;
+    if(mods & GLFW_MOD_SUPER)   modifiers |= OF_KEY_SUPER;
+
 	if(action == GLFW_PRESS || action == GLFW_REPEAT){
-		ofNotifyKeyPressed(key);
+		ofNotifyKeyPressed(key,modifiers);
 	}else if (action == GLFW_RELEASE){
-		ofNotifyKeyReleased(key);
+		ofNotifyKeyReleased(key,modifiers);
 	}
 }
 
@@ -1063,9 +1075,9 @@ bool ofAppGLFWWindow::isWindowResizeable(){
 //------------------------------------------------------------
 void ofAppGLFWWindow::iconify(bool bIconify){
 	if(bIconify)
-			glfwIconifyWindow(windowP);
+        glfwIconifyWindow(windowP);
 	else
-		glfwRestoreWindow(windowP);
+        glfwRestoreWindow(windowP);
 }
 
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -175,9 +175,12 @@ void ofNotifyDraw(){
 }
 
 //------------------------------------------
-void ofNotifyKeyPressed(int key){
+void ofNotifyKeyPressed(int key, int modifiers){
 	static ofKeyEventArgs keyEventArgs;
-	// FIXME: modifiers are being reported twice, for generic and for left/right
+
+    keyEventArgs.modifiers = modifiers;
+
+    // FIXME: modifiers are being reported twice, for generic and for left/right
 	// add operators to the arguments class so it can be checked for both
     if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
         pressedKeys.insert(OF_KEY_CONTROL);
@@ -214,8 +217,10 @@ void ofNotifyKeyPressed(int key){
 }
 
 //------------------------------------------
-void ofNotifyKeyReleased(int key){
+void ofNotifyKeyReleased(int key, int modifiers){
 	static ofKeyEventArgs keyEventArgs;
+
+    keyEventArgs.modifiers = modifiers;
 
 	// FIXME: modifiers are being reported twice, for generic and for left/right
 	// add operators to the arguments class so it can be checked for both
@@ -280,8 +285,11 @@ void ofNotifyMouseEvent(const ofMouseEventArgs & mouseEvent){
 }
 
 //------------------------------------------
-void ofNotifyMousePressed(int x, int y, int button){
+void ofNotifyMousePressed(int x, int y, int button, int modifiers){
 	static ofMouseEventArgs mouseEventArgs;
+
+    mouseEventArgs.modifiers = modifiers;
+
     if( bPreMouseNotSet ){
 		previousMouseX	= x;
 		previousMouseY	= y;
@@ -304,8 +312,10 @@ void ofNotifyMousePressed(int x, int y, int button){
 }
 
 //------------------------------------------
-void ofNotifyMouseReleased(int x, int y, int button){
+void ofNotifyMouseReleased(int x, int y, int button, int modifiers){
 	static ofMouseEventArgs mouseEventArgs;
+
+    mouseEventArgs.modifiers = modifiers;
 
 	if( bPreMouseNotSet ){
 		previousMouseX	= x;

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -44,6 +44,7 @@ class ofKeyEventArgs : public ofEventArgs {
 		Released,
 	} type;
 	int key;
+    int modifiers;
 };
 
 class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
@@ -55,6 +56,7 @@ class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
 		Dragged
 	} type;
 	int button;
+    int modifiers;
 };
 
 class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
@@ -251,12 +253,12 @@ void ofNotifySetup();
 void ofNotifyUpdate();
 void ofNotifyDraw();
 
-void ofNotifyKeyPressed(int key);
-void ofNotifyKeyReleased(int key);
+void ofNotifyKeyPressed(int key, int modifiers = 0);
+void ofNotifyKeyReleased(int key, int modifiers = 0);
 void ofNotifyKeyEvent(const ofKeyEventArgs & keyEvent);
 
-void ofNotifyMousePressed(int x, int y, int button);
-void ofNotifyMouseReleased(int x, int y, int button);
+void ofNotifyMousePressed(int x, int y, int button, int modifiers = 0);
+void ofNotifyMouseReleased(int x, int y, int button, int modifiers = 0);
 void ofNotifyMouseDragged(int x, int y, int button);
 void ofNotifyMouseMoved(int x, int y);
 void ofNotifyMouseEvent(const ofMouseEventArgs & mouseEvent);


### PR DESCRIPTION
Currently there is poor support for modifier keys.  Previously this was not implemented because GLUT did not offer good modifier key support.

With GLFW, we can now get reliable modifier key information with mouse and keyboard input.

While input event handling does need an overhaul eventually (likely when the GLUT window is deprecated and GLFW fixes its keyboard mapping issues), this fix will allow users to get minimal keyboard modifier information from GLFW.

This fix is backward compatible with existing systems because the default modifiers function arg is set to zero.
