### PR TITLE
Enable C++11 in win_cb

### DIFF
--- a/libs/openFrameworksCompiled/project/win_cb/openFrameworksLib.cbp
+++ b/libs/openFrameworksCompiled/project/win_cb/openFrameworksLib.cbp
@@ -15,6 +15,7 @@
 				<Option compiler="gcc" />
 				<Compiler>
 					<Add option="-g3" />
+					<Add option="-std=gnu++11" />
 				</Compiler>
 			</Target>
 			<Target title="release">
@@ -26,6 +27,7 @@
 				<Option createDefFile="1" />
 				<Compiler>
 					<Add option="-O3" />
+					<Add option="-std=gnu++11" />
 				</Compiler>
 				<Linker>
 					<Add option="-s" />


### PR DESCRIPTION
This enables C++11 for code::blocks, while still maintaining support for popen / pclose.

PR sent as a result of [this discussion](http://forum.openframeworks.cc/t/build-errors-with-openframeworks-master-from-github/18376/3) on the OF forum.