### PR TITLE
apothecary: add osx-fat-fmodex script

### DIFF
--- a/scripts/apothecary/formulas/fmodex.sh
+++ b/scripts/apothecary/formulas/fmodex.sh
@@ -10,7 +10,7 @@
 FORMULA_TYPES=( "osx" "vs" "win_cb" )
 
 # define the version
-VER=stable_v19_20110326
+VER=44221
 
 # tools for git use
 GIT_URL=
@@ -24,13 +24,13 @@ function download() {
 	case $TYPE in
 		"osx" )
 			# download drive image for fmodex from fmod.org
-			curl -O http://www.fmod.org/download/fmodex/api/Mac/fmodapi44221mac-installer.dmg
+			curl -O http://www.fmod.org/download/fmodex/api/Mac/fmodapi${VER}mac-installer.dmg
 			# mount dmg
-			hdiutil attach fmodapi44221mac-installer.dmg -quiet
+			hdiutil attach fmodapi${VER}mac-installer.dmg -quiet
 			# copy contents into staging folder
 			cp -R "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api/" "fmodex"
 			# remove installer dmg
-			rm fmodapi44221mac-installer.dmg
+			rm fmodapi${VER}mac-installer.dmg
 			# unmount drive image
 			hdiutil detach "/Volumes/FMOD Programmers API Mac/" -quiet 
 			;;

--- a/scripts/apothecary/formulas/fmodex.sh
+++ b/scripts/apothecary/formulas/fmodex.sh
@@ -1,0 +1,71 @@
+#! /bin/bash
+#
+# FmodEX 
+# http://www.portaudio.com/
+#
+# This is not a build script, as fmodex is linked as a dynamic library.
+# FmodEX is downloaded as a binary from the fmod.org website and copied 
+# into the openFrameworks library directory.
+
+FORMULA_TYPES=( "osx" "vs" "win_cb" )
+
+# define the version
+VER=stable_v19_20110326
+
+# tools for git use
+GIT_URL=
+GIT_TAG=
+
+# download the source code and unpack it into LIB_NAME
+function download() {
+
+	mkdir -p "fmodex"
+
+	case $TYPE in
+		"osx" )
+			# download drive image for fmodex from fmod.org
+			curl -O http://www.fmod.org/download/fmodex/api/Mac/fmodapi44221mac-installer.dmg
+			# mount dmg
+			hdiutil attach fmodapi44221mac-installer.dmg -quiet
+			# copy contents into staging folder
+			cp -R "/Volumes/FMOD Programmers API Mac/FMOD Programmers API/api/" "fmodex"
+			# remove installer dmg
+			rm fmodapi44221mac-installer.dmg
+			# unmount drive image
+			hdiutil detach "/Volumes/FMOD Programmers API Mac/" -quiet 
+			;;
+	esac
+
+	echo "downloaded fmodex"
+}
+
+# prepare the build environment, executed inside the lib src dir
+function prepare() {
+	:
+	# mount install
+}
+
+# executed inside the lib src dir
+function build() {
+	echo "build not needed for $TYPE"
+}
+
+# executed inside the lib src dir, first arg $1 is the dest libs dir root
+function copy() {
+	
+	if [ "$TYPE" == "osx" ] ; then
+		# headers
+		mkdir -p $1/include
+		cp -Rv inc/* $1/include
+		# library files
+		cp -Rv lib/libfmodex.dylib $1/lib/$TYPE/
+	else
+		: #noop
+	fi
+	:
+}
+
+# executed inside the lib src dir
+function clean() {
+	: # noop
+}


### PR DESCRIPTION
+ this is a download + copy-only script, since fmodex appears not to be available in source.
+ downloads fat binary release of fmodex for os x (64/32bit), 
+ linking verified against libstdc++ and libc++.

The current oF:master dylib supplied for fmodex on os x is slim. 
+ downloads headers and fat binary dylib for fmodex from fmod.org. 
+ Version downloaded (42221) is the version closest to the current headers in master, since the version referenced in the current headers (42220) is not available as a download for os x.