### PR TITLE
Fix get current matrix warnings + allow query current Orientation Matrix 

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -554,18 +554,16 @@ void ofGLProgrammableRenderer::uploadCurrentMatrix(){
 }
 
 //----------------------------------------------------------
-/** @brief	Queries the current OpenGL matrix state
- *  @detail Returns the specified matrix as held by the renderer's current matrix stack.
- *
- *			You can query one of the following:
- *
- *			[OF_MATRIX_MODELVIEW | OF_MATRIX_PROJECTION | OF_MATRIX_TEXTURE]
- *
- *			Each query will return the state of the matrix
- *			as it was uploaded to the shader currently bound.
- *
- *	@param	matrixMode_  Which matrix mode to query
- */
+/// \brief	Queries the current OpenGL matrix state
+///
+/// \detail Returns the current state of the matrix from the top of the renderer's current matrix stack.
+///
+///	        You can query one of the following:
+///
+///	        [OF_MATRIX_MODELVIEW | OF_MATRIX_PROJECTION | OF_MATRIX_TEXTURE | OF_MATRIX_ORIENTATION]
+///
+/// \param	matrixMode_  Which matrix mode to query
+///
 /// \note   If an invalid matrixMode is queried, this method will return the identity matrix, and
 ///         print an error message.
 ofMatrix4x4 ofGLProgrammableRenderer::getCurrentMatrix(ofMatrixMode matrixMode_) const {
@@ -578,6 +576,9 @@ ofMatrix4x4 ofGLProgrammableRenderer::getCurrentMatrix(ofMatrixMode matrixMode_)
 			break;
 		case OF_MATRIX_TEXTURE:
 			return matrixStack.getTextureMatrix();
+			break;
+		case OF_MATRIX_ORIENTATION:
+			return matrixStack.getOrientationMatrix();
 			break;
 		default:
 			ofLogWarning() << "Invalid getCurrentMatrix query";

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -527,6 +527,9 @@ ofMatrix4x4 ofGLRenderer::getCurrentMatrix(ofMatrixMode matrixMode_) const {
 		case OF_MATRIX_TEXTURE:
 			glGetFloatv(GL_TEXTURE_MATRIX, mat.getPtr());
 			break;
+		case OF_MATRIX_ORIENTATION:
+			mat = matrixStack.getOrientationMatrix();
+			break;
 		default:
 			ofLogWarning() << "Invalid getCurrentMatrix query";
 			mat = ofMatrix4x4();

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -531,7 +531,7 @@ enum ofPolyWindingMode{
 
 enum ofHandednessType {OF_LEFT_HANDED, OF_RIGHT_HANDED};
 
-enum ofMatrixMode {OF_MATRIX_MODELVIEW=0, OF_MATRIX_PROJECTION, OF_MATRIX_TEXTURE};
+enum ofMatrixMode {OF_MATRIX_MODELVIEW=0, OF_MATRIX_PROJECTION, OF_MATRIX_TEXTURE, OF_MATRIX_ORIENTATION};
 
 //--------------------------------------------
 //


### PR DESCRIPTION
Two matrix stack related commits:

b5cca6f : fixes compiler warnings by adding a default case to getCurrentMatrix, as discussed with @bilderbuchi in https://github.com/openframeworks/openFrameworks/commit/150e1972ab9c1f1ba0a8b420db70341990c2e6fe#commitcomment-6204050

e8da01f : extends getCurrentMatrix to allow querying the current orientation matrix stack. I found this extension necessary in a current project where i had to do calculations with current projection matrix but found that because openFrameworks post-applies an orientation matrix to the projection matrix i had no access to the correct, _oriented_ projection matrix my shaders were using.
