### PR TITLE
vao init upon bind fix

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -763,6 +763,7 @@ void ofVbo::bind() const{
 			glGenVertexArrays(1, &const_cast<ofVbo*>(this)->vaoID);
 			if(vaoID!=0){
 				retainVAO(vaoID);
+				vaoChanged = true;
 			}
 		}
 		glBindVertexArray(vaoID);


### PR DESCRIPTION
- fixes an issue where a newly created vao might not be filled with values, since it would be marked unchanged. This fixes it by marking newly created vao as `changed`, i.e. dirty.

to reproduce:

`ofNofill();
ofSetColor(ofColor::yellow);
ofDrawRectangle(ofRectangle(...)); // will not draw`
