### PR TITLE
added ADDON_CPPFLAGS Makefile var so ADDON_CFLAGS can be used by PG for pure C

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
@@ -67,6 +67,7 @@ define parse_addon
 	$(eval ADDON_DATA= ) \
 	$(eval ADDON_INCLUDES= ) \
 	$(eval ADDON_CFLAGS= ) \
+	$(eval ADDON_PURECFLAGS= ) \
 	$(eval ADDON_LDFLAGS= ) \
 	$(eval ADDON_LIBS= ) \
 	$(eval ADDON_PKG_CONFIG_LIBRARIES= ) \
@@ -96,6 +97,7 @@ define parse_addon
 		$(eval PROJECT_ADDONS_INCLUDES += $(PARSED_ADDONS_INCLUDES)) \
 	) \
 	$(eval PROJECT_ADDONS_CFLAGS += $(ADDON_CFLAGS)) \
+	$(eval PROJECT_ADDONS_CFLAGS += $(ADDON_PURECFLAGS)) \
 	$(if $(strip $(ADDON_LIBS)), \
 		$(eval PROJECT_ADDONS_LIBS += $(addprefix $(addon)/,$(ADDON_LIBS))), \
 		$(call parse_addons_libraries, $(addon)) \

--- a/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
@@ -67,7 +67,7 @@ define parse_addon
 	$(eval ADDON_DATA= ) \
 	$(eval ADDON_INCLUDES= ) \
 	$(eval ADDON_CFLAGS= ) \
-	$(eval ADDON_PURECFLAGS= ) \
+	$(eval ADDON_CPPFLAGS= ) \
 	$(eval ADDON_LDFLAGS= ) \
 	$(eval ADDON_LIBS= ) \
 	$(eval ADDON_PKG_CONFIG_LIBRARIES= ) \
@@ -97,7 +97,7 @@ define parse_addon
 		$(eval PROJECT_ADDONS_INCLUDES += $(PARSED_ADDONS_INCLUDES)) \
 	) \
 	$(eval PROJECT_ADDONS_CFLAGS += $(ADDON_CFLAGS)) \
-	$(eval PROJECT_ADDONS_CFLAGS += $(ADDON_PURECFLAGS)) \
+	$(eval PROJECT_ADDONS_CFLAGS += $(ADDON_CPPFLAGS)) \
 	$(if $(strip $(ADDON_LIBS)), \
 		$(eval PROJECT_ADDONS_LIBS += $(addprefix $(addon)/,$(ADDON_LIBS))), \
 		$(call parse_addons_libraries, $(addon)) \


### PR DESCRIPTION
This variable is added mainly for Xcode projects generated from the PG (see https://github.com/openframeworks/openFrameworks/issues/3430) and is added to the Makefiles for completeness. The Makefile simply appends it to PROJECT_ADDONS_CFLAGS. Tested on OS X Makefile build.