### PR TITLE
fix critical issue w/ ofVbo shallow copies (custom attributes)

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -181,6 +181,14 @@ ofVbo::ofVbo(const ofVbo & mom){
 		vaoChanged = mom.vaoChanged;
 	}
 
+	attributeIds = mom.attributeIds;
+	for (map<int, GLuint>::iterator it = attributeIds.begin(); it != attributeIds.end(); it++){
+		retain(it->second);
+	}
+	
+	attributeNumCoords = mom.attributeNumCoords;
+	attributeStrides = mom.attributeStrides;
+	attributeSize = mom.attributeSize;
 
 	totalVerts = mom.totalVerts;
 	totalIndices = mom.totalIndices;
@@ -230,6 +238,15 @@ ofVbo & ofVbo::operator=(const ofVbo& mom){
 		vaoChanged = mom.vaoChanged;
 	}
 
+	attributeIds = mom.attributeIds;
+	for (map<int, GLuint>::iterator it = attributeIds.begin(); it != attributeIds.end(); it++){
+		retain(it->second);
+	}
+	
+	attributeNumCoords = mom.attributeNumCoords;
+	attributeStrides = mom.attributeStrides;
+	attributeSize = mom.attributeSize;
+	
 	totalVerts = mom.totalVerts;
 	totalIndices = mom.totalIndices;
 


### PR DESCRIPTION
- fixes an issue where custom vbo attributes (and their buffers) would not be retained whenever the ofVbo was copied, since the ofVbo copy constructors would not include custom attribute data & GL handlers when assigning data from their mom object.
## note

this is might have especially tripped you up if you wanted to create, and then store vbos with custom attributes in a c++ vector, since push_back() does initialise by copy, and you'd have lost all your attributes upon pushing the new ofVbo to your storage vector...

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
