### PR TITLE
Don't need to erase set as destructors are already called in ~ofOpenALSoundPlayer()

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -123,7 +123,6 @@ ofOpenALSoundPlayer::ofOpenALSoundPlayer(){
 ofOpenALSoundPlayer::~ofOpenALSoundPlayer(){
 	unloadSound();
 	kiss_fftr_free(fftCfg);
-	players.erase(this);
 }
 
 //---------------------------------------


### PR DESCRIPTION
Calling 

```
players.erase(this);
```

causes the pointer in question to be destroyed (deleted), so exiting the destructor of the ofOpenALSoundPlayer causes a segmentation fault.

As the ~ofOpenALSoundPlayer() is already being called, it's fine to let ~set() do the rest of the clean up.
