### PR TITLE
Explain cryptic ofKeyEventArgs struct members

### DIFF
--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -41,13 +41,13 @@ class ofKeyEventArgs : public ofEventArgs {
 		Pressed,
 		Released,
 	} type;
-	/*! \brief For special keys, one of OF_KEY_* (see ofConstants.h). For all other keys, the Unicode code point you'd expect if this key combo (including modifier keys that may be down) was pressed in a text editor (same as codepoint). */
+	/// \brief For special keys, one of OF_KEY_* (@see ofConstants.h). For all other keys, the Unicode code point you'd expect if this key combo (including modifier keys that may be down) was pressed in a text editor (same as codepoint). 
 	int key; 
-	/*! \brief The key, independent of any modifier keys or keyboard layout settings. Typically, ASCII representation of the symbol on the physical key, so A key always returns 0x41 even if shift, alt, ctrl are down. */
+	/// \brief The keycode returned by the windowing system, independent of any modifier keys or keyboard layout settings. For ofAppGLFWWindow this value is one of GLFW_KEY_* (@see glfw3.h) - typically, ASCII representation of the symbol on the physical key, so A key always returns 0x41 even if shift, alt, ctrl are down. 
 	int keycode;
-	/*! \brief The raw scan code returned by the keyboard, OS and hardware specific. */
+	/// \brief The raw scan code returned by the keyboard, OS and hardware specific. 
 	int scancode;
-	/*! \brief The Unicode code point you'd expect if this key combo (including modifier keys) was pressed in a text editor, or -1 for non-printable characters. */
+	/// \brief The Unicode code point you'd expect if this key combo (including modifier keys) was pressed in a text editor, or -1 for non-printable characters. 
 	unsigned int codepoint;
 };
 


### PR DESCRIPTION
Nobody knows what any of these things mean without docs. So here's some docs.

(This is based on research on OSX using the GLFW window, no guarantee of validity on Windows or Linux using different windows).
