### PR TITLE
fix mainloop segfault upon window close

### DIFF
--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -113,15 +113,16 @@ int ofMainLoop::loop(){
 }
 
 void ofMainLoop::loopOnce(){
-	for(auto i = windowsApps.begin();i!=windowsApps.end();i++){
+	for(auto i = windowsApps.begin(); !windowsApps.empty() && i != windowsApps.end() ;){
 		if(i->first->getWindowShouldClose()){
 			i->first->close();
-			windowsApps.erase(i);
+			i = windowsApps.erase(i); ///< i now points at the window after the one which was just erased
 		}else{
 			currentWindow = i->first;
 			currentWindow->makeCurrent();
 			currentWindow->update();
 			currentWindow->draw();
+			i++; ///< continue to next window
 		}
 	}
 	if(pollEvents){


### PR DESCRIPTION
fixes an issue where closing the main window via mouse could crash an app.

+ if a window or app was closed through system input (via a mouse clicking on tiny x'es) or Command-Q, the ofMainLoop was bound to overshoot and cause a postmortem segfault.

This is because the iterator used to loop through all open windows was invalidated after a closed window was erased. This PR proposes to set the window iterator to the return value of `erase()` should the `windowsApps` `map` get modified. 

`erase()` is guaranteed to return the next position after the deleted element, and `::end` if there is no more element, so the loop can function as expected.