### PR TITLE
fix issue where ofFbo would be leaking its viewport

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1302,7 +1302,7 @@ void ofGLProgrammableRenderer::unbind(const ofShader & shader){
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::bind(const ofFbo & fbo, bool setupPerspective){
-	matrixStack.pushView();
+	pushView();
 	pushStyle();
 	matrixStack.setRenderSurface(fbo);
 	viewport();
@@ -1320,7 +1320,7 @@ void ofGLProgrammableRenderer::unbind(const ofFbo & fbo){
 	matrixStack.setRenderSurface(*window);
 	uploadMatrices();
 	popStyle();
-	matrixStack.popView();
+	popView();
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
because ofFbo did not restore its viewport to openGL in ofFbo::end() but only push/pop'ed the matrix stack, OpenGL and openFrameworks would get out of state sync once an fbo with different size than the screen would be unbound, leaving the viewport for the main screen at the Fbo's size.

This fixes this by using the renderer's own push/popView methods, which forward the state changes to the GPU / OpenGL upon unbind().