### PR TITLE
Fix #3677 ofBuffer::allocate()

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -111,7 +111,7 @@ void ofBuffer::clear(){
 void ofBuffer::allocate(long _size){
 	clear();
 	//we always add a 0 at the end to avoid problems with strings
-	buffer.resize(_size + 1);
+	buffer.resize(_size + 1, 0);
 }
 
 //--------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -110,7 +110,8 @@ void ofBuffer::clear(){
 //--------------------------------------------------
 void ofBuffer::allocate(long _size){
 	clear();
-	buffer.resize(_size);
+	//we always add a 0 at the end to avoid problems with strings
+	buffer.resize(_size + 1);
 }
 
 //--------------------------------------------------


### PR DESCRIPTION
ofBuffer::allocate() didn't zero-pad the buffer, now it does. This matches behavior elsewhere so ofBuffer::size() correctly returns the allocated size. Fixes #3677.