### PR TITLE
fix for ofGetFrameRate() going to infinity at high fps on windows

### DIFF
--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -150,7 +150,10 @@ void ofNotifyUpdate(){
 			oneSec  = timeNow;
 			nFramesForFPS = 0;
 		}else{
-			fps = fps*.99 + nFramesForFPS/(oneSecDiff*MICROS_TO_SEC)*.01;
+			double deltaTime = ((double)oneSecDiff)*MICROS_TO_SEC;
+			if( deltaTime > 0.0 ){
+				fps = fps*0.99 + (nFramesForFPS/deltaTime)*0.01;
+			}
 		}
 		nFramesForFPS++;
 


### PR DESCRIPTION
on windows sometimes the deltatime could be 0.0, this means that fps values could go to infinity 
we now check the deltatime is greater than 0.0
