### PR TITLE
ofXML: Two locations where null pointers could be called.

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -288,6 +288,7 @@ bool ofXml::setToChild(int index)
             element = (Poco::XML::Element*) document->documentElement()->firstChild();
         } else {
             ofLogWarning("ofXml") << "setToChild(): no element created yet";
+            return false;
         }
     }
     
@@ -838,16 +839,22 @@ bool ofXml::setTo(const string& path)
             element = parent;
             return true;
             
-        } else {
+        } else if (parent) {
             
             string remainingPath = path.substr((count * 3), path.size() - (count * 3));
             
             element = (Poco::XML::Element*) parent->getNodeByPath(remainingPath);
+
              if(!element) {
                  element = prev;
                  ofLogWarning("ofXml") << "setCurrentElement(): passed invalid path \"" << remainingPath << "\"";
                  return false;
              }
+        }
+        else
+        {
+            ofLogWarning("ofXml") << "setCurrentElement(): parent is null.";
+            return false;
         }
     }  else if(path.find("//") != string::npos) {
         


### PR DESCRIPTION
Fixes #3049
