### PR TITLE
fix missing vertex count update

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -360,6 +360,7 @@ void ofVbo::setAttributeData(int location, const float * attrib0x, int numCoords
 					registerVbo(this);
 				#endif
 				bUsingVerts = true;
+				totalVerts = total;
 			}
 				break;
 			case ofShader::COLOR_ATTRIBUTE:


### PR DESCRIPTION
fixes a bug where total vertex count would not be updated when setting vbo vertex position attributes
- this was the reason drawBitmapString would not draw, since this method draws without indices.
