### PR TITLE
ofxiOSVideoPlayer getPixels() fix.

### DIFF
--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -62,6 +62,7 @@ public:
     
 	void * getAVFoundationVideoPlayer();
     
+    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(string name));
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels & getPixelsRef());
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels & getPixelsRef() const);
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.", ofTexture * getTexture());

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -254,7 +254,7 @@ ofPixels & ofxiOSVideoPlayer::getPixels() {
 
 //----------------------------------------
 const ofPixels & ofxiOSVideoPlayer::getPixels() const {
-    return getPixels();
+    return pixels;
 }
 
 //----------------------------------------
@@ -589,6 +589,10 @@ void * ofxiOSVideoPlayer::getAVFoundationVideoPlayer() {
 }
 
 //---------------------------------------- DEPRECATED.
+bool ofxiOSVideoPlayer::loadMovie(string name) {
+    return load(name);
+}
+
 ofPixels & ofxiOSVideoPlayer::getPixelsRef() {
     return getPixels();
 }


### PR DESCRIPTION
- fix for recursive getPixels() call.
- added one more deprecation message that was missed previously.
