### PR TITLE
Fix for #3602: ellipse not exported correctly

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -1353,7 +1353,7 @@ void ofCairoRenderer::drawEllipse(float x, float y, float z, float width, float 
 	mutThis->translate(0,-y*ellipse_ratio);
 	mutThis->scale(1,ellipse_ratio);
 	mutThis->translate(0,y/ellipse_ratio);
-	cairo_arc(cr,x,y,width*0.5,0,360);
+	cairo_arc(cr,x,y,width*0.5,0,2*PI);
 	mutThis->popMatrix();
 
 	cairo_close_path(cr);


### PR DESCRIPTION
Solves issue [#3602](https://github.com/openframeworks/openFrameworks/issues/3602). It wasn't an extra line, it was circling around.