### PR TITLE
Added support for vs2010 re: ofPtr

### DIFF
--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -183,7 +183,11 @@ public:
 	: std::shared_ptr<T>(__r) { }
 
 	// tgfrerer: extends ofPtr facade to allow dynamic_pointer_cast, pt.1
-#if (_MSC_VER)
+#if (_MSC_VER==1600)	//	vs2010
+	template<typename Tp1>
+	ofPtr(const ofPtr<Tp1>& __r, std::tr1::_Dynamic_tag)
+	: std::shared_ptr<T>(__r, std::tr1::_Dynamic_tag()) { }
+#elif (_MSC_VER)
 	template<typename Tp1>
 	ofPtr(const ofPtr<Tp1>& __r, std::_Dynamic_tag)
 	: std::shared_ptr<T>(__r, std:::_Dynamic_tag()) { }


### PR DESCRIPTION
Not sure if you're explicitly ditching vs2010[express]? but this is the only change I needed to make.
