### PR TITLE
(Android) Fix for issue #2662 

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -356,7 +356,7 @@ public class OFAndroid {
 	public void pause(){
 		Log.i("OF","onPause");
 		disableTouchEvents();
-		if(mGLView!=null) mGLView.onPause();
+		
 		onPause();
 
 		synchronized (OFAndroidObject.ofObjects) {
@@ -364,7 +364,7 @@ public class OFAndroid {
 				object.onPause();
 			}
 		}
-
+		if(mGLView!=null) mGLView.onPause();
 		if(networkStateReceiver!=null){
 			try{
 				ofActivity.unregisterReceiver(networkStateReceiver);
@@ -382,7 +382,7 @@ public class OFAndroid {
 		resumed = true;
 		Log.i("OF","onResume");
 		enableTouchEvents();
-		
+		mGLView.onResume();
 		synchronized (OFAndroidObject.ofObjects) {
 			for(OFAndroidObject object : OFAndroidObject.ofObjects){
 				object.onResume();
@@ -390,7 +390,7 @@ public class OFAndroid {
 			
 		}
 		
-    	mGLView.onResume();
+    	
 		
         if(mGLView.isSetup()){
         	Log.i("OF","resume view and native");

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -231,7 +231,6 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 				Log.e("OF", "problem trying to close camera thread", e);
 			}
 			camera.setPreviewCallback(null);
-			camera.release();
 			if(supportsTextureRendering()){
 				try {
 					Class<?> surfaceTextureClass = Class.forName("android.graphics.SurfaceTexture");
@@ -240,6 +239,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 				} catch (Exception e) {
 				}
 			}
+			camera.release();
 			orientationListener.disable();
 		}
 	}
@@ -253,7 +253,6 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	@Override
 	public void appResume(){
 		if(initialized){
-			initGrabber(width,height,targetFps);
 			orientationListener.enable();
 		}
 	}

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -21,7 +21,7 @@ static map<int,ofVideoGrabber*> instances;
 static bool paused=true;
 
 
-
+jobject getCamera(JNIEnv *env, jclass javaClass, jint id);
 static jclass getJavaClass(){
 	JNIEnv *env = ofGetJNIEnv();
 
@@ -73,15 +73,30 @@ void ofPauseVideoGrabbers(){
 	ofLogVerbose("ofxAndroidVideoGrabber") << "ofPauseVideoGrabbers(): releasing textures";
 	map<int,ofVideoGrabber*>::iterator it;
 	for(it=instances.begin(); it!=instances.end(); it++){
-		it->second->getTextureReference().texData.textureID=0;
+		((ofxAndroidVideoGrabber*)it->second->getGrabber().get())->unloadTexture();
 	}
 }
 
 void ofResumeVideoGrabbers(){
 	ofLogVerbose("ofxAndroidVideoGrabber") << "ofResumeVideoGrabbers(): trying to allocate textures";
 	map<int,ofVideoGrabber*>::iterator it;
+
+	JNIEnv *env = ofGetJNIEnv();
+	if(!env){
+		ofLogError("ofxAndroidVideoGrabber") << "init grabber failed : couldn't get environment using GetEnv()";
+		return;
+	}
+	jclass javaClass = getJavaClass();
+	jmethodID javaInitGrabber = env->GetMethodID(javaClass,"initGrabber","(IIII)V");
 	for(it=instances.begin(); it!=instances.end(); it++){
-		it->second->getTextureReference().allocate(it->second->getWidth(),it->second->getHeight(),GL_RGB);
+		jobject camera = getCamera(env, javaClass, it->first);
+		((ofxAndroidVideoGrabber*)it->second->getGrabber().get())->loadTexture();
+
+		int texID= it->second->getTextureReference().texData.textureID;
+		int w=it->second->getTextureReference().texData.width;
+		int h=it->second->getTextureReference().texData.height;
+		int framerate= ((ofxAndroidVideoGrabber*)it->second->getGrabber().get())->attemptFramerate;
+		env->CallVoidMethod(camera,javaInitGrabber,w,h,framerate,texID);
 	}
 	ofLogVerbose("ofxAndroidVideoGrabber") << "ofResumeVideoGrabbers(): textures allocated";
 	paused = false;
@@ -205,7 +220,6 @@ void ofxAndroidVideoGrabber::loadTexture(){
 }
 
 void ofxAndroidVideoGrabber::reloadTexture(){
-	loadTexture();
 
 	JNIEnv *env = ofGetJNIEnv();
 	if (!env) {

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -47,6 +47,7 @@ public:
 	bool setAutoFocus(bool autofocus);
 
 	ofTexture *	getTexture();
+	void loadTexture();
 	void reloadTexture();
 	void unloadTexture();
 
@@ -54,16 +55,16 @@ public:
 
 	// only to be used internally to resize;
 	ofPixelsRef getAuxBuffer();
-private:
-	void loadTexture();
-	bool supportsTextureRendering();
+
 	int attemptFramerate;
+private:
+
+	bool supportsTextureRendering();
 	bool bIsFrameNew;
 	bool bGrabberInited;
 	ofPixelFormat internalPixelFormat;
 	ofPixels pixels;
 	ofPixels auxBuffer;
 	ofTexture texture;
-
 	jfloatArray matrixJava;
 };


### PR DESCRIPTION
This fix makes the camera work when app goes background and foreground again. 

However, notice that in some devices (for example, in Nexus 4) camera performance decreases every time the app comes from background.
