### PR TITLE
Points plaintext links to the correct targets in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,18 @@ Get involved
 
 The openframeworks forum:
 
-[http://forum.openframeworks.cc/]()
+[http://forum.openframeworks.cc/](http://forum.openframeworks.cc/)
 
 is a warm and friendly place  Please ask or answer a question.  The most important part of this project is that it's a community, more than just a tool, so please join us!  Also, this is free software, and we learn so much about what is hard, what doesn't make sense, what is useful, etc. The most basic questions are acceptable here!  Don't worry, just join the conversation.  Learning in OF is social, it's hard to do it alone, but together we can get far!
 
 Our github site is active: 
 
-[https://github.com/openframeworks/openFrameworks]()
+[https://github.com/openframeworks/openFrameworks](https://github.com/openframeworks/openFrameworks)
 
 if you have bugs or feature requests, consider opening an issue.  If you are a developer and want to help, pull requests are warmly welcome.  Please read the contributing guide for guidelines: 
 
-https://github.com/openframeworks/openFrameworks/blob/master/CONTRIBUTING.md
+[https://github.com/openframeworks/openFrameworks/blob/master/CONTRIBUTING.md](https://github.com/openframeworks/openFrameworks/blob/master/CONTRIBUTING.md
+)
 
 We also have a developer's mailing list, which is useful for discussing issues around the development and future of OF. 
 


### PR DESCRIPTION
This pull request for README.md updates the "Get involved" links for:
- forum (was broken, now points to forum)
- self-referential link to the github site (was broken, now points to GH openFrameworks repo)
- contributing guideline (was not in markdown format)

I did not inline the links with the introductory term (e.g. `[forum](http:...)` so that the href targets are obvious in a search and as to not deviate much from the current layout of the page.
