### PR TITLE
Make ofAppGLFWWindow instantiate the correct base class for GLES.

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -38,7 +38,13 @@ GLFWwindow* ofAppGLFWWindow::windowP = NULL;
 void ofGLReadyCallback();
 
 //-------------------------------------------------------
-ofAppGLFWWindow::ofAppGLFWWindow():ofAppBaseGLWindow(){
+ofAppGLFWWindow::ofAppGLFWWindow():
+#ifdef TARGET_OPENGLES
+ofAppBaseGLESWindow
+#else
+ofAppBaseGLWindow
+#endif
+{
 	bEnableSetupScreen	= true;
 	buttonInUse			= 0;
 	buttonPressed		= false;


### PR DESCRIPTION
This isn't a complete fix, but it reduces the number of errors on GLFW.

See also: https://github.com/openframeworks/openFrameworks/issues/3110
