### PR TITLE
feature request: added methods to set min&max of a slider

### DIFF
--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -45,8 +45,18 @@ void ofxSlider<Type>::setMin(Type min){
 }
 
 template<typename Type>
+Type ofxSlider<Type>::getMin(){
+    value.getMin();
+}
+
+template<typename Type>
 void ofxSlider<Type>::setMax(Type max){
-    value.setMax(max);
+    return value.setMax(max);
+}
+
+template<typename Type>
+Type ofxSlider<Type>::getMax(){
+    return value.getMax();
 }
 
 template<typename Type>

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -15,7 +15,9 @@ public:
 	ofxSlider* setup(string sliderName, Type _val, Type _min, Type _max, float width = defaultWidth, float height = defaultHeight);
 	
 	void setMin(Type min);
+	Type getMin();
 	void setMax(Type max);
+	Type getMax();
 
 	virtual bool mouseMoved(ofMouseEventArgs & args);
 	virtual bool mousePressed(ofMouseEventArgs & args);


### PR DESCRIPTION
I added two convenient methods to set the minimum and maximum of a ofxSlider. 

At the moment it is not possible to change min/max after setup. Only via deriving ofxSlider and adding the methods in the derived class. getParameter() is of little help here because it only returns a ofAbstractParameter, which also does not support setting minimum or maximum.

Tested on Ubuntu.
