### PR TITLE
Bugfix for disconnecting 1473 and K4W devices on OS X.

### DIFF
--- a/addons/ofxKinect/libs/libfreenect/src/keep_alive.c
+++ b/addons/ofxKinect/libs/libfreenect/src/keep_alive.c
@@ -1,0 +1,191 @@
+//
+//  keep_alive.c
+//  Created by Theodore Watson on 1/23/14.
+
+//This file is part of the OpenKinect Project. http://www.openkinect.org
+// 
+// Copyright (c) 2010 individual OpenKinect contributors. See the CONTRIB file 
+// for details.
+// 
+// This code is licensed to you under the terms of the Apache License, version 
+// 2.0, or, at your option, the terms of the GNU General Public License, 
+// version 2.0. See the APACHE20 and GPL20 files for the text of the licenses, 
+// or the following URLs:
+// http://www.apache.org/licenses/LICENSE-2.0
+// http://www.gnu.org/licenses/gpl-2.0.txt
+// 
+// If you redistribute this file in source form, modified or unmodified, 
+// you may:
+// 1) Leave this header intact and distribute it under the same terms, 
+// accompanying it with the APACHE20 and GPL20 files, or
+// 2) Delete the Apache 2.0 clause and accompany it with the GPL20 file, or
+// 3) Delete the GPL v2.0 clause and accompany it with the APACHE20 file
+// In all cases you must keep the copyright notice intact and include a copy 
+// of the CONTRIB file.
+// Binary distributions must follow the binary distribution requirements of 
+// either License.
+
+
+//Based on code provided by Drew Fisher
+
+/*
+ * Copyright 2011 Drew Fisher <drew.m.fisher@gmail.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS  ''AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL DREW FISHER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of Drew Fisher.
+ */
+
+
+
+
+#include "keep_alive.h"
+
+#include <libusb-1.0/libusb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h> // For usleep()
+
+#define le32(X) (X)
+#define LOG(...) fprintf(stderr, __VA_ARGS__)
+
+static uint32_t tag_seq = 1;
+static uint32_t tag_next_ack = 1;
+
+typedef struct {
+	uint32_t magic;
+	uint32_t tag;
+	uint32_t status;
+} motor_reply;
+
+typedef struct {
+	uint32_t magic;
+	uint32_t tag;
+	uint32_t arg1;
+	uint32_t cmd;
+	uint32_t arg2;
+} motor_command;
+
+static int get_reply(libusb_device_handle* dev){
+	unsigned char buffer[512];
+	memset(buffer, 0, 512);
+	int transferred = 0;
+	int res = 0;
+	res = libusb_bulk_transfer(dev, 0x81, buffer, 512, &transferred, 0);
+	if (res != 0) {
+		LOG("freenect_extra_keep_alive get_reply(): libusb_bulk_transfer failed: %d (transferred = %d)\n", res, transferred);
+	} else if (transferred != 12) {
+		LOG("freenect_extra_keep_alive get_reply(): weird - got %d bytes (expected 12)\n", transferred);
+	} else {
+		motor_reply reply;
+		memcpy(&reply, buffer, sizeof(reply));
+		if (reply.magic != 0x0a6fe000) {
+			LOG("freenect_extra_keep_alive Bad magic: %08X (expected 0A6FE000\n", reply.magic);
+			res = -1;
+		}
+		if (reply.tag != tag_next_ack) {
+			LOG("freenect_extra_keep_alive Reply tag out of order: expected %d, got %d\n", tag_next_ack, reply.tag);
+			res = -1;
+		}
+		if (reply.status != 0) {
+			LOG("freenect_extra_keep_alive reply status != 0: failure?\n");
+			res = -1;
+		}
+		tag_next_ack++;
+//		LOG("freenect_extra_keep_alive get_reply(): got %d bytes:", transferred);
+//		int i;
+//		for (i = 0; i < transferred; i++) {
+//			LOG(" %02X", buffer[i]);
+//		}
+//		LOG("\n");
+	}
+	return res;
+}
+
+static int set_led(libusb_device_handle* dev, int state) {
+	int transferred = 0;
+	int res = 0;
+	motor_command cmd;
+	cmd.magic = le32(0x06022009);
+	cmd.tag = le32(tag_seq++);
+	cmd.arg1 = le32(0);
+	cmd.cmd = le32(0x10);
+	cmd.arg2 = (uint32_t)(le32((int32_t)state));
+	unsigned char buffer[20];
+	memcpy(buffer, &cmd, 20);
+	// Send command to set LED to solid green
+//	LOG("About to send bulk transfer:");
+//	int i;
+//	for(i = 0; i < 20 ; i++) {
+//		LOG(" %02X", buffer[i]);
+//	}
+//	LOG("\n");
+	res = libusb_bulk_transfer(dev, 0x01, buffer, 20, &transferred, 0);
+	if (res != 0) {
+		LOG("freenect_extra_keep_alive set_led(): libusb_bulk_transfer failed: %d (transferred = %d)\n", res, transferred);
+		return res;
+	}
+	return get_reply(dev);
+}
+
+//this is for K4W or 1473 devices - pass in the PID of the audio device that needs the LED set.
+void freenect_extra_keep_alive(int pid){
+
+	int res;
+	int state_to_set = 4;
+
+	libusb_context* ctx = NULL;
+	libusb_init(&ctx);
+
+	libusb_device_handle* dev = NULL;
+	dev = libusb_open_device_with_vid_pid(ctx, 0x045e, pid);
+	if (dev == NULL) {
+		LOG("freenect extra keepAlive: Failed to open audio device\n");
+		libusb_exit(ctx);
+        return;
+	}
+
+	res = libusb_claim_interface(dev, 0);
+	if (res != 0) {
+		LOG("freenect extra keepAlive: Failed to claim interface 1: %d\n", res);
+        libusb_close(dev);
+        libusb_exit(ctx);
+        return;
+	}
+
+	res = set_led(dev, state_to_set);
+	if (res != 0) {
+		LOG("freenect extra keepAlive: set_led failed\n");
+        libusb_close(dev);
+        libusb_exit(ctx);
+        return;
+	}
+
+    libusb_close(dev);
+    libusb_exit(ctx);
+}

--- a/addons/ofxKinect/libs/libfreenect/src/keep_alive.h
+++ b/addons/ofxKinect/libs/libfreenect/src/keep_alive.h
@@ -1,0 +1,31 @@
+//  keep_alive.h
+//
+//  Created by Theodore Watson on 1/23/14.
+
+//This file is part of the OpenKinect Project. http://www.openkinect.org
+// 
+// Copyright (c) 2010 individual OpenKinect contributors. See the CONTRIB file 
+// for details.
+// 
+// This code is licensed to you under the terms of the Apache License, version 
+// 2.0, or, at your option, the terms of the GNU General Public License, 
+// version 2.0. See the APACHE20 and GPL20 files for the text of the licenses, 
+// or the following URLs:
+// http://www.apache.org/licenses/LICENSE-2.0
+// http://www.gnu.org/licenses/gpl-2.0.txt
+// 
+// If you redistribute this file in source form, modified or unmodified, 
+// you may:
+// 1) Leave this header intact and distribute it under the same terms, 
+// accompanying it with the APACHE20 and GPL20 files, or
+// 2) Delete the Apache 2.0 clause and accompany it with the GPL20 file, or
+// 3) Delete the GPL v2.0 clause and accompany it with the APACHE20 file
+// In all cases you must keep the copyright notice intact and include a copy 
+// of the CONTRIB file.
+// Binary distributions must follow the binary distribution requirements of 
+// either License.
+
+
+#pragma once
+void freenect_extra_keep_alive(int pid);
+

--- a/addons/ofxKinect/libs/libfreenect/src/tilt.c
+++ b/addons/ofxKinect/libs/libfreenect/src/tilt.c
@@ -47,18 +47,10 @@ freenect_raw_tilt_state* freenect_get_tilt_state(freenect_device *dev)
 int freenect_update_tilt_state(freenect_device *dev)
 {
 	freenect_context *ctx = dev->parent;
-
+	if(!(ctx->enabled_subdevices & FREENECT_DEVICE_MOTOR))
+		return 0;
     uint8_t buf[10];
 	uint16_t ux, uy, uz;
-    
-	if(!(ctx->enabled_subdevices & FREENECT_DEVICE_MOTOR)){
-        //this is needed for OS X. without it the camera timesout within 2-3 seconds
-        #ifdef TARGET_OS_MAC
-    	int ret = fnusb_control(&dev->usb_cam, 0xC0, 0x32, 0x0, 0x0, buf, 10);
-        #endif 
-		return 0;
-	}
-
 	int ret = fnusb_control(&dev->usb_motor, 0xC0, 0x32, 0x0, 0x0, buf, 10);
 	if (ret != 10) {
 		FN_ERROR("Error in accelerometer reading, libusb_control_transfer returned %d\n", ret);
@@ -77,6 +69,7 @@ int freenect_update_tilt_state(freenect_device *dev)
 
 	return ret;
 }
+
 int freenect_set_tilt_degs(freenect_device *dev, double angle)
 {
 	freenect_context *ctx = dev->parent;

--- a/addons/ofxKinect/libs/libfreenect/src/usb_libusb10.c
+++ b/addons/ofxKinect/libs/libfreenect/src/usb_libusb10.c
@@ -33,6 +33,8 @@
 #include "freenect_internal.h"
 #include "loader.h"
 
+#include "keep_alive.h"
+
 FN_INTERNAL int fnusb_num_devices(fnusb_ctx *ctx)
 {
 	libusb_device **devs; 
@@ -204,6 +206,15 @@ FN_INTERNAL int fnusb_open_subdevices(freenect_device *dev, int index)
 					/* Not the old kinect so we only set up the camera*/ 
 					ctx->enabled_subdevices = FREENECT_DEVICE_CAMERA;
 					ctx->zero_plane_res = 334;
+                    
+                    //lets also set the LED ON
+                    //this keeps the camera alive for some systems which get freezes
+                    if( desc.idProduct == PID_K4W_CAMERA ){
+                        freenect_extra_keep_alive(PID_K4W_AUDIO);
+                    }else{
+                        freenect_extra_keep_alive(PID_NUI_AUDIO);
+                    }
+                    
 				}else{
 					/* The good old kinect that tilts and tweets */
 					ctx->zero_plane_res = 322;


### PR DESCRIPTION
This fixes a known issue for OS X users where the 1473 device re-enumerates within a small time period and causes a freeze.

This PR detects 1473 devices and K4W devices and sets the LED state to solid red. 
It seems that in newer 1473 devices and 1473 devices with firmware updated by an Xbox the device will re-enumerate unless the LED is set.

NOTE: This is a critical fix for people with brand new Kinects or 1473 Kinects that have been plugged into an Xbox. 

Also submitted to the libfreenect upstream.
https://github.com/OpenKinect/libfreenect/pull/361
