### PR TITLE
Add ofFbo::clear() for consistency with other classes

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -287,7 +287,7 @@ ofFbo::ofFbo(const ofFbo & mom){
 
 ofFbo & ofFbo::operator=(const ofFbo & mom){
 	if(&mom==this) return *this;
-	destroy();
+	clear();
 	settings = mom.settings;
 	bIsAllocated = mom.bIsAllocated;
 
@@ -319,7 +319,7 @@ ofFbo & ofFbo::operator=(const ofFbo & mom){
 }
 
 ofFbo::~ofFbo(){
-	destroy();
+	clear();
 }
 
 int	ofFbo::maxColorAttachments() {
@@ -337,7 +337,7 @@ int	ofFbo::maxSamples() {
 	return _maxSamples;
 }
 
-void ofFbo::destroy() {
+void ofFbo::clear() {
 	if(fbo){
 		releaseFB(fbo);
 		fbo=0;
@@ -364,6 +364,10 @@ void ofFbo::destroy() {
 	for(int i=0; i<(int)colorBuffers.size(); i++) releaseRB(colorBuffers[i]);
 	colorBuffers.clear();
 	bIsAllocated = false;
+}
+
+void ofFbo::destroy() {
+	clear();
 }
 
 bool ofFbo::checkGLSupport() {
@@ -425,7 +429,7 @@ void ofFbo::allocate(int width, int height, int internalformat, int numSamples) 
 void ofFbo::allocate(Settings _settings) {
 	if(!checkGLSupport()) return;
 
-	destroy();
+	clear();
 
 	// check that passed values are correct
 	if(_settings.width <= 0 || _settings.height <= 0){
@@ -570,10 +574,6 @@ void ofFbo::allocate(Settings _settings) {
 
 bool ofFbo::isAllocated() const {
 	return bIsAllocated;
-}
-
-void ofFbo::clear() {
-	destroy();
 }
 
 GLuint ofFbo::createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint) {

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -337,7 +337,6 @@ int	ofFbo::maxSamples() {
 	return _maxSamples;
 }
 
-
 void ofFbo::destroy() {
 	if(fbo){
 		releaseFB(fbo);
@@ -571,6 +570,10 @@ void ofFbo::allocate(Settings _settings) {
 
 bool ofFbo::isAllocated() const {
 	return bIsAllocated;
+}
+
+void ofFbo::clear() {
+	destroy();
 }
 
 GLuint ofFbo::createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint) {

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -15,6 +15,7 @@ public:
 	//void allocateForShadow( int width, int height );
 	void allocate(Settings settings = Settings());
 	bool isAllocated() const;
+	void clear();
 
 	using ofBaseDraws::draw;
 	void draw(float x, float y) const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -15,6 +15,8 @@ public:
 	//void allocateForShadow( int width, int height );
 	void allocate(Settings settings = Settings());
 	bool isAllocated() const;
+
+	OF_DEPRECATED_MSG("Use clear instead",void destroy());
 	void clear();
 
 	using ofBaseDraws::draw;
@@ -126,8 +128,6 @@ private:
 #ifdef TARGET_OPENGLES
 	static bool bglFunctionsInitialized;
 #endif
-
-	void destroy();
 
 	// if using MSAA, we will have rendered into a colorbuffer, not directly into the texture
 	// call this to blit from the colorbuffer into the texture so we can use the results for rendering, or input to a shader etc.

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -123,9 +123,11 @@ static ofImageType ofImageTypeFromPixelFormat(ofPixelFormat pixelFormat){
 	case OF_PIXELS_GRAY:
 		return OF_IMAGE_GRAYSCALE;
 		break;
+	case OF_PIXELS_BGR:
 	case OF_PIXELS_RGB:
 		return OF_IMAGE_COLOR;
 		break;
+	case OF_PIXELS_BGRA:
 	case OF_PIXELS_RGBA:
 		return OF_IMAGE_COLOR_ALPHA;
 		break;


### PR DESCRIPTION
Just added a clear() method to ofFbo, which just calls destroy(), but adds consistency with other classes like ofImage and ofTexture. One thing to point out: destroy() is a private method, so I'm adding a public method which only calls a private method...seems kind of weird?

Addresses issue #3051