### PR TITLE
Added xenkernel linux64 makefile PLATFORM_VARIANT.

### DIFF
--- a/libs/openFrameworksCompiled/project/linux64/config.linux64.xenkernel.mk
+++ b/libs/openFrameworksCompiled/project/linux64/config.linux64.xenkernel.mk
@@ -39,4 +39,4 @@ include $(OF_SHARED_MAKEFILES_PATH)/config.linux.common.mk
 ################################################################################
 
 #PLATFORM_CFLAGS += -march=native
-#PLATFORM_CFLAGS += -mtune=native
+PLATFORM_CFLAGS += -mtune=native


### PR DESCRIPTION
A solution to this problem:

http://forum.openframeworks.cc/t/failure-compiling-of-on-an-ubuntu-12-04-03-lts-digital-ocean-droplet/13893

To use on a linux64 platform, run

```
$ cd $(OF_ROOT)/openFrameworks/libs/openFrameworksCompiled/project
$ make PLATFORM_VARIANT=xenkernel
```
