### PR TITLE
ofGstVideoPlayer fix inacurate video frame count

### DIFF
--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -221,7 +221,7 @@ bool ofGstVideoPlayer::allocate(int bpp){
 		if(framerate && GST_VALUE_HOLDS_FRACTION (framerate)){
 			fps_n = gst_value_get_fraction_numerator (framerate);
 			fps_d = gst_value_get_fraction_denominator (framerate);
-			nFrames = (float)(durationNanos / GST_SECOND) * (float)fps_n/(float)fps_d;
+			nFrames = (float)(durationNanos / (float)GST_SECOND) * (float)fps_n/(float)fps_d;
 			ofLogVerbose("ofGstVideoPlayer") << "allocate(): framerate: " << fps_n << "/" << fps_d;
 		}else{
 			ofLogWarning("ofGstVideoPlayer") << "allocate(): cannot get framerate, frame seek won't work";
@@ -240,7 +240,7 @@ bool ofGstVideoPlayer::allocate(int bpp){
 
 			fps_n = info.fps_n;
 			fps_d = info.fps_d;
-			nFrames = (float)(durationNanos / GST_SECOND) * (float)fps_n/(float)fps_d;
+			nFrames = (float)(durationNanos / (float)GST_SECOND) * (float)fps_n/(float)fps_d;
 			gst_caps_unref(caps);
 			bIsAllocated = true;
 		}else{


### PR DESCRIPTION
Fixing video frame count on ofGstVideoPlayer [related to this discussion](https://github.com/openframeworks/openFrameworks/issues/2978)
