### PR TITLE
fix ofImage channel swap warning 

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -215,7 +215,7 @@ void putBmpIntoPixels(FIBITMAP * bmp, ofPixels_<PixelType> &pix, bool swapForLit
 	}
 
 #ifdef TARGET_LITTLE_ENDIAN
-	if(swapForLittleEndian && sizeof(PixelType) == 1) {
+	if(swapForLittleEndian && sizeof(PixelType) == 1 && channels >=3 ) {
 		pix.swapRgb();
 	}
 #endif

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -423,7 +423,7 @@ void ofPixels_<PixelType>::swapRgb(){
 	}
 	break;
 	default:
-		//ofLogWarning("ofPixels") << "rgb swap not supported for this pixel format";
+		ofLogWarning("ofPixels") << "rgb swap not supported for this pixel format";
 		break;
 	}
 	switch(pixelFormat){


### PR DESCRIPTION
Every time a grayscale texture is loaded from gray pixels, the current implementation attempts to swap rgb values. This does not make sense on a grayscale image with only 1 channel. And correctly, the swap rgb method for grayscale pixels is a no-op.

Nevertheless, it leads to a warning on every load: `rgb swap not supported for this pixel format`. 

The warning is nice, but obvious to the point of being misleading.

This PR removes the warning message from the no-op swap pixels case.
