### PR TITLE
Bugfix android OFAndroidSoundPlayer

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidSoundPlayer.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidSoundPlayer.java
@@ -41,6 +41,7 @@ public class OFAndroidSoundPlayer extends OFAndroidObject{
 	
 	void unloadSound(){
 		if(player!=null){
+			player.reset();
 			player.release();
 			player = null;
 		}


### PR DESCRIPTION
This fixes the playback rate on Soundpool objects and the warning messages when unloading the MediaPlayer objects on Android
