### PR TITLE
WIP -- Feature of texture mipmap -- Don't merge yet!

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -13,6 +13,7 @@ static bool	bUsingArbTex		= true;
 static bool bUsingNormalizedTexCoords = false;
 static bool bUseCustomMinMagFilters = false;
 
+bool ofTexture::bShouldGenerateMipmaps = false;
 
 //---------------------------------
 void ofEnableTextureEdgeHack(){
@@ -44,6 +45,20 @@ void ofDisableNormalizedTexCoords(){
 	bUsingNormalizedTexCoords = false;
 }
 
+//---------------------------------
+void ofEnableTextureGenerateMipmaps(){
+	ofTexture::bShouldGenerateMipmaps = true;
+};
+
+//---------------------------------
+void ofDisableTextureGenerateMipmaps(){
+	ofTexture::bShouldGenerateMipmaps = false;
+};
+
+/// \brief Returns whether texture mipmaps are currently enabled.
+bool ofGetTextureGenerateMipmaps(){
+	return ofTexture::bShouldGenerateMipmaps;
+};
 
 
 //***** add global functions to override texture settings

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -184,6 +184,30 @@ void ofDisableTextureEdgeHack();
 /// \returns true if OF is currently using the "texture edge hack".
 bool ofIsTextureEdgeHackEnabled();
 
+/// \brief Enable mipmap generation for textures which support mipmaps.
+///
+/// Mipmaps will be generated on load. Note that by default, ofTexture
+/// will not auto-generate mipmaps.
+///
+/// \warning ofTexture uses GL_TEXTURE_RECTANGLE by default, which *does not*
+/// support mipmaps, therefore you need to call ofDisableArbTex() *before*
+/// calling ofEnableTextureGenerateMipmaps(). ofDisableArbTex() allows you
+/// to load textures as GL_TEXTURE_2D, a texture target which supports mipmaps.
+///
+/// \sa ofDisableArbTex()
+/// \sa ofDisableTextureGenerateMipmaps()
+/// \sa ofGetTextureGenerateMipmaps()
+void ofEnableTextureGenerateMipmaps();
+
+/// \brief Disable automatic texture mipmap generation
+/// No mipmaps will be auto-generated for textures loaded after this call.
+/// \sa ofEnableTextureGenerateMipmaps()
+void ofDisableTextureGenerateMipmaps();
+
+/// \brief Returns whether texture mipmap generation is currently enabled.
+/// \sa ofEnableTextureGenerateMipmaps()
+bool ofGetTextureGenerateMipmaps();
+
 /// \class ofTexture
 /// \brief An OpenGL image on the the graphics card.
 ///
@@ -630,4 +654,12 @@ protected:
 	ofPoint anchor;
 	bool bAnchorIsPct;
 	ofMesh quad;
+
+private:
+
+	static bool bShouldGenerateMipmaps; ///< whether ofTexture should generate mipmaps by default. Default == false.
+
+	friend bool ofGetTextureGenerateMipmaps();
+	friend void ofEnableTextureGenerateMipmaps();
+	friend void ofDisableTextureGenerateMipmaps();
 };


### PR DESCRIPTION
Adding mipmaps to ofTexture turned out a little more involved than i initially assumed, mostly because there are many things to consider when tinkering with ofTexture =)

I've chunked my edits into task-based clusters to make review a little bit easier, and elaborate a little more on topic in each individual commit.

I've got a couple of suggestions and questions i'd like to address before pushing forward: 
### Should we separate texture compression and texture mipmapping, since they are not related?

→ I'd favour separation, and i'd like to remove the tex-compression specific code from loadData() 
see:
https://github.com/tgfrerer/openFrameworks/blob/c9e13b053bb9a500667fbb2af3e80bc7142f3f1f/libs/openFrameworks/gl/ofTexture.cpp#L543
### Should we drop the glu based legacy mipmap generation?

→ I'd support removing this part, since it's the last hold-out for glu in our codebase, and XCode greets it with nasty deprecation messages, saying it won't be tolerating it for much longer.
see: https://github.com/tgfrerer/openFrameworks/blob/c9e13b053bb9a500667fbb2af3e80bc7142f3f1f/libs/openFrameworks/gl/ofTexture.cpp#L586
### Mipmaps need to be generated whenever texture data is loaded: Should we follow the example of ofEnableArbTex() and enable mipmap generation as an API state through e.g. ofEnableTextureGenerateMipmaps()?

→ I'm not sure about this, and would feel better not to introduce any more openFrameworks specific state, and add mipmap auto-generation as a member attribute.
