### PR TITLE
Assign allocated flag to true after allocating offscreenGWorldPixels.

### DIFF
--- a/libs/openFrameworks/video/ofQuickTimePlayer.cpp
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.cpp
@@ -241,6 +241,7 @@ void ofQuickTimePlayer::createImgMemAndGWorld(){
 	movieRect.bottom 		= height;
 	movieRect.right 		= width;
 	offscreenGWorldPixels = new unsigned char[4 * width * height + 32];
+	allocated				= true;
 	pixels.allocate(width,height,OF_IMAGE_COLOR);
 
 	#if defined(TARGET_OSX) && defined(__BIG_ENDIAN__)


### PR DESCRIPTION
Fixes #2220 (https://github.com/openframeworks/openFrameworks/issues/2220)
I have tested this by repeatedly creating and deleting an ofVideoPlayer instance.
