### PR TITLE
Fixes typo in ofxCvImage that broke getRoiPixelsRef, fixes #2520

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvImage.cpp
@@ -871,7 +871,7 @@ unsigned char*  ofxCvImage::getPixels(){
 ofPixelsRef ofxCvImage::getPixelsRef(){
 	if(!bAllocated) {
 		ofLogWarning("ofxCvImage") << "getPixelsRef(): image not allocated";	
-	} else if(bRoiPixelsDirty) {
+	} else if(bPixelsDirty) {
 		IplImage * cv8bit= getCv8BitsImage();
 
 		//Note this possible introduces a bug where pixels doesn't contain the current image.


### PR DESCRIPTION
A very obvious typo (when spotted) that i can't see should be a problem to merge. 
