### PR TITLE
allowing other addons directories

### DIFF
--- a/apps/devApps/projectGenerator/src/addons/ofAddon.cpp
+++ b/apps/devApps/projectGenerator/src/addons/ofAddon.cpp
@@ -344,11 +344,9 @@ void ofAddon::fromFS(string path, string platform){
 
     clear();
     this->platform = platform;
-	name = ofFilePath::getFileName(path);
-	addonPath = ofFilePath::join(getAddonsRoot(),name);
-
+    name = ofFilePath::getFileName(path);
     string filePath = path + "/src";
-    string ofRootPath = ofFilePath::addTrailingSlash(getOFRoot()); //we need to add a trailing slash for the erase to work properly
+    addonPath = path;//ofFilePath::join(getAddonsRoot(),name);
 
     ofLogVerbose() << "in fromFS, trying src " << filePath;
 
@@ -356,8 +354,8 @@ void ofAddon::fromFS(string path, string platform){
     getFilesRecursively(filePath, srcFiles);
 
     for(int i=0;i<(int)srcFiles.size();i++){
-    	srcFiles[i].erase (srcFiles[i].begin(), srcFiles[i].begin()+ofRootPath.length());
-		//ofLogVerbose() << " srcFiles " << srcFiles[i];
+        srcFiles[i] = getRelPath(getOFRoot(), ofFilePath::getEnclosingDirectory(srcFiles[i])) + ofFilePath::getFileName(srcFiles[i]);
+		ofLogVerbose() << " srcFiles " << srcFiles[i];
     	int init = 0;
 #ifdef TARGET_WIN32
     	int end = srcFiles[i].rfind("\\");
@@ -386,7 +384,7 @@ void ofAddon::fromFS(string path, string platform){
 
     // I need to add libFiles to srcFiles
     for (int i = 0; i < (int)libFiles.size(); i++){
-    	libFiles[i].erase (libFiles[i].begin(), libFiles[i].begin()+ofRootPath.length());
+        libFiles[i] = getRelPath(getOFRoot(), ofFilePath::getEnclosingDirectory(libFiles[i])) + ofFilePath::getFileName(libFiles[i]);
 		//ofLogVerbose() << " libFiles " << libFiles[i];
     	int init = 0;
 #ifdef TARGET_WIN32
@@ -413,7 +411,7 @@ void ofAddon::fromFS(string path, string platform){
 #endif
         if (end > 0){
 
-            libs[i].erase (libs[i].begin(), libs[i].begin()+ofRootPath.length());
+            libs[i] = getRelPath(getOFRoot(), ofFilePath::getEnclosingDirectory(libs[i])) + ofFilePath::getFileName(libs[i]);
             libs[i] = pathToOF + libs[i];
         }
 
@@ -429,7 +427,7 @@ void ofAddon::fromFS(string path, string platform){
 #endif
         if (end > 0){
 
-            frameworks[i].erase (frameworks[i].begin(), frameworks[i].begin()+ofRootPath.length());
+            frameworks[i] = getRelPath(getOFRoot(), ofFilePath::getEnclosingDirectory(frameworks[i])) + ofFilePath::getFileName(frameworks[i]);
             frameworks[i] = pathToOF + frameworks[i];
         }
 
@@ -452,21 +450,21 @@ void ofAddon::fromFS(string path, string platform){
     // get every folder in addon/src and addon/libs
 
     vector < string > libFolders;
-    ofLogVerbose() << "trying get folders recursively " << (path + "/libs");
+    ofLogVerbose() << "trying get folders recursively " << libsPath;
 
 	// the dirList verbosity is crazy, so I'm setting this off for now.
-    getFoldersRecursively(path + "/libs", libFolders, platform);
+    getFoldersRecursively(libsPath, libFolders, platform);
     vector < string > srcFolders;
-    getFoldersRecursively(path + "/src", srcFolders, platform);
+    getFoldersRecursively(filePath, srcFolders, platform);
 
     for (int i = 0; i < (int)libFolders.size(); i++){
-        libFolders[i].erase (libFolders[i].begin(), libFolders[i].begin()+ofRootPath.length());
+        libFolders[i] = getRelPath(getOFRoot(), libFolders[i]);
         libFolders[i] = pathToOF + libFolders[i];
         paths.push_back(libFolders[i]);
     }
 
     for (int i = 0; i < (int)srcFolders.size(); i++){
-        srcFolders[i].erase (srcFolders[i].begin(), srcFolders[i].begin()+ofRootPath.length());
+        srcFolders[i] = getRelPath(getOFRoot(), srcFolders[i]);
         srcFolders[i] = pathToOF + srcFolders[i];
         paths.push_back(srcFolders[i]);
     }

--- a/apps/devApps/projectGenerator/src/main.cpp
+++ b/apps/devApps/projectGenerator/src/main.cpp
@@ -11,6 +11,7 @@ int main(  int argc, char *argv[]  ){
     cout << "In main." << endl;
     
     cout << "ofGetTargetPlatform=" << ofGetTargetPlatform() << endl;
+    ofSetLogLevel(OF_LOG_NOTICE);
     
 #ifdef TARGET_LINUX
 	if(argc==1){

--- a/apps/devApps/projectGenerator/src/ofApp.h
+++ b/apps/devApps/projectGenerator/src/ofApp.h
@@ -13,6 +13,13 @@
 #include "ofxGui.h"
 #endif
 
+struct ofAddonData{
+    ofAddonData(string _absolutePath){
+        absolutePath = _absolutePath;
+    }
+    string absolutePath;
+};
+
 class ofApp : public ofBaseApp{
 
 	public:
@@ -41,6 +48,7 @@ class ofApp : public ofBaseApp{
         void updateProjectPressed();
         void createAndOpenPressed();
         void changeOFRootPressed();
+        void appendAddonsDirPressed();
 		
 		void setupDrawableOFPath();
 		
@@ -50,6 +58,7 @@ class ofApp : public ofBaseApp{
         string target;
 		vector <int> targetsToMake;
 		bool buildAllExamples;
+        vector <ofAddonData> addonList;
 
 #ifndef COMMAND_LINE_ONLY
 		string drawableOfPath;
@@ -57,7 +66,7 @@ class ofApp : public ofBaseApp{
 		ofPoint ofPathDrawPoint;
 
         ofxPanel panelAddons, panelOptions;
-        ofxButton createProject, updateProject, createAndOpen, changeOFRoot;
+        ofxButton createProject, updateProject, createAndOpen, changeOFRoot, appendAddonsDir;
 
 		ofxPanel examplesPanel;
 		ofxToggle osxToggle, iosToggle, wincbToggle, winvsToggle, linuxcbToggle, linux64cbToggle,linuxarmv6lcbToggle,linuxarmv7lcbToggle;

--- a/apps/devApps/projectGenerator/src/utils/Utils.cpp
+++ b/apps/devApps/projectGenerator/src/utils/Utils.cpp
@@ -468,51 +468,56 @@ void setOFRoot(string path){
 	OFRoot = path;
 }
 
-string getOFRelPath(string from){
-	from = ofFilePath::removeTrailingSlash(from);
+string getRelPath(string from, string to){
+    from = ofFilePath::removeTrailingSlash(from);
+    to = ofFilePath::removeTrailingSlash(to);
     Poco::Path base(true);
     base.parse(from);
-
+    
     Poco::Path path;
-    path.parse( getOFRoot() );
+    path.parse( to );
     path.makeAbsolute();
-
-
-	string relPath;
-	if (path.toString() == base.toString()){
-		// do something.
-	}
-
-	int maxx = MAX(base.depth(), path.depth());
-	for (int i = 0; i <= maxx; i++){
-
-		bool bRunOut = false;
-		bool bChanged = false;
-		if (i <= base.depth() && i <= path.depth()){
-			if (base.directory(i) == path.directory(i)){
-
-			} else {
-				bChanged = true;
-			}
-		} else {
-			bRunOut = true;
-		}
-
-
-		if (bRunOut == true || bChanged == true){
+    
+    
+    string relPath;
+    if (path.toString() == base.toString()){
+        // do something.
+    }
+    
+    int maxx = MAX(base.depth(), path.depth());
+    for (int i = 0; i <= maxx; i++){
+        
+        bool bRunOut = false;
+        bool bChanged = false;
+        if (i <= base.depth() && i <= path.depth()){
+            if (base.directory(i) == path.directory(i)){
+                
+            } else {
+                bChanged = true;
+            }
+        } else {
+            bRunOut = true;
+        }
+        
+        
+        if (bRunOut == true || bChanged == true){
             for (int j = i; j <= base.depth(); j++){
-				relPath += "../";
-			}
-			for (int j = i; j <= path.depth(); j++){
-				relPath += path.directory(j) + "/";
-			}
-			break;
-		}
-	}
-
-	ofLogVerbose() << "returning path " << relPath << endl;
-
+                relPath += "../";
+            }
+            for (int j = i; j <= path.depth(); j++){
+                relPath += path.directory(j) + "/";
+            }
+            break;
+        }
+    }
+    
+    ofLogVerbose() << "returning path " << relPath << endl;
+    
     return relPath;
+}
+
+string getOFRelPath(string from){
+    return getRelPath(from, getOFRoot());
 }
 
 void parseAddonsDotMake(string path, vector < string > & addons){

--- a/apps/devApps/projectGenerator/src/utils/Utils.h
+++ b/apps/devApps/projectGenerator/src/utils/Utils.h
@@ -43,6 +43,7 @@ void parseAddonsDotMake(string path, vector < string > & addons);
 void fixSlashOrder(string & toFix);
 string unsplitString (vector < string > strings, string deliminator );
 
+string getRelPath(string from, string to);
 string getOFRelPath(string from);
 
 bool checkConfigExists();


### PR DESCRIPTION
Adding the ability in the Project Genenerator to specify alternate
Addons directories to load addons from.

Outstanding Items:
* This includes the examples and .md files etc in the addon's root, which I don't think are included when using the current project generator
* Only tested on OSX 10.9
* Not tested with an addon that includes a framework

suggestions for test cases welcome!