### PR TITLE
add cleaner exit code to GLFW apps

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -239,7 +239,6 @@ void ofAppGLFWWindow::setupOpenGL(int w, int h, int screenMode){
 
 //--------------------------------------------
 void ofAppGLFWWindow::exit_cb(GLFWwindow* windowP_){
-	OF_EXIT_APP(0);
 }
 
 //--------------------------------------------
@@ -293,10 +292,12 @@ void ofAppGLFWWindow::runAppViaInfiniteLoop(ofBaseApp * appPtr){
 	glfwMakeContextCurrent(windowP);
 
 	ofNotifySetup();
-	while(true){
+	while(!glfwWindowShouldClose(windowP)){
 		ofNotifyUpdate();
 		display();
 	}
+    glfwDestroyWindow(windowP);
+    glfwTerminate();
 }
 
 //------------------------------------------------------------
@@ -489,6 +490,11 @@ int ofAppGLFWWindow::getHeight()
 			return windowW * pixelScreenCoordScale;
 		}
 	}
+}
+
+//------------------------------------------------------------
+GLFWwindow* ofAppGLFWWindow::getGLFWWindow(){
+    return windowP;
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -54,6 +54,8 @@ public:
 
 	int getHeight();
 	int getWidth();
+    
+    GLFWwindow* getGLFWWindow();
 
 	ofVec3f		getWindowSize();
 	ofVec3f		getScreenSize();

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -3,6 +3,7 @@
 #include "ofBaseApp.h"
 #include "ofUtils.h"
 #include "ofGraphics.h"
+#include "ofAppGLFWWindow.h"
 #include <set>
 
 static const double MICROS_TO_SEC = .000001;
@@ -210,8 +211,13 @@ void ofNotifyKeyPressed(int key){
 	
 	
 	if (key == OF_KEY_ESC && bEscQuits == true){				// "escape"
-		exitApp();
-	}
+        ofAppGLFWWindow *appGLFWWindow = dynamic_cast<ofAppGLFWWindow*>(ofGetWindowPtr());
+        if (appGLFWWindow) {
+            glfwSetWindowShouldClose(appGLFWWindow->getGLFWWindow(), true);
+        }else{
+            exitApp();
+        }
+    }
 	
 	
 }


### PR DESCRIPTION
Before openframeworks would call std::exit in order to quit. The openGl context was not getting cleaned up properly and destructors were not being called .This commit fixes that issue. related to #2603 
