### PR TITLE
add getName() for ofMesh, fixes #1556

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -618,6 +618,11 @@ void ofMesh::setName(string name_){
 }
 
 //--------------------------------------------------------------
+string ofMesh::getName() const {
+	return name;
+}
+
+//--------------------------------------------------------------
 void ofMesh::setupIndicesAuto(){
 	bIndicesChanged = true;
 	bFacesDirty = true;

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -104,6 +104,7 @@ public:
 	ofVec3f getCentroid() const;
 
 	void setName(string name_);
+	void getName() const;
 
 	bool haveVertsChanged();
 	bool haveColorsChanged();


### PR DESCRIPTION
As per #1556, probably want to just get rid of both, but if theres a setter, people expect a getter, so heres a possible patch
