### PR TITLE
fix texData.tex_[ut] coordinate naming

### DIFF
--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -137,7 +137,7 @@ void of3dPrimitive::mapTexCoordsFromTexture( ofTexture& inTexture ) {
     
     ofTextureData& tdata = inTexture.getTextureData();
     if(bNormalized)
-        mapTexCoords( 0, 0, tdata.tex_t, tdata.tex_u );
+        mapTexCoords( 0, 0, tdata.tex_s, tdata.tex_t );
     else
         mapTexCoords(0, 0, inTexture.getWidth(), inTexture.getHeight());
     

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -320,8 +320,8 @@ void ofTexture::allocate(const ofTextureData & textureData, int glFormat, int pi
 	if( texData.textureTarget==GL_TEXTURE_RECTANGLE_ARB && ofGLSupportsNPOTTextures() ){
 		texData.tex_w = texData.width;
 		texData.tex_h = texData.height;
-		texData.tex_t = texData.width;
-		texData.tex_u = texData.height;
+		texData.tex_s = texData.width;
+		texData.tex_t = texData.height;
 	}else
 #endif
 	{
@@ -335,8 +335,8 @@ void ofTexture::allocate(const ofTextureData & textureData, int glFormat, int pi
 			texData.tex_h = ofNextPow2(texData.height);
 		}
 
-		texData.tex_t = texData.width / texData.tex_w;
-		texData.tex_u = texData.height / texData.tex_h;
+		texData.tex_s = texData.width / texData.tex_w;
+		texData.tex_t = texData.height / texData.tex_h;
 
 #ifndef TARGET_OPENGLES
 		if( texData.textureTarget==GL_TEXTURE_RECTANGLE_ARB ) texData.textureTarget = GL_TEXTURE_2D;
@@ -492,13 +492,13 @@ void ofTexture::loadData(const void * data, int w, int h, int glFormat, int glTy
 	// compute new tex co-ords based on the ratio of data's w, h to texture w,h;
 #ifndef TARGET_OPENGLES
 	if (texData.textureTarget == GL_TEXTURE_RECTANGLE_ARB){
-		texData.tex_t = w;
-		texData.tex_u = h;
+		texData.tex_s = w;
+		texData.tex_t = h;
 	} else 
 #endif
 	{
-		texData.tex_t = (float)(w) / (float)texData.tex_w;
-		texData.tex_u = (float)(h) / (float)texData.tex_h;
+		texData.tex_s = (float)(w) / (float)texData.tex_w;
+		texData.tex_t = (float)(h) / (float)texData.tex_h;
 	}
 	
 	
@@ -545,8 +545,8 @@ void ofTexture::loadData(const void * data, int w, int h, int glFormat, int glTy
 			//need to find closest powers of two
 			int last_h = ofNextPow2(texData.height)>>1;
 			int next_h = ofNextPow2(texData.height);
-			if ((texData.height - last_h) < (next_h - texData.height)) texData.tex_u = last_h;
-			else texData.tex_u = next_h;
+			if ((texData.height - last_h) < (next_h - texData.height)) texData.tex_t = last_h;
+			else texData.tex_t = next_h;
 			
 			int last_w = ofNextPow2(texData.width)>>1;
 			int next_w = ofNextPow2(texData.width);
@@ -637,15 +637,14 @@ void ofTexture::loadScreenData(int x, int y, int w, int h){
 	//compute new tex co-ords based on the ratio of data's w, h to texture w,h;
 #ifndef TARGET_OPENGLES // DAMIAN
 	if (texData.textureTarget == GL_TEXTURE_RECTANGLE_ARB){
-		texData.tex_t = (float)(w);
-		texData.tex_u = (float)(h);
+		texData.tex_s = (float)(w);
+		texData.tex_t = (float)(h);
 	} else 
 #endif
 	{
-		texData.tex_t = (float)(w) / (float)texData.tex_w;
-		texData.tex_u = (float)(h) / (float)texData.tex_h;
+		texData.tex_s = (float)(w) / (float)texData.tex_w;
+		texData.tex_t = (float)(h) / (float)texData.tex_h;
 	}
-	
 	
 	enableTextureTarget(0);
 
@@ -769,8 +768,8 @@ ofPoint ofTexture::getCoordFromPoint(float xPos, float yPos){
 		
 		// (b) mult by our internal pct (since we might not be 0-1 internally)
 		
-		pctx *= texData.tex_t;
-		pcty *= texData.tex_u;
+		pctx *= texData.tex_s;
+		pcty *= texData.tex_t;
 		
 		temp.set(pctx, pcty);
 		
@@ -808,8 +807,8 @@ ofPoint ofTexture::getCoordFromPercent(float xPct, float yPct){
 		
 	} else {
 #endif	
-		xPct *= texData.tex_t;
-		yPct *= texData.tex_u;
+		xPct *= texData.tex_s;
+		yPct *= texData.tex_t;
 		temp.set(xPct, yPct);
 		
 #ifndef TARGET_OPENGLES	
@@ -987,8 +986,8 @@ void ofTexture::draw(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3,
 	
 	GLfloat tx0 = 0+offsetw;
 	GLfloat ty0 = 0+offseth;
-	GLfloat tx1 = texData.tex_t - offsetw;
-	GLfloat ty1 = texData.tex_u - offseth;
+	GLfloat tx1 = texData.tex_s - offsetw;
+	GLfloat ty1 = texData.tex_t - offseth;
 
 	quad.getVertices()[0].set(p1.x, p1.y);
 	quad.getVertices()[1].set(p2.x, p2.y);

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -118,8 +118,8 @@ public:
 		textureTarget = GL_TEXTURE_2D;
 #endif
 
+		tex_s = 0;
 		tex_t = 0;
-		tex_u = 0;
 		tex_w = 0;
 		tex_h = 0;
 		width = 0;
@@ -139,8 +139,8 @@ public:
 	int glTypeInternal; ///< GL internal format, e.g. GL_RGB8.
                         ///< \sa http://www.opengl.org/wiki/Image_Format
 	
-	float tex_t; ///< Texture horiz coordinate, ratio of width to display width. 
-	float tex_u; ///< Texture vert coordinate, ratio of height to display height.
+	float tex_s; ///< Texture horiz coordinate, ratio of width to display width.
+	float tex_t; ///< Texture vert coordinate, ratio of height to display height.
 	float tex_w; ///< Texture width.
 	float tex_h; ///< Texture height.
 	float width, height; ///< Texture display size.

--- a/libs/openFrameworks/video/ofQTKitPlayer.mm
+++ b/libs/openFrameworks/video/ofQTKitPlayer.mm
@@ -456,8 +456,8 @@ void ofQTKitPlayer::updateTexture(){
 		data.height = getHeight();
 		data.tex_w = getWidth();
 		data.tex_h = getHeight();
-		data.tex_t = getWidth();
-		data.tex_u = getHeight();
+		data.tex_s = getWidth();
+		data.tex_t = getHeight();
 	}
 }
 


### PR DESCRIPTION
This brings texData coordinate names in line with OpenGL and GLSL convention,
and maps width/height to tex_s/tex_t.

	horizontal == tex_t (old) -> tex_s (new)
	vertical   == tex_u (old) -> tex_t (new)

This PR has some initial discussion context in #3146