### PR TITLE
GLFW for Stereoscopic monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CORE
 ### app
 	/ setupOpenGL and ofApp___Window use ofWindowMode instead of int
 	/ fix exit callbacks to allow for calling of the destructors, and better signal handling
+	+ ofAppEGLWindow added new method setStereo(bool) for stereoscopic monitors
 
 ### 3d
 	/ ofEasyCam: removes roll rotation when rotating inside the arcball

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -53,6 +53,7 @@ ofAppGLFWWindow::ofAppGLFWWindow(){
 	rBits=gBits=bBits=aBits = 8;
 	depthBits			= 24;
 	stencilBits			= 0;
+	stereo				= false;
 
 	orientation 		= OF_ORIENTATION_DEFAULT;
 
@@ -124,6 +125,10 @@ void ofAppGLFWWindow::setStencilBits(int stencil){
 	stencilBits=stencil;
 }
 
+//------------------------------------------------------------
+void ofAppGLFWWindow::setStereo(bool stereo){
+	this->stereo=stereo;
+}
 
 
 #ifdef TARGET_OPENGLES
@@ -162,6 +167,7 @@ void ofAppGLFWWindow::setupOpenGL(int w, int h, ofWindowMode screenMode){
 	glfwWindowHint(GLFW_ALPHA_BITS, aBits);
 	glfwWindowHint(GLFW_DEPTH_BITS, depthBits);
 	glfwWindowHint(GLFW_STENCIL_BITS, stencilBits);
+	glfwWindowHint(GLFW_STEREO, stereo?GL_TRUE:GL_FALSE);
 #ifdef TARGET_LINUX
 	// start the window hidden so we can set the icon before it shows
 	glfwWindowHint(GLFW_VISIBLE,GL_FALSE);

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -36,6 +36,7 @@ public:
 	void		setAlphaBits(int a);
 	void		setDepthBits(int depth);
 	void		setStencilBits(int stencil);
+	void		setStereo(bool stereo);
 	void		listVideoModes();
 	bool		isWindowIconified();
 	bool		isWindowActive();
@@ -142,6 +143,7 @@ private:
 	//utils
 	int				samples;
 	int				rBits,gBits,bBits,aBits,depthBits,stencilBits;
+	bool			stereo;
 
 	ofWindowMode	windowMode;
 


### PR DESCRIPTION
It enables the GLWF for Stereoscopic monitor like this from NVidia 3D Vision:
http://www.nvidia.com/object/3d-vision-displays.html

Usage:
	ofAppGLFWWindow * window = new ofAppGLFWWindow();
	window->setStereo(true);
	ofSetupOpenGL(window,1024,768,OF_WINDOW);
	
If you set stereo true without the correct monitor the application will not run correctly.