### PR TITLE
no longer calling ofReloadGLResources in ofxiOS

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -77,7 +77,6 @@ static ofxiOSEAGLView * _instanceRef = nil;
         ofDisableTextureEdgeHack();
 
         ofGLReadyCallback();
-        ofReloadGLResources();
         
         bInit = YES;
     }


### PR DESCRIPTION
ofxiOS does not need to reload gl resources as the gl context is never lost, even when an app goes into background state.
