### PR TITLE
Include missing z coord in ofTexture::draw(ofPoint x 4)

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -1008,10 +1008,10 @@ void ofTexture::draw(const ofPoint & p1, const ofPoint & p2, const ofPoint & p3,
 	GLfloat tx1 = texData.tex_t - offsetw;
 	GLfloat ty1 = texData.tex_u - offseth;
 
-	quad.getVertices()[0].set(p1.x, p1.y);
-	quad.getVertices()[1].set(p2.x, p2.y);
-	quad.getVertices()[2].set(p3.x, p3.y);
-	quad.getVertices()[3].set(p4.x, p4.y);
+	quad.getVertices()[0].set(p1.x, p1.y, p1.z);
+	quad.getVertices()[1].set(p2.x, p2.y, p2.z);
+	quad.getVertices()[2].set(p3.x, p3.y, p3.z);
+	quad.getVertices()[3].set(p4.x, p4.y, p4.z);
 	
 	quad.getTexCoords()[0].set(tx0,ty0);
 	quad.getTexCoords()[1].set(tx1,ty0);


### PR DESCRIPTION
Looks like the z coordinate wasn't getting set in the version ofTexture::draw() which accepts 4 ofPoints – all of my textures were drawing flat in the z-plane. 
