### PR TITLE
Orthographic projection should be relative to the viewport.

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -163,7 +163,14 @@ void ofCamera::end() {
 //----------------------------------------
 ofMatrix4x4 ofCamera::getProjectionMatrix(ofRectangle viewport) const {
 	if(isOrtho) {
-		return ofMatrix4x4::newOrthoMatrix(0, viewport.width, 0, viewport.height, nearClip, farClip);
+		return ofMatrix4x4::newOrthoMatrix(
+			viewport.x - viewport.width/2,
+			viewport.x + viewport.width/2,
+			viewport.y - viewport.height/2,
+			viewport.y + viewport.height/2,
+			nearClip,
+			farClip
+		);
 	}else{
 		float aspect = forceAspectRatio ? aspectRatio : viewport.width/viewport.height;
 		ofMatrix4x4 matProjection;


### PR DESCRIPTION
The orthographic projection matrix had hardcoded left and bottom values of 0, meaning that when a camera was rotated, it would appear as if the entire scene had been rotated around the bottom left corner of the screen, regardless of where the camera was positioned.

IMHO, the view of your scene should be roughly similar when toggling between these two projections. A different projection should not require any fiddly translation by a developer to compensate. It should be handled internally by ofCamera.

Here are some screenshots to demonstrate what I'm talking about.

**Positions of primitives in space:**
Red cube is at (0, 0, 0)
Green sphere is at (0, 0, -128)
Blue cube is at (128, 0, 0)
Cyan box is at (128, 64, 0)

**Front Current**
![front broken](http://i.imgur.com/pPrSgEN.gif)

**Front Fixed**
![front fixed](http://i.imgur.com/3UFkOFa.gif)

**Left Current**
![left broken](http://i.imgur.com/7RjM8FK.gif)

**Left Fixed**
![left fixed](http://i.imgur.com/x2RWDk1.gif)
