### PR TITLE
ofVbo: don't use stride to calculate the buffer length

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -426,7 +426,7 @@ void ofVbo::setAttributeData(int location, const float * attrib0x, int numCoords
 	attributeNumCoords[location] = numCoords;
 
 	glBindBuffer(GL_ARRAY_BUFFER, attributeIds[location]);
-	glBufferData(GL_ARRAY_BUFFER, total * stride, attrib0x, usage);
+	glBufferData(GL_ARRAY_BUFFER, total * numCoords * sizeof(float), attrib0x, usage);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -512,7 +512,7 @@ void ofVbo::updateIndexData(const ofIndexType * indices, int total) {
 void ofVbo::updateAttributeData(int location, const float * attr0x, int total){
 	if(attributeIds.find(location)!=attributeIds.end() && attributeIds[location]!=0) {
 		glBindBuffer(GL_ARRAY_BUFFER, attributeIds[location]);
-		glBufferSubData(GL_ARRAY_BUFFER, 0, total*attributeStrides[location], attr0x);
+		glBufferSubData(GL_ARRAY_BUFFER, 0, total*attributeNumCoords[location]*sizeof(float), attr0x);
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 }

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -33,7 +33,7 @@ public:
 	void setNormalData(const float * normal0x, int total, int usage, int stride=0);
 	void setTexCoordData(const float * texCoord0x, int total, int usage, int stride=0);
 	
-	void setAttributeData(int location, const float * vert0x, int numCoords, int total, int usage, int stride=sizeof(float));
+	void setAttributeData(int location, const float * vert0x, int numCoords, int total, int usage, int stride=0);
 
 	void updateMesh(const ofMesh & mesh);
 


### PR DESCRIPTION
## ofVbo: don't use stride to calculate the buffer length

In current implementation of setAttributeData/updateAttributeData the stride argument is used for two orthogonal concepts:
1. to calculate the size of the buffer
2. as an argument of glVertexAttribPointer

this make impossible to use a tightly packed array as an argument to a shader.
