### PR TITLE
Bugfix of3 d primitives resolutions

### DIFF
--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -525,7 +525,7 @@ void ofCylinderPrimitive::set(float _radius, float _height, int radiusSegments, 
     vertices[0][1] = resX * (resZ+1);
     
     // 1 -> cylinder //
-    if(bCapped) {
+    if( (bCapped && getResolution().z > 0) ) {
         strides[1][0] = strides[0][0] + strides[0][1];
         vertices[1][0] = vertices[0][0] + vertices[0][1];
     } else {
@@ -606,6 +606,12 @@ void ofCylinderPrimitive::setTopCapColor( ofColor color ) {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofCylinderPrimitive") << "setTopCapColor(): must be in triangle strip mode";
     }
+    
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofCylinderPrimitive") << "setTopCapColor(): cap resolution is set to 0 returning";
+        return;
+    }
+    
     getMesh().setColorForIndices( strides[0][0], strides[0][0]+strides[0][1], color );
 }
 
@@ -622,6 +628,12 @@ void ofCylinderPrimitive::setBottomCapColor( ofColor color ) {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofCylinderPrimitive") << "setBottomCapColor(): must be in triangle strip mode";
     }
+    
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofCylinderPrimitive") << "setBottomCapColor(): cap resolution is set to 0 returning";
+        return;
+    }
+    
     getMesh().setColorForIndices( strides[2][0], strides[2][0]+strides[2][1], color );
 }
 
@@ -636,6 +648,12 @@ ofMesh ofCylinderPrimitive::getTopCapMesh() {
         ofLogWarning("ofCylinderPrimitive") << "getTopCapMesh(): must be in triangle strip mode";
         return ofMesh();
     }
+    
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofCylinderPrimitive") << "getTopCapMesh(): cap resolution is set to 0 returning empty mesh";
+        return ofMesh();
+    }
+    
     return getMesh().getMeshForIndices( strides[0][0], strides[0][0]+strides[0][1],
                              vertices[0][0], vertices[0][0]+vertices[0][1] );
 }
@@ -670,6 +688,10 @@ vector<ofIndexType> ofCylinderPrimitive::getBottomCapIndices() {
 ofMesh ofCylinderPrimitive::getBottomCapMesh() {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofCylinderPrimitive") << "getBottomCapMesh(): must be in triangle strip mode";
+        return ofMesh();
+    }
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofCylinderPrimitive") << "getBottomCapMesh(): cap resolution is set to 0 returning empty mesh";
         return ofMesh();
     }
     return getMesh().getMeshForIndices( strides[2][0], strides[2][0]+strides[2][1],
@@ -824,6 +846,10 @@ void ofConePrimitive::setCapColor( ofColor color ) {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofConePrimitive") << "setCapColor(): must be in triangle strip mode";
     }
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofConePrimitive") << "setCapColor(): cap resolution is set to 0";
+        return;
+    }
     getMesh().setColorForIndices( strides[1][0], strides[1][0]+strides[1][1], color );
 }
 
@@ -866,6 +892,11 @@ ofMesh ofConePrimitive::getCapMesh() {
     int endVertIndex    = startVertIndex + vertices[1][1];
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofConePrimitive") << "getCapMesh(): must be in triangle strip mode";
+        return ofMesh();
+    }
+    
+    if( getResolution().z == 0 ) {
+        ofLogWarning("ofConePrimitive") << "getCapMesh(): cap resolution is set to 0 returning empty mesh";
         return ofMesh();
     }
     

--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -869,8 +869,6 @@ ofMesh ofConePrimitive::getCapMesh() {
         return ofMesh();
     }
     
-//    getMesh().setColorForIndices( strides[1][0], strides[1][0]+strides[1][1], color );
-    
     return getMesh().getMeshForIndices( startIndex, endIndex, startVertIndex, endVertIndex );
 }
 

--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -508,9 +508,9 @@ void ofCylinderPrimitive::set(float _radius, float _height, int radiusSegments, 
     bCapped = _bCapped;
     resolution.set( radiusSegments, heightSegments, capSegments );
     
-    int resX = getResolution().x;
-    int resY = getResolution().y-1;
-    int resZ = getResolution().z-1;
+    int resX = getResolution().x+1;
+    int resY = getResolution().y;
+    int resZ = getResolution().z;
     
     int indexStep = 2;
     if(mode == OF_PRIMITIVE_TRIANGLES) {
@@ -520,9 +520,9 @@ void ofCylinderPrimitive::set(float _radius, float _height, int radiusSegments, 
     
     // 0 -> top cap
     strides[0][0] = 0;
-    strides[0][1] = resX * resZ * indexStep;
+    strides[0][1] = resX * (resZ) * indexStep;
     vertices[0][0] = 0;
-    vertices[0][1] = getResolution().x * getResolution().z;
+    vertices[0][1] = resX * (resZ+1);
     
     // 1 -> cylinder //
     if(bCapped) {
@@ -533,13 +533,13 @@ void ofCylinderPrimitive::set(float _radius, float _height, int radiusSegments, 
         vertices[1][0] = 0;
     }
     strides[1][1] = resX * resY * indexStep;
-    vertices[1][1] = getResolution().x * getResolution().y;
+    vertices[1][1] = resX * (resY+1);
     
     // 2 -> bottom cap
     strides[2][0] = strides[1][0] + strides[1][1];
     strides[2][1] = resX * resZ * indexStep;
     vertices[2][0] = vertices[1][0]+vertices[1][1];
-    vertices[2][1] = getResolution().x * getResolution().z;
+    vertices[2][1] = resX * (resZ+1);
     
     
     getMesh() = ofMesh::cylinder( getRadius(), getHeight(), getResolution().x, getResolution().y, getResolution().z, getCapped(), mode );
@@ -738,8 +738,8 @@ void ofConePrimitive::set( float _radius, float _height, int radiusSegments, int
     resolution.set(radiusSegments, heightSegments, capSegments);
     
     int resX = getResolution().x;
-    int resY = getResolution().y-1;
-    int resZ = getResolution().z-1;
+    int resY = getResolution().y;
+    int resZ = getResolution().z;
     
     int indexStep = 2;
     if(mode == OF_PRIMITIVE_TRIANGLES) {
@@ -748,14 +748,15 @@ void ofConePrimitive::set( float _radius, float _height, int radiusSegments, int
     }
     
     strides[ 0 ][0] = 0;
-    strides[ 0 ][1] = (resX)*(resY) * indexStep;
+    strides[ 0 ][1] = (resX+1)*(resY) * indexStep;
     vertices[0][0] = 0;
-    vertices[0][1] = getResolution().x * getResolution().y;
+    vertices[0][1] = (resX+1) * (resY+1);
     
     strides[ 1 ][0] = strides[ 0 ][0] + strides[ 0 ][1];
-    strides[ 1 ][1] = (resX)*(resZ) * indexStep;
+    strides[ 1 ][1] = (resX)*(resZ) * indexStep + (resZ) * indexStep;
     vertices[1][0] = vertices[0][0] + vertices[0][1];
-    vertices[1][1] = getResolution().x * getResolution().z;
+    vertices[1][1] = (resX+1) * (resZ+1);
+    
     
     getMesh() = ofMesh::cone( getRadius(), getHeight(), getResolution().x, getResolution().y, getResolution().z, mode );
     
@@ -867,6 +868,9 @@ ofMesh ofConePrimitive::getCapMesh() {
         ofLogWarning("ofConePrimitive") << "getCapMesh(): must be in triangle strip mode";
         return ofMesh();
     }
+    
+//    getMesh().setColorForIndices( strides[1][0], strides[1][0]+strides[1][1], color );
+    
     return getMesh().getMeshForIndices( startIndex, endIndex, startVertIndex, endVertIndex );
 }
 
@@ -929,9 +933,9 @@ void ofBoxPrimitive::set( float width, float height, float depth, int resWidth, 
     
     resolution.set( resWidth, resHeight, resDepth );
     
-    int resX = getResolution().x;
-    int resY = getResolution().y;
-    int resZ = getResolution().z;
+    int resX = getResolution().x+1;
+    int resY = getResolution().y+1;
+    int resZ = getResolution().z+1;
     
     //FRONT, resY, resX
     strides[ SIDE_FRONT ][0] = 0;


### PR DESCRIPTION
Fixes #2941. And is in response to https://github.com/openframeworks/openFrameworks/pull/3093#issuecomment-49841874.

Recalculated the vertex and index strides for of3DPrimitives so the setColor and getMesh functions for ofConePrimitive, ofBoxPrimitive and ofCylinderPrimitive work as expected.

