### PR TITLE
Remove "unimplemented" warning in ofSoundShutdown

### DIFF
--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -37,9 +37,9 @@ void ofSoundUpdate(){
 void ofSoundShutdown(){
 	#ifdef OF_SOUND_PLAYER_FMOD
 		ofFmodSoundPlayer::closeFmod();
-	#else
-		ofLogWarning("ofSoundPlayer") << "ofSoundShutdown() not implemented on this platform";
 	#endif
+	// ofSoundShutdown doesn't log an "unimplemented" message like the related functions
+	// above, because it's called by the openFrameworks shutdown routine regardless
 }
 #endif
 


### PR DESCRIPTION
The function is called by the OF shutdown routine on all platforms, leading to log spam on non-FMOD platforms. [Brought up by @procedural here](https://github.com/openframeworks/openFrameworks/commit/981e4cfa6910618a96e48cd8a92b02175d509d68#commitcomment-8687571).
