### PR TITLE
addons: use absolute path for includes

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
@@ -91,7 +91,7 @@ define parse_addon
 		) \
 	) \
 	$(if $(strip $(ADDON_INCLUDES)), \
-		$(eval PROJECT_ADDONS_INCLUDES += $(addprefix $(addon)/,$(ADDON_INCLUDES))), \
+		$(eval PROJECT_ADDONS_INCLUDES += $(abspath $(ADDON_INCLUDES))), \
 		$(call parse_addons_includes, $(addon)) \
 		$(eval PROJECT_ADDONS_INCLUDES += $(PARSED_ADDONS_INCLUDES)) \
 	) \


### PR DESCRIPTION
This patch lets parse_addon to use absolute path instead of adding the addon
path for each include. It allows to use absolute path for ADDON_INCLUDES into
the addon_config.mk files.
