### PR TITLE
make sure a pending timeObserver gets cleaned up use finalize...

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -131,7 +131,7 @@ void ofAVFoundationPlayer::close() {
         videoTexture.clear();
 		
         videoPlayer.delegate = nil;
-		[videoPlayer release];
+		[videoPlayer finalize];
         
         if(bTextureCacheSupported == true) {
             killTextureCache();

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -131,7 +131,7 @@ void ofAVFoundationPlayer::close() {
         videoTexture.clear();
 		
         videoPlayer.delegate = nil;
-		[videoPlayer finalize];
+		[videoPlayer cleanupAndAutorelease];
         
         if(bTextureCacheSupported == true) {
             killTextureCache();

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -138,4 +138,5 @@
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 
+- (void)finalize;
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -138,5 +138,5 @@
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 
-- (void)finalize;
+- (void)cleanupAndAutorelease;
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -92,7 +92,7 @@ static const NSString * ItemStatusContext;
 	[super dealloc];
 }
 
-- (void)finalize {
+- (void)cleanupAndAutorelease {
 	
 	[self cleanup];
 	[self autorelease];


### PR DESCRIPTION
In case bWillBeUpdatedExternally is set to false a timeObserver would get attached to AVPlayer.
Even if AVPlayer never starts playing, the timeObserver (and all scheduled blocks) holds a reference to self (ofAVFoundationVideoPlayer)
Therefore releasing the videoPlayer in ofAVFoundationPlayer would actually not deallocate the object and leak memory

using a finalizer gives the chance to remove the timeObserver before releasing the object...