### PR TITLE
Add missing include path in ofxOsc's addon_config

### DIFF
--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -29,7 +29,7 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	# ADDON_INCLUDES =
+	ADDON_INCLUDES = libs/oscpack/src/%
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon
@@ -66,7 +66,7 @@ common:
 	
 	# when parsing the file system looking for include paths exclude this for all or
 	# a specific platform
-    # ADDON_INCLUDES_EXCLUDE = 
+	# ADDON_INCLUDES_EXCLUDE =
 	
 win_cb:
 	# when parsing the file system looking for sources exclude this for all or


### PR DESCRIPTION
ofxOsc's addon_config didn't specify an include path of `libs/oscpack/src`, which is necessary for some of oscpack's internal includes. Presumably this didn't affect the PG since it adds basically all paths, but it should probably be specified anyway.