### PR TITLE
iOS autoreleasepool changes - Changes for #2808

### DIFF
--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -93,7 +93,7 @@ void ofAppiOSWindow::startAppWithDelegate(string appDelegateClassName) {
     bAppCreated = true;
     
     @autoreleasepool {
-        cout << " trying to lauunch delegate " << appDelegateClassName << endl;
+        cout << "trying to launch app delegate " << appDelegateClassName << endl;
         UIApplicationMain(nil, nil, nil, [NSString stringWithUTF8String:appDelegateClassName.c_str()]);
     }
 }


### PR DESCRIPTION
Changes for the iOS autoreleaseblock - Replace NSAutoreleasepool to more efficient autoreleasepool block

> @ autoreleasepool blocks are more efficient than using an instance of NSAutoreleasePool directly; you can also use them even if you do not use ARC.
> Important: If you use Automatic Reference Counting (ARC), you cannot use autorelease pools directly. > Instead, you use @ autoreleasepool blocks. For example, in place of:[b]
> https://developer.apple.com/library/ios/documentation/cocoa/reference/foundation/Classes/NSAutoreleasePool_Class/Reference/Reference.html

This is a must merge to properly support ARC Projects that include oF applications.
Currently we are kind of library hacking around using the autoreleasepool (which is potentially dangerous + may get ARC apps rejected from AppStore Submission).

It is also beneficial to normal non-ARC apps for optimisation as Apple have stated the new block way is much more efficient.

Despite the initial issue that stated iOS 5+ would be required, the code changes do allegedly work back on iOS 4.3 (as blocks were supported then and when compiled with newer versions of Xcode everything is fine).
