### PR TITLE
seem small apothecary updates

### DIFF
--- a/scripts/apothecary/README.md
+++ b/scripts/apothecary/README.md
@@ -469,7 +469,7 @@ Bash provides an easy way to debug scripts by `set -x`. Put this command in your
 
 **PLEASE PLEASE PLEASE comment your formulas!** Writing build scripts sucks! Don't make it even more hell for people that have to try and maintain what you've done. Note *any* assumptions you're making **especially** regarding things that may change based on newer releases of a library.
 
-Last, if you write a formula but can't finish/test it on all platforms, etc make a note of this using the `echoWarning` print command. This is a function provided by apothecary that prints text in <span style="color: #FF0">yellow (caution, right?)</span>. Start your info string with with "TODO: ":
+If you write a formula but can't finish/test it on all platforms, etc make a note of this using the `echoWarning` print command. This is a function provided by apothecary that prints text in <span style="color: #FF0">yellow (caution, right?)</span>. Start your info string with with "TODO: ":
 
 	if [ "$TYPE" == "win_cb" ] then ;
 		echoWarning "TODO: build win_cb"
@@ -477,6 +477,22 @@ Last, if you write a formula but can't finish/test it on all platforms, etc make
 	...
 
 Then we at least know what we're missing if the build process fails ...
+
+### Custom Apothecary Echo Wrappers
+
+There are a number of custom echo wrappers like `echoWarning`  which set the console color, etc. Use these for more informative info/debugging print instead of plain old `echo`:
+
+    echoError "somethign bad happend, print in red"
+	
+	echoWarning "something didn't work, print in yellow"
+	
+	echoInfo "regular print in white"
+	
+	echoSuccess "something worked, so print in green"
+	
+	echoVerbose "for debugging, prints extra info in white when the -v verbose flag is used"
+	
+Note the verbose `-v` flag, apothecary will already print out info about what steps it's doing so you don;t need to add this to the formual files.
 
 ### Additional Tips
 

--- a/scripts/apothecary/README.md
+++ b/scripts/apothecary/README.md
@@ -478,9 +478,9 @@ If you write a formula but can't finish/test it on all platforms, etc make a not
 
 Then we at least know what we're missing if the build process fails ...
 
-### Custom Apothecary Echo Wrappers
+#### Custom Apothecary Echo Wrappers
 
-There are a number of custom echo wrappers like `echoWarning`  which set the console color, etc. Use these for more informative info/debugging print instead of plain old `echo`:
+There are a number of custom echo wrappers like `echoWarning` which set the console color, etc. Use these for more informative info/debugging print instead of plain old `echo`:
 
     echoError "somethign bad happend, print in red"
 	
@@ -492,7 +492,7 @@ There are a number of custom echo wrappers like `echoWarning`  which set the con
 	
 	echoVerbose "for debugging, prints extra info in white when the -v verbose flag is used"
 	
-Note the verbose `-v` flag, apothecary will already print out info about what steps it's doing so you don;t need to add this to the formual files.
+Note the verbose `-v` flag. Apothecary will already print out info about what steps it's doing so you don't need to add this to the formula files.
 
 ### Additional Tips
 

--- a/scripts/apothecary/apothecary
+++ b/scripts/apothecary/apothecary
@@ -940,16 +940,17 @@ BUILD_ROOT_DIR=$BUILD_DIR/$BUILDROOT_SUBDIR
 
 # set for android sdk info
 if [[ "$TYPE" == "android" ]] ; then
-	if [[ -x ../../libs/openFrameworksCompiled/project/android/paths.make ]] ; then
+	if [[ -e ../../libs/openFrameworksCompiled/project/android/paths.make ]] ; then
 		ANDROID_NDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep NDK_ROOT | sed 's/.*=\(.*\)/\1/'`
 		ANDROID_SDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep SDK_ROOT | sed 's/.*=\(.*\)/\1/'`
 		echoVerbose "Android NDK root: $ANDROID_NDK_ROOT"
 		echoVerbose "Android SDK root: $ANDROID_SDK_ROOT"
 	else
-		echoError "Targeting android, but can't find the SDK is we're missing"
+		echoError "Targeting android, but can't find the SDK. Missing"
 		echoError "libs/openFrameworksCompiled/project/android/paths.make ..."
 		echoError "See the following for info:"
 		echoError "libs/openFrameworksCompiled/project/android/paths.make.default"
+		exit 1
 	fi
 fi
 

--- a/scripts/apothecary/apothecary
+++ b/scripts/apothecary/apothecary
@@ -78,9 +78,9 @@ IOS_MIN_SDK_VER=5.1
 # used when building for vs
 VS_VER=11
 
-# used when compiling for android
-ANDROID_NDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep NDK_ROOT | sed 's/.*=\(.*\)/\1/'`
-ANDROID_SDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep SDK_ROOT | sed 's/.*=\(.*\)/\1/'`
+# paths to android SDK, etc
+ANDROID_NDK_ROOT=
+ANDROID_SDK_ROOT=
 ANDROID_PLATFORM=android-19
 
 ################################################################################
@@ -298,7 +298,6 @@ fi
 ################################################################################
 ### FUNCTIONS
 
-
 function installAndroidToolchain() {
 
 	local WD=$(pwd)
@@ -329,7 +328,6 @@ function installAndroidToolchain() {
 	cd $WD
 
 }
-
 
 # check if a given string matches anything in VALID_TYPES,
 # bool result is set to second argument
@@ -939,6 +937,21 @@ fi
 # dependency & build root dirs
 DEPENDS_FORMULA_DIR=$APOTHECARY_DIR/$REL_FORMULAS_DIR/$DEPENDS_SUBDIR
 BUILD_ROOT_DIR=$BUILD_DIR/$BUILDROOT_SUBDIR
+
+# set for android sdk info
+if [[ "$TYPE" == "android" ]] ; then
+	if [[ -x ../../libs/openFrameworksCompiled/project/android/paths.make ]] ; then
+		ANDROID_NDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep NDK_ROOT | sed 's/.*=\(.*\)/\1/'`
+		ANDROID_SDK_ROOT=`cat ../../libs/openFrameworksCompiled/project/android/paths.make | grep SDK_ROOT | sed 's/.*=\(.*\)/\1/'`
+		echoVerbose "Android NDK root: $ANDROID_NDK_ROOT"
+		echoVerbose "Android SDK root: $ANDROID_SDK_ROOT"
+	else
+		echoError "Targeting android, but can't find the SDK is we're missing"
+		echoError "libs/openFrameworksCompiled/project/android/paths.make ..."
+		echoError "See the following for info:"
+		echoError "libs/openFrameworksCompiled/project/android/paths.make.default"
+	fi
+fi
 
 # handle commands
 echoVerbose "Running: $A_CMD $*"

--- a/scripts/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/scripts/apothecary/formulas/FreeImage/FreeImage.sh
@@ -18,6 +18,7 @@ GIT_TAG=3.16.0
 
 # download the source code and unpack it into LIB_NAME
 function download() {
+
 	if [ "$TYPE" == "vs" -o "$TYPE" == "win_cb" ] ; then
 		# For win32, we simply download the pre-compiled binaries.
 		curl -LO http://downloads.sourceforge.net/freeimage/FreeImage"$VER"Win32.zip
@@ -207,7 +208,6 @@ function build() {
 			echo "Running make for ${IOS_ARCH}"
 			echo "Please stand by..."
 
-			
 			# run makefile
 			make -f Makefile.ios >> "${LOG}" 2>&1
 			if [ $? != 0 ];
@@ -239,7 +239,6 @@ function build() {
 		mkdir -p "$CURRENTPATH/builddir/$TYPE/$IOS_ARCH"
 		LOG="$CURRENTPATH/builddir/$TYPE/build-freeimage-${VER}-lipo.log"
 
-
 		cd Dist/$TYPE/
 		# link into universal lib
 		echo "Running lipo to create fat lib"
@@ -250,7 +249,6 @@ function build() {
 					libfreeimage-i386.a \
 					libfreeimage-x86_64.a \
 					-output freeimage.a >> "${LOG}" 2>&1
-
 
 		if [ $? != 0 ];
 		then 
@@ -349,12 +347,12 @@ function copy() {
         cp -rv Dist/x86/*.a $1/lib/$TYPE/x86/
 	fi	
 
-    # Copy License Files
-    rm -rf $1/license #remove any older files if exists
+    # copy license files
+    rm -rf $1/license # remove any older files if exists
     mkdir -p $1/license
-    cp -v "license-fi.txt" "$1/license/license-fi.txt"
-    cp -v "license-gplv2.txt" "$1/license/license-gplv2.txt"
-    cp -v "license-gplv3.txt" "$1/license/license-gplv3.txt"
+    cp -v license-fi.txt $1/license/
+    cp -v license-gplv2.txt $1/license/
+    cp -v license-gplv3.txt $1/license/
 }
 
 # executed inside the lib src dir
@@ -364,7 +362,6 @@ function clean() {
 		echoWarning "TODO: clean android"
 	elif [ "$TYPE" == "ios" ] ; then
 		# clean up compiled libraries
-		
 		make clean
 		rm -rf Dist
 		rm -f *.a *.lib
@@ -376,5 +373,4 @@ function clean() {
 		# run dedicated clean script
 		clean.sh
 	fi
-
 }

--- a/scripts/apothecary/formulas/cairo.sh
+++ b/scripts/apothecary/formulas/cairo.sh
@@ -57,7 +57,6 @@ function prepare() {
 	apothecaryDepend copy pixman
 	apothecaryDepend build freetype
 	apothecaryDepend copy freetype
-
 }
 
 # executed inside the lib src dir
@@ -82,7 +81,6 @@ function build() {
 		make -j
 		make install
 	fi
-
 }
 
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
@@ -123,13 +121,12 @@ function copy() {
 		cp -v $BUILD_ROOT_DIR/lib/libpixman-1.a $1/lib/$TYPE/pixman-1.a
 	fi
 
-	# Copy License Files
-	rm -rf $1/license #remove any older files if exists
+	# copy license files
+	rm -rf $1/license # remove any older files if exists
 	mkdir -p $1/license
-	cp -v COPYING $1/license/COPYING
-	cp -v COPYING-LGPL-2.1 $1/license/COPYING-LGPL-2.1
-	cp -v COPYING-MPL-1.1 $1/license/COPYING-MPL-1.1
-
+	cp -v COPYING $1/license/
+	cp -v COPYING-LGPL-2.1 $1/license/
+	cp -v COPYING-MPL-1.1 $1/license/
 }
 
 # executed inside the lib src dir

--- a/scripts/apothecary/formulas/fmodex.sh
+++ b/scripts/apothecary/formulas/fmodex.sh
@@ -41,7 +41,7 @@ function download() {
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
-	:
+	: # noop
 	# mount install
 }
 
@@ -59,10 +59,7 @@ function copy() {
 		cp -Rv inc/* $1/include
 		# library files
 		cp -Rv lib/libfmodex.dylib $1/lib/$TYPE/
-	else
-		: #noop
 	fi
-	:
 }
 
 # executed inside the lib src dir

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -25,7 +25,6 @@ function download() {
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
-	: # noop
 	mkdir -p lib/$TYPE
 }
 
@@ -56,7 +55,6 @@ function build() {
 		esac 
 
 		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
-		
 
 		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
 			CFLAGS="-arch $OSX_ARCH -pipe -stdlib=$STDLIB -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
@@ -76,8 +74,6 @@ function build() {
 		make -j
 		make install
 		cp $BUILD_TO_DIR/lib/libfreetype.a lib/$TYPE/libfreetype-$OSX_ARCH.a
-
-
 
 		cd lib/$TYPE/
 		lipo -create libfreetype-i386.a \
@@ -254,7 +250,6 @@ function build() {
 		    echo "Build Successful for $IOS_ARCH"
 		done
 
-
 		echo "-----------------"
 		echo `pwd`
 		echo "Finished for all architectures."
@@ -368,13 +363,12 @@ function copy() {
 		cp -v build/$TYPE/x86/lib/libfreetype.a $1/lib/$TYPE/x86/libfreetype.a
 	fi
 
-	# Copy License Files
-	rm -rf $1/license #remove any older files if exists
+	# copy license files
+	rm -rf $1/license # remove any older files if exists
 	mkdir -p $1/license
-	cp -v docs/LICENSE.TXT $1/license/LICENSE.TXT
-	cp -v docs/FTL.TXT $1/license/FTL.TXT
-	cp -v docs/GPLv2.TXT $1/license/GPLv2.TXT
-
+	cp -v docs/LICENSE.TXT $1/license/
+	cp -v docs/FTL.TXT $1/license/
+	cp -v docs/GPLv2.TXT $1/license/
 }
 
 # executed inside the lib src dir
@@ -382,7 +376,6 @@ function clean() {
 
 	if [ "$TYPE" == "vs" ] ; then
 		echoWarning "TODO: clean vs"
-	
 	elif [ "$TYPE" == "android" ] ; then
 		make clean
 		rm -f build/$TYPE

--- a/scripts/apothecary/formulas/glew.sh
+++ b/scripts/apothecary/formulas/glew.sh
@@ -71,7 +71,6 @@ function copy() {
 
 	rm -rf $1/lib/$TYPE/*
 	
-	
 	# libs
 	if [ "$TYPE" == "osx" ] ; then
 		mkdir -p $1/lib/$TYPE

--- a/scripts/apothecary/formulas/glfw.sh
+++ b/scripts/apothecary/formulas/glfw.sh
@@ -35,7 +35,6 @@ function build() {
 	if [ "$TYPE" == "vs" ] ; then
 		cmake -G "Visual Studio $VS_VER"
 		vs-build "GLFW.sln"
-
 	else
 		# *nix build system
 
@@ -74,8 +73,8 @@ function copy() {
 		cp -Rv $BUILD_ROOT_DIR/lib/libglfw3.a $1/lib/$TYPE/
 	fi
 
-	# Copy License File
-    cp -v COPYING.txt $1/COPYING.txt
+	# copy license file
+    cp -v COPYING.txt $1/
 }
 
 # executed inside the lib src dir
@@ -83,6 +82,6 @@ function clean() {
 	if [ "$TYPE" == "vs" ] ; then
 		rm -f *.lib
 	else
-		make clean;
+		make clean
 	fi
 }

--- a/scripts/apothecary/formulas/kiss.sh
+++ b/scripts/apothecary/formulas/kiss.sh
@@ -68,12 +68,13 @@ function copy() {
 		cp -v libkiss.a $1/lib/linux64/libkiss.a
 	fi
 
-	# Copy License File
-    cp -v COPYING $1/COPYING
+	# copy license file
+    cp -v COPYING $1/
 }
 
 # executed inside the lib src dir
 function clean() {
+	
 	if [ "$TYPE" == "linux" -o "$TYPE" == "linux64" ] ; then
 		make clean
 		rm -f *.a

--- a/scripts/apothecary/formulas/kiss/kiss.sh
+++ b/scripts/apothecary/formulas/kiss/kiss.sh
@@ -36,7 +36,6 @@ function build() {
 		gcc -I./include -c src/kiss_fftr.c -o kiss_fftr.o
 		ar r libkiss.a kiss.o
 		echoWarning "TODO: linux build"
-
 	
 	elif [ "$TYPE" == "linux64" ] ; then
 		echoWarning "TODO: linux64 build"

--- a/scripts/apothecary/formulas/openssl.sh
+++ b/scripts/apothecary/formulas/openssl.sh
@@ -28,11 +28,11 @@ function download() {
 	else 
 		echoError "Invalid shasum for $FILENAME."
 	fi
-
 }
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
+
 	if [ "$TYPE" == "ios" ] ; then
 		# create output directories
 		mkdir -p "src"
@@ -54,8 +54,6 @@ function prepare() {
         #mkdir -p lib/$TYPE/armv7s
 		mkdir -p lib/$TYPE/arm64
 
-		
-
 		# make copies of the source files before modifying
 		cp Makefile Makefile.orig
 		cp Configure Configure.orig
@@ -64,15 +62,11 @@ function prepare() {
 		mkdir -p lib/$TYPE
 		mkdir -p lib/include
  	fi
-
-
-
 }
 
 # executed inside the lib src dir
 function build() {
 	
-
 	if [ "$TYPE" == "osx" ] ; then
 		
 		local BUILD_OPTS="-no-shared -no-asm -no-ec_nistp_64_gcc_128 -no-gmp -no-jpake -no-krb5 -no-md2 -no-rc5 -no-rfc3779 -no-sctp -no-shared -no-store -no-unit-test -no-zlib -no-zlib-dynamic"
@@ -161,7 +155,6 @@ function build() {
 		    	exit 1
 		    fi
 
-
             # we need to unset LANG otherwise sed will get upsed.
    			# unset LANG if defined
 			if test ${LANG+defined};
@@ -191,7 +184,6 @@ function build() {
             then
                 export LC_CTYPE=$OLD_LC_CTYPE
             fi
-
 
 			echo "Running make for ${OSX_ARCH}"
 			echo "Please stand by..."
@@ -246,9 +238,7 @@ function build() {
             fi
         done
 
-
         cd ../../
-
 		
 		# ------------ END OS X Recipe.
 
@@ -288,8 +278,6 @@ function build() {
 		DEVELOPER=$XCODE_DEV_ROOT
 		TOOLCHAIN=${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain
 		VERSION=$VER
-		
-
 
         local IOS_ARCHS="i386 x86_64 armv7 arm64" #armv7s
 		local STDLIB="libc++"
@@ -390,8 +378,6 @@ function build() {
                 fi
 			fi
 
-
-
 			export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
 			export CROSS_SDK="${PLATFORM}${SDKVERSION}.sdk"
 			export BUILD_TOOLS="${DEVELOPER}"
@@ -408,7 +394,6 @@ function build() {
 		    elif [ "${IOS_ARCH}" == "i386" ]; then
 		    	MIN_IOS_VERSION=5.1 # 6.0 to prevent start linking errors
 		    fi
-			
 
 			echo "Compiler: $CC"
 			echo "Building openssl-${VER} for ${PLATFORM} ${SDKVERSION} ${IOS_ARCH} : iOS Minimum=$MIN_IOS_VERSION"
@@ -439,7 +424,6 @@ function build() {
 		    if [[ "${IOS_ARCH}" == "i386" || "${IOS_ARCH}" == "x86_64" ]]; then
 		    	MIN_TYPE=-mios-simulator-version-min=
 		    fi
-
 
             # unset LANG if defined
             if test ${LANG+defined};
@@ -529,6 +513,7 @@ function build() {
 		cp "crypto/ui/ui_openssl.c.orig" "crypto/ui/ui_openssl.c"
 
 		unset TOOLCHAIN DEVELOPER
+
 	elif [ "$TYPE" == "android" ]; then
 		source $LIBS_DIR/openFrameworksCompiled/project/android/paths.make
 		
@@ -696,8 +681,8 @@ function copy() {
 	 	echoWarning "TODO: copy $TYPE lib"
 	fi
 
-    # Copy License File
-    cp -v LICENSE $1/LICENSE
+    # copy license file
+    cp -v LICENSE $1/
 }
 
 # executed inside the lib src dir

--- a/scripts/apothecary/formulas/poco/poco.sh
+++ b/scripts/apothecary/formulas/poco/poco.sh
@@ -36,6 +36,7 @@ function download() {
 
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
+
 	if [ "$SHA" != "" ] ; then
 		git reset --hard $SHA
 	fi
@@ -137,7 +138,6 @@ function build() {
 	    fi
 
 		# 64 bit
-
 		export POCO_ENABLE_CPP11=1
 		LOG="$CURRENTPATH/build/$TYPE/poco-configure-x86_64-${VER}.log"
 		./configure $BUILD_OPTS --config=Darwin64-clang-libc++  > "${LOG}" 2>&1
@@ -359,7 +359,6 @@ function build() {
 		    fi
 		done
 
-
 		cd ../../
 
 		echo "--------------------"
@@ -505,8 +504,8 @@ function copy() {
 		echoWarning "TODO: copy $TYPE lib"
 	fi
 
-	# Copy License File
-    cp -v LICENSE $1/LICENSE
+	# copy license file
+    cp -v LICENSE $1/
 }
 
 # executed inside the lib src dir
@@ -523,5 +522,4 @@ function clean() {
 	else
 		make clean
 	fi
-
 }

--- a/scripts/apothecary/formulas/portaudio.sh
+++ b/scripts/apothecary/formulas/portaudio.sh
@@ -39,8 +39,8 @@ function copy() {
 	mkdir -p $1/include
 	cp -Rv include/* $1/include
 
-	# Copy License File
-    cp -v LICENSE.txt $1/LICENSE.txt
+	# copy license file
+    cp -v LICENSE.txt $1/
 }
 
 # executed inside the lib src dir

--- a/scripts/apothecary/formulas/rtAudio.sh
+++ b/scripts/apothecary/formulas/rtAudio.sh
@@ -36,6 +36,7 @@ function prepare() {
 
 # executed inside the lib src dir
 function build() {
+
 	# The ./configure / MAKEFILE sequence is broken for OSX, making it 
 	# impossible to create universal libs in one pass.  As a result, we compile
 	# the project manually according to the author's page:
@@ -72,7 +73,6 @@ function build() {
 
 	# clean up env vars
 	# unset PKG_CONFIG PKG_CONFIG_PATH
-
 }
 
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
@@ -95,13 +95,13 @@ function copy() {
 		cp -v librtaudio.a $1/lib/$TYPE/rtaudio.a
 	fi
 
-	# Copy License File
-    cp -v readme $1/readme
-
+	# copy license file
+    cp -v readme $1/
 }
 
 # executed inside the lib src dir
 function clean() {
+	
 	if [ "$TYPE" == "vs" ] ; then
 		echoWarning "TODO: clean vs"
 	else
@@ -110,6 +110,4 @@ function clean() {
 
 	# manually clean dependencies
 	#apothecaryDependencies clean
-
-
 }

--- a/scripts/apothecary/formulas/tess2/tess2.sh
+++ b/scripts/apothecary/formulas/tess2/tess2.sh
@@ -63,7 +63,6 @@ function build() {
 			rm -f CMakeCache.txt
 			set +e
 
-
 			# Choose which stdlib to use:
 			# i386    : libstdc++
 			# x86_64  : libc++
@@ -85,7 +84,6 @@ function build() {
 			export LINKFLAGS="$CFLAGS $STD_LIB_FLAGS"
 			export LDFLAGS="$LINKFLAGS"
 			export CXXFLAGS=$CPPFLAGS
-
 
 			LOG="build-tess2-${VER}-${OSX_ARCH}-cmake.log"
 
@@ -118,7 +116,6 @@ function build() {
 			 -output libtess2.a \
 			 > "${LOG}" 2>&1
 
-
 	elif [ "$TYPE" == "vs" ] ; then
 		cmake -G "Visual Studio $VS_VER"
 		vs-build "tess2.sln"
@@ -149,7 +146,6 @@ function build() {
 		           exit 1
 		          ;;
 		esac 
-
 		
 		export CC=$TOOLCHAIN/usr/bin/$COMPILER_CTYPE
 		export CPP=$TOOLCHAIN/usr/bin/$COMPILER_CPPTYPE
@@ -165,7 +161,6 @@ function build() {
 		EXTRA_LINK_FLAGS="-stdlib=libc++ -Os -fPIC"
 		EXTRA_FLAGS="$EXTRA_LINK_FLAGS -fvisibility-inlines-hidden"
 		
-
 		# loop through architectures! yay for loops!
 		for IOS_ARCH in ${IOS_ARCHS}
 		do
@@ -200,7 +195,6 @@ function build() {
 		    if [[ "${IOS_ARCH}" == "i386" || "${IOS_ARCH}" == "x86_64" ]]; then
 		    	MIN_TYPE=-mios-simulator-version-min=
 		    fi
-
 
 			export CFLAGS="-arch $IOS_ARCH -pipe -no-cpp-precomp -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} $MIN_TYPE$MIN_IOS_VERSION -I${CROSS_TOP}/SDKs/${CROSS_SDK}/usr/include/" 
 	
@@ -322,8 +316,8 @@ function copy() {
 		cp -v libtess2.a $1/lib/$TYPE/tess2.a
 	fi
 
-	# Copy License File
-    cp -v LICENSE.txt $1/LICENSE.txt
+	# copy license file
+    cp -v LICENSE.txt $1/
 }
 
 # executed inside the lib src dir

--- a/scripts/apothecary/formulas/videoInput.sh
+++ b/scripts/apothecary/formulas/videoInput.sh
@@ -64,7 +64,6 @@ function clean() {
 	
 	if [ "$TYPE" == "vs" ] ; then
 		echoWarning "TODO: clean vs"
-	
 	elif [ "$TYPE" == "win_cb" ] ; then
 		echoWarning "TODO: clean win_cb"
 	fi


### PR DESCRIPTION
Some small apothecary updates:

* Don't need explict names when copying license files, related to #3623 
* Don't assume we have the android sdk installed, only set sdk vars when targeting android and exit with error if we can't find the path file. Also, this was opening a file with a relative path *before* the script actually changes dir so it would break if you we're not running apothecary from it's own dir. Apothecary is designed to be called from any location so it's easier to script.
* Updated readme with info on custom echo wrappers
* Small formula whitespace fixes

I also noted the following which I have questions about:

1. There are two kiss formulas right now, one should be deleted: `kiss/kiss.sh`& `kiss.sh`

2. There is lots of [commented stuff in openssh.sh](https://github.com/danomatika/openFrameworks/blob/master/scripts/apothecary/formulas/openssl.sh#L243), can we delete it?

3. freetype.sh has [commented copy commands for older versions](https://github.com/danomatika/openFrameworks/blob/master/scripts/apothecary/formulas/freetype.sh#L343), if we're not using version < 2.5, can we remove it?

4.  Better feedback/debugging? Whoever updated freeimage & poco added lots of redundant echos like "built successful" etc. A lot of this info is actually printed by apothecary already especially when you run it with the `-v` verbose flag (which is **highly** recommended for debugging). Also, there are a number of custom echo commands (echoWarning, echoError, echoInfo, echoVerbose) which provide better feedback through coloring. `echoVerbose` is especially useful for debug prints. Anyway, I updated the [readme to note these](https://github.com/danomatika/openFrameworks/tree/master/scripts/apothecary#custom-apothecary-echo-wrappers) and I suggest not using `echo` at all, if possible.

5. There are a fair number of bash style clashes ... which is not a suprise I guess with numerous authors at this point