### PR TITLE
Correct fullscreen multi monitor display on windows

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -739,31 +739,31 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
         int ypos = 0;
  
         if( bMultiWindowFullscreen ){
- 
-            int minX = 0;
-            int maxX = 0;
-            int minY = 0;
-	    int maxY = 0;
-            int monitorCount;
-            GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
-            int temp_xpos = 0;
-            int temp_ypos = 0;
-            //lets find the total width of all the monitors
-            //and we'll make the window height the height of the largest monitor.
-            for(int i = 0; i < monitorCount; i++){
-                const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[i]);
-                glfwGetMonitorPos(monitors[i], &temp_xpos, &temp_ypos);
-                minX = min(temp_xpos,minX);
-                minY = min(temp_ypos,minY);
-                maxX = max(maxX,temp_xpos + desktopMode->width);
-                maxY = max(maxY,temp_ypos + desktopMode->height);
 
-                xpos = min(xpos,temp_xpos);
-                ypos = min(ypos,temp_ypos);
-            }
- 
-            fullscreenW = maxX-minX;
-            fullscreenH = maxY-minY;
+			int minX = 0;
+			int maxX = 0;
+			int minY = 0;
+			int maxY = 0;
+			int monitorCount;
+			GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
+			int tempXPos = 0;
+			int tempYPos = 0;
+			//lets find the total width of all the monitors
+			//and we'll make the window height the height of the largest monitor.
+			for(int i = 0; i < monitorCount; i++){
+				const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[i]);
+				glfwGetMonitorPos(monitors[i], &tempXPos, &tempYPos);
+				minX = min(tempXPos,minX);
+				minY = min(tempYPos,minY);
+				maxX = max(maxX,tempXPos + desktopMode->width);
+				maxY = max(maxY,tempYPos + desktopMode->height);
+
+				xpos = min(xpos,temp_xpos);
+				ypos = min(ypos,temp_ypos);
+			}
+
+			fullscreenW = maxX-minX;
+			fullscreenH = maxY-minY;
         }else{
  
             int monitorCount;


### PR DESCRIPTION
If the primary monitor in a multi monitor setup on windows was not the top left most monitor in the monitor layout the render area would not extend to monitors above and to the left of the primary monitor. This patch corrects this situation.
