### PR TITLE
fix for ofTrueTypeFont reloading textures only after a successful load.

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -368,8 +368,9 @@ void ofTrueTypeFont::finishLibraries(){
 
 //------------------------------------------------------------------
 ofTrueTypeFont::ofTrueTypeFont(){
-	bLoadedOk		= false;
-	bMakeContours	= false;
+	bLoadedOk           = false;
+    bLastFontLoadedOk   = false;
+	bMakeContours       = false;
 	#if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
 		all_fonts().insert(this);
 	#endif
@@ -407,6 +408,9 @@ void ofTrueTypeFont::unloadTextures(){
 }
 
 void ofTrueTypeFont::reloadTextures(){
+    if(bLastFontLoadedOk == false) {
+        return;
+    }
 	loadFont(filename, fontSize, bAntiAliased, bFullCharacterSet, bMakeContours, simplifyAmt, dpi);
 }
 
@@ -476,6 +480,7 @@ bool ofTrueTypeFont::loadFont(string _filename, int _fontSize, bool _bAntiAliase
 
 
 	bLoadedOk 			= false;
+    bLastFontLoadedOk	= false;
 	bAntiAliased 		= _bAntiAliased;
 	bFullCharacterSet 	= _bFullCharacterSet;
 	fontSize			= _fontSize;
@@ -728,6 +733,7 @@ bool ofTrueTypeFont::loadFont(string _filename, int _fontSize, bool _bAntiAliase
 	// ------------- close the library and typeface
 	FT_Done_Face(face);
   	bLoadedOk = true;
+    bLastFontLoadedOk = true;
 	return true;
 }
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -81,6 +81,7 @@ public:
 
 protected:
 	bool			bLoadedOk;
+    bool            bLastFontLoadedOk;
 	bool 			bAntiAliased;
 	bool 			bFullCharacterSet;
 	int 			nCharacters;


### PR DESCRIPTION
added bLastFontLoadedOk flag which keeps track of a successful font load.
when reloadTextures() is called, it only reloads the textures if the font was previously loaded.
this fix stops this error message on iOS,
[ error ] ofTrueTypeFont: loadFontFace(): couldn't create new face for"": FT_Error 2 unknown freetype
