### PR TITLE
undef "windows.h" near & far macros in ofMain.h

### DIFF
--- a/libs/openFrameworks/ofMain.h
+++ b/libs/openFrameworks/ofMain.h
@@ -88,11 +88,23 @@
 #include "ofMesh.h"
 #include "ofNode.h"
 
-// undef <windows.h> near & far macros
+// undef unsafe <windows.h> macros
+#ifdef RGB
+	#undef RGB
+#endif
+
 #ifdef near
 	#undef near
 #endif
 
 #ifdef far
 	#undef far
+#endif
+
+#ifdef min
+	#undef min
+#endif
+
+#ifdef max
+	#undef max
 #endif


### PR DESCRIPTION
undef "windows.h" near & far macros in ofMain.h to avoid later name conflicts in the applications
