### PR TITLE
ofSoundDevice doxygen comments, fix warning

### DIFF
--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -201,6 +201,17 @@ int ofSoundStream::getBufferSize(){
 }
 
 //------------------------------------------------------------
+ofSoundDevice::ofSoundDevice()
+: name("Unknown")
+, deviceID(0)
+, inputChannels(0)
+, outputChannels(0)
+, isDefaultInput(false)
+, isDefaultOutput(false) {
+
+}
+
+//------------------------------------------------------------
 vector<ofSoundDevice> ofSoundStream::getMatchingDevices(const std::string& name, unsigned int inChannels, unsigned int outChannels) {
 	vector<ofSoundDevice> devs = getDeviceList();
 	vector<ofSoundDevice> hits;

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -121,10 +121,10 @@ std::vector<ofSoundDevice> ofSoundStreamListDevices();
 /// thread from your app's update() / draw() thread.
 class ofSoundStream{
 public:
-    ofSoundStream();
-    
-    void setSoundStream(shared_ptr<ofBaseSoundStream> soundStreamPtr);
-    shared_ptr<ofBaseSoundStream> getSoundStream();
+	ofSoundStream();
+	
+	void setSoundStream(shared_ptr<ofBaseSoundStream> soundStreamPtr);
+	shared_ptr<ofBaseSoundStream> getSoundStream();
 	
 	/// \brief Prints a list of available audio devices to the console
 	void printDeviceList();
@@ -134,89 +134,89 @@ public:
 	
 	/// \brief Get all devices which match the arguments (name can be a partial match)
 	std::vector<ofSoundDevice> getMatchingDevices(const std::string& name, unsigned int inChannels = UINT_MAX, unsigned int outChannels = UINT_MAX);
-
-    /// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
-    void setDeviceID(int deviceID);
+	
+	/// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
+	void setDeviceID(int deviceID);
 	
 	/// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
 	void setDevice(const ofSoundDevice& device);
-
-    /// \brief Sets up and starts the stream.
-    /// \param app pointer to the app which will own the sound stream.
-    /// \param outChannels number of requested output channels (i.e. 2 for stereo).
-    /// \param inChannels number of requested input channels.
-    /// \param sampleRate requested sample rate (44100 is typical).
-    /// \param bufferSize requested buffer size (256 is typical). Smaller
-    ///        values will be more responsive, but less stable.
-    /// \param nBuffers number of buffers to queue. Less buffers will be more
-    ///        responsive, but less stable.
-    /// \return true on success
-    bool setup(ofBaseApp * app, int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers);
-
-    /// \brief Sets up and starts the stream.
-    /// \param outChannels number of requested output channels (i.e. 2 for stereo).
-    /// \param inChannels number of requested input channels.
-    /// \param sampleRate requested sample rate (44100 is typical).
-    /// \param bufferSize requested buffer size (256 is typical). Smaller values
-    ///        will be more responsive, but less stable.
-    /// \param nBuffers number of buffers to queue. Less buffers will be more
-    ///        responsive, but less stable.
-    /// \return true on success
-    bool setup(int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers);
-
-    /// \brief Sets the object which will have audioIn() called when the device receives audio.
-    void setInput(ofBaseSoundInput * soundInput);
 	
-    /// \brief Sets the object which will have audioIn() called when the device receives audio.
-    void setInput(ofBaseSoundInput &soundInput);
-
-    /// \brief Sets the object which will have audioOut() called when the device requests audio.
-    void setOutput(ofBaseSoundOutput * soundOutput);
+	/// \brief Sets up and starts the stream.
+	/// \param app pointer to the app which will own the sound stream.
+	/// \param outChannels number of requested output channels (i.e. 2 for stereo).
+	/// \param inChannels number of requested input channels.
+	/// \param sampleRate requested sample rate (44100 is typical).
+	/// \param bufferSize requested buffer size (256 is typical). Smaller
+	///        values will be more responsive, but less stable.
+	/// \param nBuffers number of buffers to queue. Less buffers will be more
+	///        responsive, but less stable.
+	/// \return true on success
+	bool setup(ofBaseApp * app, int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers);
 	
-    /// \brief Sets the object which will have audioOut() called when the device requests audio.
-    void setOutput(ofBaseSoundOutput &soundOutput);
-
-    /// \brief Starts a stream (note that setup() will start the stream on its own).
-    void start();
-
-    /// \brief Stops the stream.
-    void stop();
-
-    /// \brief stops the stream and cleans up its resources.
-    void close();
-
-    /// \brief Queries the number of "ticks" passed since the stream started.
-    ///
-    /// This is a representation of how many buffers have passed through the
-    /// stream since it started. This can be converted to seconds with the
-    /// following formula:
-    ///
-    ///    secondsOfPlayback = (tickCount * bufferSize) / sampleRate
-    ///
-    /// \return number of buffers passed through the stream since it started.
-    long unsigned long getTickCount();
-
-    /// \brief Queries the stream's number of input channels.
-    /// \return the number of input channels (e.g. 2 for stereo).
-    int getNumInputChannels();
-    
-    /// \brief Queries the stream's number of output channels.
-    /// \return the number of output channels (e.g. 2 for stereo).
-    int getNumOutputChannels();
-
-    /// \brief Queries the stream's sample rate
-    /// \return the current sample rate of the stream
-    /// \note The returned sample rate may differ from the requested sample rate.
-    int getSampleRate();
-
-    /// \brief Queries the stream's buffer size.
-    /// \return the current buffer size of the stream.
-    int getBufferSize();
+	/// \brief Sets up and starts the stream.
+	/// \param outChannels number of requested output channels (i.e. 2 for stereo).
+	/// \param inChannels number of requested input channels.
+	/// \param sampleRate requested sample rate (44100 is typical).
+	/// \param bufferSize requested buffer size (256 is typical). Smaller values
+	///        will be more responsive, but less stable.
+	/// \param nBuffers number of buffers to queue. Less buffers will be more
+	///        responsive, but less stable.
+	/// \return true on success
+	bool setup(int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers);
+	
+	/// \brief Sets the object which will have audioIn() called when the device receives audio.
+	void setInput(ofBaseSoundInput * soundInput);
+	
+	/// \brief Sets the object which will have audioIn() called when the device receives audio.
+	void setInput(ofBaseSoundInput &soundInput);
+	
+	/// \brief Sets the object which will have audioOut() called when the device requests audio.
+	void setOutput(ofBaseSoundOutput * soundOutput);
+	
+	/// \brief Sets the object which will have audioOut() called when the device requests audio.
+	void setOutput(ofBaseSoundOutput &soundOutput);
+	
+	/// \brief Starts a stream (note that setup() will start the stream on its own).
+	void start();
+	
+	/// \brief Stops the stream.
+	void stop();
+	
+	/// \brief stops the stream and cleans up its resources.
+	void close();
+	
+	/// \brief Queries the number of "ticks" passed since the stream started.
+	///
+	/// This is a representation of how many buffers have passed through the
+	/// stream since it started. This can be converted to seconds with the
+	/// following formula:
+	///
+	///    secondsOfPlayback = (tickCount * bufferSize) / sampleRate
+	///
+	/// \return number of buffers passed through the stream since it started.
+	long unsigned long getTickCount();
+	
+	/// \brief Queries the stream's number of input channels.
+	/// \return the number of input channels (e.g. 2 for stereo).
+	int getNumInputChannels();
+	
+	/// \brief Queries the stream's number of output channels.
+	/// \return the number of output channels (e.g. 2 for stereo).
+	int getNumOutputChannels();
+	
+	/// \brief Queries the stream's sample rate
+	/// \return the current sample rate of the stream
+	/// \note The returned sample rate may differ from the requested sample rate.
+	int getSampleRate();
+	
+	/// \brief Queries the stream's buffer size.
+	/// \return the current buffer size of the stream.
+	int getBufferSize();
 	
 	/// \brief Retrieves a list of available audio devices and prints device descriptions to the console
 	OF_DEPRECATED_MSG("Use printDeviceList instead", std::vector<ofSoundDevice> listDevices());
 	
 protected:
-    shared_ptr<ofBaseSoundStream> soundStream;
-
+	shared_ptr<ofBaseSoundStream> soundStream;
+	
 };

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -21,7 +21,14 @@
 #endif
 
 /// \brief Represents information about a sound device on the system.
-struct ofSoundDevice {
+class ofSoundDevice {
+public:
+	
+	ofSoundDevice(): name("Unknown"), deviceID(0), inputChannels(0), outputChannels(0), isDefaultInput(false), isDefaultOutput(false) { }
+	
+	friend std::ostream& operator << (std::ostream& os, const ofSoundDevice& dev);
+	friend std::ostream& operator << (std::ostream& os, const std::vector<ofSoundDevice>& devs);
+	
 	std::string name;
 	unsigned int deviceID;
 	unsigned int inputChannels;
@@ -29,11 +36,6 @@ struct ofSoundDevice {
 	bool isDefaultInput;
 	bool isDefaultOutput;
 	std::vector<unsigned int> sampleRates;
-	
-	ofSoundDevice(): name("Unknown"), deviceID(0), inputChannels(0), outputChannels(0), isDefaultInput(false), isDefaultOutput(false) { }
-	
-	friend std::ostream& operator << (std::ostream& os, const ofSoundDevice& dev);
-	friend std::ostream& operator << (std::ostream& os, const std::vector<ofSoundDevice>& devs);
 };
 
 /// \brief Sets up and starts a global ofSoundStream.

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -20,6 +20,7 @@
 	#define OF_SOUND_STREAM_TYPE ofxEmscriptenSoundStream
 #endif
 
+/// \class ofSoundDevice
 /// \brief Represents information about a sound device on the system.
 class ofSoundDevice {
 public:
@@ -29,12 +30,26 @@ public:
 	friend std::ostream& operator << (std::ostream& os, const ofSoundDevice& dev);
 	friend std::ostream& operator << (std::ostream& os, const std::vector<ofSoundDevice>& devs);
 	
+	/// \brief Descriptive name for the device
+	/// This is the same string that ofSoundStream::getMatchingDevices() will be looking for
 	std::string name;
+	
+	/// \brief The device's unique ID (to be used in ofSoundStream::setDeviceID() )
 	unsigned int deviceID;
+	
+	/// \brief Number of input channels the device supports
 	unsigned int inputChannels;
+	
+	/// \brief Number of output channels the device supports
 	unsigned int outputChannels;
+	
+	/// \brief If true, this device will be used by ofSoundStream unless changed with setDeviceID()
 	bool isDefaultInput;
+	
+	/// \brief If true, this device will be used by ofSoundStream unless changed with setDeviceID()
 	bool isDefaultOutput;
+	
+	/// \brief List of sample rates the device claims to support
 	std::vector<unsigned int> sampleRates;
 };
 
@@ -120,10 +135,10 @@ public:
 	/// \brief Get all devices which match the arguments (name can be a partial match)
 	std::vector<ofSoundDevice> getMatchingDevices(const std::string& name, unsigned int inChannels = UINT_MAX, unsigned int outChannels = UINT_MAX);
 
-    /// \brief sets the device represented by the stream, see ofSoundStream::listDevices().
+    /// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
     void setDeviceID(int deviceID);
 	
-	/// \brief sets the device represented by the stream, see ofSoundStream::listDevices().
+	/// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
 	void setDevice(const ofSoundDevice& device);
 
     /// \brief Sets up and starts the stream.

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -24,7 +24,7 @@
 class ofSoundDevice {
 public:
 	
-	ofSoundDevice(): name("Unknown"), deviceID(0), inputChannels(0), outputChannels(0), isDefaultInput(false), isDefaultOutput(false) { }
+	ofSoundDevice();
 	
 	friend std::ostream& operator << (std::ostream& os, const ofSoundDevice& dev);
 	friend std::ostream& operator << (std::ostream& os, const std::vector<ofSoundDevice>& devs);


### PR DESCRIPTION
This PR:

- Makes ofSoundDevice a class (instead of a struct), makes it conform tighter to OF style
- Fixes a warning RE: above for ofSoundDevice (forward declared as a class, but actually a struct)
- Adds doxygen comments to ofSoundDevice, fixes outdated ones in ofSoundStream
- Fixes the inconsistent whitespace in ofSoundStream.h