### PR TITLE
OSX Retina Mouse Input Fix

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -877,10 +877,10 @@ void ofAppGLFWWindow::mouse_cb(GLFWwindow* windowP_, int button, int state, int 
 	}
 
 	if (state == GLFW_PRESS) {
-		ofNotifyMousePressed(ofGetMouseX()*instance->pixelScreenCoordScale, ofGetMouseY()*instance->pixelScreenCoordScale, button);
+		ofNotifyMousePressed(ofGetMouseX(), ofGetMouseY(), button);
 		instance->buttonPressed=true;
 	} else if (state == GLFW_RELEASE) {
-		ofNotifyMouseReleased(ofGetMouseX()*instance->pixelScreenCoordScale, ofGetMouseY()*instance->pixelScreenCoordScale, button);
+		ofNotifyMouseReleased(ofGetMouseX(), ofGetMouseY(), button);
 		instance->buttonPressed=false;
 	}
 	instance->buttonInUse = button;


### PR DESCRIPTION
Fixes mouse pressed and mouse released events being scaled incorrectly.
https://github.com/openframeworks/openFrameworks/issues/2998

Problem was the Mouse Moved and Mouse Dragged events were already
scaling the X,Y positions to the retina pixel level. This led to the
Mouse Pressed and Mouse Released events polling that already scaled
position (ofGetMouseX() / ofGetMouseY()) and then multiplying that by the pixelScreenCoordScale again.
