### PR TITLE
Missing include in codeblocks template.

### DIFF
--- a/scripts/win_cb/template/emptyExample.cbp
+++ b/scripts/win_cb/template/emptyExample.cbp
@@ -67,6 +67,7 @@
 			<Add directory="..\..\..\libs\openFrameworks\video" />
 			<Add directory="..\..\..\libs\poco\include" />
 			<Add directory="..\..\..\libs\tess2\include" />
+			<Add directory="..\..\..\libs\openssl\include" />
 			<Add directory="..\..\..\libs\cairo\include\cairo" />
 		</Compiler>
 		<Linker>


### PR DESCRIPTION
This include is not missing in the openFrameworks library cbp, but it is
missing in the projects cbp.
