### PR TITLE
refactor renderers to remove some unused methods

### DIFF
--- a/libs/openFrameworks/app/ofAppNoWindow.h
+++ b/libs/openFrameworks/app/ofAppNoWindow.h
@@ -60,7 +60,6 @@ private:
 	void draw(const ofPath & shape) const{}
 	void draw(const of3dPrimitive&, ofPolyRenderMode) const{}
 	void draw(const ofNode&) const{}
-	void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const{}
 	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
 	void draw(const vector<ofPoint> & vertexData, ofPrimitiveMode drawMode) const{}
 	void draw(const ofImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -111,11 +111,6 @@ void ofGLProgrammableRenderer::finishRender() {
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals)  const{
-	draw(vertexData, OF_MESH_FILL, useColors, useTextures, useNormals); // tig: use default mode if no render mode specified.
-}
-
-//----------------------------------------------------------
 void ofGLProgrammableRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{
 	if (vertexData.getVertices().empty()) return;
 	
@@ -257,7 +252,7 @@ void ofGLProgrammableRenderer::drawInstanced(const ofVboMesh & mesh, ofPolyRende
 	// ideally the glPolygonMode (or the polygon draw mode) should be part of ofStyle so that we can keep track
 	// of its state on the client side...
 
-	glPolygonMode(GL_FRONT_AND_BACK, currentStyle.bFill ?  GL_LINE : GL_FILL);
+	glPolygonMode(GL_FRONT_AND_BACK, currentStyle.bFill ?  GL_FILL : GL_LINE);
 #else
 	if(renderType == OF_MESH_POINTS){
 		draw(mesh.getVbo(),GL_POINTS,0,mesh.getNumVertices());
@@ -362,7 +357,7 @@ void ofGLProgrammableRenderer::draw(const ofImage & image, float x, float y, flo
 		const ofTexture& tex = image.getTexture();
 		if(tex.isAllocated()) {
 			const_cast<ofGLProgrammableRenderer*>(this)->bind(tex,0);
-			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),false,true,false);
+			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),OF_MESH_FILL,false,true,false);
 			const_cast<ofGLProgrammableRenderer*>(this)->unbind(tex,0);
 		} else {
 			ofLogWarning("ofGLProgrammableRenderer") << "draw(): texture is not allocated";
@@ -377,7 +372,7 @@ void ofGLProgrammableRenderer::draw(const ofFloatImage & image, float x, float y
 		const ofTexture& tex = image.getTexture();
 		if(tex.isAllocated()) {
 			const_cast<ofGLProgrammableRenderer*>(this)->bind(tex,0);
-			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),false,true,false);
+			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),OF_MESH_FILL,false,true,false);
 			const_cast<ofGLProgrammableRenderer*>(this)->unbind(tex,0);
 		} else {
 			ofLogWarning("ofGLProgrammableRenderer") << "draw(): texture is not allocated";
@@ -392,7 +387,7 @@ void ofGLProgrammableRenderer::draw(const ofShortImage & image, float x, float y
 		const ofTexture& tex = image.getTexture();
 		if(tex.isAllocated()) {
 			const_cast<ofGLProgrammableRenderer*>(this)->bind(tex,0);
-			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),false,true,false);
+			draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),OF_MESH_FILL,false,true,false);
 			const_cast<ofGLProgrammableRenderer*>(this)->unbind(tex,0);
 		} else {
 			ofLogWarning("ofGLProgrammableRenderer") << "draw(): texture is not allocated";
@@ -405,7 +400,7 @@ void ofGLProgrammableRenderer::draw(const ofTexture & tex, float x, float y, flo
 	const_cast<ofGLProgrammableRenderer*>(this)->setAttributes(true,false,true,false);
 	if(tex.isAllocated()) {
 		const_cast<ofGLProgrammableRenderer*>(this)->bind(tex,0);
-		draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),false,true,false);
+		draw(tex.getMeshForSubsection(x,y,z,w,h,sx,sy,sw,sh,isVFlipped(),currentStyle.rectMode),OF_MESH_FILL,false,true,false);
 		const_cast<ofGLProgrammableRenderer*>(this)->unbind(tex,0);
 	} else {
 		ofLogWarning("ofGLProgrammableRenderer") << "draw(): texture is not allocated";
@@ -418,7 +413,7 @@ void ofGLProgrammableRenderer::draw(const ofBaseVideoDraws & video, float x, flo
 		return;
 	}
 	const_cast<ofGLProgrammableRenderer*>(this)->bind(video);
-	draw(video.getTexture().getMeshForSubsection(x,y,0,w,h,0,0,w,h,isVFlipped(),currentStyle.rectMode),false,true,false);
+	draw(video.getTexture().getMeshForSubsection(x,y,0,w,h,0,0,w,h,isVFlipped(),currentStyle.rectMode),OF_MESH_FILL,false,true,false);
 	const_cast<ofGLProgrammableRenderer*>(this)->unbind(video);
 }
 

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -34,7 +34,6 @@ public:
     
 	using ofBaseRenderer::draw;
 	using ofBaseGLRenderer::draw;
-	void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const;
 	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType) const;
     void draw(const ofNode& node) const;

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -29,7 +29,6 @@ public:
 
 	using ofBaseRenderer::draw;
 	using ofBaseGLRenderer::draw;
-	void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const;
 	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType) const;
     void draw(const ofNode& model) const;

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -324,14 +324,17 @@ ofVec3f ofCairoRenderer::transform(ofVec3f vec) const{
 	return vec;
 }
 
-void ofCairoRenderer::draw(const ofMesh & primitive, bool useColors, bool useTextures, bool useNormals) const{
+void ofCairoRenderer::draw(const ofMesh & primitive, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
+    if(useColors || useTextures || useNormals){
+        ofLogWarning("ofCairoRenderer") << "draw(): cairo mesh rendering doesn't support colors, textures, or normals. drawing wireframe ...";
+    }
 	if(primitive.getNumVertices() == 0){
 		return;
 	}
 	if(primitive.getNumIndices() == 0){
 		ofMesh indexedMesh = primitive;
 		indexedMesh.setupIndicesAuto();
-		draw(indexedMesh, useColors, useTextures, useNormals);
+		draw(indexedMesh, mode, useColors, useTextures, useNormals);
 		return;
 	}
 	cairo_new_path(cr);
@@ -393,13 +396,6 @@ void ofCairoRenderer::draw(const ofMesh & primitive, bool useColors, bool useTex
 
 		cairo_stroke( cr );
 	}
-}
-
-void ofCairoRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
-    if(useColors || useTextures || useNormals){
-        ofLogWarning("ofCairoRenderer") << "draw(): cairo mesh rendering doesn't support colors, textures, or normals. drawing wireframe ...";
-    }
-	draw(vertexData,false,false,false);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -38,7 +38,6 @@ public:
 	void draw(const ofPath & shape) const;
 	void draw(const ofPath::Command & path) const;
 	void draw(const ofPolyline & poly) const;
-	void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const;
 	void draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType ) const;
     void draw(const ofNode& node) const;

--- a/libs/openFrameworks/graphics/ofRendererCollection.h
+++ b/libs/openFrameworks/graphics/ofRendererCollection.h
@@ -55,12 +55,6 @@ public:
 		 }
 	 }
 
-	 void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const{
-		 for(int i=0;i<(int)renderers.size();i++){
-			 renderers[i]->draw(vertexData,useColors, useTextures, useNormals);
-		 }
-	 }
-
 	 void draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
 		 for(int i=0;i<(int)renderers.size();i++){
 			 renderers[i]->draw(vertexData,mode,useColors,useTextures,useNormals);

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -513,7 +513,6 @@ public:
 	virtual void draw(const ofMesh & mesh, ofPolyRenderMode renderType) const{
 		draw(mesh,renderType,mesh.usingColors(),mesh.usingTextures(),mesh.usingNormals());
 	}
-	virtual void draw(const ofMesh & vertexData, bool useColors, bool useTextures, bool useNormals) const=0;
 	virtual void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const=0;
 	virtual void draw(const of3dPrimitive& model, ofPolyRenderMode renderType) const=0;
 	virtual void draw(const ofNode& model) const=0;


### PR DESCRIPTION
- fixes #3667
- removes renderer.draw(mesh) without polygon mode which was behaving
different in fixed and programmable
- fixes programable::drawInstanced(mesh) which was setting the wrong
polygon mode afterwards