### PR TITLE
ofFbo working with ofTextures created externally.

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -514,10 +514,10 @@ void ofFbo::createAndAttachTexture(GLenum internalFormat, GLenum attachmentPoint
 	tex.setTextureWrap(settings.wrapModeHorizontal, settings.wrapModeVertical);
 	tex.setTextureMinMagFilter(settings.minFilter, settings.maxFilter);
     
-    createAndAttachTexture(tex, internalFormat, attachmentPoint);
+    attachTexture(tex, attachmentPoint);
 }
 
-void ofFbo::createAndAttachTexture(ofTexture & tex, GLenum internalFormat, GLenum attachmentPoint) {
+void ofFbo::attachTexture(ofTexture & tex, GLenum attachmentPoint) {
 	// bind fbo for textures (if using MSAA this is the newly created fbo, otherwise its the same fbo as before)
 	GLint temp;
 	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &temp);
@@ -528,11 +528,12 @@ void ofFbo::createAndAttachTexture(ofTexture & tex, GLenum internalFormat, GLenu
         textures.resize(attachmentPoint+1);
     }
     textures[attachmentPoint] = tex;
+    
+    GLenum internalFormat = tex.getTextureData().glTypeInternal;
 	
 	settings.colorFormats.resize(attachmentPoint + 1);
 	settings.colorFormats[attachmentPoint] = internalFormat;
 	settings.numColorbuffers = settings.colorFormats.size();
-
 
 	// if MSAA, bind main fbo and attach renderbuffer
 	if(settings.numSamples) {

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -48,7 +48,7 @@ public:
 
 	bool checkStatus();
 	void createAndAttachTexture(GLenum internalFormat, GLenum attachmentPoint);
-    void createAndAttachTexture(ofTexture & texture, GLenum internalFormat, GLenum attachmentPoint);
+    void attachTexture(ofTexture & texture, GLenum attachmentPoint);
 	GLuint createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint);
 	void createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum attachment );
 	void createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum attachment, GLenum transferFormat, GLenum transferType );


### PR DESCRIPTION
the original PR #2596 had some merging issues so this new PR was created.

@arturoc, regarding your last point.
i think it should be safe to include this in 0.8.1
ofFbo functionality is still exactly the same and internally the ofFbo still does the same thing,
only thing that changes is that ofFbo now exposes another method which people can use to add ofTexture objects externally.

can't think of anything else that could cause issues... should be pretty safe.
