### PR TITLE
Unhandled Exception fix in ofURLFileLoader.

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -45,6 +45,9 @@ ofURLFileLoader::ofURLFileLoader() {
 		catch (Poco::SystemException & PS) {
 			ofLogError("ofURLFileLoader") << "couldn't create factory: " << PS.displayText();
 		}
+		catch (Poco::ExistsException & PS) {
+			ofLogError("ofURLFileLoader") << "couldn't create factory: " << PS.displayText();
+		}
 	}
 }
 


### PR DESCRIPTION
Thrown under some circumstances internally from `URIStreamOpener::registerStreamFactory`.
