### PR TITLE
Remove ofMesh setName() in ofxAssimpModelLoader

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
@@ -85,8 +85,6 @@ static void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, ofxAssimpMeshHelper *
 			ofm.addIndex(aim->mFaces[i].mIndices[j]);
 		}
 	}
-    
-	ofm.setName(string(aim->mName.data));
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
This is just a cleanup PR. 

ofMesh's setName() was removed in #2651, but that causes a minor compile error in ofxAssimpModelLoader. This PR just takes out that line.
