### PR TITLE
Allow access to pixel color through index (like setColor)

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -939,6 +939,12 @@ ofColor_<PixelType> ofImage_<PixelType>::getColor(int x, int y) const {
 
 //------------------------------------
 template<typename PixelType>
+ofColor_<PixelType> ofImage_<PixelType>::getColor(int index) const {
+	return pixels.getColor(index);
+}
+
+//------------------------------------
+template<typename PixelType>
 void ofImage_<PixelType>::setColor(int x, int y, const ofColor_<PixelType>& color) {
 	pixels.setColor(x, y, color);
 }

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -366,7 +366,13 @@ public:
     /// \param y y position of pixel
     /// \returns The ofColor representing the pixels at the x and y position passed in.
     ofColor_<PixelType> getColor(int x, int y) const;
-    
+
+	/// \brief This returns the ofColor representing the pixels at the index
+	/// passed in.
+	/// \param index index into pixel data
+	/// \returns The ofColor representing the pixels at the index position passed in.
+	ofColor_<PixelType> getColor(int index) const;
+   
     /// \brief Get height of image as a float.
     /// \returns Height of image as float.
     float getHeight() const;

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -511,9 +511,8 @@ int ofPixels_<PixelType>::getPixelIndex(int x, int y) const {
 }
 
 template<typename PixelType>
-ofColor_<PixelType> ofPixels_<PixelType>::getColor(int x, int y) const {
+ofColor_<PixelType> ofPixels_<PixelType>::getColor(int index) const {
 	ofColor_<PixelType> c;
-	int index = getPixelIndex(x, y);
 
 	switch(pixelFormat){
 		case OF_PIXELS_RGB:
@@ -554,6 +553,11 @@ ofColor_<PixelType> ofPixels_<PixelType>::getColor(int x, int y) const {
 	}
 
 	return c;
+}
+
+template<typename PixelType>
+ofColor_<PixelType> ofPixels_<PixelType>::getColor(int x, int y) const {
+	return getColor(getPixelIndex(x, y));
 }
 
 template<typename PixelType>

--- a/libs/openFrameworks/graphics/ofPixels.h
+++ b/libs/openFrameworks/graphics/ofPixels.h
@@ -217,6 +217,9 @@ public:
 	
 	/// \brief Get the color at a x,y position
 	ofColor_<PixelType> getColor(int x, int y) const;
+
+	/// \brief Get the color at a specific index
+	ofColor_<PixelType> getColor(int index) const;
 	
 	/// \brief Set the color of the pixel at the x,y location
 	void setColor(int x, int y, const ofColor_<PixelType>& color);


### PR DESCRIPTION
It is quite useful to be able to get access to an image through index.
It's possible to get pixel by index so there's precedent.