### PR TITLE
fix ofImageType retrieval issue in ofTexture.readToPixels()

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -972,8 +972,7 @@ void ofTexture::draw(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3,
 //----------------------------------------------------------
 void ofTexture::readToPixels(ofPixels & pixels){
 #ifndef TARGET_OPENGLES
-	GLuint glType = ofGetGlTypeFromInternal(texData.glTypeInternal);
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(glType));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
 	bind();
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_UNSIGNED_BYTE, pixels.getPixels());
 	unbind();
@@ -983,8 +982,7 @@ void ofTexture::readToPixels(ofPixels & pixels){
 //----------------------------------------------------------
 void ofTexture::readToPixels(ofShortPixels & pixels){
 #ifndef TARGET_OPENGLES
-	GLuint glType = ofGetGlTypeFromInternal(texData.glTypeInternal);
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(glType));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
 	bind();
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_UNSIGNED_SHORT,pixels.getPixels());
 	unbind();
@@ -994,8 +992,7 @@ void ofTexture::readToPixels(ofShortPixels & pixels){
 //----------------------------------------------------------
 void ofTexture::readToPixels(ofFloatPixels & pixels){
 #ifndef TARGET_OPENGLES
-	GLuint glType = ofGetGlTypeFromInternal(texData.glTypeInternal);
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(glType));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
 	bind();
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_FLOAT,pixels.getPixels());
 	unbind();


### PR DESCRIPTION
fixes an issue where readToPixels() would by default receive an incorrect ofImageType.

`ofGetGlTypeFromInternal(texData.glTypeInternal)` returns a GL type as in: `GL_UNSIGNED_BYTE` etc,
whilst `ofGetImageTypeFromGLType( parameter )` expects as parameter something along the lines of `GL_RGB` or `GL_RGBA`, in almost all cases returned `OF_IMAGE_UNDEFINED`, even when attempting to allocate a basic `RGBA` image.

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
