### PR TITLE
ofGLProgrammableRenderer fixes for RPi

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -966,7 +966,7 @@ void ofGLProgrammableRenderer::beginDefaultShader(){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::endCustomShader(){
 	usingCustomShader = false;
-	if(!uniqueShader) beginDefaultShader();
+	beginDefaultShader();
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
These changes are only applied to RPi conditionals (uniqueShader) so this won't effect any other platforms.

This has been tested against and passes all the display errors/inconsistencies listed at 
- allows shaders to be used in draw
- stops GL INVALID_OPERATION at glDrawArrays when fbo/texture is used in update
- consistent fbo/shader behavior in update() and draw()
  passes all tests listed at
  https://github.com/openframeworks/openFrameworks/issues/2593#issuecomment-26657402

I also did performance tests against non-fbo/shader app usage and saw no performance hits. This is where the previous fix failed (disabling the unique shader)

closes #2593  - I hope for good ;)
