### PR TITLE
fixes for mouse registration issues with ofxGui

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -69,6 +69,8 @@ ofxBaseGui::ofxBaseGui(){
 	thisBorderColor=borderColor;
 	thisTextColor=textColor;
 	thisFillColor=fillColor;
+    
+    bRegisteredForMouseEvents = false;
 
 	/*if(!fontLoaded){
 		loadFont(OF_TTF_MONO,10,true,true);
@@ -91,8 +93,24 @@ void ofxBaseGui::setUseTTF(bool bUseTTF){
 }
 
 ofxBaseGui::~ofxBaseGui(){
+    unregisterMouseEvents();
 }
 
+void ofxBaseGui::registerMouseEvents(){
+    if(bRegisteredForMouseEvents == true) {
+        return; // already registered.
+    }
+    bRegisteredForMouseEvents = true;
+	ofRegisterMouseEvents(this, OF_EVENT_ORDER_BEFORE_APP);
+}
+
+void ofxBaseGui::unregisterMouseEvents(){
+    if(bRegisteredForMouseEvents == false) {
+        return; // not registered.
+    }
+	ofUnregisterMouseEvents(this, OF_EVENT_ORDER_BEFORE_APP);
+    bRegisteredForMouseEvents = false;
+}
 
 void ofxBaseGui::draw(){
 	currentFrame = ofGetFrameNum();

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -59,7 +59,9 @@ public:
 	virtual ofAbstractParameter & getParameter() = 0;
 	static void loadFont(string filename, int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=false, int dpi=0);
 	static void setUseTTF(bool bUseTTF);
-
+    
+    void registerMouseEvents();
+    void unregisterMouseEvents();
 
 	virtual bool mouseMoved(ofMouseEventArgs & args) = 0;
 	virtual bool mousePressed(ofMouseEventArgs & args) = 0;
@@ -103,4 +105,5 @@ protected:
 
 private:
 	unsigned long currentFrame;
+    bool bRegisteredForMouseEvents;
 }; 

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -5,7 +5,7 @@ ofxButton::ofxButton(){
 }
 
 ofxButton::~ofxButton(){
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
+	//
 }
 
 ofxButton* ofxButton::setup(string toggleName, float width, float height){
@@ -18,7 +18,7 @@ ofxButton* ofxButton::setup(string toggleName, float width, float height){
 	value = false;
 	checkboxRect.set(1, 1, b.height - 2, b.height - 2);
 
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
+	registerMouseEvents();
 
 	value.addListener(this,&ofxButton::valueChanged);
 

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -81,7 +81,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, string _f
 	}
 
 	parameters = _parameters;
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
+    registerMouseEvents();
 
 	generateDraw();
     
@@ -97,7 +97,7 @@ void ofxGuiGroup::add(ofxBaseGui * element){
 
 	//if(b.width<element->getWidth()) b.width = element->getWidth();
     
-	ofUnregisterMouseEvents(element);
+    element->unregisterMouseEvents();
     
 	ofxGuiGroup * subgroup = dynamic_cast<ofxGuiGroup*>(element);
 	if(subgroup!=NULL){
@@ -312,14 +312,6 @@ ofxBaseGui * ofxGuiGroup::getControl(string name){
 		}
 	}
 	return NULL;
-}
-
-void ofxGuiGroup::registerMouseEvents(){
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
-}
-
-void ofxGuiGroup::unregisterMouseEvents(){
-	ofUnregisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
 }
 
 bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -59,8 +59,6 @@ public:
 	virtual void setPosition(float x, float y);
 protected:
 	virtual void render();
-    void registerMouseEvents();
-    void unregisterMouseEvents();
     virtual bool setValue(float mx, float my, bool bCheck);
     void sizeChangedCB();
     

--- a/addons/ofxGui/src/ofxPanel.cpp
+++ b/addons/ofxGui/src/ofxPanel.cpp
@@ -21,7 +21,7 @@ ofxPanel::ofxPanel(const ofParameterGroup & parameters, string filename, float x
 }
 
 ofxPanel::~ofxPanel(){
-	unregisterMouseEvents();
+	//
 }
 
 ofxPanel * ofxPanel::setup(string collectionName, string filename, float x, float y){

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -28,7 +28,7 @@ ofxSlider<Type>* ofxSlider<Type>::setup(ofParameter<Type> _val, float width, flo
 	bGuiActive = false;
 
 	value.addListener(this,&ofxSlider::valueChanged);
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
+	registerMouseEvents();
 	generateDraw();
 	return this;
 }

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -7,7 +7,6 @@ ofxToggle::ofxToggle(ofParameter<bool> _bVal, float width, float height){
 
 ofxToggle::~ofxToggle(){
 	value.removeListener(this,&ofxToggle::valueChanged);
-	ofUnregisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
 }
 
 ofxToggle * ofxToggle::setup(ofParameter<bool> _bVal, float width, float height){
@@ -20,7 +19,7 @@ ofxToggle * ofxToggle::setup(ofParameter<bool> _bVal, float width, float height)
 	checkboxRect.set(1, 1, b.height - 2, b.height - 2);
 
 	value.addListener(this,&ofxToggle::valueChanged);
-	ofRegisterMouseEvents(this,OF_EVENT_ORDER_BEFORE_APP);
+	registerMouseEvents();
 	generateDraw();
 
 	return this;


### PR DESCRIPTION
when creating ofxGui elements like so `new ofxPanel()` and then deleting them,
i noticed that mouse events were not being unregistered properly, so they next time the mouse was pressed after the object was deleted, it would crash the app.

the issues that i found included,
- ofxPanel was registering for mouse events 3 times on setup!
- ofxButton was registering for events in setup and registering again in the destructor.
- ofxSlider never unregistered mouse events when destroyed.

the solutions in this PR include,
- added mouse register and unregister methods to ofxBaseGui, so all classes that extend ofxBaseGui register and unregister for mouse events via these method.

```
void registerMouseEvents();
void unregisterMouseEvents();
```

`registerMouseEvents()` and `unregisterMouseEvents()` have a flag which makes sure that no multiple mouse registration can be made and that no mouse events are unregistered if they have not been registered for in the first place.

`~ofxBaseGui()` destructor now unregisters mouse events for every `ofxBaseGui` object.

```
ofxBaseGui::~ofxBaseGui(){
    unregisterMouseEvents();
}
```
