### PR TITLE
Adding missing ofSoundStreamSetDeviceID() functition

### DIFF
--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -46,6 +46,11 @@ void ofSoundStreamListDevices(){
 }
 
 //------------------------------------------------------------
+void ofSoundStreamSetDeviceID(int deviceID){
+	soundStreamOutput.setDeviceID(deviceID);
+}
+
+//------------------------------------------------------------
 ofSoundStream::ofSoundStream(){
 	#ifdef OF_SOUND_STREAM_TYPE
 		setSoundStream( shared_ptr<OF_SOUND_STREAM_TYPE>(new OF_SOUND_STREAM_TYPE) );

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -62,6 +62,9 @@ void ofSoundStreamClose();
 /// \brief Prints a list of available devices to the console
 void ofSoundStreamListDevices();
 
+/// \brief Sets the device represented by the stream, see ofSoundStreamListDevices().
+void ofSoundStreamSetDeviceID(int deviceID);
+
 /// \class ofSoundStream
 /// \brief Gives access to audio input and output devices
 ///


### PR DESCRIPTION
I have different device id for sound output on Linux, without this function you can't switch it if a stream was created with `ofSoundStreamSetup()`.