### PR TITLE
Apothecary - Poco Formula Update to 1.6 Release

### DIFF
--- a/scripts/apothecary/formulas/poco/poco.sh
+++ b/scripts/apothecary/formulas/poco/poco.sh
@@ -8,11 +8,11 @@
 # specify specfic build configs in poco/config using ./configure --config=NAME
 
 # define the version
-VER=apothecary-1.7
+VER=1.6.0-release
 
 # tools for git use
-GIT_URL=https://github.com/bakercp/poco
-GIT_TAG=poco-$VER
+GIT_URL=https://github.com/pocoproject/poco
+GIT_TAG=poco-1.6.0-release
 
 # For Poco Builds, we omit both Data/MySQL and Data/ODBC because they require
 # 3rd Party libraries.  See https://github.com/pocoproject/poco/blob/develop/README


### PR DESCRIPTION
Switched to the Release of @PocoProject ’s Poco 1.6-release tag.
- @bakercp ’s and @danoli3 ’s fixes have been merged for 1.6 release of
Poco, so shouldn’t need our fork any more for the moment.

Also passing: [![Build Status](https://travis-ci.org/danoli3/apothecary-den.svg?branch=poco-ios)](https://travis-ci.org/danoli3/apothecary-den)