### PR TITLE
ofThread set-OS-thread name support

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -224,7 +224,13 @@ string ofxTCPClient::receive(){
 	}
 
 	// check for connection reset or disconnection
-	if((length==-1 && (ofxNetworkCheckError() == ECONNRESET) ) || length == 0){
+	int errorCode = ofxNetworkCheckError();
+#ifdef TARGET_WIN32
+	bool aborted = errorCode == WSAECONNABORTED;
+#else
+	bool aborted = false;
+#endif
+	if((length==-1 && ( errorCode == ECONNRESET || aborted )) || length == 0){
 		close();
 		if(tmpStr.length()==0) // return if there's no more data left in the buffer
 			return "";

--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -225,12 +225,7 @@ string ofxTCPClient::receive(){
 
 	// check for connection reset or disconnection
 	int errorCode = ofxNetworkCheckError();
-#ifdef TARGET_WIN32
-	bool aborted = errorCode == WSAECONNABORTED;
-#else
-	bool aborted = false;
-#endif
-	if((length==-1 && ( errorCode == ECONNRESET || aborted )) || length == 0){
+	if((length==-1 && ( errorCode == ECONNRESET || errorCode == ECONNABORTED )) || length == 0){
 		close();
 		if(tmpStr.length()==0) // return if there's no more data left in the buffer
 			return "";

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -294,7 +294,7 @@ int ofxTCPManager::Receive(char* pBuff, const int iSize)
 {
   if (m_hSocket == INVALID_SOCKET) return(SOCKET_ERROR);
 
-  if (m_dwTimeoutSend	!= NO_TIMEOUT)
+  if (m_dwTimeoutReceive	!= NO_TIMEOUT)
   	{
   		fd_set fd;
   		FD_ZERO(&fd);
@@ -321,7 +321,7 @@ int ofxTCPManager::ReceiveAll(char* pBuff, const int iSize)
 
 	unsigned long timestamp= GetTickCount();
 
-	if (m_dwTimeoutSend	!= NO_TIMEOUT)
+	if (m_dwTimeoutReceive	!= NO_TIMEOUT)
 	{
 		fd_set fd;
 		FD_ZERO(&fd);

--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -13,7 +13,7 @@ class ofThread : protected Poco::Runnable{
 
 	public:
 	
-		ofThread();
+		ofThread(const char* threadName=nullptr);
 		virtual ~ofThread();
 	
 		/// returns true if the thread is currently running
@@ -26,6 +26,9 @@ class ofThread : protected Poco::Runnable{
 		
 		/// get the unique thread name, in the form of "Thread id#"
 		string getThreadName();
+
+		/// set the internal and OS thread name (if created)
+		void setThreadName(const string& threadName);
 		
 		/// start the thread
 		///
@@ -174,6 +177,9 @@ class ofThread : protected Poco::Runnable{
 		///
 		virtual void threadedFunction();
 		
+		///	set the OS thread name. Seperate function because [C2712] we can't use objects with try() that require unwinding (ie, std::string)
+		bool	setOSThreadName(const char* threadName);
+	
 		/// the internal mutex called through lock() & unlock()
 		ofMutex mutex;
 


### PR DESCRIPTION
via constructor or setThreadName you can now set the OS thread's name in windows. This is reflected in the visual studio debugger (and crashdumps IIRC).
