### PR TITLE
ofxiOSKeybaord exposes UITextField

### DIFF
--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -39,7 +39,7 @@
 - (void) updateOrientation;
 - (void) makeSecure;
 - (void) setFieldLength: (int)len;
-
+- (UITextField *)getTextField;
 
 @end
 
@@ -71,7 +71,7 @@ public:
     OF_DEPRECATED_MSG("Use getText() instead.", string getLabelText());
 	bool isKeyboardShowing();
 	
-	
+    UITextField * getKeyboardTextField();
 	
 protected:
 	

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
@@ -151,7 +151,9 @@ void ofxiOSKeyboard::updateOrientation()
 	[keyboard updateOrientation];
 }
 
-
+UITextField * ofxiOSKeyboard::getKeyboardTextField() {
+    return [keyboard getTextField];
+}
 
 // CLASS IMPLEMENTATIONS--------------objc------------------------
 //----------------------------------------------------------------
@@ -435,4 +437,8 @@ void ofxiOSKeyboard::updateOrientation()
 	[_textField becomeFirstResponder];
 }
 //--------------------------------------------------------------
+- (UITextField *)getTextField {
+    return _textField;
+}
+
 @end


### PR DESCRIPTION
theres been a few feature requests where users want to enable different features on the UITextField inside ofxiOSKeybaord. rather then bloating ofxiOSKeyboard with an esoteric api, UITextField has now been exposed so users can make calls to it directly.
