### PR TITLE
[ios] use correct audio category for routing audio to speaker

### DIFF
--- a/addons/ofxiOS/src/sound/SoundInputStream.m
+++ b/addons/ofxiOS/src/sound/SoundInputStream.m
@@ -142,9 +142,9 @@ static OSStatus soundInputStreamRenderCallback(void *inRefCon,
 		}
 		
 		UInt32 overrideAudioRoute = kAudioSessionOverrideAudioRoute_Speaker;
-		success = AudioSessionSetProperty(kAudioSessionProperty_OverrideAudioRoute,
-												   sizeof(UInt32),
-												   &overrideAudioRoute);
+		success = AudioSessionSetProperty(kAudioSessionProperty_OverrideCategoryDefaultToSpeaker,
+										  sizeof(UInt32),
+										  &overrideAudioRoute);
 		if(success != noErr) {
 			if([self.delegate respondsToSelector:@selector(soundStreamError:error:)]) {
 				[self.delegate soundStreamError:self error:@"Couldn't override audio route"];


### PR DESCRIPTION
closes #2100

I can't test this properly, since I don't have an iPhone (which is necessary since this is about selecting the phone receiver vs the "real" speaker).

pinging @oftheo / @julapy for device testing :)
