### PR TITLE
Thread timeout settable, keyboard, mouse detection info

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -1364,7 +1364,7 @@ void ofAppEGLWindow::setupNativeMouse() {
     if(mouse_fd < 0) {
         ofLogError("ofAppEGLWindow") << "setupMouse(): did not open mouse, mouse_fd < 0";
     }else {
-		mouseDetected = true;
+        mouseDetected = true;
 	}
 
 
@@ -1410,9 +1410,8 @@ void ofAppEGLWindow::setupNativeKeyboard() {
     
     if(keyboard_fd < 0) {
         ofLogError("ofAppEGLWindow") << "setupKeyboard(): did not open keyboard, keyboard_fd < 0";
-    }else
-	{
-		keyboardDetected = true;
+    }else {
+        keyboardDetected = true;
 	}
 }
 

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -76,7 +76,7 @@ public:
 	virtual ~ofAppEGLWindow();
 
 	void exit(ofEventArgs &e);
-	void setThreadTimeout(long timeOut){ threadTimeout = timeOut; }
+    void setThreadTimeout(long timeOut){ threadTimeout = timeOut; }
     void setGLESVersion(int glesVersion);
 	virtual void setupOpenGL(int w, int h, int screenMode);
 


### PR DESCRIPTION
ofAppEGLWindow calls `waitForThread` which by default has an infinite timeout. This can causes certain apps to hang indefinitely. This gives the user an option to set the timeout

This also adds 2 methods `hasMouse()` and `hasKeyboard()` so an app can tell whether a mouse/keyboard have been detected. This can be useful in writing examples for different configurations 
i.e 

```
ofAppEGLWindow *appEGLWindow = (ofAppEGLWindow *) ofGetWindowPtr();
if(appEGLWindow->hasMouse()) x = mouseX;
```
