### PR TITLE
Use non-deprecated startThread() in ofOpenALSoundPlayer

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -880,7 +880,7 @@ void ofOpenALSoundPlayer::play(){
 	if(isStreaming){
 		setPosition(0);
 		stream_end = false;
-		startThread(true,false);
+		startThread(true);
 	}
 
 }


### PR DESCRIPTION
fixes #3029
