### PR TITLE
Update ofShader.cpp to use logging modules

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -227,7 +227,7 @@ string ofShader::parseForIncludes( const string& source, const string& sourceDir
 string ofShader::parseForIncludes( const string& source, vector<string>& included, int level, const string& sourceDirectoryPath) {
     
 	if ( level > 32 ) {
-		ofLog( OF_LOG_ERROR, "glsl header inclusion depth limit reached, might be caused by cyclic header inclusion" );
+		ofLogError( "ofShader", "glsl header inclusion depth limit reached, might be caused by cyclic header inclusion" );
 		return "";
 	}
 	
@@ -249,7 +249,7 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 		string include = line.substr(matches[1].offset, matches[1].length);
 		
 		if ( std::find( included.begin(), included.end(), include ) != included.end() ) {
-			ofLogVerbose() << include << " already included";
+			ofLogVerbose("ofShader") << include << " already included";
 			continue;
 		}
 		
@@ -261,7 +261,7 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 		
 		ofBuffer buffer = ofBufferFromFile( include );
 		if ( !buffer.size() ) {
-			ofLogError() <<"Could not open glsl include file " << include;
+			ofLogError("ofShader") <<"Could not open glsl include file " << include;
 			continue;
 		}
 		
@@ -277,7 +277,7 @@ string ofShader::getShaderSource(GLenum type)  const{
 	if (shaderSource.find(type) != shaderSource.end()) {
 		return shaderSource[type];
 	} else {
-		ofLogError() << "No shader source for shader of type: " << nameForType(type);
+		ofLogError("ofShader") << "No shader source for shader of type: " << nameForType(type);
 		return "";
 	}
 }
@@ -400,7 +400,7 @@ void ofShader::checkProgramInfoLog(GLuint program) {
 			}
 		}
 #endif
-		ofLog(OF_LOG_ERROR, msg + infoBuffer);
+		ofLogError("ofShader", msg + infoBuffer);
 		delete [] infoBuffer;
 	}
 }
@@ -435,7 +435,7 @@ bool ofShader::linkProgram() {
 		for(unordered_map<GLenum, GLuint>::const_iterator it = shaders.begin(); it != shaders.end(); ++it){
 			GLuint shader = it->second;
 			if(shader) {
-				ofLogVerbose() << "linkProgram(): attaching " << nameForType(it->first) << " shader to program " << program;
+				ofLogVerbose("ofShader") << "linkProgram(): attaching " << nameForType(it->first) << " shader to program " << program;
 				glAttachShader(program, shader);
 			}
 		}


### PR DESCRIPTION
There were a number of logging messages produced by ofShader that did not have the module set to "ofShader". This update fixes most of these with really trivial changes. 

Unless I'm missing something, it appears that due to limitations in the ofLog interface there is no way to add module information to the ofLog messages that take a log level as an argument (as in the ofShader::checkShaderInfoLog() function). To do so would need a constructor for ofLog that takes a module string as an argument or something.
