### PR TITLE
ofMesh: fixed bug of saving mesh as ply ASCII file

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -613,11 +613,6 @@ void ofMesh::setIndex(ofIndexType index, ofIndexType  val){
 }
 
 //--------------------------------------------------------------
-void ofMesh::setName(string name_){
-	name = name_;
-}
-
-//--------------------------------------------------------------
 void ofMesh::setupIndicesAuto(){
 	bIndicesChanged = true;
 	bFacesDirty = true;
@@ -1071,9 +1066,9 @@ void ofMesh::save(string path, bool useBinary) const{
 			os << endl;
 		}
 	}
-	int numIndices = data.getNumIndices();
-	if(numIndices) {
-		for(int i = 0; i < numIndices; i += faceSize) {
+
+	if(data.getNumIndices()) {
+		for(int i = 0; i < data.getNumIndices(); i += faceSize) {
 			if(useBinary) {
 				os.write((char*) &faceSize, sizeof(unsigned char));
 				for(int j = 0; j < faceSize; j++) {
@@ -1081,17 +1076,15 @@ void ofMesh::save(string path, bool useBinary) const{
 					os.write((char*) &curIndex, sizeof(int));
 				}
 			} else {
-				if(i+2 >= numIndices) {
+				if (i+2 >= data.getNumIndices())
+				{
 					break;
 				}
 				os << (int) faceSize << " " << data.getIndex(i) << " " << data.getIndex(i+1) << " " << data.getIndex(i+2) << endl;
 			}
 		}
 	} else if(data.getMode() == OF_PRIMITIVE_TRIANGLES) {
-		for(int i = 0; i < numIndices; i += faceSize) {
-			if(i+2 >= numIndices) {
-				break;
-			}
+		for(int i = 0; i < data.getNumVertices(); i += faceSize) {
 			int indices[] = {i, i + 1, i + 2};
 			if(useBinary) {
 				os.write((char*) &faceSize, sizeof(unsigned char));


### PR DESCRIPTION
There's a bug in ofMesh::save() function and I couldn't load ply ASCII file properly. (indices out of bounds)
I think binary is ok but not sure.
