### PR TITLE
bugfix / feature - detects when an OF app has been launched as a Retina ...

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -231,7 +231,8 @@ void ofAppGLFWWindow::setupOpenGL(int w, int h, int screenMode){
         //have to update the windowShape to account for retina coords
         if( windowMode == OF_WINDOW ){
             setWindowShape(windowW, windowH);
-        }    }
+        }
+	}
     
     ofGLReadyCallback();
 

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -79,7 +79,6 @@ public:
     int         getPixelScreenCoordScale();
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
-	Display*#if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
 	Display* 	getX11Display();
 	Window  	getX11Window();
 #endif


### PR DESCRIPTION
Detects when an OF app has been launched as a Retina / Hidpi app and applies the pixel scale to all window related calls.

Currently, launching an OF app in Hidpi mode would result in a viewport 1/4 of the size of the window, drawn in the lower left of the window. This was due to the fact that ofAppGLFWWindow was returning screen level coordinates and not taking into account the pixel count. 

( see: http://forum.openframeworks.cc/t/high-resolution-capable-osx-causes-really-small-window-inside-opengl-window/14566 ) 

This PR detects if an app is running in Hidpi mode and returns the correct coords / mouse positions and window sizes so the app can run and function in the expected way. 

Via the window you can also query to see what the pixel to coord ratio is: 
via ofAppGLFWWindow::getPixelScreenCoordScale(); 
