### PR TITLE
Fix for create_package.sh

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -432,6 +432,14 @@ function createPackage {
 	if [ "$pkg_platform" != "osx" ] && [ "$pkg_platform" != "ios" ]; then
 		rm -Rf "xcode templates"
 	fi
+	
+	
+	#download and copy OF compiled
+	#cd $pkg_ofroot/libs/openFrameworksCompiled/lib/${pkg_platform}
+    	#if [ "$pkg_platform" = "win_cb" ]; then
+	#	wget http://openframeworks.cc/git_pkgs/OF_compiled/${pkg_platform}/openFrameworks.lib
+	#	wget http://openframeworks.cc/git_pkgs/OF_compiled/${pkg_platform}/openFrameworksDebug.lib
+	#fi
 
 
     #if snow leopard change 10.4u to 10.5


### PR DESCRIPTION
Fixes an issue where create_package.sh would download HTML files instead of lib files, when creating a package for win_cb.

I think the best solution is to just remove those lines from the script and let CodeBlocks recompile the libs (openFrameworks.lib and openFrameworksDebug.lib).
