### PR TITLE
iOS Changes for new Libraries [After new libraries merged]

### DIFF
--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -103,7 +103,7 @@ void ofAppiOSWindow::startAppWithDelegate(string appDelegateClassName) {
     bAppCreated = true;
     
     @autoreleasepool {
-        UIApplicationMain(nil, nil, nil, [NSString stringWithUTF8String:appDelegateClassName.c_str()]);
+        UIApplicationMain(0, nil, nil, [NSString stringWithUTF8String:appDelegateClassName.c_str()]);
     }
 }
 

--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
@@ -110,7 +110,7 @@ void ofxiOSMapKit::_setRegion(CLLocationCoordinate2D center, MKCoordinateSpan sp
 void ofxiOSMapKit::setType(ofxiOSMapKitType type) {
     if(isOpen()) {
         ofLogVerbose("ofxiOSMapKit") << "setType(): setting map type: " << (int) type;
-        mapView.mapType = type;
+        mapView.mapType = (MKMapType)type;
     }
 }
 

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -17,10 +17,6 @@
 		#include <OpenGL/glu.h>
 	#endif
 
-	#ifdef TARGET_OPENGLES
-		#include "glu.h"
-	#endif
-
 	#ifdef TARGET_LINUX
 		#include <GL/glu.h>
 	#endif

--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -3,7 +3,7 @@
 #include "ofConstants.h"
 #include "ofColor.h"
 
-#if (_MSC_VER) || ((defined(TARGET_EMSCRIPTEN) || defined(TARGET_LINUX)) && __cplusplus>=201103L)
+#if (_MSC_VER) || ((defined(TARGET_EMSCRIPTEN) || defined(TARGET_LINUX) || defined(TARGET_OF_IOS)) && __cplusplus>=201103L)
 #include <memory>
 #else
 #include <tr1/memory>
@@ -182,7 +182,7 @@ public:
 	template<typename Tp1>
 	ofPtr(const ofPtr<Tp1>& __r, std::_Dynamic_tag)
 	: std::shared_ptr<T>(__r, std:::_Dynamic_tag()) { }
-#elif !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_LINUX)
+#elif !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_LINUX) && !defined(TARGET_OF_IOS)
 	template<typename Tp1>
 	ofPtr(const ofPtr<Tp1>& __r, std::__dynamic_cast_tag)
 	: std::shared_ptr<T>(__r, std::__dynamic_cast_tag()) { }
@@ -204,7 +204,7 @@ template<typename _Tp, typename _Tp1>
 ofPtr<_Tp>
 	dynamic_pointer_cast(const ofPtr<_Tp1>& __r)
 { return ofPtr<_Tp>(__r, std::_Dynamic_tag()); }
-#elif !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_LINUX)
+#elif !defined(TARGET_EMSCRIPTEN) && !defined(TARGET_LINUX) && !defined(TARGET_OF_IOS)
 template<typename _Tp, typename _Tp1>
 ofPtr<_Tp>
 	dynamic_pointer_cast(const ofPtr<_Tp1>& __r)

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -1,5 +1,5 @@
 #pragma once
-		#include <stdint.h>
+#include <stdint.h>
 
 //-------------------------------
 #define OF_VERSION_MAJOR 0
@@ -61,10 +61,11 @@ enum ofTargetPlatform{
 #elif defined( __APPLE_CC__)
 	#include <TargetConditionals.h>
 
-	#if (TARGET_OS_IPHONE_SIMULATOR) || (TARGET_OS_IPHONE) || (TARGET_IPHONE)
+	#if TARGET_OS_IPHONE_SIMULATOR || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE || TARGET_IPHONE
 		#define TARGET_OF_IPHONE
         #define TARGET_OF_IOS
 		#define TARGET_OPENGLES
+        #include <unistd.h>
 	#else
 		#define TARGET_OSX
 	#endif

--- a/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
@@ -10,30 +10,33 @@ HEADER_GLEW = "$(OF_PATH)/libs/glew/include"
 HEADER_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/include"
 HEADER_TESS2 = "$(OF_PATH)/libs/tess2/include"
 HEADER_RTAUDIO = "$(OF_PATH)/libs/rtaudio/include"
-HEADER_GLU = "$(OF_PATH)/libs/glu/include_ios"
 HEADER_SSL = "$(OF_PATH)/libs/openssl/include"
 
-LIB_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/lib/osx/freeimage.a"
-LIB_TESS = "$(OF_PATH)/libs/tess2/lib/osx/tess2.a"
-LIB_GLU = "$(OF_PATH)/libs/glu/lib/ios/glu.a"
-LIB_SSL = "$(OF_PATH)/libs/openssl/lib/osx/ssl.a"
-LIB_CRYPTO = "$(OF_PATH)/libs/openssl/lib/osx/crypto.a"
+//------- Libraries
+LIB_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/lib/ios/freeimage.a"
+LIB_FREETYPE = "$(OF_PATH)/libs/freetype/lib/ios/freetype.a"
+LIB_TESS = "$(OF_PATH)/libs/tess2/lib/ios/tess2.a"
+LIB_OPENSSL_1 = "$(OF_PATH)/libs/openssl/lib/ios/ssl.a"
+LIB_OPENSSL_2 = "$(OF_PATH)/libs/openssl/lib/ios/crypto.a"
+LIB_OPENSSL = $(LIB_OPENSSL_1) $(LIB_OPENSSL_2)
+LIB_POCO_0 = "$(OF_PATH)/libs/poco/lib/ios/PocoCrypto.a"
+LIB_POCO_1 = "$(OF_PATH)/libs/poco/lib/ios/PocoData.a"
+LIB_POCO_2 = "$(OF_PATH)/libs/poco/lib/ios/PocoDataSQLite.a"
+LIB_POCO_3 = "$(OF_PATH)/libs/poco/lib/ios/PocoJSON.a"
+LIB_POCO_4 = "$(OF_PATH)/libs/poco/lib/ios/PocoUtil.a"
+LIB_POCO_5 = "$(OF_PATH)/libs/poco/lib/ios/PocoXML.a"
+LIB_POCO_6 = "$(OF_PATH)/libs/poco/lib/ios/PocoNet.a"
+LIB_POCO_7 = "$(OF_PATH)/libs/poco/lib/ios/PocoNetSSL.a"
+LIB_POCO_8 = "$(OF_PATH)/libs/poco/lib/ios/PocoZip.a"
+LIB_POCO_9 = "$(OF_PATH)/libs/poco/lib/ios/PocoFoundation.a"
+LIB_POCO = $(LIB_POCO_0) $(LIB_POCO_1) $(LIB_POCO_2) $(LIB_POCO_3) $(LIB_POCO_4) $(LIB_POCO_5) $(LIB_POCO_6) $(LIB_POCO_7) $(LIB_POCO_8) $(LIB_POCO_9)
 
-LIB_FREEIMAGE_IPHONE = "$(OF_PATH)/libs/FreeImage/lib/ios/freeimage.a"
-LIB_FREETYPE_IPHONE = "$(OF_PATH)/libs/freetype/lib/ios/freetype.a"
-LIB_POCOFOUNDATION_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoFoundation.a"
-LIB_POCONET_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoNet.a"
-LIB_POCONETSSL_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoNetSSL.a"
-LIB_POCOCRYPTO_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoCrypto.a"
-LIB_POCOUTIL_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoUtil.a"
-LIB_POCOXML_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoXML.a"
-LIB_POCOZIP_IPHONE = "$(OF_PATH)/libs/poco/lib/ios/PocoZip.a"
-LIB_TESS_IPHONE = "$(OF_PATH)/libs/tess2/lib/ios/tess2.a"
-LIB_GLU_IPHONE = "$(OF_PATH)/libs/glu/lib/ios/glu-ios.a"
-LIB_SSL_IPHONE = "$(OF_PATH)/libs/openssl/lib/ios/ssl.a"
-LIB_CRYPTO_IPHONE = "$(OF_PATH)/libs/openssl/lib/ios/crypto.a"
 
 MISC_FLAGS = "-ObjC"
 
-OF_CORE_LIBS = $(MISC_FLAGS) $(LIB_FREETYPE) $(LIB_FREEIMAGE) $(LIB_POCOFOUNDATION) $(LIB_POCONET) $(LIB_POCONETSSL) $(LIB_POCOCRYPTO) $(LIB_POCOXML) $(LIB_POCOZIP) $(LIB_POCOUTIL) $(LIB_FREETYPE_IPHONE) $(LIB_FREEIMAGE_IPHONE) $(LIB_POCONET_IPHONE) $(LIB_POCONETSSL_IPHONE) $(LIB_POCOCRYPTO_IPHONE) $(LIB_POCOXML_IPHONE) $(LIB_POCOZIP_IPHONE) $(LIB_POCOUTIL_IPHONE) $(LIB_POCOFOUNDATION_IPHONE) $(LIB_TESS_IPHONE) $(LIB_GLU) $(LIB_GLU_IPHONE) $(LIB_SSL_IPHONE) $(LIB_CRYPTO_IPHONE)
-OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_OFXIOS) $(HEADER_OFXMULTITOUCH) $(HEADER_OFXACCELEROMETER) $(HEADER_POCO) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_RTAUDIO) $(HEADER_GLU) $(HEADER_SSL)
+OF_CORE_LIBS = $(MISC_FLAGS) $(LIB_POCO) $(LIB_FREEIMAGE) $(LIB_FREETYPE) $(LIB_OPENSSL) $(LIB_TESS)
+OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_OFXIOS) $(HEADER_OFXMULTITOUCH) $(HEADER_OFXACCELEROMETER) $(HEADER_POCO) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_RTAUDIO) $(HEADER_SSL)
+ 
+// once all libraries are compiled for libc++ / all architectures
+CLANG_CXX_LIBRARY = libc++
+CLANG_CXX_LANGUAGE_STANDARD = c++11

--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -1140,6 +1140,11 @@
 		BB24DED310DA7A3F00E9C588 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"armv7,",
+					"arm64,",
+					armv7s,
+				);
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = NO;
@@ -1165,6 +1170,11 @@
 		BB24DED410DA7A3F00E9C588 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"armv7,",
+					"arm64,",
+					armv7s,
+				);
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
 				COPY_PHASE_STRIP = YES;
 				DEAD_CODE_STRIPPING = NO;
@@ -1191,6 +1201,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E41D3E9113B38BE900A75A5D /* Debug.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
 				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/ios/build/debug/";
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
@@ -1200,7 +1211,6 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SYMROOT = "$(SRCROOT)/../../lib/ios/";
-				VALID_ARCHS = armv7;
 				WARNING_CFLAGS = (
 					"-Wno-non-virtual-dtor",
 					"-Wno-overloaded-virtual",
@@ -1212,6 +1222,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E41D3E9213B38BE900A75A5D /* Release.xcconfig */;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
 				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/ios/build/release/";
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
@@ -1221,7 +1232,6 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SYMROOT = "$(SRCROOT)/../../lib/ios/";
-				VALID_ARCHS = armv7;
 				WARNING_CFLAGS = (
 					"-Wno-non-virtual-dtor",
 					"-Wno-overloaded-virtual",

--- a/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
@@ -149,8 +149,8 @@
 				<string>5.1.1</string>
 				<key>PRODUCT_NAME</key>
 				<string>${TARGET_NAME}</string>
-				<key>VALID_ARCHS</key>
-				<string>armv7</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1</string>
 			</dict>
 			<key>isa</key>
 			<string>XCBuildConfiguration</string>
@@ -171,8 +171,8 @@
 				<string>5.1.1</string>
 				<key>PRODUCT_NAME</key>
 				<string>${TARGET_NAME}</string>
-				<key>VALID_ARCHS</key>
-				<string>armv7</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1</string>
 			</dict>
 			<key>isa</key>
 			<string>XCBuildConfiguration</string>
@@ -185,6 +185,7 @@
 			<array>
 				<string>1D6058940D05DD3E006BFB54</string>
 				<string>1D6058950D05DD3E006BFB54</string>
+				<string>9986B3F519F4944700F9CCAA</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
 			<string>0</string>
@@ -246,6 +247,20 @@
 			<dict>
 				<key>LastUpgradeCheck</key>
 				<string>0600</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>1D6058900D05DD3D006BFB54</key>
+					<dict>
+						<key>SystemCapabilities</key>
+						<dict>
+							<key>com.apple.Maps.iOS</key>
+							<dict>
+								<key>enabled</key>
+								<string>0</string>
+							</dict>
+						</dict>
+					</dict>
+				</dict>
 			</dict>
 			<key>buildConfigurationList</key>
 			<string>C01FCF4E08A954540054247B</string>
@@ -505,6 +520,84 @@
 
 </string>
 		</dict>
+		<key>9986B3F419F4944700F9CCAA</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>E41D3ED613B38FB500A75A5D</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>YES</string>
+				<key>ARCHS</key>
+				<array>
+					<string>arm64,</string>
+					<string>armv7,</string>
+					<string>armv7s</string>
+				</array>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string></string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Distribution</string>
+				<key>COMPRESS_PNG_FILES</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>c11</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>s</string>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_THUMB_SUPPORT</key>
+				<string>NO</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>5.1.1</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>NO</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1</string>
+				<key>VALID_ARCHS</key>
+				<string>arm64 armv7 armv7s</string>
+				<key>WARNING_LDFLAGS</key>
+				<string>-no_arch_warnings</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Production</string>
+		</dict>
+		<key>9986B3F519F4944700F9CCAA</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ofxiOS_Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ofxiOS-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>5.1.1</string>
+				<key>PRODUCT_NAME</key>
+				<string>${TARGET_NAME}</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Production</string>
+		</dict>
 		<key>BB16E9930F2B1E5900518274</key>
 		<dict>
 			<key>children</key>
@@ -638,6 +731,7 @@
 			<array>
 				<string>C01FCF4F08A954540054247B</string>
 				<string>C01FCF5008A954540054247B</string>
+				<string>9986B3F419F4944700F9CCAA</string>
 			</array>
 			<key>defaultConfigurationIsVisible</key>
 			<string>0</string>
@@ -654,8 +748,14 @@
 			<dict>
 				<key>ALWAYS_SEARCH_USER_PATHS</key>
 				<string>YES</string>
+				<key>ARCHS</key>
+				<array>
+					<string>arm64,</string>
+					<string>armv7,</string>
+					<string>armv7s</string>
+				</array>
 				<key>CLANG_CXX_LIBRARY</key>
-				<string>libstdc++</string>
+				<string>libc++</string>
 				<key>CODE_SIGN_IDENTITY</key>
 				<string></string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
@@ -663,7 +763,7 @@
 				<key>COMPRESS_PNG_FILES</key>
 				<string>NO</string>
 				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>c99</string>
+				<string>c11</string>
 				<key>GCC_OPTIMIZATION_LEVEL</key>
 				<string>0</string>
 				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
@@ -691,7 +791,7 @@
 				<key>TARGETED_DEVICE_FAMILY</key>
 				<string>1</string>
 				<key>VALID_ARCHS</key>
-				<string>armv7</string>
+				<string>arm64 armv7 armv7s</string>
 				<key>WARNING_LDFLAGS</key>
 				<string>-no_arch_warnings</string>
 			</dict>
@@ -708,8 +808,14 @@
 			<dict>
 				<key>ALWAYS_SEARCH_USER_PATHS</key>
 				<string>YES</string>
+				<key>ARCHS</key>
+				<array>
+					<string>arm64,</string>
+					<string>armv7,</string>
+					<string>armv7s</string>
+				</array>
 				<key>CLANG_CXX_LIBRARY</key>
-				<string>libstdc++</string>
+				<string>libc++</string>
 				<key>CODE_SIGN_IDENTITY</key>
 				<string></string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
@@ -717,13 +823,13 @@
 				<key>COMPRESS_PNG_FILES</key>
 				<string>NO</string>
 				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>c99</string>
+				<string>c11</string>
 				<key>GCC_DYNAMIC_NO_PIC</key>
 				<string>NO</string>
 				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
 				<string>NO</string>
 				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>3</string>
+				<string>s</string>
 				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
 				<string>NO</string>
 				<key>GCC_THUMB_SUPPORT</key>
@@ -741,7 +847,7 @@
 				<key>TARGETED_DEVICE_FAMILY</key>
 				<string>1</string>
 				<key>VALID_ARCHS</key>
-				<string>armv7</string>
+				<string>arm64 armv7 armv7s</string>
 				<key>WARNING_LDFLAGS</key>
 				<string>-no_arch_warnings</string>
 			</dict>


### PR DESCRIPTION
- Changed target architectures for oF core project 
- Changed target architectures for template project `arm64, armv7, armv7s` for iPhoneOS
- Changed target architectures for template projcet `i386, x86_64` for iPhoneSimulator
- Fix for mapkit type issue
- Fix for type issue in ofAppiOSWindow
- Removed `glu.h`
- Updated core `xconfig` for new libraries.
- Updated projects for libc++
- Added production target type for template project (clone of release with distribution target).
