### PR TITLE
Modify ofVbo bind method to allow 2d vertices

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -653,7 +653,7 @@ void ofVbo::bind(){
 				glVertexPointer(vertSize, GL_FLOAT, vertStride, 0);
 			}else{
 				glEnableVertexAttribArray(ofShader::POSITION_ATTRIBUTE);
-				glVertexAttribPointer(ofShader::POSITION_ATTRIBUTE, 3, GL_FLOAT, GL_FALSE, vertStride, 0);
+				glVertexAttribPointer(ofShader::POSITION_ATTRIBUTE, vertSize, GL_FLOAT, GL_FALSE, vertStride, 0);
 			}
 		}else if(supportVAOs){
 			if(!programmable){


### PR DESCRIPTION
Currently ofVbo bind method always sets number of components in vertex position data to 3. Fix to set number of components to either 2 or 3 based on numCoords argument to setVertexData call when passing in pointer to float array of vertices.
