### PR TITLE
Android building script error when building from Windows

### DIFF
--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -35,6 +35,7 @@ ifeq ($(shell uname),Darwin)
 	HOST_PLATFORM = darwin-x86
 else ifneq (,$(findstring MINGW32_NT,$(shell uname)))
 	HOST_PLATFORM = windows
+	PWD = $(shell pwd)
 else
 	HOST_PLATFORM = linux-$(shell uname -m)
 endif


### PR DESCRIPTION
When building an Android project on Windows (using MinGW), the value of $(PWD) is not always set to the correct path.

In a few cases it is set to a Windows style path (C:\openFrameworks\apps\devApps\VboExample) instead of a Unix style (/c/openFrameworks/apps/devApps/VboExample) one. 

This will cause the buildscript to fail (especially when it is trying to change the directory and zip the assets on line 518).
