### PR TITLE
use cc.openframeworks.ofapp as identifier on osx

### DIFF
--- a/scripts/osx/template/openFrameworks-Info.plist
+++ b/scripts/osx/template/openFrameworks-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.openFrameworks</string>
+	<string>cc.openFrameworks.ofapp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
Closes #2644
