### PR TITLE
Bugfix fbo colorbuffer loop

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -522,7 +522,8 @@ void ofFbo::createAndAttachTexture(GLenum internalFormat, GLenum attachmentPoint
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + attachmentPoint, tex.texData.textureTarget, tex.texData.textureID, 0);
 	textures.push_back(tex);
 	
-	settings.colorFormats.resize(attachmentPoint + 1);
+        if(settings.colorFormats.size() <= attachmentPoint)
+        	settings.colorFormats.resize(attachmentPoint + 1);
 	settings.colorFormats[attachmentPoint] = internalFormat;
 	settings.numColorbuffers = settings.colorFormats.size();
 


### PR DESCRIPTION
Fixes a bug that would inhibit the creation of multiple colorbuffers. The first iteration of creating colorbuffers would in all cases resize the vector array to 1 and thereby break the loop after just one colorbuffer had been created.
