### PR TITLE
shader uniform fixes

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -730,18 +730,18 @@ void ofShader::setUniforms(const ofParameterGroup & parameters) const{
 }
 	
 //--------------------------------------------------------------
-void ofShader::setUniformMatrix3f(const string & name, const ofMatrix3x3 & m)  const{
+void ofShader::setUniformMatrix3f(const string & name, const ofMatrix3x3 & m, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
-		if (loc != -1) glUniformMatrix3fv(loc, 1, GL_FALSE, &m.a);
+		if (loc != -1) glUniformMatrix3fv(loc, count, GL_FALSE, &m.a);
 	}
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniformMatrix4f(const string & name, const ofMatrix4x4 & m)  const{
+void ofShader::setUniformMatrix4f(const string & name, const ofMatrix4x4 & m, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
-		if (loc != -1) glUniformMatrix4fv(loc, 1, GL_FALSE, m.getPtr());
+		if (loc != -1) glUniformMatrix4fv(loc, count, GL_FALSE, m.getPtr());
 	}
 }
 

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -83,9 +83,11 @@ public:
 	void setUniforms(const ofParameterGroup & parameters) const;
 
 	// note: it may be more optimal to use a 4x4 matrix than a 3x3 matrix, if possible
-	void setUniformMatrix3f(const string & name, const ofMatrix3x3 & m) const;
-	void setUniformMatrix4f(const string & name, const ofMatrix4x4 & m) const;
+	void setUniformMatrix3f(const string & name, const ofMatrix3x3 & m, int count = 1) const;
+	void setUniformMatrix4f(const string & name, const ofMatrix4x4 & m, int count = 1) const;
 
+	GLint getUniformLocation(const string & name) const;
+	
 	// set attributes that vary per vertex (look up the location before glBegin)
 	GLint getAttributeLocation(const string & name) const;
 
@@ -163,8 +165,6 @@ private:
 	mutable unordered_map<string, GLint> uniformLocations;
 	mutable unordered_map<GLenum, string> shaderSource;
 
-	GLint getUniformLocation(const string & name) const;
-	
 	void checkProgramInfoLog(GLuint program);
 	bool checkProgramLinkStatus(GLuint program);
 	void checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLevel);


### PR DESCRIPTION
ofShader::setUniformMatrix now accepts a (optional) count parameter, so you can pass an array of matrices. useful when sending many matrices to the shader e.g. for bones, skinning, setting transformations of many objects simultaneously. 

Also made getUniformLocation public, so in the app we can manually get uniform location for a custom uniforms, like structs etc. 

Fully backwards compatible since the 'count' parameter defaults to 1 (like it does for the float set Uniforms)
