### PR TITLE
Fix the problem that frame rate becomes slower than the specified value.

### DIFF
--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -16,6 +16,7 @@ static unsigned long long	lastFrameTime = 0;
 static bool      			bFrameRateSet = 0;
 static int      			nFramesForFPS = 0;
 static int      			nFrameCount	  = 0;
+static unsigned long long   prevMicro = 0;
 
 // core events instance & arguments
 ofCoreEvents & ofEvents(){
@@ -125,9 +126,12 @@ void ofNotifyUpdate(){
 	// calculate sleep time to adjust to target fps
 	unsigned long long timeNow = ofGetElapsedTimeMicros();
 	if (nFrameCount != 0 && bFrameRateSet == true){
-		unsigned long long diffMicros = timeNow - timeThen;
+		unsigned long long diffMicros = timeNow - prevMicro;
+        prevMicro = timeNow;
 		if(diffMicros < microsForFrame){
 			unsigned long long waitMicros = microsForFrame - diffMicros;
+            // Theoretical value
+            prevMicro += waitMicros;
 			#ifdef TARGET_WIN32
 				Sleep(waitMicros*MICROS_TO_MILLIS);
 			#else


### PR DESCRIPTION
In my environment(OSX and oF0.8.1), app's fps becomes slower than specified value by ofSetFrameRate().
For example, if I set fps to 60, the actual value becomes about 57.
Since oF0.8.0, time to sleep for adjust desired fps is calculated by micro seconds order, but it is slightly larger value. It may be caused by overhead of sleep function call, I don't know exactly.

I modified code to take into account entire time to call sleep function.
It doesn't  tested on other OS.
I appreciate your feedback!
