### PR TITLE
Android assets unzipping fix

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -219,7 +219,7 @@ public class OFAndroid {
 	    		String app_name="";
 				try {
 					int app_name_id = Class.forName(packageName+".R$string").getField("app_name").getInt(null);
-					app_name = ofActivity.getResources().getText(app_name_id).toString();
+					app_name = ofActivity.getResources().getText(app_name_id).toString().toLowerCase();
 					Log.i("OF","app name: " + app_name);
 					
 					if(copydata){


### PR DESCRIPTION
This pullrequest fixes a bug that prevents the assets from being unzipped on Android.

When the app is launched for the first time, OF will unzip the assets to the data folder.

The assets zip file is automatically created by the Makefile and it uses the application name (in lowercase). For example: The assets from the app androidGuiExample are stored in androidguiexampleresources.zip.

However, in OFAndroid.java there is a bug which causes the assets to never be unzipped. The application package name isn't converted to lowercase. 

Currently the value of app_name is "/androidGuiExampleresources.zip" instead of "/androidguiexampleresources.zip". This will cause the check on line 240 to fail and prevent the assets from being extracted.
