### PR TITLE
fix apothecary fat osx lib for tess2

### DIFF
--- a/scripts/apothecary/formulas/tess2/tess2.sh
+++ b/scripts/apothecary/formulas/tess2/tess2.sh
@@ -92,8 +92,6 @@ function build() {
 			echo "Building library slice for ${OSX_ARCH}..."
 
 			cmake -G 'Unix Makefiles' \
-				-DCMAKE_C_FLAGS="-arch ${OSX_ARCH}" \
-				-DCMAKE_CXX_FLAGS="-arch ${OSX_ARCH}" \
 				.
 			make clean >> "${LOG}" 2>&1
 			make >> "${LOG}" 2>&1

--- a/scripts/apothecary/formulas/tess2/tess2.sh
+++ b/scripts/apothecary/formulas/tess2/tess2.sh
@@ -21,7 +21,7 @@ COMPILER_CTYPE=clang # clang, gcc
 COMPILER_CPPTYPE=clang++ # clang, gcc
 STDLIB=libc++
 
-GIT_REV=master
+GIT_REV=24e4bdd4158909e9720422208ab0a0aca788e700
 
 # download the source code and unpack it into LIB_NAME
 function download() {
@@ -54,17 +54,72 @@ function build() {
 	
 	if [ "$TYPE" == "osx" ] ; then
 
-		local buildOpts="--build build/$TYPE"
+		OSX_ARCHS="i386 x86_64" 
 
-		# 32 bit
-		rm -f CMakeCache.txt
-		cmake -G 'Unix Makefiles' \
-			$buildOpts \
-			-DCMAKE_C_FLAGS="-arch i386 -arch x86_64" \
-			-DCMAKE_CXX_FLAGS="-arch i386 -arch x86_64" \
-			.
-		make clean 
-		make
+		for OSX_ARCH in ${OSX_ARCHS}
+		do
+
+			unset CFLAGS CPPFLAGS LINKFLAGS CXXFLAGS LDFLAGS
+			rm -f CMakeCache.txt
+			set +e
+
+
+			# Choose which stdlib to use:
+			# i386    : libstdc++
+			# x86_64  : libc++
+
+			case $OSX_ARCH in
+				i386 )
+					#	choose libstdc++ for i386
+					STD_LIB_FLAGS="-stdlib=libstdc++"
+					;;
+				x86_64 )
+					STD_LIB_FLAGS="-stdlib=libc++"
+					;;
+			esac
+			
+			OPTIM_FLAGS="-O3"				 # 	choose "fastest" optimisation
+
+			export CFLAGS="-arch $OSX_ARCH $OPTIM_FLAGS"
+			export CPPFLAGS=$CFLAGS
+			export LINKFLAGS="$CFLAGS $STD_LIB_FLAGS"
+			export LDFLAGS="$LINKFLAGS"
+			export CXXFLAGS=$CPPFLAGS
+
+
+			LOG="build-tess2-${VER}-${OSX_ARCH}-cmake.log"
+
+			echo "Building library slice for ${OSX_ARCH}..."
+
+			cmake -G 'Unix Makefiles' \
+				-DCMAKE_C_FLAGS="-arch ${OSX_ARCH}" \
+				-DCMAKE_CXX_FLAGS="-arch ${OSX_ARCH}" \
+				.
+			make clean >> "${LOG}" 2>&1
+			make >> "${LOG}" 2>&1
+
+			# now we need to create a directory were we can keep our current build result.
+
+			mkdir -p $TYPE
+			mv libtess2.a $TYPE/libtess2-$OSX_ARCH.a
+
+		done
+
+		# combine into fat lib using lipo
+		echo "Running lipo to create fat lib"
+		echo "Please stand by..."
+
+		LIPO_SLICES=	#initialise empty
+
+		for OSX_ARCH in ${OSX_ARCHS}; do
+			LIPO_SLICES+="${TYPE}/libtess2-${OSX_ARCH}.a "
+		done
+
+		LOG="build-tess2-${VER}-lipo.log"
+		lipo -create $LIPO_SLICES \
+			 -output libtess2.a \
+			 > "${LOG}" 2>&1
+
 
 	elif [ "$TYPE" == "vs" ] ; then
 		cmake -G "Visual Studio $VS_VER"
@@ -80,7 +135,6 @@ function build() {
 		
 		DEVELOPER=$XCODE_DEV_ROOT
 		TOOLCHAIN=${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain
-		VERSION=$VER
 
 		mkdir -p "builddir/$TYPE"
 	


### PR DESCRIPTION
+ before, only libc++ based library slices were generated for tess2 on os x 
+ this uses a more explicit build for os x, making sure we have the correct std libraries linked to the i386 and x84_64 slices.
+ also compiles libtess2 with o3 (fastest) for desktop os x
+ cleans up osx build script slightly