### PR TITLE
fixes ofSerial::writeBytes on unix which fixes firmata sendPWM and servo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ OF 0.9.0
 
 CORE
 ----
+### communication
+	/ fixes for ofSerial::writeBytes which fixes firmata's PWM and servo
+
 ### gl
 	+ Programmable lights and materials
 	+ New area light type on programmable renderer
 	+ Separate model matrix
 	+ ofGetCurrentNormalMatrix
 	+ ofSetOpenGL(ES)Version, allows to set any specific GL version
+	/ ofVboMesh: update vbo before returning reference
 
 ### graphics
 	+ ofTruetypeFont: kerning and better hinting and spacing

--- a/examples/communication/firmataExample/src/ofApp.cpp
+++ b/examples/communication/firmataExample/src/ofApp.cpp
@@ -7,8 +7,8 @@
  * The Arduio FIO and Arduino Mini should also work.
  * The Arduino MEGA and other variants based on microcontrollers
  * other than the ATMega168 and ATMega328 are not currently supported.
- * 
- * To use this example, open Arduino (preferably Arduino 1.0) and 
+ *
+ * To use this example, open Arduino (preferably Arduino 1.0) and
  * navigate to File -> Examples -> Firmata and open StandardFirmata.
  * Compile and upload StandardFirmata for your board, then close
  * the Arduino application and run this application.
@@ -32,7 +32,7 @@ void ofApp::setup(){
 	ofSetFrameRate(60);
 
 	ofBackground(255,0,130);
-    
+
     buttonState = "digital pin:";
     potValue = "analog pin:";
 
@@ -43,8 +43,8 @@ void ofApp::setup(){
     // replace the string below with the serial port for your Arduino board
     // you can get this from the Arduino application or via command line
     // for OSX, in your terminal type "ls /dev/tty.*" to get a list of serial devices
-	ard.connect("/dev/tty.usbmodemfd121", 57600);
-	
+	ard.connect("/dev/ttyACM3", 57600);
+
 	// listen for EInitialized notification. this indicates that
 	// the arduino is ready to receive commands and it is safe to
 	// call setupArduino()
@@ -61,29 +61,29 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::setupArduino(const int & version) {
-	
+
 	// remove listener because we don't need it anymore
 	ofRemoveListener(ard.EInitialized, this, &ofApp::setupArduino);
-    
+
     // it is now safe to send commands to the Arduino
     bSetupArduino = true;
-    
+
     // print firmware name and version to the console
-    ofLogNotice() << ard.getFirmwareName(); 
+    ofLogNotice() << ard.getFirmwareName();
     ofLogNotice() << "firmata v" << ard.getMajorFirmwareVersion() << "." << ard.getMinorFirmwareVersion();
-        
+
     // Note: pins A0 - A5 can be used as digital input and output.
     // Refer to them as pins 14 - 19 if using StandardFirmata from Arduino 1.0.
     // If using Arduino 0022 or older, then use 16 - 21.
     // Firmata pin numbering changed in version 2.3 (which is included in Arduino 1.0)
-    
+
     // set pins D2 and A5 to digital input
     ard.sendDigitalPinMode(2, ARD_INPUT);
     ard.sendDigitalPinMode(19, ARD_INPUT);  // pin 21 if using StandardFirmata from Arduino 0022 or older
 
     // set pin A0 to analog input
     ard.sendAnalogPinReporting(0, ARD_ANALOG);
-    
+
     // set pin D13 as digital output
 	ard.sendDigitalPinMode(13, ARD_OUTPUT);
     // set pin A4 as digital output
@@ -91,14 +91,14 @@ void ofApp::setupArduino(const int & version) {
 
     // set pin D11 as PWM (analog output)
 	ard.sendDigitalPinMode(11, ARD_PWM);
-    
+
     // attach a servo to pin D9
     // servo motors can only be attached to pin D3, D5, D6, D9, D10, or D11
     ard.sendServoAttach(9);
-	
+
     // Listen for changes on the digital and analog pins
     ofAddListener(ard.EDigitalPinChanged, this, &ofApp::digitalPinChanged);
-    ofAddListener(ard.EAnalogPinChanged, this, &ofApp::analogPinChanged);    
+    ofAddListener(ard.EAnalogPinChanged, this, &ofApp::analogPinChanged);
 }
 
 //--------------------------------------------------------------
@@ -107,12 +107,18 @@ void ofApp::updateArduino(){
 	// update the arduino, get any data or messages.
     // the call to ard.update() is required
 	ard.update();
-	
+
 	// do not send anything until the arduino has been set up
 	if (bSetupArduino) {
         // fade the led connected to pin D11
-		ard.sendPwm(11, (int)(128 + 128 * sin(ofGetElapsedTimef())));   // pwm...
+		if(!ard.sendPwm(11, (int)(128 + 128 * sin(ofGetElapsedTimef())), true)){
+			ofLogError() << "couldn't send pwm";   // pwm...
+		}
 	}
+
+
+    float alpha = 0.1;
+    smoothedAnalog0 = smoothedAnalog0 * (1.0-alpha) + newAnalog0 * alpha;
 
 }
 
@@ -133,55 +139,46 @@ void ofApp::digitalPinChanged(const int & pinNum) {
 void ofApp::analogPinChanged(const int & pinNum) {
     // do something with the analog input. here we're simply going to print the pin number and
     // value to the screen each time it changes
-    potValue = "analog pin: " + ofToString(pinNum) + " = " + ofToString(ard.getAnalog(pinNum));
+    newAnalog0 = ard.getAnalog(0);
+    potValue = "analog pin: " + ofToString(pinNum) + " = " + ofToString(newAnalog0);
 }
 
 
 //--------------------------------------------------------------
 void ofApp::draw(){
 	bgImage.draw(0,0);
-    
+
+
     ofEnableAlphaBlending();
     ofSetColor(0, 0, 0, 127);
     ofRect(510, 15, 275, 150);
     ofDisableAlphaBlending();
-    
+
     ofSetColor(255, 255, 255);
 	if (!bSetupArduino){
 		font.drawString("arduino not ready...\n", 515, 40);
 	} else {
 		font.drawString(potValue + "\n" + buttonState +
 						"\nsending pwm: " + ofToString((int)(128 + 128 * sin(ofGetElapsedTimef()))), 515, 40);
-        
+
         ofSetColor(64, 64, 64);
-        smallFont.drawString("If a servo is attached, use the left arrow key to rotate " 
-                             "\ncounterclockwise and the right arrow key to rotate clockwise.", 200, 550);
+        smallFont.drawString("If a servo is attached, drag mouse left and right to rotate it.", 200, 550);
         ofSetColor(255, 255, 255);
 
 	}
+
+    ofSetColor(255,0,0);
+	ofRect(ofGetWidth() - 80, ofGetHeight()-40, 30, -ofMap(smoothedAnalog0,0,1024,0,200));
+	ofSetColor(255);
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed  (int key){
-    switch (key) {
-        case OF_KEY_RIGHT:
-            // rotate servo head to 180 degrees
-            ard.sendServo(9, 180, false);
-            ard.sendDigital(18, ARD_HIGH);  // pin 20 if using StandardFirmata from Arduino 0022 or older
-            break;
-        case OF_KEY_LEFT:
-            // rotate servo head to 0 degrees
-            ard.sendServo(9, 0, false);
-            ard.sendDigital(18, ARD_LOW);  // pin 20 if using StandardFirmata from Arduino 0022 or older
-            break;
-        default:
-            break;
-    }
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
-
 }
 
 //--------------------------------------------------------------
@@ -191,6 +188,7 @@ void ofApp::mouseMoved(int x, int y ){
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
+	ard.sendServo(9, x/float(ofGetWidth())*180, false);
 
 }
 
@@ -217,6 +215,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/communication/firmataExample/src/ofApp.h
+++ b/examples/communication/firmataExample/src/ofApp.h
@@ -3,7 +3,6 @@
 #include "ofMain.h"
 #include "ofEvents.h"
 
-
 class ofApp : public ofBaseApp{
 
 public:
@@ -28,16 +27,17 @@ public:
     ofTrueTypeFont      smallFont;
 	ofArduino	ard;
 	bool		bSetupArduino;			// flag variable for setting up arduino once
-    
+	int 		servoAngle;
 private:
-    
+
     void setupArduino(const int & version);
     void digitalPinChanged(const int & pinNum);
     void analogPinChanged(const int & pinNum);
 	void updateArduino();
-    
+
     string buttonState;
     string potValue;
+    float newAnalog0, smoothedAnalog0;
 
 };
 

--- a/examples/communication/serialExample/src/ofApp.cpp
+++ b/examples/communication/serialExample/src/ofApp.cpp
@@ -25,7 +25,6 @@ void ofApp::setup(){
 	nTimesRead = 0;
 	nBytesRead = 0;
 	readTime = 0;
-	memset(bytesReadString, 0, 4);
 }
 
 //--------------------------------------------------------------
@@ -48,17 +47,11 @@ void ofApp::update(){
 		nBytesRead = 0;
 		int nRead  = 0;  // a temp variable to keep count per read
 
-		unsigned char bytesReturned[4];
 
-		memset(bytesReadString, 0, 4);
-		memset(bytesReturned, 0, 3);
-
-		while( (nRead = serial.readBytes( bytesReturned, 3)) > 0){
+		while( (nRead = serial.readBytes(bytesReadString, 3)) > 0){
 			nTimesRead++;
 			nBytesRead = nRead;
 		};
-
-		memcpy(bytesReadString, bytesReturned, 3);
 
 		bSendSerialMessage = false;
 		readTime = ofGetElapsedTimef();
@@ -76,7 +69,7 @@ void ofApp::draw(){
 	msg += "click to test serial:\n";
 	msg += "nBytes read " + ofToString(nBytesRead) + "\n";
 	msg += "nTimes read " + ofToString(nTimesRead) + "\n";
-	msg += "read: " + ofToString(bytesReadString) + "\n";
+	msg += "read: " + bytesReadString.getText() + "\n";
 	msg += "(at time " + ofToString(readTime, 3) + ")";
 	font.drawString(msg, 50, 100);
 }

--- a/examples/communication/serialExample/src/ofApp.cpp
+++ b/examples/communication/serialExample/src/ofApp.cpp
@@ -17,7 +17,7 @@ void ofApp::setup(){
 	// (ie, COM4 on a pc, /dev/tty.... on linux, /dev/tty... on a mac)
 	// arduino users check in arduino app....
 	int baud = 9600;
-	serial.setup("/dev/ttyACM3", baud); //open the first device
+	serial.setup(0, baud); //open the first device
 	//serial.setup("COM4", baud); // windows example
 	//serial.setup("/dev/tty.usbserial-A4001JEC", baud); // mac osx example
 	//serial.setup("/dev/ttyUSB0", baud); //linux example
@@ -48,17 +48,17 @@ void ofApp::update(){
 		nBytesRead = 0;
 		int nRead  = 0;  // a temp variable to keep count per read
 
-		unsigned char bytesReturned[6];
+		unsigned char bytesReturned[4];
 
-		memset(bytesReadString, 0, 7);
-		memset(bytesReturned, 0, 6);
+		memset(bytesReadString, 0, 4);
+		memset(bytesReturned, 0, 3);
 
-		while( (nRead = serial.readBytes( bytesReturned, 6)) > 0){
+		while( (nRead = serial.readBytes( bytesReturned, 3)) > 0){
 			nTimesRead++;
 			nBytesRead = nRead;
 		};
 
-		memcpy(bytesReadString, bytesReturned, 6);
+		memcpy(bytesReadString, bytesReturned, 3);
 
 		bSendSerialMessage = false;
 		readTime = ofGetElapsedTimef();

--- a/examples/communication/serialExample/src/ofApp.cpp
+++ b/examples/communication/serialExample/src/ofApp.cpp
@@ -3,25 +3,25 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofSetVerticalSync(true);
-	
+
 	bSendSerialMessage = false;
-	ofBackground(255);	
+	ofBackground(255);
 	ofSetLogLevel(OF_LOG_VERBOSE);
-	
+
 	font.loadFont("DIN.otf", 64);
-	
+
 	serial.listDevices();
 	vector <ofSerialDeviceInfo> deviceList = serial.getDeviceList();
-	
+
 	// this should be set to whatever com port your serial device is connected to.
 	// (ie, COM4 on a pc, /dev/tty.... on linux, /dev/tty... on a mac)
 	// arduino users check in arduino app....
 	int baud = 9600;
-	serial.setup(0, baud); //open the first device
+	serial.setup("/dev/ttyACM3", baud); //open the first device
 	//serial.setup("COM4", baud); // windows example
 	//serial.setup("/dev/tty.usbserial-A4001JEC", baud); // mac osx example
 	//serial.setup("/dev/ttyUSB0", baud); //linux example
-	
+
 	nTimesRead = 0;
 	nBytesRead = 0;
 	readTime = 0;
@@ -30,36 +30,36 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::update(){
-	
+
 	if (bSendSerialMessage){
-		
+
 		// (1) write the letter "a" to serial:
 		serial.writeByte('a');
-		
+
 		// (2) read
 		// now we try to read 3 bytes
 		// since we might not get them all the time 3 - but sometimes 0, 6, or something else,
 		// we will try to read three bytes, as much as we can
 		// otherwise, we may have a "lag" if we don't read fast enough
-		// or just read three every time. now, we will be sure to 
+		// or just read three every time. now, we will be sure to
 		// read as much as we can in groups of three...
-		
+
 		nTimesRead = 0;
 		nBytesRead = 0;
 		int nRead  = 0;  // a temp variable to keep count per read
-		
-		unsigned char bytesReturned[3];
-		
-		memset(bytesReadString, 0, 4);
-		memset(bytesReturned, 0, 3);
-		
-		while( (nRead = serial.readBytes( bytesReturned, 3)) > 0){
-			nTimesRead++;	
+
+		unsigned char bytesReturned[6];
+
+		memset(bytesReadString, 0, 7);
+		memset(bytesReturned, 0, 6);
+
+		while( (nRead = serial.readBytes( bytesReturned, 6)) > 0){
+			nTimesRead++;
 			nBytesRead = nRead;
 		};
-		
-		memcpy(bytesReadString, bytesReturned, 3);
-		
+
+		memcpy(bytesReadString, bytesReturned, 6);
+
 		bSendSerialMessage = false;
 		readTime = ofGetElapsedTimef();
 	}
@@ -82,23 +82,23 @@ void ofApp::draw(){
 }
 
 //--------------------------------------------------------------
-void ofApp::keyPressed  (int key){ 
-	
+void ofApp::keyPressed  (int key){
+
 }
 
 //--------------------------------------------------------------
-void ofApp::keyReleased(int key){ 
-	
+void ofApp::keyReleased(int key){
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -108,21 +108,21 @@ void ofApp::mousePressed(int x, int y, int button){
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
-	
+void ofApp::dragEvent(ofDragInfo dragInfo){
+
 }
 

--- a/examples/communication/serialExample/src/ofApp.h
+++ b/examples/communication/serialExample/src/ofApp.h
@@ -22,8 +22,8 @@ class ofApp : public ofBaseApp{
 		ofTrueTypeFont		font;
 
 		bool		bSendSerialMessage;			// a flag for sending serial
-		char		bytesRead[3];				// data from serial, we will be trying to read 3
-		char		bytesReadString[4];			// a string needs a null terminator, so we need 3 + 1 bytes
+		ofBuffer	bytesRead;				// data from serial, we will be trying to read 3
+		ofBuffer	bytesReadString;			// a string needs a null terminator, so we need 3 + 1 bytes
 		int			nBytesRead;					// how much did we read?
 		int			nTimesRead;					// how many times did we read?
 		float		readTime;					// when did we last read?				

--- a/libs/openFrameworks/communication/ofArduino.h
+++ b/libs/openFrameworks/communication/ofArduino.h
@@ -90,16 +90,19 @@
 #define ARD_TOTAL_DIGITAL_PINS							22 // total number of pins currently supported
 #define ARD_TOTAL_ANALOG_PINS							6
 #define ARD_TOTAL_PORTS                                 3 // total number of ports for the board
+
 // pin modes
-#define ARD_INPUT                                       0x00
-#define ARD_OUTPUT                                      0x01
-#define ARD_ANALOG                                      0x02 // analog pin in analogInput mode
-#define ARD_PWM                                         0x03 // digital pin in PWM output mode
-#define ARD_SERVO                                       0x04 // digital pin in Servo output mode
-#define ARD_HIGH                                        1
-#define ARD_LOW                                         0
-#define ARD_ON                                          1
-#define ARD_OFF                                         0
+enum ofFirmataPinModes{
+	ARD_INPUT = 0x00,
+	ARD_OUTPUT = 0x01,
+	ARD_ANALOG = 0x02, // analog pin in analogInput mode
+	ARD_PWM = 0x03, // digital pin in PWM output mode
+	ARD_SERVO = 0x04, // digital pin in Servo output mode
+	ARD_HIGH = 1,
+	ARD_LOW = 0,
+	ARD_ON = 1,
+	ARD_OFF = 0
+};
 
 /*
  #if defined(__AVR_ATmega168__)  // Arduino NG and Diecimila
@@ -192,7 +195,7 @@ class ofArduino{
 				// the pins mode has to be set to ARD_OUTPUT or ARD_INPUT (in the latter mode pull-up resistors are enabled/disabled)
 				// Note: pin 16-21 can also be used if analog inputs 0-5 are used as digital pins
 
-				void sendPwm(int pin, int value, bool force = false);
+				bool sendPwm(int pin, int value, bool force = false);
 				// pin: 3, 5, 6, 9, 10 and 11
 				// value: 0 (always off) to 255 (always on).
 				// the pins mode has to be set to ARD_PWM
@@ -217,11 +220,11 @@ class ofArduino{
 				void sendSysExEnd();
 				// sends the FIRMATA_END_SYSEX command
 
-				void sendByte(unsigned char byte);
+				bool sendByte(unsigned char byte);
 				// sends a byte without wrapping it in a firmata message, data has to be in the 0-127 range,
 				// values > 127 will be interpreted as commands.
 
-				void sendValueAsTwo7bitBytes(int value);
+				bool sendValueAsTwo7bitBytes(int value);
 				// sends a value as two 7-bit bytes without wrapping it in a firmata message
 				// values in the range 0 - 16384 will be sent as two bytes within the 0-127 data range.
 

--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -561,6 +561,27 @@ bool ofSerial::writeByte(unsigned char singleByte){
 	writeBytes(&singleByte,1);
 }
 
+int ofSerial::readBytes(char * buffer, int length){
+	return readBytes((unsigned char*) buffer, length);
+}
+
+int ofSerial::writeBytes(char * buffer, int length){
+	return writeBytes((unsigned char*)buffer, length);
+}
+
+bool ofSerial::writeByte(char singleByte){
+	return writeByte((unsigned char)singleByte);
+}
+
+int ofSerial::readBytes(ofBuffer & buffer, int length){
+	buffer.allocate(length);
+	return readBytes(buffer.getBinaryBuffer(),length);
+}
+
+int ofSerial::writeBytes(ofBuffer & buffer){
+	return writeBytes(buffer.getBinaryBuffer(),buffer.size());
+}
+
 //----------------------------------------------------------------
 int ofSerial::readByte(){
 

--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -8,6 +8,10 @@
 	#include <dirent.h>
 #endif
 
+#ifdef TARGET_LINUX
+	#include <linux/serial.h>
+#endif
+
 
 #include <fcntl.h>
 #include <errno.h>
@@ -164,10 +168,7 @@ void ofSerial::buildDeviceList(){
 		prefixMatch.push_back("tty.");
 	#endif
 	#ifdef TARGET_LINUX
-		#ifdef TARGET_RASPBERRY_PI
-			prefixMatch.push_back("ttyACM");
-		#endif
-
+		prefixMatch.push_back("ttyACM");
 		prefixMatch.push_back("ttyS");
 		prefixMatch.push_back("ttyUSB");
 		prefixMatch.push_back("rfc");
@@ -372,6 +373,13 @@ bool ofSerial::setup(string portName, int baud){
 		options.c_oflag &= (tcflag_t) ~(OPOST);
 		options.c_cflag |= CS8;
 		tcsetattr(fd,TCSANOW,&options);
+		#ifdef TARGET_LINUX
+			struct serial_struct kernel_serial_settings;
+			if (ioctl(fd, TIOCGSERIAL, &kernel_serial_settings) == 0) {
+				kernel_serial_settings.flags |= ASYNC_LOW_LATENCY;
+				ioctl(fd, TIOCSSERIAL, &kernel_serial_settings);
+			}
+		#endif
 
 		bInited = true;
 		ofLogNotice("ofSerial") << "opened " << portName << " sucessfully @ " << baud << " bps";
@@ -468,17 +476,27 @@ int ofSerial::writeBytes(unsigned char * buffer, int length){
 
 	//---------------------------------------------
 	#if defined( TARGET_OSX ) || defined( TARGET_LINUX )
-	    int numWritten = write(fd, buffer, length);
-		if(numWritten <= 0){
-			if ( errno == EAGAIN )
-				return 0;
-			ofLogError("ofSerial") << "writeBytes(): couldn't write to port: " << errno << " " << strerror(errno);
-			return OF_SERIAL_ERROR;
+		int n, written=0;
+		fd_set wfds;
+		struct timeval tv;
+		while (written < length) {
+			n = write(fd, (const char *)buffer + written, length - written);
+			if (n < 0 && (errno == EAGAIN || errno == EINTR)) n = 0;
+			//printf("Write, n = %d\n", n);
+			if (n < 0) return OF_SERIAL_ERROR;
+			if (n > 0) {
+				written += n;
+			} else {
+				tv.tv_sec = 10;
+				tv.tv_usec = 0;
+				FD_ZERO(&wfds);
+				FD_SET(fd, &wfds);
+				n = select(fd+1, NULL, &wfds, NULL, &tv);
+				if (n < 0 && errno == EINTR) n = 1;
+				if (n <= 0) return OF_SERIAL_ERROR;
+			}
 		}
-
-		ofLogVerbose("ofSerial") << "wrote " << (int) numWritten << " bytes";
-
-	    return numWritten;
+		return written;
     #endif
     //---------------------------------------------
 
@@ -540,41 +558,7 @@ bool ofSerial::writeByte(unsigned char singleByte){
 		return false;
 	}
 
-	unsigned char tmpByte[1];
-	tmpByte[0] = singleByte;
-
-	//---------------------------------------------
-	#if defined( TARGET_OSX ) || defined( TARGET_LINUX )
-	    int numWritten = 0;
-	    numWritten = write(fd, tmpByte, 1);
-		if(numWritten <= 0 ){
-			if ( errno == EAGAIN )
-				return 0;
-			 ofLogError("ofSerial") << "writeByte(): couldn't write to port: " << errno << " " << strerror(errno);
-			 //return OF_SERIAL_ERROR; // this looks wrong.
-			 return false;
-		}
-		ofLogVerbose("ofSerial") << "wrote byte";
-
-		return (numWritten > 0 ? true : false);
-    #endif
-    //---------------------------------------------
-
-    //---------------------------------------------
-	#ifdef TARGET_WIN32
-		DWORD written = 0;
-		if(!WriteFile(hComm, tmpByte, 1, &written,0)){
-			 ofLogError("ofSerial") << "writeByte(): couldn't write to port";
-			 //return OF_SERIAL_ERROR; // this looks wrong.
-			 return false;
-		}
-
-		ofLogVerbose("ofSerial") << "wrote byte";
-
-		return ((int)written > 0 ? true : false);
-	#endif
-	//---------------------------------------------
-
+	writeBytes(&singleByte,1);
 }
 
 //----------------------------------------------------------------

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -2,6 +2,7 @@
 
 #include "ofConstants.h"
 #include "ofTypes.h"
+#include "ofFileUtils.h"
 
 #if defined( TARGET_OSX ) || defined( TARGET_LINUX ) || defined (TARGET_ANDROID)
 	#include <termios.h>
@@ -46,6 +47,11 @@ class ofSerial {
 			int 			readBytes(unsigned char * buffer, int length);
 			int 			writeBytes(unsigned char * buffer, int length);
 			bool			writeByte(unsigned char singleByte);
+			int 			readBytes(char * buffer, int length);
+			int 			writeBytes(char * buffer, int length);
+			bool			writeByte(char singleByte);
+			int 			readBytes(ofBuffer & buffer, int length);
+			int 			writeBytes(ofBuffer & buffer);
 			int             readByte();  // returns -1 on no read or error...
 			void			flush(bool flushIn = true, bool flushOut = true);
 			int				available();

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -116,8 +116,9 @@ void ofBuffer::clear(){
 
 //--------------------------------------------------
 void ofBuffer::allocate(long _size){
-	clear();
-	buffer.resize(_size);
+	buffer.resize(_size+1);
+	buffer.back() = 0;
+	nextLinePos = 0;
 }
 
 //--------------------------------------------------


### PR DESCRIPTION
fixes firmata's pwm and servo on unix by fixing ofSerial::writeBytes to call select on the port if no bytes were received and by looping till all bytes are sent

also simplifies and fixes the communication examples and adds some simple methods to use ofSerial with ofBuffer