### PR TITLE
Bugfix 3346: fix crop related runtime error

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -933,8 +933,7 @@ void ofPixels_<PixelType>::crop(int x, int y, int _width, int _height){
 	if (bAllocated){
 		ofPixels_<PixelType> crop;
 		cropTo(crop,x,y,_width,_height);
-		allocate(_width,_height,getPixelFormat());
-		memcpy(pixels, crop.pixels, size());
+		swap(crop);
 	}
 }
 


### PR DESCRIPTION
As arturo pointed out, swap is the right way to do it. The reason that my previous fix actually fixed it was the call to allocate which resets some more internal variables, not because of memcpy. The real issue is that not all of the internal variables are being copied. Manually copying the pixelSize variable from the crop object to the current object stopped the error from happening. I changed the crop function to use the existing ofPixels::swap mehtod which handles swapping all of the internal variables.
