### PR TITLE
Fix for parsing a string of format "r,g,b,a" (*without* white spaces after the comma's). 

### DIFF
--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -531,25 +531,25 @@ public:
     friend istream& operator >> (istream& is, ofColor_<PixelType>& color) {
         if(sizeof(PixelType) == 1) {
             int component;
-            is >> component;
+            is >> std::skipws >> component;
             color.r = component;
-            is.ignore(2);
-            is >> component;
+            is.ignore(1);
+            is >> std::skipws >> component;
             color.g = component;
-            is.ignore(2);
-            is >> component;
+            is.ignore(1);
+            is >> std::skipws >> component;
             color.b = component;
-            is.ignore(2);
-            is >> component;
+            is.ignore(1);
+            is >> std::skipws >> component;
             color.a = component;
         }else{
-            is >> color.r;
-            is.ignore(2);
-            is >> color.g;
-            is.ignore(2);
-            is >> color.b;
-            is.ignore(2);
-            is >> color.a;
+            is >> std::skipws >> color.r;
+            is.ignore(1);
+            is >> std::skipws >> color.g;
+            is.ignore(1);
+            is >> std::skipws >> color.b;
+            is.ignore(1);
+            is >> std::skipws >> color.a;
         }
         return is;
     }


### PR DESCRIPTION
This adds support for the XML standard and allows for more general use. 

The previous implementation only worked for the "r, g, b, a", with spaces.
