### PR TITLE
changed crop function to reallocate pixels and use memcpy. fixes #3346

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -933,9 +933,8 @@ void ofPixels_<PixelType>::crop(int x, int y, int _width, int _height){
 	if (bAllocated){
 		ofPixels_<PixelType> crop;
 		cropTo(crop,x,y,_width,_height);
-		std::swap(crop.pixels,pixels);
-		width = crop.width;
-		height = crop.height;
+		allocate(_width,_height,getPixelFormat());
+		memcpy(pixels, crop.pixels, size());
 	}
 }
 


### PR DESCRIPTION
fix for #3346, please test.
I found that the crop function uses std::swap to copy the cropped pixels into the current object's pixels array, however I believe this was actually just swapping the pointers to the pixels arrays, leading to the run-time error after the local variable 'crop' gets deallocated, and is subsequently accessed within the swapRgb function
