### PR TITLE
Eliminate unnecessary destructor, copy and assignment ops in ofColor.

### DIFF
--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -179,30 +179,11 @@ float ofColor_<float>::limit() {
 }
 
 template<typename PixelType>
-ofColor_<PixelType>::ofColor_():
-    r(limit()),
-    g(limit()),
-    b(limit()),
-    a(limit()){
-}
-
-template<typename PixelType>
-ofColor_<PixelType>::~ofColor_(){}
-
-template<typename PixelType>
 ofColor_<PixelType>::ofColor_(float _r, float _g, float _b, float _a):
     r(_r),
     g(_g),
     b(_b),
     a(_a){
-}
-
-template<typename PixelType>
-ofColor_<PixelType>::ofColor_(const ofColor_<PixelType>& color):
-    r(color.r),
-    g(color.g),
-    b(color.b),
-    a(color.a){
 }
 
 template<typename PixelType>
@@ -527,16 +508,6 @@ int ofColor_<unsigned char>::getHex() const {
 template<typename PixelType>
 int ofColor_<PixelType>::getHex() const {
 	return ((ofColor) *this).getHex();
-}
-
-
-template<typename PixelType>
-ofColor_<PixelType> & ofColor_<PixelType>::operator = (const ofColor_<PixelType>& color){
-	r = color.r;
-	g = color.g;
-	b = color.b;
-	a = color.a;
-	return *this;
 }
 
 

--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -57,10 +57,11 @@ template<typename PixelType>
 class ofColor_{
 public:
     /// \brief Construct an ofColor_ instance.
-    ofColor_<PixelType>();
-
-    /// \brief Destroy an ofColor_ instance.
-    ~ofColor_<PixelType>();
+    ofColor_<PixelType>():
+        r(limit()),
+        g(limit()),
+        b(limit()),
+        a(limit()) {};
 
     /// \brief Construct an ofColor_ by using channel values.
     ///
@@ -76,10 +77,6 @@ public:
                         float green,
                         float blue,
                         float alpha = limit());
-
-    /// \brief Construct an ofColor_ from an existing ofColor_.
-    /// \param color The ofColor_ to copy.
-    ofColor_<PixelType>(const ofColor_<PixelType>& color);
 
     /// \brief Construct an ofColor_ from an existing ofColor_.
     ///
@@ -407,15 +404,6 @@ public:
                 float saturation,
                 float brightness,
                 float alpha = limit());
-
-    /// \brief Assign a color using an existing color.
-    ///
-    /// R, G, B and A components are set to the the values of the assigned
-    /// color.
-    ///
-    /// \param color The color to assign.
-    /// \returns A reference to itself.
-    ofColor_<PixelType>& operator = (const ofColor_<PixelType>& color);
 
     /// \brief Assign a color using an existing color.
     ///


### PR DESCRIPTION
ofColor does not need these operations to be explicitly defined because the
compiler-supplied versions should be sufficient. Further, defining them
explicitly (and making them not inline) will hurt performance by requiring
unnecessary function calls.

Removing these also makes the class trivially copyable, which is also desirable
(it makes it possible to copy arrays of ofColor with memcpy instead of
individually copying each element, for example).
