### PR TITLE
Exclude ._ files from package on OS X.

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -493,7 +493,7 @@ function createPackage {
     if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "android" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxarmv7l" ]; then
         mkdir of_v${pkg_version}_${pkg_platform}_release
         mv openFrameworks/* of_v${pkg_version}_${pkg_platform}_release
-        tar czf of_v${pkg_version}_${pkg_platform}_release.tar.gz of_v${pkg_version}_${pkg_platform}_release
+        COPYFILE_DISABLE=true tar czf of_v${pkg_version}_${pkg_platform}_release.tar.gz of_v${pkg_version}_${pkg_platform}_release
         rm -Rf of_v${pkg_version}_${pkg_platform}_release
     else
         mkdir of_v${pkg_version}_${pkg_platform}_release
@@ -519,7 +519,7 @@ if [ "$platform" = "all" ]; then
     echo dir: $PWD
     mkdir of_v${version}_all
     mv addons apps export libs other scripts $packageroot/of_v${version}_all
-    tar czf of_v$version_all_FAT.tar.gz of_v${version}_all
+    COPYFILE_DISABLE=true tar czf of_v$version_all_FAT.tar.gz of_v${version}_all
     rm -Rf of_v${version}_all
     mv * $packageroot/..
     #rm -Rf $packageroot


### PR DESCRIPTION
On OS X, tar will include ._ files in the archive unless COPYFILE_DISABLE is set.