### PR TITLE
Critical compilation fix for windows not using GLFW. Fixes iOS/Android

### DIFF
--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -3,7 +3,9 @@
 #include "ofBaseApp.h"
 #include "ofUtils.h"
 #include "ofGraphics.h"
+#ifdef GLFW_INCLUDE_NONE
 #include "ofAppGLFWWindow.h"
+#endif
 #include <set>
 
 static const double MICROS_TO_SEC = .000001;
@@ -217,12 +219,16 @@ void ofNotifyKeyPressed(int key){
 	
 	
 	if (key == OF_KEY_ESC && bEscQuits == true){				// "escape"
+#ifdef GLFW_INCLUDE_NONE
         ofAppGLFWWindow *appGLFWWindow = dynamic_cast<ofAppGLFWWindow*>(ofGetWindowPtr());
         if (appGLFWWindow) {
             glfwSetWindowShouldClose(appGLFWWindow->getGLFWWindow(), true);
         }else{
             exitApp();
         }
+#else 
+        exitApp();
+#endif
     }
 	
 	


### PR DESCRIPTION
Fixes #2894 which breaks iOS / Android in my tests.

iOS Build error:
ofAppGLFWWindow.h : Line 10.
`openFrameworks/libs/openFrameworks/app/ofAppGLFWWindow.h:10:10: 'GLFW/glfw3.h' file not found`

Android throws similar error however focused on ofEvent.cpp

Problem caused by:
https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/events/ofEvents.cpp#L6
And 
https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/events/ofEvents.cpp#L219-225

-Wrapped functions that are related to GLFW in the preprocessor defined
in it when used for ofEvents.cpp
