### PR TITLE
fix critical ModelViewMatrix issue when ofFbo::begin(setupScreen==false) 

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -294,8 +294,10 @@ void ofGLProgrammableRenderer::draw(ofShortImage & image, float x, float y, floa
 void ofGLProgrammableRenderer::setCurrentFBO(ofFbo * fbo){
 	if(fbo!=NULL){
 		matrixStack.setRenderSurface(*fbo);
+		uploadMatrices();
 	}else{
 		matrixStack.setRenderSurface(*ofGetWindowPtr());
+		uploadMatrices();
 	}
 }
 


### PR DESCRIPTION
## symptom

ModelViewMatrix appears uninitialised when ofFbo::begin() has been called with setupScreen==false. Until a matrix stack refresh is triggered (through e.g. an identity operation like ofScale(1,1,1) / ofRotate(0,0,0,1) etc.), geometry will be drawn as if the current modelViewMatrix were the identity matrix. 
## explanation

by default an ofFbo begins with setupScreen==true, which means its setupScreen method will be called when the fbo begins. This method will also initialise the modelview matrix uniforms for the default shader of that fbo, and upload these uniforms to the shader.

If the ofFbo is started with begin(false) setupScreen will not be called & the current modelview matrix values will not be sent to the current shader. This can lead to difficult to debug behaviour, since as soon as the internal matrix stack gets touched through any matrix operation, anything will look like normal.
## replicate

This issue will only appear if you do the following:

myFbo.begin(false);
ofPushMatrix();
// the following line will not draw as expected, since modelView Matrix not yet submitted to shader
ofDrawGridPlane(1000, 20, false);
ofTranslate(10,10,10);
// from here on, anything draws as expected.
ofRotate(0,1,0,0);
ofDrawSphere();
ofPopMatrix();
# fix

This PR fixes this issue by submitting the matrix stack initially, when we set the fbo as our current render target.
# see also

This PR might have a positive impact on #2593
