### PR TITLE
fix c++11 av foundation player

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -266,9 +266,9 @@ ofPixels & ofAVFoundationPlayer::getPixels() {
     
     vImage_Buffer dest = {
         pixels.getData(),
-        pixels.getHeight(),
-        pixels.getWidth(),
-        pixels.getWidth() * pixels.getNumChannels()
+        static_cast<vImagePixelCount>(pixels.getHeight()),
+        static_cast<vImagePixelCount>(pixels.getWidth()),
+        static_cast<size_t>(pixels.getWidth() * pixels.getNumChannels())
     };
     
     vImage_Error err = kvImageNoError;


### PR DESCRIPTION
c++11 requires a static cast, since some types cannot be unambiguously inferred in the initialiser list

This fix is necessary for c++11 / 64bit compilation and #3627, and is backwards compatible with 32 bit. Tested on both.