### PR TITLE
iOS Examples Update for new Window System 

### DIFF
--- a/examples/ios/CoreLocationExample/src/main.mm
+++ b/examples/ios/CoreLocationExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/ImagePickerExample/src/main.mm
+++ b/examples/ios/ImagePickerExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/KeyboardExample/src/main.mm
+++ b/examples/ios/KeyboardExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = true; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = true; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/MapKitExample/src/main.mm
+++ b/examples/ios/MapKitExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/PrimitivesExample/src/main.mm
+++ b/examples/ios/PrimitivesExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = true; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/TouchAndAccelExample/src/main.mm
+++ b/examples/ios/TouchAndAccelExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/advancedEventsExample/src/main.mm
+++ b/examples/ios/advancedEventsExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/advancedGraphics/src/main.mm
+++ b/examples/ios/advancedGraphics/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = true; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/assimpExample/src/main.mm
+++ b/examples/ios/assimpExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = true; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/audioInputExample/src/main.mm
+++ b/examples/ios/audioInputExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/audioOutputExample/src/main.mm
+++ b/examples/ios/audioOutputExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/dirListExample/src/main.mm
+++ b/examples/ios/dirListExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/emptyExample/src/main.mm
+++ b/examples/ios/emptyExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = true; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = true; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 4; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/eventsExample/src/main.mm
+++ b/examples/ios/eventsExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/fontShapesExample/src/main.mm
+++ b/examples/ios/fontShapesExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/fontsExample/src/main.mm
+++ b/examples/ios/fontsExample/src/main.mm
@@ -6,19 +6,17 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = true; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 4; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }
 

--- a/examples/ios/graphicsExample/src/main.mm
+++ b/examples/ios/graphicsExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/iPhoneGuiExample/src/main.mm
+++ b/examples/ios/iPhoneGuiExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/imageLoaderExample/src/main.mm
+++ b/examples/ios/imageLoaderExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/iosCustomSizeExample/src/main.mm
+++ b/examples/ios/iosCustomSizeExample/src/main.mm
@@ -1,24 +1,24 @@
 #include "ofMain.h"
+#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main(){
 
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
+    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
     
-    ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-    bool bUseNative = true;
+    bool bUseNative = false;
     if (bUseNative){
         /**
          *
@@ -33,7 +33,7 @@ int main(){
          *
          **/
         
-        window.startAppWithDelegate("MyAppDelegate");
+        window->startAppWithDelegate("MyAppDelegate");
     }
     else {
         /**
@@ -43,6 +43,6 @@ int main(){
          *
          **/
         
-        ofRunApp(new ofApp());
+        return ofRunApp(new SquareApp());
     }
 }

--- a/examples/ios/iosES2ShaderExample/src/main.mm
+++ b/examples/ios/iosES2ShaderExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES2; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES2; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/iosExternalDisplayExample/src/main.mm
+++ b/examples/ios/iosExternalDisplayExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/iosNativeExample/src/main.mm
+++ b/examples/ios/iosNativeExample/src/main.mm
@@ -1,24 +1,24 @@
 #include "ofMain.h"
+#include "ofAppiOSWindow.h"
 #include "SquareApp.h"
 
 int main(){
 
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
+    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-    bool bUseNative = true;
+    bool bUseNative = false;
     if (bUseNative){
         /**
          *
@@ -33,7 +33,7 @@ int main(){
          *
          **/
         
-        window.startAppWithDelegate("MyAppDelegate");
+        window->startAppWithDelegate("MyAppDelegate");
     }
     else {
         /**
@@ -43,6 +43,7 @@ int main(){
          *
          **/
         
-        ofRunApp(new SquareApp());
+        return ofRunApp(new SquareApp());
     }
+
 }

--- a/examples/ios/iosOrientationExample/src/main.mm
+++ b/examples/ios/iosOrientationExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = true; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = true; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/iosStoryboardExample/src/main.mm
+++ b/examples/ios/iosStoryboardExample/src/main.mm
@@ -1,24 +1,24 @@
 #include "ofMain.h"
+#include "ofAppiOSWindow.h"
 #include "SquareApp.h"
 
 int main(){
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = true; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
+    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-    bool bUseNative = true;
+    bool bUseNative = false;
     if (bUseNative){
         /**
          *
@@ -33,7 +33,7 @@ int main(){
          *
          **/
         
-        window.startAppWithDelegate("MyAppDelegate");
+        window->startAppWithDelegate("MyAppDelegate");
     }
     else {
         /**
@@ -43,6 +43,7 @@ int main(){
          *
          **/
         
-        ofRunApp(new SquareApp());
+        return ofRunApp(new SquareApp());
     }
+
 }

--- a/examples/ios/moviePlayerExample/src/main.mm
+++ b/examples/ios/moviePlayerExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/ofxGuiExample/src/main.mm
+++ b/examples/ios/ofxGuiExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/opencvExample/src/main.mm
+++ b/examples/ios/opencvExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/opencvFaceExample/src/main.mm
+++ b/examples/ios/opencvFaceExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/oscReceiverExample/src/main.mm
+++ b/examples/ios/oscReceiverExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/oscSenderExample/src/main.mm
+++ b/examples/ios/oscSenderExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/polygonExample/src/main.mm
+++ b/examples/ios/polygonExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/soundPlayerExample/src/main.mm
+++ b/examples/ios/soundPlayerExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/textureExample/src/main.mm
+++ b/examples/ios/textureExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/vboExample/src/main.mm
+++ b/examples/ios/vboExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/videoGrabberExample/src/main.mm
+++ b/examples/ios/videoGrabberExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }

--- a/examples/ios/xmlSettingsExample/src/main.mm
+++ b/examples/ios/xmlSettingsExample/src/main.mm
@@ -6,18 +6,16 @@ int main() {
     
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
-    ofAppiOSWindow::Settings settings;
+    ofiOSWindowSettings settings;
     settings.enableRetina = false; // enables retina resolution if the device supports it.
     settings.enableDepth = false; // enables depth buffer for 3d drawing.
     settings.enableAntiAliasing = false; // enables anti-aliasing which smooths out graphics on the screen.
     settings.numOfAntiAliasingSamples = 0; // number of samples used for anti-aliasing.
     settings.enableHardwareOrientation = false; // enables native view orientation.
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
-    settings.rendererType = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
+    settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    ofAppiOSWindow window(settings);
+    ofCreateWindow(settings);
     
-	ofSetupOpenGL(&window, 0, 0, OF_FULLSCREEN);
-    
-	ofRunApp(new ofApp);
+	return ofRunApp(new ofApp);
 }


### PR DESCRIPTION
Updated the iOS examples for the new windowing system.

Did a quick find and replace in SublimeText and some tweaking for the iOS Native windows.

Results:

Tested and working for most examples.
iOS Native examples still needs some core work to get it functional it seems (runs just crashes on oF App selection). (this is an issue outside of this PR).
@julapy @ofTheo

Previous PR with 0 changes and infinity commits: #3592