### PR TITLE
windows specific fixes to project files

### DIFF
--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
@@ -58,6 +58,9 @@
     <Bscmake>
       <PreserveSbr>true</PreserveSbr>
     </Bscmake>
+    <Lib>
+      <AdditionalDependencies>winmm.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -66,7 +69,11 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;POCO_STATIC;CAIRO_WIN32_STATIC_BUILD;DISABLE_SOME_FLOATING_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
+    <Lib>
+      <AdditionalDependencies>winmm.lib</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\openFrameworks\3d\of3dPrimitives.h" />
@@ -79,6 +86,8 @@
     <ClInclude Include="..\..\..\openFrameworks\app\ofAppGLFWWindow.h" />
     <ClInclude Include="..\..\..\openFrameworks\app\ofAppNoWindow.h" />
     <ClInclude Include="..\..\..\openFrameworks\app\ofBaseApp.h" />
+    <ClInclude Include="..\..\..\openFrameworks\app\ofMainLoop.h" />
+    <ClInclude Include="..\..\..\openFrameworks\app\ofWindowSettings.h" />
     <ClInclude Include="..\..\..\openFrameworks\gl\ofBufferObject.h" />
     <ClInclude Include="..\..\..\openFrameworks\gl\ofFbo.h" />
     <ClInclude Include="..\..\..\openFrameworks\gl\ofGLRenderer.h" />
@@ -160,6 +169,7 @@
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppGlutWindow.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppNoWindow.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppRunner.cpp" />
+    <ClCompile Include="..\..\..\openFrameworks\app\ofMainLoop.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\events\ofEvents.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\gl\ofBufferObject.cpp" />
     <ClCompile Include="..\..\..\openFrameworks\gl\ofFbo.cpp" />

--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
@@ -279,6 +279,12 @@
     <ClInclude Include="..\..\..\openFrameworks\sound\ofSoundUtils.h">
       <Filter>libs\openFrameworks\sound</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\openFrameworks\app\ofMainLoop.h">
+      <Filter>libs\openFrameworks\app</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\openFrameworks\app\ofWindowSettings.h">
+      <Filter>libs\openFrameworks\app</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppGlutWindow.cpp">
@@ -481,6 +487,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\openFrameworks\sound\ofBaseSoundStream.cpp">
       <Filter>libs\openFrameworks\sound</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\openFrameworks\app\ofMainLoop.cpp">
+      <Filter>libs\openFrameworks\app</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* adds winmm.lib as a linker dependency (needed for high precision timer)
* enables multi-core compilation
* adds `ofMainLoop` and `ofWindowSettings` to openFrameworks project file