### PR TITLE
Use existing Poco time functions.  Reduce custom code.

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -124,16 +124,14 @@ unsigned int ofGetUnixTime(){
 //default ofGetTimestampString returns in this format: 2011-01-15-18-29-35-299
 //--------------------------------------------------
 string ofGetTimestampString(){
-	string timeFormat = "%Y-%m-%d-%H-%M-%S-%i";
-	Poco::LocalDateTime now;
-	return Poco::DateTimeFormatter::format(now, timeFormat);
+	static const string timeFormat = "%Y-%m-%d-%H-%M-%S-%i";
+	return Poco::DateTimeFormatter::format(Poco::LocalDateTime(), timeFormat);
 }
 
 //specify the string format - eg: %Y-%m-%d-%H-%M-%S-%i ( 2011-01-15-18-29-35-299 )
 //--------------------------------------------------
 string ofGetTimestampString(string timestampFormat){
-	Poco::LocalDateTime now;
-	return Poco::DateTimeFormatter::format(now, timestampFormat);
+	return Poco::DateTimeFormatter::format(Poco::LocalDateTime(), timestampFormat);
 }
 
 //--------------------------------------------------


### PR DESCRIPTION
We currently use some of `Poco::LocalDateTime`.  This PR uses it more to reduce the lines of custom code.

Probably worth considering `Poco::Timestamp` for `ofGetSystemTime*()` calls as well. 
