### PR TITLE
ios mainloop fixes

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -17,6 +17,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 
 @interface ofxiOSEAGLView() {
     BOOL bInit;
+	shared_ptr<ofBaseApp> appSharedPtr;
 }
 - (void)updateDimensions;
 @end
@@ -66,10 +67,10 @@ static ofxiOSEAGLView * _instanceRef = nil;
             static_cast<ofGLRenderer*>(window->renderer().get())->setup();
         }
         
-        if(app != ofGetAppPtr()) {              // check if already running.
-            ofRunApp(shared_ptr<ofBaseApp>(app));    // this fallback only case occurs when app not created in main().
+        if(app != ofGetAppPtr()) {      // check if already running.
+			appSharedPtr = shared_ptr<ofBaseApp>(app);
+            ofRunApp(appSharedPtr);		// this fallback only case occurs when app not created in main().
         }
-        ofRegisterTouchEvents(app);
         ofxiOSAlerts.addListener(app);
 
         ofDisableTextureEdgeHack();
@@ -93,9 +94,11 @@ static ofxiOSEAGLView * _instanceRef = nil;
     if(!bInit) {
         return;
     }
-    
-    window->events().notifyExit();
-    
+
+	window->events().notifyExit();
+	
+	ofGetMainLoop()->exit();
+	
     [activeTouches release];
     
     delete screenSize;
@@ -105,25 +108,10 @@ static ofxiOSEAGLView * _instanceRef = nil;
     delete windowPos;
     windowPos = NULL;
     
-    ofBaseApp * baseAppPtr = ofGetAppPtr();
-    ofRemoveListener(window->events().setup,          baseAppPtr, &ofBaseApp::setup,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().update,         baseAppPtr, &ofBaseApp::update,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().draw,           baseAppPtr, &ofBaseApp::draw,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().exit,           baseAppPtr, &ofBaseApp::exit,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().keyPressed,     baseAppPtr, &ofBaseApp::keyPressed,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().keyReleased,    baseAppPtr, &ofBaseApp::keyReleased,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().mouseMoved,     baseAppPtr, &ofBaseApp::mouseMoved,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().mouseDragged,   baseAppPtr, &ofBaseApp::mouseDragged,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().mousePressed,   baseAppPtr, &ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().mouseReleased,  baseAppPtr, &ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().windowResized,  baseAppPtr, &ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().windowEntered,  baseAppPtr, &ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().messageEvent,   baseAppPtr, &ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
-    ofRemoveListener(window->events().fileDragEvent,  baseAppPtr, &ofBaseApp::dragged,OF_EVENT_ORDER_APP);
-    
-    ofUnregisterTouchEvents(app);
     ofxiOSAlerts.removeListener(app);
-    ofSetAppPtr(shared_ptr<ofBaseApp>((app = NULL)));
+
+	appSharedPtr = shared_ptr<ofBaseApp>((app = NULL));
+	ofSetAppPtr(appSharedPtr);
     
     window = NULL;
     

--- a/examples/ios/iosNativeExample/src/main.mm
+++ b/examples/ios/iosNativeExample/src/main.mm
@@ -16,9 +16,9 @@ int main(){
     settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
     shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
-    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
+    ofAppiOSWindow * window = (ofAppiOSWindow *)(windowBase.get());
     
-    bool bUseNative = false;
+    bool bUseNative = true;
     if (bUseNative){
         /**
          *

--- a/examples/ios/iosStoryboardExample/src/main.mm
+++ b/examples/ios/iosStoryboardExample/src/main.mm
@@ -16,9 +16,9 @@ int main(){
     settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
     shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
-    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
+    ofAppiOSWindow * window = (ofAppiOSWindow *)(windowBase.get());
     
-    bool bUseNative = false;
+    bool bUseNative = true;
     if (bUseNative){
         /**
          *

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -70,7 +70,7 @@ void ofInit(){
 	initialized = true;
 	Poco::ErrorHandler::set(new ofThreadErrorLogger);
 
-#if defined(TARGET_ANDROID) || defined(TARGET_IOS)
+#if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
     // manage own exit
 #else
 	atexit(ofExitCallback);

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -37,6 +37,7 @@ ofMainLoop::ofMainLoop()
 }
 
 ofMainLoop::~ofMainLoop() {
+	exit();
 }
 
 shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & settings){
@@ -103,11 +104,10 @@ int ofMainLoop::loop(){
 		while(!bShouldClose && !windowsApps.empty()){
 			loopOnce();
 		}
+		exit();
 	}else{
 		windowLoop();
 	}
-	exitEvent.notify(this);
-	windowsApps.clear();
 	return status;
 }
 
@@ -125,6 +125,44 @@ void ofMainLoop::loopOnce(){
 	if(pollEvents){
 		pollEvents();
 	}
+}
+
+void ofMainLoop::exit(){
+	for(auto i = windowsApps.begin();i!=windowsApps.end();i++){
+		shared_ptr<ofAppBaseWindow> window = i->first;
+		shared_ptr<ofBaseApp> app = i->second;
+		
+		if(window == NULL) {
+			continue;
+		}
+		if(app == NULL) {
+			continue;
+		}
+		
+		ofRemoveListener(window->events().setup,app.get(),&ofBaseApp::setup,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().update,app.get(),&ofBaseApp::update,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().draw,app.get(),&ofBaseApp::draw,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().exit,app.get(),&ofBaseApp::exit,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().keyPressed,app.get(),&ofBaseApp::keyPressed,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().keyReleased,app.get(),&ofBaseApp::keyReleased,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseMoved,app.get(),&ofBaseApp::mouseMoved,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseDragged,app.get(),&ofBaseApp::mouseDragged,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mousePressed,app.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseReleased,app.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseScrolled,app.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().windowEntered,app.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().windowResized,app.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().messageEvent,app.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().fileDragEvent,app.get(),&ofBaseApp::dragged,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().touchCancelled,app.get(),&ofBaseApp::touchCancelled,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().touchDoubleTap,app.get(),&ofBaseApp::touchDoubleTap,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().touchDown,app.get(),&ofBaseApp::touchDown,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().touchMoved,app.get(),&ofBaseApp::touchMoved,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().touchUp,app.get(),&ofBaseApp::touchUp,OF_EVENT_ORDER_APP);
+	}
+	
+	exitEvent.notify(this);
+	windowsApps.clear();
 }
 
 shared_ptr<ofAppBaseWindow> ofMainLoop::getCurrentWindow(){

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -33,6 +33,7 @@ public:
 	void run(shared_ptr<ofBaseApp> app);
 	int loop();
 	void loopOnce();
+	void exit();
 	ofCoreEvents & events();
 	void shouldClose(int status);
 	shared_ptr<ofAppBaseWindow> getCurrentWindow();


### PR DESCRIPTION
this is a fix to get ofxiOS working correctly with the new multi-window feature.

@arturoc,
found one issue where after `windowLoop()` was called, `windowsApps` was being cleared.
this resulted in `ofGetAppPtr()` returning NULL when while iOS (and Android) apps are running.

to fix this ive created an `exit()` function in `ofMainLoop` which is called after the while loop is finished and the app is ready to exit. the `exit()` function is also called by ofxiOS when it needs to remove apps and remove the event listener.

let me know if you see any issue with these modifications.
be good to get this in soon as its causing crashes with some of the ios examples.