### PR TITLE
updated TARGET_OF_IPHONE guard to TARGET_OF_IOS

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -7,7 +7,7 @@
 #include "ofEvents.h"
 #include "ofThread.h"
 
-#if defined (TARGET_OF_IPHONE) || defined (TARGET_OSX)
+#if defined (TARGET_OF_IOS) || defined (TARGET_OSX)
 #include <OpenAL/al.h>
 #include <OpenAL/alc.h>
 #else


### PR DESCRIPTION
ofOpenALSoundPlayer was still using TARGET_OF_IOS guard which is deprecated,
have updated to TARGET_OF_IOS.
