### PR TITLE
ofGLReadyCallback() updated

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -183,16 +183,9 @@ void ofGLReadyCallback(){
 	ofLogVerbose("ofAppRunner") << "GL ready";
 	ofLogVerbose("ofAppRunner") << "Vendor:   " << (char*)glGetString(GL_VENDOR);
 	ofLogVerbose("ofAppRunner") << "Renderer: " << (char*)glGetString(GL_RENDERER);
-
-	std::string openGlVersionString = (char*)glGetString(GL_VERSION);
-	std::vector<std::string> versionParts = ofSplitString(openGlVersionString, ".");
-	
-	ofLogVerbose("ofAppRunner") << "Version:  " << openGlVersionString;
-	if (ofFromString<int>(versionParts.front()) >= 2) {
-	    ofLogVerbose("ofAppRunner") << "GLSL:     " << (char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
-	} else {
-	    ofLogVerbose("ofAppRunner") << "GLSL:     GLSL not available with OpenGL versions < 2.0.";
-	}
+	ofLogVerbose("ofAppRunner") << "Version:  " << (char*)glGetString(GL_VERSION);
+	char* glslVer = (char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
+	ofLogVerbose("ofAppRunner") << "GLSL:     " << (glslVer ? glslVer : "Error getting GLSL version.");
 
     if(ofGetGLProgrammableRenderer()){
     	ofGetGLProgrammableRenderer()->setup();


### PR DESCRIPTION
Updated `ofGLReadyCallback()` to fix crash on check for GLSL version when the OpenGL context version is < 2.0. Upon reflection, the crash probably happens when a null pointer returned by `glGetString()` (due to an internal error) is dereferenced, not within `glGetString()`, but I haven't tested this possible cause.

fixes #2954
