### PR TITLE
Don't include glew for Android or iOS (Fixes #3541)

### DIFF
--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -1,9 +1,6 @@
 #include "ofBufferObject.h"
 #include "ofConstants.h"
 #include "ofAppRunner.h"
-#if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
-	#include <GL/glew.h>
-#endif
 
 ofBufferObject::Data::Data()
 :id(0)

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -1,7 +1,9 @@
 #include "ofBufferObject.h"
 #include "ofConstants.h"
 #include "ofAppRunner.h"
-#include "GL/glew.h"
+#if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
+	#include <GL/glew.h>
+#endif
 
 ofBufferObject::Data::Data()
 :id(0)


### PR DESCRIPTION
After 6370ffda1040845e102efec07ad95bf11773eb82 glew.h was included in ofBufferObject.cpp. Because of that I couldn't get OFX to compile for Android or iOS. I think the user who reported bug #3541 was affected by this as well. This macro check seems to fix it.