### PR TITLE
added ofxiOSSoundPlayer getAVSoundPlayer() method.

### DIFF
--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
@@ -37,6 +37,8 @@ public:
     bool isLoaded();
     float getVolume();
     
+    void * getAVSoundPlayer();
+    
 protected:
     
     void * soundPlayer;

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
@@ -158,3 +158,7 @@ float ofxiOSSoundPlayer::getVolume() {
     }
     return [(AVSoundPlayer *)soundPlayer volume];
 }
+
+void * ofxiOSSoundPlayer::getAVSoundPlayer() {
+    return soundPlayer;
+}


### PR DESCRIPTION
ofxiOSSoundPlayer getAVSoundPlayer() returns a pointer reference to the native AVSoundPlayer object. 
this is important to have for the user to have access to the obj-C code.
this is the same as in the ofxiOSVideoPlayer.
