### PR TITLE
"Bug fix" for regex example

### DIFF
--- a/examples/utils/regularExpressionExample/src/ofApp.cpp
+++ b/examples/utils/regularExpressionExample/src/ofApp.cpp
@@ -45,7 +45,7 @@ void ofApp::searchGoogleImages() {
         // in the webpage there is a table for all the images. we
         // want to get the content in the table using 
         // the <table> (.*?) </table> expression        
-        RegularExpression regEx("<table class=\"images_table\" style=\"table-layout:fixed\" width=\"100%\">(.*?)</table>");
+        RegularExpression regEx("<table class=\"images_table\" style=\"table-layout:fixed\" [^>]+>(.*?)</table>");
         RegularExpression::Match match;
         int found = regEx.match(rawData, match);
         


### PR DESCRIPTION
Re: #3292

The order of attributes on the table tag in the HTML returned from Google has changed slightly.  width now comes before style.  Tested on 0.8.4 and on master with windows codeblocks 12.11.
