### PR TITLE
Apothecary - FreeType 2.5.0 Formulae  

### DIFF
--- a/scripts/apothecary/formulas/android_configure.sh
+++ b/scripts/apothecary/formulas/android_configure.sh
@@ -16,11 +16,12 @@ export TOOLCHAIN_PATH=${NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${HOST_PLATFO
 export CC=${NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${HOST_PLATFORM}/bin/${ANDROID_PREFIX}-gcc
 export CXX=${NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${HOST_PLATFORM}/bin/${ANDROID_PREFIX}-g++
 export AR=${NDK_ROOT}/toolchains/${TOOLCHAIN}/prebuilt/${HOST_PLATFORM}/bin/${ANDROID_PREFIX}-ar
-export CFLAGS="--sysroot=${SYSROOT} -fno-short-enums"
 
+#export CFLAGS="--sysroot=${SYSROOT} -fno-short-enums"
 #export CFLAGS="$CFLAGS -I${SYSROOT}/usr/include/ -I${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/include -I${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI}/include -I${NDK_ROOT}/sources/android/cpufeatures"
+export CFLAGS="-nostdlib --sysroot=${SYSROOT} -fno-short-enums"
 export CFLAGS="$CFLAGS -I${SYSROOT}/usr/include/ -I${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/include -I${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}/include"
-export LDFLAGS="--sysroot=${SYSROOT} -L${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/${TOOLCHAIN_VERSION}/libs/${ABI} -lz -lsupc++ -llog -ldl -lm -lc -lgnustl_static -lgcc"
+export LDFLAGS="--sysroot=${SYSROOT} -nostdlib -L${NDK_ROOT}/sources/cxx-stl/gnu-libstdc++/libs/${ABI}"
 
 if [ $ABI = armeabi-v7a ]; then
     export CFLAGS="$CFLAGS -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16"

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -113,7 +113,7 @@ function build() {
 		COMPILER_CPPTYPE=clang++ # clang, gcc
 		STDLIB=libc++
 
-		IOS_ARCHS="i386 x86_64 armv7 armv7s arm64"
+		IOS_ARCHS="i386 x86_64 armv7 arm64" # armv7s
 
 		SDKVERSION=`xcrun -sdk iphoneos --show-sdk-version`	
 		set -e
@@ -251,8 +251,9 @@ function build() {
 		echo "Please stand by..."
 		# link into universal lib
 		cd lib/$TYPE/
+
+		# libfreetype-armv7s.a  \
 		lipo -create libfreetype-armv7.a \
-					libfreetype-armv7s.a  \
 					libfreetype-arm64.a \
 					libfreetype-i386.a \
 					libfreetype-x86_64.a \

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -37,15 +37,29 @@ function build() {
 
 		local STDLIB="libstdc++"
 		local OSX_ARCH="i386"
+
+		set -e
+		CURRENTPATH=`pwd`
+
+		# Validate environment
+		case $XCODE_DEV_ROOT in  
+		     *\ * )
+		           echo "Your Xcode path contains whitespaces, which is not supported."
+		           exit 1
+		          ;;
+		esac
+		case $CURRENTPATH in  
+		     *\ * )
+		           echo "Your path contains whitespaces, which is not supported by 'make install'."
+		           exit 1
+		          ;;
+		esac 
+
 		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
-		export CC=$TOOLCHAIN/usr/bin/cc
-		export CPP=$TOOLCHAIN/usr/bin/cpp
-		export CXX=$TOOLCHAIN/usr/bin/c++
+		
 
 		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
-			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden" \
-			CPP=$CPP \
-			CXX=$CXX
+			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean 
 		make
 		make install
@@ -57,9 +71,7 @@ function build() {
 		local STDLIB="libc++"
 		local OSX_ARCH="x86_64"
 		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
-			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden" \
-			CPP=$CPP \
-			CXX=$CXX
+			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean
 		make
 		make install
@@ -278,7 +290,7 @@ function build() {
 
 	elif [ "$TYPE" == "android" ] ; then
 		
-        source ../../../../libs/openFrameworksCompiled/project/android/paths.make
+        source $LIBS_DIR/openFrameworksCompiled/project/android/paths.make
 		
 		# armv7
 		ABI=armeabi-v7a

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -277,18 +277,43 @@ function build() {
 		unset IOS_DEVROOT IOS_SDKROOT IOS_AR IOS_HOST IOS_PREFIX  CPP CXX CXXCPP CXXCPP CC LD AS AR NM RANLIB LDFLAGS STDLIB
 
 	elif [ "$TYPE" == "android" ] ; then
-		echoWarning "TODO: build android"
+		
+        source ../../../../libs/openFrameworksCompiled/project/android/paths.make
+		
+		# armv7
+		ABI=armeabi-v7a
+		local BUILD_TO_DIR=$BUILD_DIR/freetype/build/$TYPE/$ABI
+		source ../../formulas/android_configure.sh $ABI
+
+		./configure --prefix=$BUILD_TO_DIR --host armv7a-linux-android --with-harfbuzz=no --enable-static=yes --enable-shared=no 
+		make clean 
+		make
+		make install
+		
+		# x86
+		ABI=x86
+		local BUILD_TO_DIR=$BUILD_DIR/freetype/build/$TYPE/$ABI
+		source ../../formulas/android_configure.sh $ABI
+
+		./configure --prefix=$BUILD_TO_DIR --host x86-linux-android --with-harfbuzz=no --enable-static=yes --enable-shared=no 
+		make clean 
+		make
+		make install
+
+		echo "-----------"
+		echo "$BUILD_DIR"
 	fi
 }
 
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
 function copy() {
+    #remove old include files if they exist
+    rm -rf $1/include
 
 	# copy headers 
-	mkdir -p $1/include/freetype2/config
+	mkdir -p $1/include/freetype2/
 
 	# copy files from the build root
-
 	cp -Rv include/* $1/include/freetype2/
 
 	# older versions before 2.5.x
@@ -310,7 +335,8 @@ function copy() {
 		# cp -v lib/$TYPE/libfreetype.a $1/lib/$TYPE/libfreetype.a
 		echoWarning "TODO: copy win_cb lib"
 	elif [ "$TYPE" == "android" ] ; then
-		echoWarning "TODO: copy android lib"
+		cp -v build/$TYPE/armeabi-v7a/lib/libfreetype.a $1/lib/$TYPE/armeabi-v7a/libfreetype.a
+		cp -v build/$TYPE/x86/lib/libfreetype.a $1/lib/$TYPE/x86/libfreetype.a
 	fi
 }
 
@@ -321,7 +347,8 @@ function clean() {
 		echoWarning "TODO: clean vs"
 	
 	elif [ "$TYPE" == "android" ] ; then
-		echoWarning "TODO: clean android"
+		make clean
+		rm -f build/$TYPE
 	elif [ "$TYPE" == "ios" ] ; then
 		make clean
 		rm -f *.a *.lib

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -9,11 +9,11 @@
 FORMULA_TYPES=( "osx" "vs" "win_cb" "ios" "android" )
 
 # define the version
-VER=2.4.12
+VER=2.5.3
 
 # tools for git use
 GIT_URL=http://git.savannah.gnu.org/r/freetype/freetype2.git
-GIT_TAG=VER-2-4-12
+GIT_TAG=VER-2-5-3
 
 # download the source code and unpack it into LIB_NAME
 function download() {
@@ -26,23 +26,55 @@ function download() {
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
 	: # noop
+	mkdir -p lib/$TYPE
 }
 
 # executed inside the lib src dir
 function build() {
 	
 	if [ "$TYPE" == "osx" ] ; then
+		local BUILD_TO_DIR=$BUILD_DIR/freetype/build/$TYPE/
 
-		export CFLAGS="-arch i386 -arch x86_64"
+		local STDLIB="libstdc++"
+		local OSX_ARCH="i386"
+		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
+		export CC=$TOOLCHAIN/usr/bin/cc
+		export CPP=$TOOLCHAIN/usr/bin/cpp
+		export CXX=$TOOLCHAIN/usr/bin/c++
 
-		# 32 + 64 bit
-		./configure --prefix=$BUILD_ROOT_DIR
+		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
+			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden" \
+			CPP=$CPP \
+			CXX=$CXX
+		make clean 
+		make
+		make install
+		cp $BUILD_TO_DIR/lib/libfreetype.a lib/$TYPE/libfreetype-$OSX_ARCH.a
 
-		make clean; 
-		make;
-		make install;
+		unset OSX_ARCH STDLIB
 
-		unset CFLAGS
+		# x86_64
+		local STDLIB="libc++"
+		local OSX_ARCH="x86_64"
+		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
+			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden" \
+			CPP=$CPP \
+			CXX=$CXX
+		make clean
+		make
+		make install
+		cp $BUILD_TO_DIR/lib/libfreetype.a lib/$TYPE/libfreetype-$OSX_ARCH.a
+
+		cd lib/$TYPE/
+		lipo -create libfreetype-i386.a \
+					libfreetype-x86_64.a \
+					-output libfreetype.a
+		cd ../../
+
+		unset OSX_ARCH STDLIB TOOLCHAIN CC CPP CXX
+
+		echo "-----------"
+		echo "$BUILD_DIR"
 	
 	elif [ "$TYPE" == "vs" ] ; then
    		make clean
@@ -62,34 +94,113 @@ function build() {
 		make
 
 	elif [ "$TYPE" == "ios" ] ; then
-		# http://shift.net.nz/2010/09/compiling-freetype-for-iphoneios/
-		# http://stackoverflow.com/questions/6425643/compiling-freetype-for-iphone
-	
+
+		unset IOS_DEVROOT IOS_SDKROOT
+		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
+		local IOS_DEVROOT=$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer
+		local IOS_SDKROOT=$IOS_DEVROOT/SDKs/iPhoneOS$IOS_SDK_VER.sdk
+		local IOS_CC=$TOOLCHAIN/usr/bin/cc
+		local IOS_HOST="arm-apple-darwin"
+		local IOS_PREFIX="/usr/local/iphone"
+
+		export CPP=$TOOLCHAIN/usr/bin/cpp
+		export CXX=$TOOLCHAIN/usr/bin/c++
+		export CXXCPP=$TOOLCHAIN/usr/bin/cpp
+		export CC=$TOOLCHAIN/usr/bin/cc
+		export LD=$TOOLCHAIN/usr/bin/ld
+		export AR=$TOOLCHAIN/usr/bin/ar
+		export AS=$TOOLCHAIN/usr/bin/as
+		export NM=$TOOLCHAIN/usr/bin/nm
+		export RANLIB=$TOOLCHAIN/usr/bin/ranlib
+		export LDFLAGS="-L$IOS_SDKROOT/usr/lib/"
+
+		local STDLIB="libc++" 
+		#local STDLIB="libstdc++"
+
 		# armv7
-		./configure --without-bzip2 --prefix=/usr/local/iphone --host=arm-apple-darwin --enable-static=yes --enable-shared=no \
-			CC=$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc \
-			CFLAGS="-arch armv7 -pipe -std=c99 -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk/usr/include/libxml2 -isysroot $XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk" \
-			AR=$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/usr/bin/ar \
-			LDFLAGS="-arch armv7 -isysroot $XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk -miphoneos-version-min=$IOS_MIN_SDK_VER"
+		local IOS_ARCH="armv7"
+		./configure --without-bzip2 --prefix=$IOS_PREFIX --host=$IOS_HOST --enable-static=yes --enable-shared=no \
+			CC=$IOS_CC \
+			CFLAGS="-arch $IOS_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$IOS_SDKROOT/usr/include/libxml2 -isysroot $IOS_SDKROOT" \
+			AR=$AR \
+			LDFLAGS="-arch $IOS_ARCH -isysroot $IOS_SDKROOT -miphoneos-version-min=$IOS_MIN_SDK_VER"
 		make clean; make
-		cp objs/.libs/libfreetype.a libfreetype-armv7.a
+		cp objs/.libs/libfreetype.a lib/$TYPE/libfreetype-$IOS_ARCH.a
+		unset IOS_ARCH
 
 		# armv7s
-		./configure --without-bzip2 --prefix=/usr/local/iphone --host=arm-apple-darwin --enable-static=yes --enable-shared=no \
-			CC=$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/usr/bin/gcc \
-			CFLAGS="-arch armv7s -pipe -std=c99 -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk/usr/include/libxml2 -isysroot $XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk" \
-			AR=$XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/usr/bin/ar \
-			LDFLAGS="-arch armv7s -isysroot $XCODE_DEV_ROOT/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS$IOS_SDK_VER.sdk -miphoneos-version-min=$IOS_MIN_SDK_VER"
+		local IOS_ARCH="armv7s"
+		./configure --without-bzip2 --prefix=$IOS_PREFIX --host=$IOS_HOST --enable-static=yes --enable-shared=no \
+			CC=$IOS_CC \
+			CFLAGS="-arch $IOS_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$IOS_SDKROOT/usr/include/libxml2 -isysroot $IOS_SDKROOT" \
+			AR=$AR \
+			LDFLAGS="-arch $IOS_ARCH -isysroot $IOS_SDKROOT -miphoneos-version-min=$IOS_MIN_SDK_VER"
 		make clean; make
-		cp objs/.libs/libfreetype.a libfreetype-armv7s.a
+		cp objs/.libs/libfreetype.a lib/$TYPE/libfreetype-$IOS_ARCH.a
+		unset IOS_ARCH
+
+		# arm64
+
+		local IOS_MIN_ARM64_SDK_VER="7.0"
+		local IOS_ARCH="arm64"
+		#export STDLIB="libc++"
+		./configure --without-bzip2 --prefix=$IOS_PREFIX --host=$IOS_HOST --enable-static=yes --enable-shared=no \
+			CC=$IOS_CC \
+			CFLAGS="-arch $IOS_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$IOS_SDKROOT/usr/include/libxml2 -isysroot $IOS_SDKROOT" \
+ 			AS=$AS \
+ 			AR=$AR \
+	        NM=$IOS_DEVROOT/usr/bin/nm \
+			LDFLAGS="-arch $IOS_ARCH -isysroot $IOS_SDKROOT -miphoneos-version-min=$IOS_MIN_SDK_VER"
+		make clean; make
+		cp objs/.libs/libfreetype.a lib/$TYPE/libfreetype-$IOS_ARCH.a
+		unset IOS_ARCH
+		unset IOS_MIN_ARM64_SDK_VER
 
 		# simulator
-		./configure CFLAGS="-arch i386"
+
+		# i386
+		unset IOS_DEVROOT IOS_SDKROOT
+		#export STDLIB="libstdc++"
+		local IOS_DEVROOT=$XCODE_DEV_ROOT/Platforms/iPhoneSimulator.platform/Developer
+		local IOS_SDKROOT=$IOS_DEVROOT/SDKs/iPhoneSimulator$IOS_SDK_VER.sdk
+
+		unset LDFLAGS
+		export LDFLAGS="-L$IOS_SDKROOT/usr/lib/"
+		local IOS_ARCH="i386"
+		./configure --without-bzip2 --enable-static=yes --enable-shared=no \
+			CC=$IOS_CC \
+			CFLAGS="-arch $IOS_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$IOS_SDKROOT/usr/include/libxml2 -isysroot $IOS_SDKROOT" \
+			CPP=$CPP \
+			CXX=$CXX \
+			LDFLAGS="-arch $IOS_ARCH -isysroot $IOS_SDKROOT -miphoneos-version-min=$IOS_MIN_SDK_VER"
 		make clean; make
-		cp objs/.libs/libfreetype.a libfreetype-i386.a
+		cp objs/.libs/libfreetype.a lib/$TYPE/libfreetype-$IOS_ARCH.a
+		unset IOS_ARCH
+
+		# x86_64
+		local IOS_ARCH="x86_64"
+		#export STDLIB="libc++"
+		./configure --without-bzip2 --enable-static=yes --enable-shared=no \
+			CC=$IOS_CC \
+			CFLAGS="-arch $IOS_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden -miphoneos-version-min=$IOS_MIN_SDK_VER -I$IOS_SDKROOT/usr/include/libxml2 -isysroot $IOS_SDKROOT" \
+			CPP=$CPP \
+			CXX=$CXX \
+			LDFLAGS="-arch $IOS_ARCH -isysroot $IOS_SDKROOT -miphoneos-version-min=$IOS_MIN_SDK_VER"
+		make clean; make
+		cp objs/.libs/libfreetype.a lib/$TYPE/libfreetype-$IOS_ARCH.a
+		unset IOS_ARCH
 
 		# link into universal lib
-		lipo -create libfreetype-armv7.a libfreetype-armv7s.a libfreetype-i386.a -output libfreetype.a
+		cd lib/$TYPE/
+		lipo -create libfreetype-armv7.a \
+					libfreetype-armv7s.a  \
+					libfreetype-arm64.a \
+					libfreetype-i386.a \
+					libfreetype-x86_64.a \
+					-output libfreetype.a
+		cd ../../
+ 
+		unset IOS_DEVROOT IOS_SDKROOT IOS_AR IOS_HOST IOS_PREFIX  CPP CXX CXXCPP CXXCPP CC LD AS AR NM RANLIB LDFLAGS STDLIB
 
 	elif [ "$TYPE" == "android" ] ; then
 		echoWarning "TODO: build android"
@@ -100,24 +211,29 @@ function build() {
 function copy() {
 
 	# copy headers 
-	mkdir -p $1/include/freetype2/freetype/config
+	mkdir -p $1/include/freetype2/config
 
 	# copy files from the build root
-	cp -Rv $BUILD_ROOT_DIR/include/freetype2/* $1/include/freetype2/
-	cp -Rv $BUILD_ROOT_DIR/include/ft2build.h $1/include/freetype2/
+
+	cp -Rv include/* $1/include/freetype2/
+
+	# older versions before 2.5.x
+	#mkdir -p $1/include/freetype2/freetype/config
+	#cp -Rv include/* $1/include/freetype2/freetype
+	#cp -Rv include/ft2build.h $1/include/
 
 	# copy lib
 	mkdir -p $1/lib/$TYPE
 
-	if [ "$TYPE" == "osx" -o "$TYPE" == "ios" ] ; then
-		# TODO use the lib prefix.  
-		# Required CoreOF.xcconfig mod.
-		# Required ios CoreOF.xcconfig mod.
-		cp -v $BUILD_ROOT_DIR/lib/libfreetype.a $1/lib/$TYPE/freetype.a
+	if [ "$TYPE" == "osx" ] ; then
+		cp -v lib/$TYPE/libfreetype.a $1/lib/$TYPE/freetype.a
+	elif [ "$TYPE" == "ios" ] ; then
+		cp -v lib/$TYPE/libfreetype.a $1/lib/$TYPE/freetype.a
 	elif [ "$TYPE" == "vs" ] ; then
+		# cp -v lib/$TYPE/libfreetype.lib $1/lib/$TYPE/libfreetype.lib
 		echoWarning "TODO: copy vs lib"
 	elif [ "$TYPE" == "win_cb" ] ; then
-		#cp -v objs/.libs/libfreetype.a $1/lib/$TYPE/freetype.a
+		# cp -v lib/$TYPE/libfreetype.a $1/lib/$TYPE/libfreetype.a
 		echoWarning "TODO: copy win_cb lib"
 	elif [ "$TYPE" == "android" ] ; then
 		echoWarning "TODO: copy android lib"


### PR DESCRIPTION
Formula's for:
- [x] OSX FAT (32 bit w/ libstdc++ and 64 bit w/ libc++)  [![Build Status](https://travis-ci.org/danoli3/apothecary-den.svg?branch=freetype-osx)](https://travis-ci.org/danoli3/apothecary-den/branches)
- [x] iOS FAT (armv7, ~~armv7s~~~, arm64, i386, x86_64 all with libc++) [![Build Status](https://travis-ci.org/danoli3/apothecary-den.svg?branch=freetype-ios)](https://travis-ci.org/danoli3/apothecary-den/branches)
- [x] Android - armeabi (@arturoc ?)
- [x] Android - armeabi-v7a (@arturoc ?)
- [x] Android - x86 (@arturoc ?)
- [ ] VS
- [ ] win_cb
- [x] Linux (32 bit)
- [x] Linux (64 bit)
- [x] Linux Armv6l
- [x] Linux Armv7l
- [x] emscripten

Notes:
-------------------------------
ofTrueTypeFont path fixes for FreeType 2.5.0+ are in a separate PR Here:


Original PR:
https://github.com/openframeworks/openFrameworks/pull/3152


