### PR TITLE
Kinect sensor coordinate to color image coordinate conversion

### DIFF
--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -143,6 +143,12 @@ public:
 	
 	/// get the focal length of the IR sensor in mm
 	float getZeroPlaneDistance();
+	
+	/// convert sensor index to color image index; only valid when registration is disabled
+	int sensorToColorIndex(int i);
+	int sensorToColorIndex(int i, float distance);
+	ofPoint sensorToColorCoordinate(const ofPoint & p);
+	ofPoint sensorToColorCoordinate(const ofPoint & p, float distance);
 
 /// \section RGB Data
 


### PR DESCRIPTION
`ofxKinect::sensorToColorCoordinate(const ofPoint & p, float distance)` converts a sensor (depth w/o registration or IR image) coordinate to the corresponding color image coordinate. The other way round is not possible since this conversion requires a depth value.

I was only able to test with osx10.9.4+Kinect1473, and maybe there are some issues with other Kinect models so it should be tested before merging.
