### PR TITLE
ofBaseApp: remove mouseReleased(void) - the variant with x/y/button para...

### DIFF
--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -27,7 +27,6 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void mouseMoved( int x, int y ){}
 		virtual void mouseDragged( int x, int y, int button ){}
 		virtual void mousePressed( int x, int y, int button ){}
-		virtual void mouseReleased(){}
 		virtual void mouseReleased(int x, int y, int button ){}
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }


### PR DESCRIPTION
...ms is always called anyway, so this one was essentially unused and confusing.

fixes #2668
