### PR TITLE
move global texture references to private

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -14,6 +14,10 @@
 #import "ofAVFoundationVideoPlayer.h"
 #endif
 
+#if defined TARGET_OF_IOS || defined TARGET_OSX
+#import <CoreVideo/CoreVideo.h>
+#endif
+
 class ofAVFoundationPlayer : public ofBaseVideoPlayer {
 	
 public:
@@ -101,5 +105,15 @@ protected:
     ofPixels pixels;
 	ofPixelFormat pixelFormat;
 	ofTexture videoTexture;
+	
+#ifdef TARGET_OF_IOS
+	CVOpenGLESTextureCacheRef _videoTextureCache = NULL;
+	CVOpenGLESTextureRef _videoTextureRef = NULL;
+#endif
+	
+#ifdef TARGET_OSX
+	CVOpenGLTextureCacheRef _videoTextureCache = NULL;
+	CVOpenGLTextureRef _videoTextureRef = NULL;
+#endif
 };
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -9,16 +9,6 @@
 #import "ofAVFoundationVideoPlayer.h"
 
 //--------------------------------------------------------------
-#ifdef TARGET_OF_IOS
-CVOpenGLESTextureCacheRef _videoTextureCache = NULL;
-CVOpenGLESTextureRef _videoTextureRef = NULL;
-#endif
-
-#ifdef TARGET_OSX
-CVOpenGLTextureCacheRef _videoTextureCache = NULL;
-CVOpenGLTextureRef _videoTextureRef = NULL;
-#endif
-
 ofAVFoundationPlayer::ofAVFoundationPlayer() {
 	videoPlayer = NULL;
     pixelFormat = OF_PIXELS_RGBA;


### PR DESCRIPTION
moving global TextureRef and TextureCacheRef to protected instance variables
each movie-player should own their own Texture and TextureCache