### PR TITLE
add normalMatrix to ofMatrixStack

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -14,6 +14,7 @@
 static const int OF_NO_TEXTURE=-1;
 
 static const string MODELVIEW_MATRIX_UNIFORM="modelViewMatrix";
+static const string MODELVIEW_MATRIX_NORMAL="normalMatrix";
 static const string PROJECTION_MATRIX_UNIFORM="projectionMatrix";
 static const string MODELVIEW_PROJECTION_MATRIX_UNIFORM="modelViewProjectionMatrix";
 static const string TEXTURE_MATRIX_UNIFORM="textureMatrix";
@@ -540,6 +541,7 @@ void ofGLProgrammableRenderer::uploadCurrentMatrix(){
 	switch(matrixStack.getCurrentMatrixMode()){
 	case OF_MATRIX_MODELVIEW:
 		currentShader->setUniformMatrix4f(MODELVIEW_MATRIX_UNIFORM, matrixStack.getModelViewMatrix());
+		currentShader->setUniformMatrix3f(MODELVIEW_MATRIX_NORMAL, matrixStack.getNormalMatrix());
 		currentShader->setUniformMatrix4f(MODELVIEW_PROJECTION_MATRIX_UNIFORM, matrixStack.getModelViewProjectionMatrix());
 		break;
 	case OF_MATRIX_PROJECTION:

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -643,6 +643,17 @@ void ofShader::setUniformMatrix4f(const string & name, const ofMatrix4x4 & m) {
 	}
 }
 
+//--------------------------------------------------------------
+void ofShader::setUniformMatrix3f(const string & name, const ofMatrix3x3 & m) {
+	if(bLoaded) {
+		int loc = getUniformLocation(name);
+		if (loc != -1){
+			float send[9] = {m.a, m.b, m.c, m.d, m.e, m.f, m.g, m.h, m.i};
+			glUniformMatrix3fv(loc, 1, GL_FALSE, send);
+		}
+	}
+}
+
 #ifndef TARGET_OPENGLES
 //--------------------------------------------------------------
 void ofShader::setAttribute1s(GLint location, short v1) {

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -11,6 +11,7 @@
 #include "ofBaseTypes.h"
 #include "ofTexture.h"
 #include "ofMatrix4x4.h"
+#include "ofMatrix3x3.h"
 #include "Poco/RegularExpression.h"
 #include <map>
 #include "ofAppBaseWindow.h"
@@ -70,6 +71,7 @@ public:
 	void setUniform4fv(const string & name, float* v, int count = 1);
 	
 	void setUniformMatrix4f(const string & name, const ofMatrix4x4 & m);
+	void setUniformMatrix3f(const string & name, const ofMatrix3x3 & m);
 
 	// set attributes that vary per vertex (look up the location before glBegin)
 	GLint getAttributeLocation(const string & name);

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -166,6 +166,10 @@ const ofMatrix4x4 & ofMatrixStack::getModelViewMatrix() const{
 	return modelViewMatrix;
 }
 
+const ofMatrix3x3 & ofMatrixStack::getNormalMatrix() const{
+	return normalMatrix;
+}
+
 const ofMatrix4x4 & ofMatrixStack::getModelViewProjectionMatrix() const{
 	return modelViewProjectionMatrix;
 }
@@ -266,7 +270,7 @@ void ofMatrixStack::clearStacks(){
 	if (tmpCounter > 0 ){
 		ofLogWarning("ofMatrixStack") << "clearStacks(): found " << tmpCounter << "extra modelview matrices on the stack, did you forget to pop somewhere?";
 	}
-	
+
 	tmpCounter = 0;
 	while (!projectionMatrixStack.empty()){
 		projectionMatrixStack.pop();
@@ -349,11 +353,15 @@ void ofMatrixStack::multMatrix (const float * m){
 	updatedRelatedMatrices();
 }
 
-
 void ofMatrixStack::updatedRelatedMatrices(){
 	switch(currentMatrixMode){
 	case OF_MATRIX_MODELVIEW:
 		modelViewProjectionMatrix = modelViewMatrix * orientedProjectionMatrix;
+		normalMatrix.set(modelViewMatrix._mat[0][0], modelViewMatrix._mat[0][1], modelViewMatrix._mat[0][2],
+						modelViewMatrix._mat[1][0], modelViewMatrix._mat[1][1], modelViewMatrix._mat[1][2],
+						modelViewMatrix._mat[2][0], modelViewMatrix._mat[2][1], modelViewMatrix._mat[2][2]);
+		normalMatrix.invert();
+		normalMatrix.transpose();
 		break;
 	case OF_MATRIX_PROJECTION:
 		orientedProjectionMatrix = projectionMatrix * orientationMatrix;

--- a/libs/openFrameworks/utils/ofMatrixStack.h
+++ b/libs/openFrameworks/utils/ofMatrixStack.h
@@ -13,6 +13,7 @@
 #include "ofRectangle.h"
 #include "ofGraphics.h"
 #include "ofMatrix4x4.h"
+#include "ofMatrix3x3.h"
 
 class ofAppBaseWindow;
 class ofFbo;
@@ -34,6 +35,7 @@ public:
 
 	const ofMatrix4x4 & getProjectionMatrix() const;
 	const ofMatrix4x4 & getModelViewMatrix() const;
+	const ofMatrix3x3 & getNormalMatrix() const;
 	const ofMatrix4x4 & getModelViewProjectionMatrix() const;
 	const ofMatrix4x4 & getTextureMatrix() const;
 	const ofMatrix4x4 & getCurrentMatrix() const;
@@ -75,6 +77,7 @@ private:
     ofMatrixMode currentMatrixMode;
 
 	ofMatrix4x4	modelViewMatrix;
+	ofMatrix3x3 normalMatrix;
 	ofMatrix4x4	projectionMatrix;
 	ofMatrix4x4	textureMatrix;
 	ofMatrix4x4 modelViewProjectionMatrix;


### PR DESCRIPTION
and upload it to shader when using the programmableRenderer

A lot of shader examples you find need a normal matrix. Especially when ported from older glsl languages. This uploads the matrix automatically.
