### PR TITLE
Added support for mouse wheel scroll. 

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -910,7 +910,7 @@ void ofAppGLFWWindow::motion_cb(GLFWwindow* windowP_, double x, double y) {
 
 //------------------------------------------------------------
 void ofAppGLFWWindow::scroll_cb(GLFWwindow* windowP_, double x, double y) {
-	//TODO: implement scroll events
+	ofNotifyMouseScrolled(x, y);
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -136,6 +136,7 @@ void ofRunApp(ofBaseApp * OFSA){
     ofAddListener(ofEvents().mouseDragged,OFSAptr.get(),&ofBaseApp::mouseDragged,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().mousePressed,OFSAptr.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().mouseReleased,OFSAptr.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
+    ofAddListener(ofEvents().mouseScrolled,OFSAptr.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().windowEntered,OFSAptr.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().windowResized,OFSAptr.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().messageEvent,OFSAptr.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
@@ -324,6 +325,7 @@ void ofExitCallback(){
     ofRemoveListener(ofEvents().mouseDragged,OFSAptr.get(),&ofBaseApp::mouseDragged,OF_EVENT_ORDER_APP);
     ofRemoveListener(ofEvents().mousePressed,OFSAptr.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
     ofRemoveListener(ofEvents().mouseReleased,OFSAptr.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
+    ofRemoveListener(ofEvents().mouseScrolled,OFSAptr.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
     ofRemoveListener(ofEvents().windowResized,OFSAptr.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
     ofRemoveListener(ofEvents().windowEntered,OFSAptr.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
     ofRemoveListener(ofEvents().messageEvent,OFSAptr.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
@@ -392,6 +394,7 @@ void ofRunApp(shared_ptr<ofBaseApp> OFSA){
     ofAddListener(ofEvents().mouseDragged,OFSA.get(),&ofBaseApp::mouseDragged,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().mousePressed,OFSA.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().mouseReleased,OFSA.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
+    ofAddListener(ofEvents().mouseScrolled,OFSA.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().windowEntered,OFSA.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().windowResized,OFSA.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
     ofAddListener(ofEvents().messageEvent,OFSA.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -28,6 +28,7 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void mouseDragged( int x, int y, int button ){}
 		virtual void mousePressed( int x, int y, int button ){}
 		virtual void mouseReleased(int x, int y, int button ){}
+		virtual void mouseScrolled(float x, float y ){}
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }
 		virtual void gotMessage(ofMessage msg){ }
@@ -79,6 +80,9 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 			mouseX=mouse.x;
 			mouseY=mouse.y;
 			mouseReleased(mouse.x,mouse.y,mouse.button);
+		}
+		virtual void mouseScrolled(ofMouseEventArgs & mouse){
+			mouseScrolled(mouse.x,mouse.y);
 		}
 		virtual void windowEntry(ofEntryEventArgs & entry){
 			windowEntry(entry.state);

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -285,6 +285,8 @@ void ofNotifyMouseEvent(const ofMouseEventArgs & mouseEvent){
 			break;
 		case ofMouseEventArgs::Released:
 			ofNotifyMouseReleased(mouseEvent.x,mouseEvent.y,mouseEvent.button);
+		case ofMouseEventArgs::Scrolled:
+			ofNotifyMouseScrolled(mouseEvent.x,mouseEvent.y);
 			break;
 		
 	}
@@ -380,6 +382,15 @@ void ofNotifyMouseMoved(int x, int y){
 	mouseEventArgs.y = y;
     mouseEventArgs.type = ofMouseEventArgs::Moved;
 	ofNotifyEvent( ofEvents().mouseMoved, mouseEventArgs );
+}
+
+void ofNotifyMouseScrolled(float x, float y){
+	static ofMouseEventArgs mouseEventArgs;
+	
+	mouseEventArgs.x = x;
+	mouseEventArgs.y = y;
+    mouseEventArgs.type = ofMouseEventArgs::Scrolled;
+	ofNotifyEvent( ofEvents().mouseScrolled, mouseEventArgs );
 }
 
 //------------------------------------------

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -53,7 +53,8 @@ class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
 		Pressed,
 		Moved,
 		Released,
-		Dragged
+		Dragged,
+		Scrolled
 	} type;
 	int button;
 };
@@ -118,6 +119,7 @@ class ofCoreEvents {
 	ofEvent<ofMouseEventArgs> 	mouseDragged;
 	ofEvent<ofMouseEventArgs> 	mousePressed;
 	ofEvent<ofMouseEventArgs> 	mouseReleased;
+	ofEvent<ofMouseEventArgs> 	mouseScrolled;
 
 	ofEvent<ofAudioEventArgs> 	audioReceived;
 	ofEvent<ofAudioEventArgs> 	audioRequested;
@@ -142,6 +144,7 @@ class ofCoreEvents {
 		mouseReleased.disable();
 		mousePressed.disable();
 		mouseMoved.disable();
+		mouseScrolled.disable();
 		audioReceived.disable();
 		audioRequested.disable();
 		touchDown.disable();
@@ -164,6 +167,7 @@ class ofCoreEvents {
 		mouseReleased.enable();
 		mousePressed.enable();
 		mouseMoved.enable();
+		mouseScrolled.enable();
 		audioReceived.enable();
 		audioRequested.enable();
 		touchDown.enable();
@@ -187,6 +191,7 @@ void ofRegisterMouseEvents(ListenerClass * listener, int prio=OF_EVENT_ORDER_AFT
 	ofAddListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved,prio);
 	ofAddListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed,prio);
 	ofAddListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased,prio);
+	ofAddListener(ofEvents().mouseScrolled,listener,&ListenerClass::mouseReleased,prio);
 }
 
 template<class ListenerClass>
@@ -220,6 +225,7 @@ void ofUnregisterMouseEvents(ListenerClass * listener, int prio=OF_EVENT_ORDER_A
 	ofRemoveListener(ofEvents().mouseMoved,listener,&ListenerClass::mouseMoved,prio);
 	ofRemoveListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed,prio);
 	ofRemoveListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased,prio);
+	ofRemoveListener(ofEvents().mouseScrolled,listener,&ListenerClass::mouseReleased,prio);
 }
 
 template<class ListenerClass>
@@ -260,6 +266,7 @@ void ofNotifyMousePressed(int x, int y, int button);
 void ofNotifyMouseReleased(int x, int y, int button);
 void ofNotifyMouseDragged(int x, int y, int button);
 void ofNotifyMouseMoved(int x, int y);
+void ofNotifyMouseScrolled(float x, float y);
 void ofNotifyMouseEvent(const ofMouseEventArgs & mouseEvent);
 
 void ofNotifyExit();


### PR DESCRIPTION
Implements scroll wheel functionality in GLFW. Seems a bit too straight forward, not sure why this wasn't already in master.

__Only tested on OS X 10.10__

This enables the following:
```c++
void ofApp::mouseScrolled(float x, float y)
{
	ofLog() << "Scroll " << x << "x" << y << endl;
}
```