### PR TITLE
ofxiOSMapKit fixes

### DIFF
--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
@@ -110,7 +110,7 @@ void ofxiOSMapKit::_setRegion(CLLocationCoordinate2D center, MKCoordinateSpan sp
 void ofxiOSMapKit::setType(ofxiOSMapKitType type) {
     if(isOpen()) {
         ofLogVerbose("ofxiOSMapKit") << "setType(): setting map type: " << (int) type;
-        mapView.mapType = type;
+        mapView.mapType = (MKMapType)type;
     }
 }
 


### PR DESCRIPTION
- Casting to correct type on assignment (ofxiOSMapKitType is a enum clone of MKMapType anyway).
- Fixes the thrown compile error in Xcode 6 with llvm libc++

Just to be clear `mapView.mapType` is `MKMapType`
