### PR TITLE
fix #3518, glPolygonMode programmableGL

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -256,7 +256,7 @@ void ofGLProgrammableRenderer::drawInstanced(const ofVboMesh & mesh, ofPolyRende
 	// ideally the glPolygonMode (or the polygon draw mode) should be part of ofStyle so that we can keep track
 	// of its state on the client side...
 
-	//glPolygonMode(GL_FRONT_AND_BACK, currentStyle.bFill ?  GL_LINE : GL_FILL);
+	glPolygonMode(GL_FRONT_AND_BACK, currentStyle.bFill ?  GL_LINE : GL_FILL);
 #else
 	if(renderType == OF_MESH_POINTS){
 		draw(mesh.getVbo(),GL_POINTS,0,mesh.getNumVertices());
@@ -956,9 +956,17 @@ void ofGLProgrammableRenderer::setFillMode(ofFillFlag fill){
 	if(currentStyle.bFill){
 		path.setFilled(true);
 		path.setStrokeWidth(0);
+		#ifndef TARGET_OPENGLES
+			// GLES does not support glPolygonMode
+			glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+		#endif
 	}else{
 		path.setFilled(false);
 		path.setStrokeWidth(currentStyle.lineWidth);
+		#ifndef TARGET_OPENGLES
+			// GLES does not support glPolygonMode
+			glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+		#endif
 	}
 }
 


### PR DESCRIPTION
This fixes #3518.

---

Using the Programmable GL Renderer, `GL_POLYGON_MODE` would lead to unexpected behaviour when using the following choreography of `ofFill`, `ofMesh`, and "naked" `ofVbo`s:

		ofFill();
		ofPushStyle(); // 0
		ofNoFill();
		ofDrawRectangle(10,10,10,10); // 1, 2
		ofPopStyle();  // 3
		vbo.drawElements( GL_TRIANGLES, 60); // <- draws as wireframe, but should be filled!

This happens because of how `GL_POLYGON_MODE` is

0. `ofPushStyle` would push current fill state to `ofStyle` stack
1. `ofDrawRecangle() --> ofMesh` would set the correct `GL_POLYGON_MODE` to draw itself based on its internal fill state.
2. `ofMesh` would then attempt to restore `GL_POLYGON_MODE` based on current fill state style.
3. `ofPopStyle` would restore current fill state from `ofStyle` stack, but would not change `GL_POLYGON_MODE`

* @pierrep suggested fixing this by setting `GL_POLYGON_MODE` in `ofGLProgrammableRenderer::setFillMode()`
* this works because then, `ofPopStyle` does the correct thing again.
* It also means that we can now call `ofFill()` or `ofNoFill()` before drawing "naked" vbos, and it will do the right thing =) thanks @pierrep !
* this also follows the lead of ofBlendMode, which attempts to sync ofStyle with gl state, too.
* also makes sure that ` ofGLProgrammableRenderer::drawInstanced(const ofVboMesh & mesh, ofPolyRenderMode renderType, int primCount) const` restores `GL_POLYGON_MODE`.

This GL state leak would not happen on the fixed function GL renderer, since this renderer would use `glPush/PopAttrib` to keep track of internal GL state.
`glPush/PopAttrib` have been deprecated from modern OpenGL, where the renderer is expected to keep track of GL state for performance reasons.