### PR TITLE
fixing compileOF.sh (for ARMv7)

### DIFF
--- a/scripts/linux/compileOF.sh
+++ b/scripts/linux/compileOF.sh
@@ -18,7 +18,7 @@ exit_code=$?
 if [ $exit_code != 0 ]; then
   echo "there has been a problem compiling Debug OF library"
   echo "please report this problem in the forums"
-  chown -R $ID:$GROUP_ID ../lib/${LIBSPATH}/*
+  chown -R $ID:$GROUP_ID ../lib/*
   exit $exit_code
 fi
 
@@ -27,10 +27,10 @@ exit_code=$?
 if [ $exit_code != 0 ]; then
   echo "there has been a problem compiling Release OF library"
   echo "please report this problem in the forums"
-  chown -R $ID:$GROUP_ID ../lib/${LIBSPATH}/*
+  chown -R $ID:$GROUP_ID ../lib/*
   exit $exit_code
 fi
 
-chown -R $ID:$GROUP_ID ../lib/${LIBSPATH}/*
+chown -R $ID:$GROUP_ID ../lib/*
 
 


### PR DESCRIPTION
Hi *,

this patch removes an overly specific path to the "chown" command during the compilation of oF. At least on ARMv7 the $LIBSPATH (of compileOF.sh) conflicts/is out of sync with the $PLATFORM_LIB_SUBPATH (of config.shared.mk). The former is used for the "chown" command, the latter for the actual compilation output. The "libs/openFrameworkCompiled/lib" directory should be owned by the user anyway.

Cheers,
tpltnt