### PR TITLE
ofGLUtils fix for GL_HALF_FLOAT

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -647,9 +647,9 @@ int ofGetBytesPerChannelFromGLType(int glType){
 #ifndef TARGET_OPENGLES
 		case GL_UNSIGNED_INT:
 			return 4;
-#endif
 		case GL_HALF_FLOAT:
 			return 2;
+#endif
 
 		default:
 			ofLogError("ofGetBytesPerChannelFromGLType") << "unknown type returning 1";


### PR DESCRIPTION
On master right now:
Undefined `GL_HALF_FLOAT` in OpenGLES. 

Needed to move `#endif` down to below this case to compile.
