### PR TITLE
initially enable mouseInput for ofEasyCam

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -19,7 +19,7 @@ ofEasyCam::ofEasyCam(){
 	sensitivityZ= .7f;
 
 	bDistanceSet = false; 
-	bMouseInputEnabled = false;
+	bMouseInputEnabled = true;
 	bDoRotate = false;
 	bApplyInertia =false;
 	bDoTranslate = false;


### PR DESCRIPTION
This restores the default behaviour of ofEasyCam, which used to have mouse input enabled by default, and addresses an issue reported by @kylemcdonald on #3661.