### PR TITLE
Add gradle/ directory and scripts to .gitignore

### DIFF
--- a/libs/openFrameworksCompiled/project/android/.gitignore
+++ b/libs/openFrameworksCompiled/project/android/.gitignore
@@ -1,3 +1,6 @@
 # Gradle files
 .gradle/
 .idea/
+/gradle/
+/gradlew
+/gradlew.bat


### PR DESCRIPTION
This ignores the gradle files automatically added by Android Studio.