### PR TITLE
ofxiOSVideoPlayer getPixels fix.

### DIFF
--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -254,7 +254,7 @@ ofPixels & ofxiOSVideoPlayer::getPixels() {
 
 //----------------------------------------
 const ofPixels & ofxiOSVideoPlayer::getPixels() const {
-    return pixels;
+    return const_cast<ofxiOSVideoPlayer*>(this)->getPixels();
 }
 
 //----------------------------------------


### PR DESCRIPTION
correct implementation of `const ofPixels & ofxiOSVideoPlayer::getPixels() const`
