### PR TITLE
Fixing minor Android project linking issues to ofxAndroid

### DIFF
--- a/libs/openFrameworks/.project
+++ b/libs/openFrameworks/.project
@@ -87,7 +87,7 @@
 		<link>
 			<name>ofxAndroid</name>
 			<type>2</type>
-			<location>/Users/welovecode/Documents/openFrameworks_git/addons/ofxAndroid</location>
+			<locationURI>$%7BPARENT-2-PROJECT_LOC%7D/addons/ofxAndroid</locationURI>
 		</link>
 		<link>
 			<name>project</name>


### PR DESCRIPTION
Fixes fixed path to relative path.

Issue:
`/Users/welovecode/Documents/openFrameworks_git/addons/ofxAndroid`
Change to :
`PARENT-2-PROJECT_LOC/addons/ofxAndroid`
Where `PARENT-2-PROJECT` == `../../`  (back 2 directories from the project directory)
