### PR TITLE
fix tr1/memory compile issue on OS X 10.9 for makefiles

### DIFF
--- a/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
+++ b/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
@@ -69,8 +69,11 @@ PLATFORM_REQUIRED_ADDONS =
 # Note: Be sure to leave a leading space when using a += operator to add items to the list
 ##########################################################################################
 
+# Link against libstdc++ to silence tr1/memory errors on latest versions of osx
+PLATFORM_CFLAGS = -stdlib=libstdc++
+
 # Warning Flags (http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html)
-PLATFORM_CFLAGS = -Wall
+PLATFORM_CFLAGS += -Wall
 
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
 PLATFORM_CFLAGS += -fexceptions


### PR DESCRIPTION
Of compiles fine for me now on mavericks using the makefiles. Maybe this should be put in a clause checking if we are on OSX 10.9 as that is the only version I have tried. Would appreciate more testing before merging, however I think it can sneak in as most people on OSX will be compiling via Xcode so this shouldn't be catastrophic if it broke on other peoples boxes and needed a revert/fix.

For explanation, see
https://github.com/openframeworks/openFrameworks/commit/4b669b86c635257af6a764772d0d46df37677244
