### PR TITLE
Fix iosvideo grabber getPixelsRef

### DIFF
--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
@@ -74,7 +74,7 @@ class AVFoundationVideoGrabber{
 		ofPixelFormat getPixelFormat();
 	
 		unsigned char * getPixels(){
-			return pixels;
+			return pixels.getPixels();
 		}
 		float getWidth(){
 			return width;
@@ -82,9 +82,10 @@ class AVFoundationVideoGrabber{
 		float getHeight(){
 			return height;
 		}
-	
+		ofPixelsRef getPixelsRef();
 		GLint internalGlDataType;
-		unsigned char * pixels;
+	ofPixels pixels;
+	//		unsigned char * pixels;
 		bool newFrame;
 	
 		int width, height;

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
@@ -25,9 +25,10 @@ unsigned char * ofxiOSVideoGrabber::getPixels() {
 }
 
 ofPixelsRef ofxiOSVideoGrabber::getPixelsRef(){
-    static ofPixels dummy;
+   // static ofPixels dummy;
     //@TODO implement me
-    return dummy;
+    //return dummy;,
+	return grabber->getPixelsRef();	
 }
 
 void ofxiOSVideoGrabber::close() {


### PR DESCRIPTION
I was doing some CV stuff on iOS and found that the videoGrabber had the getPixelsRef function unimplemented.
I'd rather have someone like @julapy or @obviousjim to check what I've done. 
On the other hand, where is that I should document this fixes (sorry, I'm being lazy).
Best!