### PR TITLE
fixes the segfault on exit fix, sticking strictly to cpp98 conventions.

### DIFF
--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -113,10 +113,10 @@ int ofMainLoop::loop(){
 }
 
 void ofMainLoop::loopOnce(){
-	for(auto i = windowsApps.begin(); !windowsApps.empty() && i != windowsApps.end() ;){
+	for(map<shared_ptr<ofAppBaseWindow>,shared_ptr<ofBaseApp> >::iterator i = windowsApps.begin(); !windowsApps.empty() && i != windowsApps.end() ;){
 		if(i->first->getWindowShouldClose()){
 			i->first->close();
-			i = windowsApps.erase(i); ///< i now points at the window after the one which was just erased
+			windowsApps.erase(i++); ///< i now points at the window after the one which was just erased
 		}else{
 			currentWindow = i->first;
 			currentWindow->makeCurrent();


### PR DESCRIPTION
* makes #3664 OS X cpp98 compatible - and un-breaks OS X builds.
* uses an explicit declaration of the iterator type in favour of c++11 'auto' (it aint pretty but it's backwards compatible and essentially the same)
* uses the idiom lined out on http://stackoverflow.com/questions/8234779/how-to-remove-from-a-map-while-iterating-it

Tested on 
- [x] Windows VS2012
- [x] OS X
