### PR TITLE
fix freetype apothecary script, and therefore cairo

### DIFF
--- a/scripts/apothecary/formulas/cairo.sh
+++ b/scripts/apothecary/formulas/cairo.sh
@@ -79,7 +79,7 @@ function build() {
 					--disable-xlib \
 					--disable-qt 
 
-		make
+		make -j
 		make install
 	fi
 

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -61,7 +61,7 @@ function build() {
 		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
 			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean 
-		make
+		make -j
 		make install
 		cp $BUILD_TO_DIR/lib/libfreetype.a lib/$TYPE/libfreetype-$OSX_ARCH.a
 
@@ -73,14 +73,24 @@ function build() {
 		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
 			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean
-		make
+		make -j
 		make install
 		cp $BUILD_TO_DIR/lib/libfreetype.a lib/$TYPE/libfreetype-$OSX_ARCH.a
+
+
 
 		cd lib/$TYPE/
 		lipo -create libfreetype-i386.a \
 					libfreetype-x86_64.a \
 					-output libfreetype.a
+
+		# copy pkgconfig file to _buildroot/lib/pkgconfig
+		cp -v $BUILD_TO_DIR/lib/pkgconfig/freetype2.pc $BUILD_ROOT_DIR/lib/pkgconfig/
+
+		# # copy fat lib to where pkgconfig points to, so that subsequent build stages will find it.
+		# pkgconfig points to the $BUILD_TO_DIR
+		cp -vf libfreetype.a $BUILD_TO_DIR/lib/libfreetype.a
+
 		cd ../../
 
 		unset OSX_ARCH STDLIB TOOLCHAIN CC CPP CXX


### PR DESCRIPTION
In the OS X recipe, freetype's pkgconfig entry did not point to the correct fat static library, and would therefore scuttle the cairo build.

This pr fixes this by copying the fat static freeimage lib to the point indicated by freeimage's pkgconfig .pc file, so that the build can proceed properly. Also enables multi-processor builds to save time drinking tea.

## builds FAT libs for cairo, freetype:
* 32bit libstdc++
* 64bit libc++

This should get us one step closer to tackling #2016
