### PR TITLE
fix incorrect signature for ofGetTimestampString

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -117,7 +117,7 @@ string ofGetTimestampString();
 ///
 /// \param timestampFormat The formatting pattern.
 /// \returns the formatted timestamp as a std::string.
-string ofGetTimestampString(string timestampFormat);
+string ofGetTimestampString(const string& timestampFormat);
 
 /// \brief Get the current year.
 /// \returns the current year.


### PR DESCRIPTION
This looks like the last regression from #2914 . I flipped on "Missing Function Prototypes" in Xcode, which found this one and no others in `ofUtils.h`, so that should be it.

Aside: there's a few internal OF functions which throw warnings for this (`ofGLReadyCallback()`, `ofURLFileLoaderShutdown()`, `ofInitFreeImage()`) but nothing in the OF headers.

ping @kylemcdonald , @bakercp
