### PR TITLE
Alternative to manual #undef verify trick for Poco.

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -59,7 +59,8 @@ enum ofTargetPlatform{
 #if defined( __WIN32__ ) || defined( _WIN32 )
 	#define TARGET_WIN32
 #elif defined( __APPLE_CC__)
-	#include <TargetConditionals.h>
+    #define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
+    #include <TargetConditionals.h>
 
 	#if (TARGET_OS_IPHONE_SIMULATOR) || (TARGET_OS_IPHONE) || (TARGET_IPHONE)
 		#define TARGET_OF_IPHONE


### PR DESCRIPTION
- Defines macros w/ underscore.
- This is default behavior in OSX 10.9+ in AssertMacros.h

(cherry picked from commit 50c52f371460bea5ca95cdeb3a4687bc0d9003db)
