### PR TITLE
ofxiOSGetDeviceInfo for querying device type and major / minor versions. 

### DIFF
--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -56,6 +56,17 @@ enum ofxiOSDeviceType {
     OFXIOS_DEVICE_UNKNOWN
 };
 
+// this is the new way for getting device info.
+// we can add other parameters later.
+// maybe also methods for checking if device is newer or older than a certain model.
+class ofxiOSDeviceInfo{
+    public:
+    
+        ofxiOSDeviceType deviceType;
+        string deviceString;
+        int versionMajor;
+        int versionMinor;
+};
 
 
 // Possible return values for ofxiOSGetDeviceRevision
@@ -97,6 +108,9 @@ ofxiOSDeviceType ofxiOSGetDeviceType();
 
 // return device revision
 string ofxiOSGetDeviceRevision();
+
+// return device revision and type parsd from string
+ofxiOSDeviceInfo ofxiOSGetDeviceInfo();
 
 // return application key UIWindow
 UIWindow *ofxiOSGetUIWindow();

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.mm
@@ -60,11 +60,60 @@ string ofxiOSGetDeviceRevision() {
 	string device(machine);
 	
 		delete[] machine;
+        
+    //the simulator comes in as x86_64 - lets get it to be a bit more specific
+    //this should detect that and instead return iPhone Simualtor
+    if( device.substr(0, 3) == "x86"){
+        NSString * dev = [[UIDevice currentDevice] model];
+        device = ofxNSStringToString(dev);
+    }
 			
 	return device;
 	}else{
 		return "";
 	}
+}
+
+//--------------------------------------------------------------
+// TODO: could this be safe to just cache once? Device type shouldn't change while app is running.
+ofxiOSDeviceInfo ofxiOSGetDeviceInfo(){
+    ofxiOSDeviceInfo info;
+    
+    info.deviceType = ofxiOSGetDeviceType();
+    info.deviceString = ofxiOSGetDeviceRevision();
+    vector <string> split = ofSplitString(info.deviceString, ",");
+    
+    if( split.size() == 2 ){
+        if( split[0].size() ){
+            
+            //this is a safe way to get the major number while allowing for a two digit major value.
+            //ie: iPhone10,1
+            //we default to looking for one digit but by removing the device from the string it could allow for two or more.
+            
+            int startOffset = split[0].size()-1;
+            if( split[0].substr(0, 6) == "iPhone" ){
+                startOffset = 6;
+            }else if( split[0].substr(0, 4) == "iPad" ){
+                startOffset = 4;
+            }else if( split[0].substr(0, 4) == "iPod" ){
+                startOffset = 4;
+            }
+        
+            info.versionMajor = ofToInt(split[0].substr(startOffset));
+        }else{
+            info.versionMajor = 0;
+        }
+        if( split[1].size() ){
+            info.versionMinor = ofToInt(split[1]);
+        }else{
+            info.versionMinor = 0;
+        }
+    }else{
+        info.versionMajor = 0;
+        info.versionMinor = 0;
+    }
+        
+    return info;
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
As discussed in #2872 

This is a more future proof approach for determining version of iOS devices ( vs the older approach of listing every single possible device i.e.: OFXIOS_DEVICE_IPHONE_3GS  OFXIOS_DEVICE_IPHONE_3GS_CHINA etc ) 

It returns ofxiOSDeviceInfo which contains device type, device string and major and minor versions of the device. 
In the future we could add more info to ofxiOSDeviceInfo i.e.: `bHasCamera` `bRetina` etc 

Here is how it currently works with the an iPhone 5 and the simulator. 

```
ofxiOSDeviceInfo info = ofxiOSGetDeviceInfo();
cout << "device type " << (int)info.deviceType <<endl;
cout << "device string " << info.deviceString <<endl;
cout << "versionMajor " << info.versionMajor <<endl;
cout << "versionMinor " << info.versionMinor <<endl;

device type 0  // ( OFXIOS_DEVICE_IPHONE )
device string iPhone5,2
versionMajor 5
versionMinor 2

device type 0 // ( OFXIOS_DEVICE_IPHONE )
device string iPhone Simulator
versionMajor 0
versionMinor 0
```

pinging @julapy @admsyn 
