### PR TITLE
ofxiOSVideoGrabber made compatible with new API

### DIFF
--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -1,6 +1,6 @@
-#ifndef _OF_IOS_VIDEO_GRABBER
-#define _OF_IOS_VIDEO_GRABBER
 
+
+#pragma once
 
 class AVFoundationVideoGrabber;
 
@@ -8,46 +8,67 @@ class AVFoundationVideoGrabber;
 
 class ofxiOSVideoGrabber : public ofBaseVideoGrabber {
 	
-	public :
+public:
 	
 	ofxiOSVideoGrabber();
 	~ofxiOSVideoGrabber();
 	
-	//needs implementing
-	vector <ofVideoDevice> listDevices() const;
-	void getDeviceList() const {};
-	bool initGrabber(int w, int h);
-    bool isInitialized() const;
-	
-	bool			setPixelFormat(ofPixelFormat pixelFormat);
-	ofPixelFormat 	getPixelFormat() const;
+    //---------------------------------------
+    // inherited from ofBaseVideoGrabber
+    //---------------------------------------
+    
+	vector<ofVideoDevice> listDevices() const;
+    bool setup(int w, int h);
 
-	bool isFrameNew() const;
-	
-	unsigned char * getPixels();
-	ofPixels&		getPixelsRef();
-	const ofPixels& getPixelsRef() const;
-
-	void close();	
-	
 	float getHeight() const;
 	float getWidth() const;
-	
+    
+    ofTexture * getTexturePtr();
+    
+    void setVerbose(bool bTalkToMe);
+    void setDeviceID(int deviceID);
+    void setDesiredFrameRate(int framerate);
+    void videoSettings();
+    
+    //---------------------------------------
+    // inherited from ofBaseVideo
+    //---------------------------------------
+    
+    bool isFrameNew() const;
+    void close();
+    bool isInitialized() const;
+    
+    bool setPixelFormat(ofPixelFormat pixelFormat);
+    ofPixelFormat getPixelFormat() const;
+    
+    //---------------------------------------
+    // inherited from ofBaseHasPixels
+    //---------------------------------------
+    
+	ofPixels & getPixels();
+	const ofPixels & getPixels() const;
+    
+    //---------------------------------------
+    // inherited from ofBaseUpdates
+    //---------------------------------------
+    
 	void update();
-	
-	void setDeviceID(int _deviceID);
-	
-	void setDesiredFrameRate(int framerate);
-	
-	//should implement!
-	/*void setVerbose(bool bTalkToMe);
-	
-	void videoSettings();*/
-	
+    
+    //---------------------------------------
+    // deprecated.
+    //---------------------------------------
+    
+    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.", bool initGrabber(int w, int h));
+    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.", void getDeviceList() const);
+    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels&	getPixelsRef());
+    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels&  getPixelsRef() const);
+    
 protected:
+    
 	shared_ptr<AVFoundationVideoGrabber> grabber;
+    
+    ofPixels pixels;
+    
 };
-
-#endif
 
 #define ofxiPhoneVideoGrabber ofxiOSVideoGrabber

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
@@ -1,47 +1,23 @@
 #if defined  __arm__
 
-#include "AVFoundationVideoGrabber.h"
 #include "ofxiOSVideoGrabber.h"
+#include "AVFoundationVideoGrabber.h"
 
 ofxiOSVideoGrabber::ofxiOSVideoGrabber() {
 	grabber = shared_ptr<AVFoundationVideoGrabber>(new AVFoundationVideoGrabber());
 }
 
 ofxiOSVideoGrabber::~ofxiOSVideoGrabber() {
+    //
 }
 
-//needs implementing
+//--------------------------------------------------------------
 vector <ofVideoDevice> ofxiOSVideoGrabber::listDevices() const {
 	return grabber->listDevices();
 }
 
-bool ofxiOSVideoGrabber::initGrabber(int w, int h) {
-	return grabber->initGrabber(w, h);
-}
-
-bool ofxiOSVideoGrabber::isInitialized() const{
-    return grabber->isInitialized();
-}
-
-bool ofxiOSVideoGrabber::isFrameNew() const {
-	return grabber->isFrameNew();
-}
-
-unsigned char * ofxiOSVideoGrabber::getPixels() {
-	return grabber->getPixels();
-}
-
-ofPixels& ofxiOSVideoGrabber::getPixelsRef(){
-    static ofPixels dummy;
-    //@TODO implement me
-    return dummy;
-}
-
-const ofPixels& ofxiOSVideoGrabber::getPixelsRef() const {
-    return getPixelsRef();
-}
-
-void ofxiOSVideoGrabber::close() {
+bool ofxiOSVideoGrabber::setup(int w, int h) {
+    return grabber->initGrabber(w, h);
 }
 
 float ofxiOSVideoGrabber::getHeight() const {
@@ -52,25 +28,84 @@ float ofxiOSVideoGrabber::getWidth() const {
 	return grabber->getWidth();
 }
 
-void ofxiOSVideoGrabber::update() {
-	grabber->update();
+ofTexture * ofxiOSVideoGrabber::getTexturePtr() {
+    return NULL;
 }
 
-void ofxiOSVideoGrabber::setDeviceID(int _deviceID) {
-	grabber->setDevice(_deviceID);
+void ofxiOSVideoGrabber::setVerbose(bool bTalkToMe) {
+    ofLogWarning("ofxiOSVideoGrabber") << "setVerbose() is not implemented";
+}
+
+void ofxiOSVideoGrabber::setDeviceID(int deviceID) {
+    grabber->setDevice(deviceID);
 }
 
 void ofxiOSVideoGrabber::setDesiredFrameRate(int framerate) {
-	grabber->setCaptureRate(framerate);
+    grabber->setCaptureRate(framerate);
+}
+
+void ofxiOSVideoGrabber::videoSettings() {
+    ofLogWarning("ofxiOSVideoGrabber") << "videoSettings() is not implemented";
+}
+
+//--------------------------------------------------------------
+bool ofxiOSVideoGrabber::isFrameNew() const {
+	return grabber->isFrameNew();
+}
+
+void ofxiOSVideoGrabber::close() {
+    ofLogWarning("ofxiOSVideoGrabber") << "close() is not implemented";
+}
+
+bool ofxiOSVideoGrabber::isInitialized() const{
+    return grabber->isInitialized();
 }
 
 bool ofxiOSVideoGrabber::setPixelFormat(ofPixelFormat internalPixelFormat) {
 	return grabber->setPixelFormat(internalPixelFormat);
 }
 
-
 ofPixelFormat ofxiOSVideoGrabber::getPixelFormat() const {
     return grabber->getPixelFormat();
+}
+
+//--------------------------------------------------------------
+ofPixels & ofxiOSVideoGrabber::getPixels() {
+    return pixels;
+}
+
+const ofPixels & ofxiOSVideoGrabber::getPixels() const {
+    return getPixels();
+}
+
+//--------------------------------------------------------------
+void ofxiOSVideoGrabber::update() {
+	grabber->update();
+    
+    if(grabber->isFrameNew() == true) {
+        pixels.setFromPixels(grabber->getPixels(),
+                             getWidth(),
+                             getHeight(),
+                             grabber->getPixelFormat());
+    }
+}
+
+//-------------------------------------------------------------- DEPRECATED.
+bool ofxiOSVideoGrabber::initGrabber(int w, int h) {
+    ofLogWarning("ofxiOSVideoGrabber") << "initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.";
+    return setup(w, h);
+}
+
+void ofxiOSVideoGrabber::getDeviceList() const {
+    ofLogWarning("ofxiOSVideoGrabber") << "getDeviceList() is deprecated, use listDevices() instead.";
+};
+
+ofPixels& ofxiOSVideoGrabber::getPixelsRef(){
+	return getPixels();
+}
+
+const ofPixels& ofxiOSVideoGrabber::getPixelsRef() const{
+	return getPixels();
 }
 
 #endif

--- a/examples/ios/videoGrabberExample/src/ofApp.mm
+++ b/examples/ios/videoGrabberExample/src/ofApp.mm
@@ -18,16 +18,19 @@ void ofApp::update(){
 	
 	grabber.update();
 	
-	unsigned char * src = grabber.getPixels();
-	int totalPix = grabber.getWidth() * grabber.getHeight() * 3;
-	
-	for(int k = 0; k < totalPix; k+= 3){
-		pix[k  ] = 255 - src[k];
-		pix[k+1] = 255 - src[k+1];
-		pix[k+2] = 255 - src[k+2];		
-	}
-	
-	tex.loadData(pix, grabber.getWidth(), grabber.getHeight(), GL_RGB);
+    if(grabber.isFrameNew() == true) {
+        ofPixels & pixels = grabber.getPixels();
+        unsigned char * src = pixels.getData();
+        int totalPix = grabber.getWidth() * grabber.getHeight() * 3;
+        
+        for(int k = 0; k < totalPix; k+= 3){
+            pix[k  ] = 255 - src[k];
+            pix[k+1] = 255 - src[k+1];
+            pix[k+2] = 255 - src[k+2];		
+        }
+        
+        tex.loadData(pix, grabber.getWidth(), grabber.getHeight(), GL_RGB);
+    }
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
- replaced initGrabber() with setup()
- replaced getPixelsRef() with getPixels()
- replaced getDeviceList() with listDevices()
- added deprecation messages.
- general cleanup.
