### PR TITLE
Remove errant + chars in ofMath

### DIFF
--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -114,21 +114,22 @@ float ofDist(float x1, float y1, float x2, float y2) {
 	return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2));
 }
 
- //--------------------------------------------------
-+float ofDist(float x1, float y1, float z1, float x2, float y2, float z2) {
-+	return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2));
-+}
-+//--------------------------------------------------
- float ofDistSquared(float x1, float y1, float x2, float y2) {
- 	return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) );
- }
- 
- //--------------------------------------------------
-+float ofDistSquared(float x1, float y1, float z1, float x2, float y2, float z2) {
-+	return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2) );
-+}
-+
-+//--------------------------------------------------
+//--------------------------------------------------
+float ofDist(float x1, float y1, float z1, float x2, float y2, float z2) {
+	return sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2));
+}
+
+//--------------------------------------------------
+float ofDistSquared(float x1, float y1, float x2, float y2) {
+	return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) );
+}
+
+//--------------------------------------------------
+float ofDistSquared(float x1, float y1, float z1, float x2, float y2, float z2) {
+	return ( (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2) );
+}
+
+//--------------------------------------------------
 float ofClamp(float value, float min, float max) {
 	return value < min ? min : value > max ? max : value;
 }


### PR DESCRIPTION
Looks like #3544 pulled in some + chars in ofMath, breaking compilation (I guess a copy+paste from a git diff?).

`<joke>`
There's too much math in ofMath. This makes there be less math.
`</joke>`

ping @ofTheo / @manish-juneja