### PR TITLE
debian/install_dependencies.sh: fixed -n option not being respected in apt-cache show

### DIFF
--- a/scripts/linux/debian/install_dependencies.sh
+++ b/scripts/linux/debian/install_dependencies.sh
@@ -16,7 +16,7 @@ GSTREAMER_VERSION=0.10
 GSTREAMER_FFMPEG=gstreamer${GSTREAMER_VERSION}-ffmpeg
 
 echo "detecting latest gstreamer version"
-apt-cache show -n libgstreamer1.0-dev
+apt-cache show libgstreamer1.0-dev &> /dev/null
 exit_code=$?
 if [ $exit_code = 0 ]; then
     echo selecting gstreamer 1.0


### PR DESCRIPTION
See discussion on #2866
Apparently apt-cache show -n doesn't work anymore. This is a workaround for that. Tested on Debian Jessie (testing)
