### PR TITLE
fixes #2829 ofVbo custom attribute stride

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -424,9 +424,10 @@ void ofVbo::setAttributeData(int location, const float * attrib0x, int numCoords
 
 	attributeStrides[location] = stride;
 	attributeNumCoords[location] = numCoords;
+	attributeSize[location] = (stride == 0) ? numCoords * sizeof(float) : stride;
 
 	glBindBuffer(GL_ARRAY_BUFFER, attributeIds[location]);
-	glBufferData(GL_ARRAY_BUFFER, total * stride, attrib0x, usage);
+	glBufferData(GL_ARRAY_BUFFER, total * attributeSize[location], attrib0x, usage);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -512,7 +513,7 @@ void ofVbo::updateIndexData(const ofIndexType * indices, int total) {
 void ofVbo::updateAttributeData(int location, const float * attr0x, int total){
 	if(attributeIds.find(location)!=attributeIds.end() && attributeIds[location]!=0) {
 		glBindBuffer(GL_ARRAY_BUFFER, attributeIds[location]);
-		glBufferSubData(GL_ARRAY_BUFFER, 0, total*attributeStrides[location], attr0x);
+		glBufferSubData(GL_ARRAY_BUFFER, 0, total * attributeSize[location], attr0x);
 		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 }

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -134,6 +134,7 @@ private:
 	bool bBound;
 
 	map<int,GLuint> attributeIds;
+	map<int,int> attributeSize;
 	map<int,int> attributeStrides;
 	map<int,int> attributeNumCoords;
 


### PR DESCRIPTION
addresses an issue (#2829) where the buffer length would be calculated wrongly if stride for a custom ofVbo attribute was set to 0.

Based on @cinghiale's suggestion, and the ensueing discussion.

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
