### PR TITLE
Necessary changes to support Android Studio on Windows.

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -39,6 +39,8 @@ Here are download links for r9d, which has been tested and works fine:
 - Linux 32-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86.tar.bz2
 - Linux 64-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86_64.tar.bz2 
 
+On Windows, you will also need to install MinGW in order to build openFrameworks. MinGW provides some essential build tools which are not included in the NDK. Follow just the "Installing the MinGW and Msys" instructions on this page: http://www.multigesture.net/articles/how-to-install-mingw-msys-and-eclipse-on-windows/.
+
 ### Download openFrameworks
 
 Download it from the downloads page:

--- a/libs/openFrameworksCompiled/project/android/build.gradle
+++ b/libs/openFrameworksCompiled/project/android/build.gradle
@@ -19,6 +19,8 @@ allprojects {
     }
 }
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 // OpenFrameworks support functions
 /**
  * Initialization task to set up NDK paths.
@@ -41,6 +43,10 @@ task ofNdkSetup {
     if (ndkDirectory == null) {
         throw new GradleException("NDK not configured. Add ndk.dir=/path/to/ndk to local.properties.")
     }
+    if (ndkDirectory.contains(' ')) {
+        // Make really hates spaces in filenames, so we have to avoid them.
+        throw new GradleException("NDK path cannot contain spaces; please move the NDK.")
+    }
     def ndkDir = new File(ndkDirectory)
     if (!ndkDir.directory) {
         throw new GradleException("NDK directory is invalid. Check ndk.dir path in local.properties.")
@@ -48,6 +54,36 @@ task ofNdkSetup {
 
     /* Find suitable make executable */
     def make = null;
+    def num_parallel = Runtime.runtime.availableProcessors() - 1; // Assume that parallel support works on most systems
+
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        /* Require MinGW on Windows */
+        make = "make"
+        def proc = [make, "--version"].execute()
+        proc.waitFor()
+        if (proc.exitValue() != 0) {
+            throw new GradleException("Building on Windows requires MinGW to be installed!")
+        }
+        def makever = proc.in.text
+        if (!makever.contains("GNU Make")) {
+            throw new GradleException("make executable does not refer to GNU Make: please check that you have added MinGW to the system PATH variable!")
+        }
+        if (makever.contains("3.81")) {
+            /* GNU Make 3.81 on MinGW has a bug that prevents parallel builds from working. */
+            logger.info " -> disabling parallel build for msys-make 3.81"
+            num_parallel = 1;
+        }
+
+        /* Test to see that MinGW is installed properly */
+        proc = ["sh", "-c", "find --version"].execute()
+        proc.waitFor()
+        if (proc.exitValue() != 0) {
+            throw new GradleException("Building on Windows requires MinGW and msys to be on PATH!\nPlease add both MinGW\\bin and MinGW\\msys\\1.0\\bin to your system PATH variable.")
+        }
+
+        /* Replace backslashes by forward slashes to make Make happy */
+        ndkDirectory = ndkDirectory.replace('\\','/');
+    }
 
     new File(ndkDirectory, "prebuilt").eachDir { dir ->
         if(make != null)
@@ -70,18 +106,27 @@ task ofNdkSetup {
         throw new GradleException("GNU make not found in NDK...")
     }
 
-    logger.info " -> found make $make"
+    logger.info " -> found make '$make'"
+    if (num_parallel > 1) {
+        logger.info " -> using $num_parallel parallel jobs"
+    }
+
 
     ext.sdkDirectory = sdkDirectory
     ext.ndkDirectory = ndkDirectory
     ext.make = make
+    ext.num_parallel = num_parallel
 }
 
 /**
  * Helper function to run make with a given set of options
  */
 def ofRunMake(List opts) {
-    List cmd = [rootProject.ofNdkSetup.ext.make, "-j4"] + opts
+    def num_parallel = rootProject.ofNdkSetup.ext.num_parallel
+    if (num_parallel > 1) {
+        opts.add(0, "-j$num_parallel")
+    }
+    List cmd = [rootProject.ofNdkSetup.ext.make] + opts
     logger.info("Executing make command " + cmd)
     def proc = cmd.execute()
     proc.in.eachLine {line ->

--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -91,7 +91,11 @@ else
 	HOST_PLATFORM = darwin-x86
 endif
 else ifneq (,$(findstring MINGW32_NT,$(shell uname)))
+ifneq ($(wildcard $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/windows-x86_64),)
+	HOST_PLATFORM = windows-x86_64
+else
 	HOST_PLATFORM = windows
+endif
 	PWD = $(shell pwd)
 else
 ifneq ($(wildcard $(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/linux-x86_64),)


### PR DESCRIPTION
On Windows, we still need to depend on MinGW to provide grep and find, and maybe some other tools. This patch forces the Android Studio build system to use the MinGW make program, and also rejects spaces in NDK path names (a common pitfall, especially on Windows and OS X).