### PR TITLE
incremented index in ofTrueTypeFont::getStringBoundingBox

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -956,11 +956,11 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(string c, float x, float y){
 		int cy = ((unsigned char)c[index]) - NUM_CHARACTER_TO_START;
  	    if (cy < nCharacters){ 			// full char set or not?
 	       if (c[index] == '\n') {
-				yoffset += lineHeight;
-				xoffset = 0 ; //reset X Pos back to zero
-				prevCy = -1;
-                index++;
-				continue;
+               yoffset += lineHeight;
+               xoffset = 0 ; //reset X Pos back to zero
+               prevCy = -1;
+               index++;
+               continue;
 	       }
 
 	       if(cy > -1){


### PR DESCRIPTION
Small fix in ofTrueTypeFont::getStringBoundingBox while loop, as mentioned here: https://github.com/openframeworks/openFrameworks/issues/2787
