### PR TITLE
Update ofUtils.cpp

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -801,10 +801,11 @@ string ofSystem(const string& command){
 	if (ret == NULL){
 		ofLogError("ofUtils") << "ofSystem(): error opening return file for command \"" << command  << "\"";
 	}else{
-		do {
-		      c = fgetc (ret);
-		      strret += c;
-		} while (c != EOF);
+		c = fgetc (ret);
+		while (c != EOF) {
+			strret += c;
+			c = fgetc (ret);
+		}
 #ifdef TARGET_WIN32
 		_pclose (ret);
 #else


### PR DESCRIPTION
Changed `char c;` to `int c;` in ofSystem() because fgetc() returns int and EOF is also declared as int. Otherwise the comparison `c != EOF` fails in my tests on Raspberry Pi (Raspbian Wheezy) and ofSystem() gets stuck in the do-while-loop. (That's probably because EOF is defined as -1 and when fgetc returns this to a char variable, it is interpreted as 255 and a comparison with EOF fails.)
