### PR TITLE
Remove linux-only guard in drag-drop implementation

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -4,6 +4,7 @@
 #include "ofBaseApp.h"
 #include "ofGLProgrammableRenderer.h"
 #include "ofAppRunner.h"
+#include "Poco/URI.h"
 
 #ifdef TARGET_LINUX
 	#include "ofIcon.h"
@@ -16,7 +17,6 @@
 	#endif
 	#include "GLFW/glfw3native.h"
 	#include <X11/Xatom.h>
-	#include "Poco/URI.h"
 #elif defined(TARGET_OSX)
 	#include <Cocoa/Cocoa.h>
 	#define GLFW_EXPOSE_NATIVE_COCOA
@@ -918,11 +918,9 @@ void ofAppGLFWWindow::drop_cb(GLFWwindow* windowP_, int numFiles, const char** d
 	ofDragInfo drag;
 	drag.position.set(ofGetMouseX(), ofGetMouseY());
 	drag.files.resize(numFiles);
-#ifdef TARGET_LINUX
 	for(int i=0; i<(int)drag.files.size(); i++){
 		drag.files[i] = Poco::URI(dropString[i]).getPath();
 	}
-#endif
 	ofNotifyDragEvent(drag);
 }
 


### PR DESCRIPTION
This commit:
- Takes out an `ifdef` that kept the important bits from actually happening on non-linux platforms
- Adds `Poco/URI.h` to the included files for all platforms

I _haven't_ tested this on windows, and I also don't know why there was an `ifdef` guard in the first place, so this could use a +1 from @arturoc at least :) (due to fe347fea16bf349544add7c028258e7fe3314cd0 )

Fixes #3059
