### PR TITLE
Update ofxAssimpModelLoader.cpp

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -17,7 +17,7 @@ ofxAssimpModelLoader::~ofxAssimpModelLoader(){
 
 //------------------------------------------
 bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
-    file.open(modelName);
+    file.open(modelName, ofFile::ReadOnly, true); // Since it may be a binary file we should read it in binary -Ed
     if(!file.exists()) {
         ofLogVerbose("ofxAssimpModelLoader") << "loadModel(): model does not exist: \"" << modelName << "\"";
         return false;


### PR DESCRIPTION
fixes issue #1932 - ofxAssimpModelLoader example fails on Windows when loading 3DS model (when pressing '5')
Models were being loaded in text mode instead of binary mode causing issues with binary formats like .3ds.  
