### PR TITLE
Fix for GL_HALF_FLOAT OpenGLES 2.0

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -143,6 +143,9 @@ int ofGetGlFormat(const ofPixels_<T> & pixels) {
         #ifndef GL_UNSIGNED_INT
             #define GL_UNSIGNED_INT                         GL_UNSIGNED_INT_OES
         #endif
+        #ifndef GL_HALF_FLOAT
+            #define GL_HALF_FLOAT                           GL_HALF_FLOAT_OES
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
This fixes undefined `GL_HALF_FLOAT` for OpenGLES 2.0 which was stopping compile.
- Fix for OpenGLES 2.0 missing define for `GL_HALF_FLOAT`.

Note this `GL_HALF_FLOAT` / `GL_HALF_FLOAT_OES` will not work
on OpenGLES 1.1 so that case may still be undefined for earlier targets.

Also note worthy: It will also not work on Hardware Devices earlier than iPhone 4S or iPad 2 (and earlier can run OpenGLES 2.0)
