### PR TITLE
Fixes Missing SDKROOT for iOS+OFLib

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -1228,7 +1228,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				OBJROOT = "$(SRCROOT)/../../lib/ios/build/debug";
 				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = "";
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SYMROOT = "$(SRCROOT)/../../lib/ios/";
 				VALID_ARCHS = armv7;
@@ -1249,7 +1249,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
 				OBJROOT = "$(SRCROOT)/../../lib/ios/build/release";
 				ONLY_ACTIVE_ARCH = NO;
-				SDKROOT = "";
+				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SYMROOT = "$(SRCROOT)/../../lib/ios/";
 				VALID_ARCHS = armv7;


### PR DESCRIPTION
When compiling the ```iOS+OFLib``` the ```SDKROOT``` was not being defined so it was having all sorts of trouble with the core framework locations (which require this variable).

![screen shot 2014-11-08 at 1 05 26 am](https://cloud.githubusercontent.com/assets/830748/4954072/8f075288-6688-11e4-824d-dfe97b2b1f76.png)
![screen shot 2014-11-08 at 1 05 38 am](https://cloud.githubusercontent.com/assets/830748/4954073/907f845a-6688-11e4-803e-5867f5a8de78.png)

It was falling into the ```/System/Library/Frameworks``` which is incorrect, although it had some for OS X with the same name, always failed on iOS specific frameworks.

This fix just defines the SDKROOT and all goes back to normal iOS SDK location.