### PR TITLE
iOS Video Grabber changes for Simulator

### DIFF
--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
@@ -12,7 +12,6 @@
 #include "ofxiOS.h"
 #include "ofxiOSExtras.h"
 
-#if defined  __arm__
 
 class AVFoundationVideoGrabber;
 
@@ -96,5 +95,4 @@ class AVFoundationVideoGrabber{
 };
 
 
-#endif	// (__arm__) compile only for ARM
 

--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
@@ -11,10 +11,12 @@
 #import <CoreVideo/CoreVideo.h>
 #import <CoreMedia/CoreMedia.h>
 
-#if defined  __arm__
-
 #define IS_IOS_7_OR_LATER    ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0)
 #define IS_IOS_6_OR_LATER    ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0)
+
+#if TARGET_IPHONE_SIMULATOR
+#warning Target = iOS Simulator - The AVFoundationVideoGrabber will not function on the iOS Simulator
+#endif
 
 @interface iOSVideoGrabber() <AVCaptureVideoDataOutputSampleBufferDelegate> {
 	AVCaptureDeviceInput		*captureInput;	
@@ -40,6 +42,9 @@
 		bInitCalled = NO;
 		grabberPtr = NULL;
 		deviceID = 0;
+        width = 0;
+        height = 0;
+        currentFrame = 0;
 	}
 	return self;
 }
@@ -354,6 +359,8 @@ AVFoundationVideoGrabber::AVFoundationVideoGrabber(){
 	fps		= 30;
 	grabber = [iOSVideoGrabber alloc];
 	pixels	= NULL;
+    width = 0;
+    height = 0;
 	
 	internalGlDataType = GL_RGB;
 	newFrame = false;
@@ -551,5 +558,5 @@ ofPixelFormat AVFoundationVideoGrabber::getPixelFormat() {
 	}
 }
 
-#endif	// (__arm__) compile only for ARM
+
 

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
@@ -1,5 +1,3 @@
-#if defined  __arm__
-
 #include "ofxiOSVideoGrabber.h"
 #include "AVFoundationVideoGrabber.h"
 
@@ -17,7 +15,16 @@ vector <ofVideoDevice> ofxiOSVideoGrabber::listDevices() const {
 }
 
 bool ofxiOSVideoGrabber::setup(int w, int h) {
-    return grabber->initGrabber(w, h);
+    if(grabber->initGrabber(w, h)) {
+        return true;
+    } else {
+        ofLog(OF_LOG_ERROR, "Failed to init the ofxiOSVideoGrabber");
+#if TARGET_IPHONE_SIMULATOR
+        ofLog(OF_LOG_WARNING, "ofxiOSVideoGrabber::setup(int w, int h) :: The iOS Video Grabber will not function on the iOS Simulator");
+#endif
+        return false;
+    }
+    
 }
 
 float ofxiOSVideoGrabber::getHeight() const {
@@ -108,4 +115,3 @@ const ofPixels& ofxiOSVideoGrabber::getPixelsRef() const{
 	return getPixels();
 }
 
-#endif


### PR DESCRIPTION
- Removes preprocessor for arm architecture
- When targeting a iOS Simulator device will throw a #warning to inform
  the developer that the grabber will not function in the simulator
- Initialises some variables (width/height/currentframe) to default of
  0 in case init fails (which it will with simulator target)
- In realtime will throw a `OF_LOG_WARNING` when running on the simulator
  at time of init to inform the developer this will not function
  correctly.
- Allows developer to compile and test code even with a project using
  the iOS Video Grabber on the iOS Simulator
- Fixes issue with arm64 not compiling

This fixes the following issues:
- iOS videoGrabber not working on arm64 https://github.com/openframeworks/openFrameworks/issues/3387
- ios videoGrabberExample should build on simulator https://github.com/openframeworks/openFrameworks/issues/1659
