### PR TITLE
OpenGLES - GL_HALF_FLOAT is only defined in GLESv3 - Merge Fix for #3409

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -140,7 +140,7 @@ string ofGLSLVersionFromGL(int major, int minor);
 	#ifdef GL_DEPTH_COMPONENT32_OES
         #define GL_DEPTH_COMPONENT32						GL_DEPTH_COMPONENT32_OES
     #endif
-    #if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
+    #ifdef TARGET_OPENGLES
         #ifndef GL_UNSIGNED_INT
             #define GL_UNSIGNED_INT                         GL_UNSIGNED_INT_OES
         #endif


### PR DESCRIPTION
Reference Pull request:  Fix compile error on Android: GL_HALF_FLOAT is only defined in GLESv3 #3409 