### PR TITLE
fixes some minor issues with the compute shader particles example

### DIFF
--- a/examples/gl/computeShaderParticlesExample/src/ofApp.cpp
+++ b/examples/gl/computeShaderParticlesExample/src/ofApp.cpp
@@ -67,7 +67,14 @@ void ofApp::update(){
 	compute.setUniform3f("attractor1",atractor1.x,atractor1.y,atractor1.z);
 	compute.setUniform3f("attractor2",atractor2.x,atractor2.y,atractor2.z);
 	compute.setUniform3f("attractor3",atractor3.x,atractor3.y,atractor3.z);
-	compute.dispatchCompute(particles.size()/1024, 1, 1);
+	
+	// since each work group has a local_size of 1024 (this is defined in the shader)
+	// we only have to issue 1 / 1024 workgroups to cover the full workload.
+	// note how we add 1024 and subtract one, this is a fast way to do the equivalent
+	// of std::ceil() in the float domain, i.e. to round up, so that we're also issueing
+	// a work group should the total size of particles be < 1024
+	compute.dispatchCompute((particles.size() + 1024 -1 )/1024, 1, 1);
+	
 	compute.end();
 
 	particlesBuffer.copyTo(particlesBuffer2);
@@ -113,6 +120,9 @@ void ofApp::keyPressed(int key){
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
+	if (key == 'f'){
+		ofToggleFullscreen();
+	}
 
 }
 


### PR DESCRIPTION
* makes sure to issue the right number of workgroups + add comment outlining reasoning
* use GL_STREAM_DRAW as usage hint - although this does not make a difference on my driver implementation, but is more correct, since the particle data is constantly read and written on the GPU
* adds key toggle for fullscreen