### PR TITLE
Added destroyPixels option to ofImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ CORE
 ### Graphics
 	/ ofImage: convert format when loading different image types
 	/ Fix ofSetupPerspective not using passed width and height
+	+ Added destroyPixels option to clean up pixel buffer memory after pixels are loaded into texture memory
 ### Math
 	/ fix ofQuaternion setOrientation and getEulerOrientation
 ### Utils

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -542,7 +542,8 @@ ofImage_<PixelType>::ofImage_(){
 	height						= 0;
 	bpp							= 0;
 	type						= OF_IMAGE_UNDEFINED;
-	bUseTexture					= true;		// the default is, yes, use a texture
+	bUseTexture			= true;		// the default is, yes, use a texture
+  bDestroyPixels  = false;  // By default, keep pixels around.
 
 	//----------------------- init free image if necessary
 	ofInitFreeImage();
@@ -553,11 +554,12 @@ ofImage_<PixelType>::ofImage_(){
 template<typename PixelType>
 ofImage_<PixelType>::ofImage_(const ofPixels_<PixelType> & pix){
 	width						= 0;
-	height						= 0;
+	height					= 0;
 	bpp							= 0;
 	type						= OF_IMAGE_UNDEFINED;
-	bUseTexture					= true;		// the default is, yes, use a texture
-
+	bUseTexture			= true;		// the default is, yes, use a texture
+  bDestroyPixels  = false;  // By default, keep pixels around.
+  
 	//----------------------- init free image if necessary
 	ofInitFreeImage();
 
@@ -568,10 +570,11 @@ ofImage_<PixelType>::ofImage_(const ofPixels_<PixelType> & pix){
 template<typename PixelType>
 ofImage_<PixelType>::ofImage_(const ofFile & file){
 	width						= 0;
-	height						= 0;
+	height					= 0;
 	bpp							= 0;
 	type						= OF_IMAGE_UNDEFINED;
-	bUseTexture					= true;		// the default is, yes, use a texture
+	bUseTexture			= true;		// the default is, yes, use a texture
+  bDestroyPixels  = false;  // By default, keep pixels around.
 
 	//----------------------- init free image if necessary
 	ofInitFreeImage();
@@ -583,10 +586,11 @@ ofImage_<PixelType>::ofImage_(const ofFile & file){
 template<typename PixelType>
 ofImage_<PixelType>::ofImage_(const string & filename){
 	width						= 0;
-	height						= 0;
+	height					= 0;
 	bpp							= 0;
 	type						= OF_IMAGE_UNDEFINED;
-	bUseTexture					= true;		// the default is, yes, use a texture
+	bUseTexture			= true;		// the default is, yes, use a texture
+  bDestroyPixels  = false;  // By default, keep pixels around.
 
 	//----------------------- init free image if necessary
 	ofInitFreeImage();
@@ -633,13 +637,13 @@ void ofImage_<PixelType>::reloadTexture(){
 
 //----------------------------------------------------------
 template<typename PixelType>
-bool ofImage_<PixelType>::loadImage(const ofFile & file){
-	return loadImage(file.getAbsolutePath());
+bool ofImage_<PixelType>::loadImage(const ofFile & file, bool destroyPixels){
+	return loadImage(file.getAbsolutePath(), destroyPixels);
 }
 
 //----------------------------------------------------------
 template<typename PixelType>
-bool ofImage_<PixelType>::loadImage(string fileName){
+bool ofImage_<PixelType>::loadImage(string fileName, bool destroyPixels){
 #if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
 	registerImage(this);
 #endif
@@ -655,12 +659,13 @@ bool ofImage_<PixelType>::loadImage(string fileName){
 			tex.setRGToRGBASwizzles(true);
 		}
 	}
+  bDestroyPixels = destroyPixels;
 	update();
 	return bLoadedOk;
 }
 
 template<typename PixelType>
-bool ofImage_<PixelType>::loadImage(const ofBuffer & buffer){
+bool ofImage_<PixelType>::loadImage(const ofBuffer & buffer, bool destroyPixels){
 #if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
 	registerImage(this);
 #endif
@@ -676,6 +681,7 @@ bool ofImage_<PixelType>::loadImage(const ofBuffer & buffer){
 			tex.setRGToRGBASwizzles(true);
 		}
 	}
+  bDestroyPixels = destroyPixels;
 	update();
 	return bLoadedOk;
 }
@@ -923,6 +929,14 @@ void ofImage_<PixelType>::update(){
 			}
 		}
 		tex.loadData(pixels);
+    
+    // Once pixels are loaded into texture memory, optionally
+    // destroy pixel data to free up memory.
+		if(bDestroyPixels) {
+			if (pixels.isAllocated()) {
+				pixels.clear();
+			}
+		}
 	}
 }
 

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -166,17 +166,17 @@ public:
     /// \brief Loads an image given by fileName.
     /// \param fileName Program looks for image given by fileName, relative to the data folder.
     /// \returns Returns true if image loaded correctly.
-    bool loadImage(string fileName);
+    bool loadImage(string fileName, bool destroyPixels=true);
     
     /// \brief Loads an image from an ofBuffer instance created by, for instance, ofFile::readToBuffer(). 
     ///
     /// This actually loads the image data into an ofPixels object and then into the texture.
-    bool loadImage(const ofBuffer & buffer);
+    bool loadImage(const ofBuffer & buffer, bool destroyPixels=true);
     
     /// \brief Loads an image from an ofFile instance created by, for instance, ofDirectory::getFiles().
     ///
     /// This actually loads the image data into an ofPixels object and then into the texture.
-    bool loadImage(const ofFile & file);
+    bool loadImage(const ofFile & file, bool destroyPixels=true);
     
     /// \brief Saves the image to the file path in fileName with the image quality specified by compressionLevel.
     /// \param fileName Saves image to this path, relative to the data folder.
@@ -489,8 +489,8 @@ protected:
 
     ofPixels_<PixelType> pixels;
     bool bUseTexture;
+    bool bDestroyPixels;  // Option to free up pixel buffer memory after pixels are loaded into texture memory.
     ofTexture tex;
-
 };
 
 typedef ofImage_<unsigned char> ofImage;


### PR DESCRIPTION
When you're loading lots of big images in your app, system memory gets eaten up very quickly by ofImage pixel data. In many situations, once the pixels are loaded into texture memory, the pixel data is no longer needed. 

So we've added in an optional flag (that defaults to false for backward compatibility) to free the pixel memory once the data has been loaded into texture memory. 

This code has been tested on OSX.  
