### PR TITLE
Close file descriptors and fix OpenAL issue

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -628,9 +628,25 @@ void ofOpenALSoundPlayer::update(ofEventArgs & args){
 //------------------------------------------------------------
 void ofOpenALSoundPlayer::unloadSound(){
 	ofRemoveListener(ofEvents().update,this,&ofOpenALSoundPlayer::update);
-	alDeleteBuffers(buffers.size(),&buffers[0]);
+	
+	// Delete sources before buffers.
 	alDeleteSources(sources.size(),&sources[0]);
+	alDeleteBuffers(buffers.size(),&buffers[0]);
+
+	// Free resources and close file descriptors.
+#ifdef OF_USING_MPG123
+	if(mp3streamf){
+		mpg123_close(mp3streamf);
+		mpg123_delete(mp3streamf);
+	}
+	mp3streamf = 0;
+#endif
+
+	if(streamf){
+		sf_close(streamf);
+	}
 	streamf = 0;
+	
 	bLoadedOk = false;
 }
 


### PR DESCRIPTION
unloadSound() did not previously close file descriptors which would eventually lead to a crash when too many file descriptors where open (about 1000 for Raspberry Pi).

OpenAL sources must be deleted before buffers otherwise it will result in **Illegal Operation**.
