### PR TITLE
fix ofVbo::updateAttributeData for programmable GL built-ins

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -529,9 +529,11 @@ void ofVbo::updateAttributeData(int location, const float * attr0x, int total){
 				attr = &texCoordAttribute;
 				break;
 			default:
-				customAttributes[location].location = location;
-				attr = &customAttributes[location];
-				vaoChanged = true;
+				if(customAttributes.find(location)!=customAttributes.end() && customAttributes[location].isAllocated()) {
+					customAttributes[location].location = location;
+					attr = &customAttributes[location];
+					vaoChanged = true;
+				}
 				break;
 		}
 	} else {
@@ -539,7 +541,7 @@ void ofVbo::updateAttributeData(int location, const float * attr0x, int total){
 			attr = &customAttributes[location];
 		}
 	}
-	if (attr !=NULL) {
+	if (attr !=NULL && attr->isAllocated()) {
 		attr->updateData(0, total*attr->stride, attr0x);
 	}
 }


### PR DESCRIPTION
- this makes sure that "redirected" programmable attributes are updated using their built-in vertexAttributes, otherwise updateAttributeData would have no effect on locations 0,1,2,3 in programmable GL.
