### PR TITLE
Fixes: #1758 iOS use "rysnc" rather than "cp" when copying "bin/data" files

### DIFF
--- a/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 			<key>shellPath</key>
 			<string>/bin/sh</string>
 			<key>shellScript</key>
-			<string>cp -rf bin/data/ "$TARGET_BUILD_DIR/$PRODUCT_NAME.app"
+			<string>rsync -avz --exclude='.DS_Store' "${SRCROOT}/bin/data/" "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
 
 


### PR DESCRIPTION
See issue: #1758

This follows the same method that Xcode uses to copy files to App
packages.
- Will not copy files if already on destination (this will increase
performance).
- If file has been updated and already exists on the target app, you
will need to clean build (same workflow as Xcode native adding
resources).
- Tested working with iOS projects to simulator and device.

Currently CP copys the files to the .app folder everytime, updating the modification datetime and therefore causing the copy times to devices every single build. So say you build a project to your iPad... every single time you have to transfer all the files in your data folder to the target device, even if nothing has changed.

The new method will copy a new file once, like Xcode, to the .app and then not update it until a clean.
This means that the files are cached and build / test times are almost instant after the first deployment.
