### PR TITLE
Implement support for Android Studio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ Desktop.ini
 .csettings
 /libs/openFrameworksCompiled/project/android/paths.make
 
+# Android Studio
+*.iml
+
 #########################
 # miscellaneous
 #########################

--- a/addons/ofxAndroid/ofAndroidLib/AndroidManifest.xml
+++ b/addons/ofxAndroid/ofAndroidLib/AndroidManifest.xml
@@ -1,15 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="cc.openframeworks.cc"
-      android:versionCode="1"
-      android:versionName="1.0">
-    <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="17" />
-    <application android:icon="@drawable/icon" android:label="@string/app_name">
-
-
-    </application>
-
-
-</manifest> 
+<manifest package="cc.openframeworks.cc">
+</manifest>

--- a/addons/ofxAndroid/ofAndroidLib/build.gradle
+++ b/addons/ofxAndroid/ofAndroidLib/build.gradle
@@ -1,0 +1,70 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 19
+    buildToolsVersion "21.1.1"
+
+    defaultConfig {
+        minSdkVersion 8
+        targetSdkVersion 17
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+    // Configure source folders like Eclipse
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+    }
+}
+
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+}
+
+/** Configure OpenFrameworks by writing paths.make */
+task configureOF(dependsOn: rootProject.ofNdkSetup) {
+    def projectRoot = file("$projectDir/../../../libs/openFrameworksCompiled/project")
+    ext.projectRoot = projectRoot.absolutePath
+
+    doLast {
+        def pathsFile = file("$projectRoot/android/paths.make")
+        pathsFile.withPrintWriter { out ->
+            out.println("NDK_ROOT=${rootProject.ofNdkSetup.ext.ndkDirectory}")
+            out.println("SDK_ROOT=${rootProject.ofNdkSetup.ext.sdkDirectory}")
+        }
+    }
+}
+
+task compileReleaseOF(dependsOn: configureOF) << {
+    rootProject.ofRunMake(["-C", configureOF.ext.projectRoot, "PLATFORM_OS=Android", "Release"])
+}
+
+task compileDebugOF(dependsOn: configureOF) << {
+    rootProject.ofRunMake(["-C", configureOF.ext.projectRoot, "PLATFORM_OS=Android", "Debug"])
+}
+
+task cleanOF(dependsOn: configureOF) << {
+    rootProject.ofRunMake(["-C", configureOF.ext.projectRoot, "PLATFORM_OS=Android", "clean"])
+}
+
+
+clean {
+    dependsOn cleanOF
+}
+
+project.afterEvaluate {
+    compileDebugNdk.dependsOn(compileDebugOF)
+    compileReleaseNdk.dependsOn(compileReleaseOF)
+}

--- a/docs/android.md
+++ b/docs/android.md
@@ -3,11 +3,101 @@
 Android
 =======
 
+The Android distribution of openFrameworks is setup to work with either the Eclipse IDE or the newer Android Studio IDE. The projects are currently using a custom toolchain based on Makefiles to compile and install applications.
+
+# Android Studio
+
+## Summary
+
+Setting up openFrameworks with Android Studio is fairly straightforward. The basic steps are:
+
+- Install Android Studio and the Android SDK
+- Install the Android NDK (r10b or lower)
+- Download openFrameworks from the download page or from git
+- In Android Studio, use **File ➞ Import Project** and select the `settings.gradle` file in the root of the openFrameworks directory
+- Set the path to the NDK in local.properties (`ndk.dir`)
+- Build and run
+
+## Installation
+
+### Install Android Studio and the SDK
+
+Download and install Android Studio from http://tools.android.com/download/studio/canary/latest (you need Android Studio 0.9.0 or higher). It should come with (or automatically install) a recent SDK, though you can customize the SDK version later from within Android Studio using **Tools ➞ Android ➞ SDK Manager**.
+
+In the event that Android Studio does not come with an SDK, you can install it from http://developer.android.com/sdk/index.html (under "Get the SDK for an existing IDE").
+
+### Install the Android NDK
+
+For the current version of openFrameworks, you need to install Android NDK revision r10b or earlier. r10c breaks compatibility with some libraries, and should (at this time) be avoided.
+
+Here are download links for r9d, which has been tested and works fine:
+
+- Windows 32-bit: http://dl.google.com/android/ndk/android-ndk-r9d-windows-x86.zip
+- Windows 64-bit: http://dl.google.com/android/ndk/android-ndk-r9d-windows-x86_64.zip
+- Mac OS X 32-bit: http://dl.google.com/android/ndk/android-ndk-r9d-darwin-x86.tar.bz2
+- Mac OS X 64-bit: http://dl.google.com/android/ndk/android-ndk-r9d-darwin-x86_64.tar.bz2
+- Linux 32-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86.tar.bz2
+- Linux 64-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86_64.tar.bz2 
+
+### Download openFrameworks
+
+Download it from the downloads page:
+
+http://openframeworks.cc/download
+
+You may also check out the openFrameworks source from GitHub (under master branch): http://github.com/openframeworks/openFrameworks
+
+### Import the project
+
+At the Android Studio welcome screen select **Import Non-Android Studio project**, or use the **File ➞ Import Project** menu item. Browse to  the `settings.gradle` file in the `libs/openFrameworksCompiled/project/android` directory. Accept all the prompts and wait for Android Studio to set up the project.
+
+At this point you will get an error about the NDK not being configured. Onto the next step...
+
+### Configure the NDK
+
+Edit the file `local.properties` and add a line like this:
+
+    ndk.dir=/path/to/the/ndk
+
+Save and resync the project (either press the "Try Again" link on the "Gradle project sync failed" banner, or use **Tools ➞ Android ➞ Sync Project with Gradle Files**).
+
+You'll have to wait a bit: the first sync will automatically build openFrameworks. If it doesn't work (Gradle sync still fails), try looking at the Troubleshooting tips.
+
+### Build and run
+
+Press the Play button next to the `androidEmptyExample` shown in the toolbar. With any luck, it should build the app, and momentarily deploy it to your Android device (or prompt you to deploy it on a suitable emulator). If the app runs, congratulations! You have setup openFrameworks.
+
+## Creating new projects
+
+1. Copy the provided example app (make sure to put it in a subdirectory of `apps`, at the same level as the sample)
+2. Double-click on `build.gradle` and press "Add Now..."
+3. If that doesn't work, add the project to `settings.gradle` manually.
+4. Perform a project sync (it should prompt you to do this).
+
+## Creating projects from examples
+
+1. Copy the `build.gradle` file from `androidEmptyExample` into the examples directory.
+2. Follow steps 2-4 above.
+
+## Troubleshooting
+
+- You may need to adjust the following numbers to match your installed Android Studio and Android SDK. Android Studio should offer to fix these values for you when you open the appropriate build files.
+
+    - The Gradle version specified in `/build.gradle`
+    - The `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion`, `targetSdkVersion` values
+        in `/addons/ofxAndroid/ofAndroidLib/build.gradle` and `/apps/myApps/androidEmptyExample/build.gradle`
+
+- If you get strange linker errors (e.g. errors about a missing `__srget`), try using the r9d version of the NDK. Newer NDKs (particularly r10c and up) don't work with some versions of OpenFrameworks.
+
+
+Eclipse
+=======
+
 This information is also online: http://openframeworks.cc/setup/android-eclipse
 
 **Note**: see the FAQ at the bottom of this page if you're having trouble.
 
-The Android distribution of openFrameworks is based on the Eclipse IDE. The current version of the Android plugin for Eclipse has several problems with projects that mix C++ and Java code, so the projects are currently using a custom toolchain based on makefiles + Ant tasks to compile and install applications. If you are used to Android development in Eclipse, things are a little different. Check the following instructions to know how to install the development environment and compile/install applications.
+The current version of the Android plugin for Eclipse has several problems with projects that mix C++ and Java code, so the projects are currently using a custom toolchain based on makefiles + Ant tasks to compile and install applications. If you are used to Android development in Eclipse, things are a little different. Check the following instructions to know how to install the development environment and compile/install applications.
 
 Right now this is only tested on Linux and OS X. To use it on Windows, check the instructions on this link: http://www.multigesture.net/articles/how-to-setup-openframeworks-for-android-on-windows/
 

--- a/examples/android/androidEmptyExample/build.gradle
+++ b/examples/android/androidEmptyExample/build.gradle
@@ -1,0 +1,57 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 19
+    buildToolsVersion "21.1.1"
+
+    defaultConfig {
+        minSdkVersion 8
+        targetSdkVersion 17
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    // Configure source folders like Eclipse
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            jni.srcDirs = ['jni']
+            java.srcDirs = ['srcJava']
+            resources.srcDirs = ['srcJava']
+            aidl.srcDirs = ['srcJava']
+            renderscript.srcDirs = ['srcJava']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+            jniLibs.srcDirs = ['libs']
+        }
+    }
+}
+
+dependencies {
+    compile project(':ofAndroidLib')
+}
+
+task compileReleaseOF(dependsOn: rootProject.ofNdkSetup) << {
+    rootProject.ofRunMake(["-C", projectDir.absolutePath, "PLATFORM_OS=Android", "Release"])
+}
+
+task compileDebugOF(dependsOn: rootProject.ofNdkSetup) << {
+    rootProject.ofRunMake(["-C", projectDir.absolutePath, "PLATFORM_OS=Android", "Debug"])
+}
+
+task cleanOF(dependsOn: rootProject.ofNdkSetup) << {
+    rootProject.ofRunMake(["-C", projectDir.absolutePath, "PLATFORM_OS=Android", "clean"])
+}
+
+clean {
+    dependsOn cleanOF
+}
+
+project.afterEvaluate {
+    compileDebugNdk.dependsOn(compileDebugOF)
+    compileReleaseNdk.dependsOn(compileReleaseOF)
+}

--- a/libs/openFrameworksCompiled/project/android/.gitignore
+++ b/libs/openFrameworksCompiled/project/android/.gitignore
@@ -1,0 +1,3 @@
+# Gradle files
+.gradle/
+.idea/

--- a/libs/openFrameworksCompiled/project/android/build.gradle
+++ b/libs/openFrameworksCompiled/project/android/build.gradle
@@ -1,0 +1,103 @@
+// build.gradle project file for Android Studio support
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.0.1'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+// OpenFrameworks support functions
+/**
+ * Initialization task to set up NDK paths.
+ */
+task ofNdkSetup {
+    logger.lifecycle name
+
+    /* Find NDK directory */
+    def localProperties = new File(rootDir, "local.properties")
+    if (!localProperties.exists()) {
+        throw new GradleException("local.properties is missing!")
+    }
+
+    Properties properties = new Properties()
+    localProperties.withInputStream { instr ->
+        properties.load(instr)
+    }
+    String sdkDirectory = properties.get("sdk.dir")
+    String ndkDirectory = properties.get("ndk.dir")
+    if (ndkDirectory == null) {
+        throw new GradleException("NDK not configured. Add ndk.dir=/path/to/ndk to local.properties.")
+    }
+    def ndkDir = new File(ndkDirectory)
+    if (!ndkDir.directory) {
+        throw new GradleException("NDK directory is invalid. Check ndk.dir path in local.properties.")
+    }
+
+    /* Find suitable make executable */
+    def make = null;
+
+    new File(ndkDirectory, "prebuilt").eachDir { dir ->
+        if(make != null)
+            return
+
+        def binDir = new File(dir, "bin");
+        for(fn in ["make", "make.exe"]) {
+            def makeFile = new File(binDir, fn);
+            if(makeFile.exists()) {
+                def proc = [makeFile.absolutePath, "--version"].execute()
+                proc.waitFor()
+                if(proc.exitValue() == 0) {
+                    make = makeFile;
+                }
+            }
+        }
+    }
+
+    if(make == null) {
+        throw new GradleException("GNU make not found in NDK...")
+    }
+
+    logger.info " -> found make $make"
+
+    ext.sdkDirectory = sdkDirectory
+    ext.ndkDirectory = ndkDirectory
+    ext.make = make
+}
+
+/**
+ * Helper function to run make with a given set of options
+ */
+def ofRunMake(List opts) {
+    List cmd = [rootProject.ofNdkSetup.ext.make, "-j4"] + opts
+    logger.info("Executing make command " + cmd)
+    def proc = cmd.execute()
+    proc.in.eachLine {line ->
+        logger.lifecycle(line)
+    }
+    proc.err.eachLine {line ->
+        if(line.contains(": warning:")) {
+            logger.warn(line)
+        } else if(line.contains(": error:") || line.contains(": ***")) {
+            logger.error(line)
+        } else {
+            logger.quiet(line)
+        }
+    }
+    proc.waitFor()
+    if(proc.exitValue() != 0) {
+        throw new GradleException("make failed with exit status " + proc.exitValue())
+    }
+}

--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -534,7 +534,7 @@ afterplatform:$(RESFILE)
 	
 $(RESFILE): $(DATA_FILES)
 	@echo compressing and copying resources from bin/data into res
-	cd $(PROJECT_PATH); \
+	cd "$(PROJECT_PATH)"; \
 	if [ -d "bin/data" ]; then \
 		mkdir -p res/raw; \
 		rm res/raw/$(RESNAME).zip; \
@@ -549,14 +549,14 @@ $(RESFILE): $(DATA_FILES)
 	fi
 
 install:	
-	cd $(OF_ROOT)/addons/ofxAndroid/ofAndroidLib; \
+	cd "$(OF_ROOT)/addons/ofxAndroid/ofAndroidLib"; \
 	echo installing on $(HOST_PLATFORM); \
 	if [ "$(HOST_PLATFORM)" = "windows" ]; then \
 	cmd //c $(SDK_ROOT)/tools/android.bat update project --target $(SDK_TARGET) --path .; \
 	else \
 	$(SDK_ROOT)/tools/android update project --target $(SDK_TARGET) --path .; \
 	fi 
-	cd $(PROJECT_PATH); \
+	cd "$(PROJECT_PATH)"; \
 	if [ -d "bin/data" ]; then \
 		mkdir -p res/raw; \
 		rm res/raw/$(RESNAME).zip; \

--- a/libs/openFrameworksCompiled/project/android/settings.gradle
+++ b/libs/openFrameworksCompiled/project/android/settings.gradle
@@ -1,0 +1,18 @@
+// settings.gradle project file for Android Studio support
+
+// openFrameworks-relative root directories (don't touch)
+def ofxRoot = '../../../../'
+
+include ':examples'
+project(':examples').projectDir = new File(ofxRoot + 'examples')
+
+include ':apps'
+project(':apps').projectDir = new File(ofxRoot + 'apps')
+
+include ':ofAndroidLib'
+project(':ofAndroidLib').projectDir = new File(ofxRoot + 'addons/ofxAndroid/ofAndroidLib')
+
+// your projects go here
+include 'examples:android:androidEmptyExample'
+// Add your own projects like this:
+// includeFlat 'apps:myApps:myAwesomeApp'

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -352,8 +352,8 @@ function createPackage {
 	
 	#android, move paths.default.make to paths.make
 	if [ "$pkg_platform" == "android" ]; then
-	    cd ${pkg_root}
-	    mv libs/openFrameworksCompiled/android/paths.default.make libs/openFrameworksCompiled/android/paths.make
+	    cd ${pkg_ofroot}
+	    mv libs/openFrameworksCompiled/project/android/paths.default.make libs/openFrameworksCompiled/project/android/paths.make
 	fi
 
     #delete other platforms OF project files
@@ -365,7 +365,7 @@ function createPackage {
     #remove osx in ios from openFrameworksCompiled 
     #(can't delete by default since it needs to keep things in libs for the simulator)
     if [ "$pkg_platform" = "ios" ]; then
-	    rm -Rf ${pkg_ofroot}libs/openFrameworksCompiled/lib/osx
+	    rm -Rf ${pkg_ofroot}/libs/openFrameworksCompiled/lib/osx
     	rm -Rf ${pkg_ofroot}/libs/openFrameworksCompiled/project/osx
     fi
 
@@ -414,7 +414,6 @@ function createPackage {
 	if [ "$pkg_platform" == "ios" ]; then
 		rm -Rf osx
 	fi
-    rm create_package.sh
 
     #delete .svn dirs
     cd $pkg_ofroot


### PR DESCRIPTION
This change incorporates all the necessary build files, packaging changes, makefile
tweaks and documentation needed to make openFrameworks work on Android Studio.

This resolves issue #3408.