### PR TITLE
Cleanup namespace osx

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -159,6 +159,8 @@ enum ofTargetPlatform{
 	#undef Rect
 
 	#undef check
+	#undef nil
+
 	#if defined(__LITTLE_ENDIAN__)
 		#define TARGET_LITTLE_ENDIAN		// intel cpu
 	#endif

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -151,6 +151,7 @@ enum ofTargetPlatform{
 	#include <OpenGL/gl.h>
 	#include <ApplicationServices/ApplicationServices.h>
 
+	#undef check
 	#if defined(__LITTLE_ENDIAN__)
 		#define TARGET_LITTLE_ENDIAN		// intel cpu
 	#endif

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -148,8 +148,15 @@ enum ofTargetPlatform{
 	#endif
 	#include <unistd.h>
 	#include "GL/glew.h"
+
+	#define Point MacTypesPoint
+	#define Rect MacTypesRect
+
 	#include <OpenGL/gl.h>
 	#include <ApplicationServices/ApplicationServices.h>
+
+	#undef Point
+	#undef Rect
 
 	#undef check
 	#if defined(__LITTLE_ENDIAN__)

--- a/libs/openFrameworks/video/ofQTKitMovieRenderer.h
+++ b/libs/openFrameworks/video/ofQTKitMovieRenderer.h
@@ -2,11 +2,16 @@
 // Copyright (c) 2012 openFrameworks team
 // openFrameworks is released under the MIT License. See libs/_Licence.txt
 
+#define Point MacTypesPoint
+#define Rect MacTypesRect
+
 #import <Cocoa/Cocoa.h>
 #import <Quartz/Quartz.h>
 #import <QTKit/QTKit.h>
 #import <OpenGL/OpenGL.h>
 
+#undef Point
+#undef Rect
 
 @interface QTKitMovieRenderer : NSObject
 {

--- a/libs/openFrameworks/video/ofQtUtils.h
+++ b/libs/openFrameworks/video/ofQtUtils.h
@@ -7,9 +7,15 @@
 
 
 #ifdef TARGET_OSX
+	#define Point MacTypesPoint
+	#define Rect MacTypesRect
+
 	#include <QuickTime/QuickTime.h>
 	#include <CoreServices/CoreServices.h>
 	#include <ApplicationServices/ApplicationServices.h>
+
+	#undef Point
+	#undef Rect
 #else
 	#include <QTML.h>
 	#include <FixMath.h>


### PR DESCRIPTION
Cleanup global namspace in osx.

- Remove check() macro in AssertMacros.h, This is often conflicts boost or PCL or other C++ libraries.
- Rename Point and Rect struct to MacTypesPoint and MacTypesRect in MacTypes.h