### PR TITLE
Minor improvements to ofTrueTypeFont font metrics

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -398,6 +398,7 @@ ofTrueTypeFont::ofTrueTypeFont(){
 	nCharacters = 0;
 	blend_enabled = true;
 	lineHeight = 0;
+	ascenderHeight = descenderHeight = 0;
 	bAntiAliased = true;
 	texture_2d_enabled = true;
 	encoding = OF_ENCODING_UTF8;
@@ -512,6 +513,12 @@ bool ofTrueTypeFont::loadFont(string _filename, int _fontSize, bool _bAntiAliase
 	FT_Set_Char_Size( face, fontSize << 6, fontSize << 6, dpi, dpi);
 	float fontUnitScale = ((float)fontSize * dpi) / (72 * face->units_per_EM);
 	lineHeight = face->height * fontUnitScale;
+	ascenderHeight = face->ascender * fontUnitScale;
+	descenderHeight = face->descender * fontUnitScale;
+	glyphBBox.set(face->bbox.xMin * fontUnitScale,
+				  face->bbox.yMin * fontUnitScale,
+				  (face->bbox.xMax - face->bbox.xMin) * fontUnitScale,
+				  (face->bbox.yMax - face->bbox.yMin) * fontUnitScale);
 
 	//------------------------------------------------------
 	//kerning would be great to support:
@@ -785,6 +792,21 @@ void ofTrueTypeFont::setLineHeight(float _newLineHeight) {
 //-----------------------------------------------------------
 float ofTrueTypeFont::getLineHeight(){
 	return lineHeight;
+}
+
+//-----------------------------------------------------------
+float ofTrueTypeFont::getAscenderHeight() const {
+	return ascenderHeight;
+}
+
+//-----------------------------------------------------------
+float ofTrueTypeFont::getDescenderHeight() const {
+	return descenderHeight;
+}
+
+//-----------------------------------------------------------
+const ofRectangle & ofTrueTypeFont::getGlyphBBox() const {
+	return glyphBBox;
 }
 
 //-----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -99,6 +99,34 @@ public:
 	/// \param height Line height for text drawn on screen.
 	void setLineHeight(float height);
 
+	/// \brief Get the ascender distance for this font.
+	///
+	/// The ascender is the vertical distance from the baseline to the highest "character" coordinate.
+	/// The meaning of "character" coordinate depends on the font. Some fonts take accents into account,
+	/// others do not, and still others define it simply to be the highest coordinate over all glyphs.
+	///
+	/// \returns Returns font ascender height in pixels.
+	float		getAscenderHeight() const;
+
+	/// \brief Get the descender distance for this font.
+	///
+	/// The descender is the vertical distance from the baseline to the lowest "character" coordinate.
+	/// The meaning of "character" coordinate depends on the font. Some fonts take accents into account,
+	/// others do not, and still others define it simply to be the lowest coordinate over all glyphs.
+	/// This value will be negative for descenders below the baseline (which is typical).
+	///
+	/// \returns Returns font descender height in pixels.
+	float		getDescenderHeight() const;
+
+	/// \brief Get the global bounding box for this font.
+	///
+	/// The global bounding box is the rectangle inside of which all glyphs in the font can fit.
+    /// Glyphs are drawn starting from (0,0) in the returned box (though note that the box can
+    /// extend in any direction out from the origin).
+    ///
+	/// \returns Returns font descender height in pixels.
+    const ofRectangle & getGlyphBBox() const;
+
 	/// \brief Returns letter spacing of font object.
 	///
 	/// You can control this by the ofTrueTypeFont::setLetterSpacing() function. 1.0 = default spacing, 
@@ -214,6 +242,9 @@ protected:
 	vector <ofTTFCharacter> charOutlinesNonVFlipped;
 
 	float lineHeight;
+	float ascenderHeight;
+	float descenderHeight;
+	ofRectangle glyphBBox;
 	float letterSpacing;
 	float spaceSize;
 


### PR DESCRIPTION
These small patches add correct line-height detection, as well as support for retrieving the ascender, descender and glyph bounding box information from FreeType.

I've tested these with a range of fonts on my computer and have gotten useful results.

The addition of ascender/descender information makes it possible to position fonts correctly within a box.
