### PR TITLE
fix TARGET_WIN32 compile error in ofAppGlutWindow

### DIFF
--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -123,7 +123,7 @@ void HandleFiles(WPARAM wParam)
     // allocated by the application is released.
     DragFinish(hDrop);
 
-	ofAppPtr->dragEvent(info);
+	instance->events().notifyDragEvent(info);
 
 }
 


### PR DESCRIPTION
Replaces ofAppPtr by instance->events() as glfw window does it.
+ this only affects Windows builds, as it only appears within the TARGET_WIN32 #ifdef

@arturoc, I hope this is the right way to make sure the right window instance receives the drag event - I copied GLFW window behaviour.