### PR TITLE
Fix for issue with UDP multicast socket on OSX.

### DIFF
--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -61,6 +61,9 @@ bool ofxUDPManager::Create()
 	{
 		int unused = true;
 		setsockopt(m_hSocket, SOL_SOCKET, SO_REUSEADDR, (char*)&unused, sizeof(unused));
+		#ifdef __APPLE__   // MacOS/X requires an additional call
+			setsockopt(m_hSocket, SOL_SOCKET, SO_REUSEPORT, (char*)&unused, sizeof(unused));
+		#endif
 	}
 	bool ret = m_hSocket !=	INVALID_SOCKET;
 	if(!ret) ofxNetworkCheckError();


### PR DESCRIPTION
Previously I was unable to bind multiple listeners to the same multicast
socket as OSX seems to require SO_REUSEPORT option to also be set on the
socket.

Resolves #2937.
