### PR TITLE
added getter for type long 

### DIFF
--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -180,6 +180,16 @@ string ofxXmlSettings::getValue(const string& tag, const string& defaultValue, i
 }
 
 //---------------------------------------------------------
+long long ofxXmlSettings::getValue(const string& tag, long long defaultValue, int which){
+    TiXmlHandle valHandle(NULL);
+	if (readTag(tag, valHandle, which)){
+		string longStr = valHandle.ToText()->ValueStr();
+		return atoll(longStr.c_str());
+	}
+	return defaultValue;
+}
+
+//---------------------------------------------------------
 bool ofxXmlSettings::readTag(const string&  tag, TiXmlHandle& valHandle, int which){
 
 	vector<string> tokens = tokenize(tag,":");

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -73,6 +73,7 @@ class ofxXmlSettings: public ofBaseFileSerializer{
 		int 	getValue(const string&  tag, int            defaultValue, int which = 0);
 		double 	getValue(const string&  tag, double         defaultValue, int which = 0);
 		string 	getValue(const string&  tag, const string& 	defaultValue, int which = 0);
+		long long 	getValue(const string&  tag, long long  defaultValue, int which = 0);
 
 		int 	setValue(const string&  tag, int            value, int which = 0);
 		int 	setValue(const string&  tag, double         value, int which = 0);

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -73,7 +73,7 @@ class ofxXmlSettings: public ofBaseFileSerializer{
 		int 	getValue(const string&  tag, int            defaultValue, int which = 0);
 		double 	getValue(const string&  tag, double         defaultValue, int which = 0);
 		string 	getValue(const string&  tag, const string& 	defaultValue, int which = 0);
-		long long 	getValue(const string&  tag, long long  defaultValue, int which = 0);
+		long long getValue(const string&  tag, long long 	defaultValue, int which = 0);
 
 		int 	setValue(const string&  tag, int            value, int which = 0);
 		int 	setValue(const string&  tag, double         value, int which = 0);


### PR DESCRIPTION
Added getter() for type long long (long is rarely bigger than int on current architecture).

This way you can grab values > 2.147.483.647 from XML files. For example OpenStreetMaps node IDs.  