### PR TITLE
fix blendmode style tracking in fixed function + programmable renderer

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1068,6 +1068,7 @@ void ofGLProgrammableRenderer::setBlendMode(ofBlendMode blendMode){
 		default:
 			break;
 	}
+	currentStyle.blendingMode = blendMode;
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -1184,6 +1184,7 @@ void ofGLRenderer::setBlendMode(ofBlendMode blendMode){
 		default:
 			break;
 	}
+	currentStyle.blendingMode = blendMode;
 }
 
 void ofGLRenderer::setBitmapTextMode(ofDrawBitmapMode mode){


### PR DESCRIPTION
updates `blendingMode` in renderer`.currentStyle` whenever the blendmode is set. This allows `ofPush|PopStyle()` to store + recover blend modes as expected

Since the renderer's blendmode was not updated in either programmable or fixed function renderer, push/pop style would not work as expected: `push` would not store the current blend mode, while `pop` would "restore" the blendmode to the default value of `OF_BLENDING_ALPHA(1)`