### PR TITLE
Qualify unordered_map when including via tr1

### DIFF
--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #else
 #include <tr1/unordered_map>
+using std::tr1::unordered_map;
 #endif
 #include "ofAppBaseWindow.h"
 


### PR DESCRIPTION
0a1d32a38c3d19e9def19b835c8ea2dbf51aed98 introduced a minor compile error, in that it uses an unqualified `unordered_map` when including it from tr1. This PR adds a `using std::tr1::unordered_map;` when compiling in non-C++11 mode.
