### PR TITLE
notifyParameterChanged was not being called on ofParameter changing

### DIFF
--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -73,7 +73,9 @@ vector<string> ofAbstractParameter::getGroupHierarchyNames() const{
 
 
 void ofAbstractParameter::notifyParent(){
-	if(getParent()) getParent()->notifyParameterChanged(*this);
+	if(getParent()) {
+        getParent()->notifyParameterChanged(*this);
+    }
 }
 
 void ofAbstractParameter::setSerializable(bool serializable){

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -10,9 +10,10 @@ ofParameterGroup::ofParameterGroup()
 
 void ofParameterGroup::add(ofAbstractParameter & param){
 	shared_ptr<ofAbstractParameter> group = param.newReference();
+    group->setParent(this);
+	param.setParent(this);        
 	obj->parameters.push_back(group);
 	obj->parametersIndex[group->getEscapedName()] = obj->parameters.size()-1;
-	group->setParent(this);
 }
 
 void ofParameterGroup::clear(){


### PR DESCRIPTION
I noticed this when running the oscParametersReceiver and oscParametersSender examples in ofxGui. Basically they weren't syching, and the reason was that notifyParameterChanged() was not being called, because the parent (ofParamenterGroup) hadn't properly been assigned. This works, but I'm not sure if this is a regression, and whether calling setParent twice is necessary.
