### PR TITLE
Enabling GL_PROGRAM_POINT_SIZE in ofGLProgrammableRenderer

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -750,10 +750,12 @@ void ofGLProgrammableRenderer::setBlendMode(ofBlendMode blendMode){
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::enablePointSprites(){
+	glEnable(GL_PROGRAM_POINT_SIZE);
 }
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::disablePointSprites(){
+	glDisable(GL_PROGRAM_POINT_SIZE);
 }
 
 


### PR DESCRIPTION
Fix for https://github.com/openframeworks/openFrameworks/issues/2711 and I can't imagine we'd want pointsprite w/o a size, seems like an easy source of confusion since so many examples use it.
