### PR TITLE
ofxiOS scaleFactor fix

### DIFF
--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -92,10 +92,11 @@ public:
     bool isRendererES2();
     bool isRendererES1();
     
-    bool enableRetina();
+    bool enableRetina(float retinaScale=0);
     bool disableRetina();
     bool isRetinaEnabled();
     bool isRetinaSupportedOnDevice();
+    float getRetinaScale();
     
     bool enableDepthBuffer();
     bool disableDepthBuffer();
@@ -108,6 +109,7 @@ public:
     
     struct Settings {
         bool enableRetina;
+        float retinaScale;
         bool enableDepth;
         bool enableAntiAliasing;
         int numOfAntiAliasingSamples;

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -40,6 +40,7 @@
 //-------------------------------------------------------------------------------------
 ofAppiOSWindow::Settings::Settings() {
     enableRetina = false;
+    retinaScale = 0;
     enableDepth = false;
     enableAntiAliasing = false;
     numOfAntiAliasingSamples = 0;
@@ -298,9 +299,10 @@ void ofAppiOSWindow::setVerticalSync(bool enabled) {
 }
 
 //----------------------------------------------------------------------------------- retina.
-bool ofAppiOSWindow::enableRetina() {
+bool ofAppiOSWindow::enableRetina(float retinaScale) {
     if(isRetinaSupportedOnDevice()) {
         settings.enableRetina = true;
+        settings.retinaScale = retinaScale;
     }
     return settings.enableRetina;
 }
@@ -329,6 +331,10 @@ bool ofAppiOSWindow::isRetinaSupportedOnDevice() {
     }
     
     return bRetinaSupportedOnDevice;
+}
+
+float ofAppiOSWindow::getRetinaScale() {
+    return settings.retinaScale;
 }
 
 //----------------------------------------------------------------------------------- depth buffer.

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -43,7 +43,8 @@ static ofxiOSEAGLView * _instanceRef = nil;
                       andDepth:ofAppiOSWindow::getInstance()->isDepthBufferEnabled()
                          andAA:ofAppiOSWindow::getInstance()->isAntiAliasingEnabled()
                  andNumSamples:ofAppiOSWindow::getInstance()->getAntiAliasingSampleCount()
-                     andRetina:ofAppiOSWindow::getInstance()->isRetinaEnabled()];
+                     andRetina:ofAppiOSWindow::getInstance()->isRetinaEnabled()
+                andRetinaScale:ofAppiOSWindow::getInstance()->getRetinaScale()];
     
     if(self) {
         

--- a/addons/ofxiOS/src/gl/EAGLView.h
+++ b/addons/ofxiOS/src/gl/EAGLView.h
@@ -50,7 +50,8 @@
     
 @protected
     id <ESRenderer> renderer;
-	int scaleFactor;
+    CGFloat scaleFactor;
+    CGFloat scaleFactorPref;
     
     BOOL bUseDepth;
     BOOL bUseFSAA;
@@ -76,12 +77,13 @@
 @property (nonatomic) float animationFrameInterval;
 @property (nonatomic) float animationFrameRate;
 
-- (id) initWithFrame:(CGRect)frame
- andPreferedRenderer:(ESRendererVersion)rendererVersion
-            andDepth:(bool)depth
-               andAA:(bool)fsaaEnabled
-       andNumSamples:(int)samples
-           andRetina:(bool)retinaEnabled;
+- (id)initWithFrame:(CGRect)frame
+andPreferedRenderer:(ESRendererVersion)rendererVersion
+           andDepth:(bool)depth
+              andAA:(bool)fsaaEnabled
+      andNumSamples:(int)samples
+          andRetina:(bool)retinaEnabled
+     andRetinaScale:(CGFloat)retinaScale;
 
 - (void) startAnimation;
 - (void) stopAnimation;


### PR DESCRIPTION
with the release of iPhone 6 and iPhone6+ the content scale of the opengl view can now go up to 3.0
its now important to have more control over the scaleFactor to prevent old projects breaking on these new devices.

a scale can now be specified when enabling retina.
if no scale is provided when enabling retina then ofxiOS assumes you would like to launch with maximum supported scale which maintains backwards compatibility.

where this comes in handy is on the iPhone6+ where the maximum scale factor is now 3.0 
and if you have a project that now looks shrunken on the iPhone6+, you can set the scale factor to 2.0 (same as on the iPhone4 - iPhone5S) and your app will display correctly.

to specify a scale factor use,
`ofAppiOSWindow::enableRetina(float retinaScale)`
or specify in the main.mm using `ofAppiOSWindow::Settings`

ive tested this thoroughly as i needed this working for a current project.
if anyone spots any issues, please let me know.
