### PR TITLE
Fix invalid itr increment in ofMainLoop on windows/vs

### DIFF
--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -112,14 +112,15 @@ int ofMainLoop::loop(){
 }
 
 void ofMainLoop::loopOnce(){
-	for(auto i = windowsApps.begin();i!=windowsApps.end();i++){
+	for(auto i = windowsApps.begin();i!=windowsApps.end();){
 		if(i->first->getWindowShouldClose()){
 			i->first->close();
-			windowsApps.erase(i);
+			windowsApps.erase(i++);
 		}else{
 			currentWindow = i->first;
 			i->first->update();
 			i->first->draw();
+			++i;
 		}
 	}
 	if(pollEvents){

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -112,10 +112,13 @@ int ofMainLoop::loop(){
 }
 
 void ofMainLoop::loopOnce(){
-	for(auto i = windowsApps.begin();i!=windowsApps.end();){
+	auto i = windowsApps.begin();
+	while(i!=windowsApps.end()) {
 		if(i->first->getWindowShouldClose()){
-			i->first->close();
-			windowsApps.erase(i++);
+			auto windowToClose = i;
+			++i;
+			windowToClose->first->close();
+			windowsApps.erase(windowToClose);
 		}else{
 			currentWindow = i->first;
 			i->first->update();


### PR DESCRIPTION
When closing an app window on windows, there's a debug assertion raised:
```
Expression: map/set iterator not incrementable
```
..on this for loop condition in ofMainLoop:
```
void ofMainLoop::loopOnce(){
    >   for(auto i = windowsApps.begin();i!=windowsApps.end();i++){
        ...
```
This PR modifies the increment condition and the erase call to `windowsApps.erase(i++);`, which stops it from firing. I'm not 100% up to speed on the new multiwindow changes, but I tested the changes with @arturoc 's explicitRendererExample on windows + osx and everything seems to work correctly after this fix.

(This is Windows 7 and visual studio 2012 express)