### PR TITLE
Add missing "case" for left alt key release in events example

### DIFF
--- a/examples/events/eventsExample/src/ofApp.cpp
+++ b/examples/events/eventsExample/src/ofApp.cpp
@@ -150,6 +150,9 @@ void ofApp::keyReleased(int key){
 			case OF_KEY_RIGHT_CONTROL:
 				sprintf(eventString, "keyReleased = (%i) %s", key, "RIGHT CONTROL");
 				break;
+			case OF_KEY_LEFT_ALT:
+				sprintf(eventString, "keyReleased = (%i) %s", key, "LEFT ALT");
+				break;
 			case OF_KEY_RIGHT_ALT:
 				sprintf(eventString, "keyReleased = (%i) %s", key, "RIGHT ALT");
 				break;


### PR DESCRIPTION
Was just testing the 0.8.2 RC and noticed the events example didn't show a "key released" message when releasing left alt. Turns out this is just because there's no "case" for it in the example, instead of it being a real bug :)
