### PR TITLE
Edited connection flags for Linux ofSerial

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -371,6 +371,8 @@ bool ofSerial::setup(string portName, int baud){
 		options.c_iflag &= (tcflag_t) ~(INLCR | IGNCR | ICRNL | IGNBRK);
 		options.c_oflag &= (tcflag_t) ~(OPOST);
 		options.c_cflag |= CS8;
+	        options.c_cflag |= CRTSCTS;  // disables hardware flow control
+                options.c_lflag &= ~(ICANON | ECHO | ISIG); // enables data to be processed as raw input
 		tcsetattr(fd,TCSANOW,&options);
 
 		bInited = true;


### PR DESCRIPTION
Using linux based systems with ofArduino, causes an incorrect initialization of serial port because of missing flags.

References:
[http://forum.openframeworks.cc/t/einitialized-never-fired-with-ofarduino/15704](http://forum.openframeworks.cc/t/einitialized-never-fired-with-ofarduino/15704)
[http://forum.openframeworks.cc/t/ofarduino-and-raspberry-pi/12443](http://forum.openframeworks.cc/t/ofarduino-and-raspberry-pi/12443)
