### PR TITLE
Fix #3398 ,if click android back key,it will crash

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -1104,12 +1104,13 @@ public class OFAndroid {
 	 */
 	public static boolean keyDown(int keyCode, KeyEvent event) {
         if ((keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0)) {
-            if( onBackPressed() ) {
+		mGLView.queueEvent(new Runnable() {
+        		@Override
+        		public void run() {
+        			onBackPressed();
+        		}
+        		});
             	return true;
-           	} else {
-           		// let the Android system handle the back button
-           		return false;
-           	}
         }
 		
         if (KeyEvent.isModifierKey(keyCode)) {
@@ -1120,8 +1121,13 @@ public class OFAndroid {
         }
         else
         {
-        	int unicodeChar = event.getUnicodeChar();
-        	onKeyDown(unicodeChar);
+        	final int unicodeChar = event.getUnicodeChar();
+        	mGLView.queueEvent(new Runnable() {
+        		@Override
+        		public void run() {
+        			onKeyDown(unicodeChar);
+        		}
+        	});
 
         	// return false to let Android handle certain keys
     		// like the back and menu keys
@@ -1144,8 +1150,13 @@ public class OFAndroid {
         }
         else
         {
-    		int unicodeChar = event.getUnicodeChar();
-    		onKeyUp(unicodeChar);
+    		final int unicodeChar = event.getUnicodeChar();
+        	mGLView.queueEvent(new Runnable() {
+        		@Override
+        		public void run() {
+        			onKeyUp(unicodeChar);
+        		}
+        	});
     		
     		// return false to let Android handle certain keys
     		// like the back and menu keys


### PR DESCRIPTION
on android,if u click the back key,it will crash.

11-06 23:09:45.158: E/libEGL(9627): call to OpenGL ES API with no current context (logged once per thread)

the problem is that u can't make native call for onBackPressed,it should be called in navtive GL thread,not in Android thread.
I fix this bug.
I have tested this!