### PR TITLE
apothecary: remove harfbuzz dependency from freetype

### DIFF
--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -58,7 +58,7 @@ function build() {
 
 		local TOOLCHAIN=$XCODE_DEV_ROOT/Toolchains/XcodeDefault.xctoolchain 
 
-		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --enable-static=yes --enable-shared=no \
+		./configure --prefix=$BUILD_TO_DIR --without-bzip2 --with-harfbuzz=no --enable-static=yes --enable-shared=no \
 			CFLAGS="$FAT_CFLAGS -pipe -Wno-trigraphs -fpascal-strings -O2 -Wreturn-type -Wunused-variable -fmessage-length=0 -fvisibility=hidden"
 		make clean 
 		make

--- a/scripts/apothecary/formulas/freetype.sh
+++ b/scripts/apothecary/formulas/freetype.sh
@@ -201,7 +201,7 @@ function build() {
 			echo "Please stand by..."
 
 			echo "Configuring..."
-			./configure --without-bzip2 --prefix=$IOS_PREFIX --host=$IOS_HOST --enable-static=yes --enable-shared=no \
+			./configure --without-bzip2 --prefix=$IOS_PREFIX --host=$IOS_HOST --with-harfbuzz=no --enable-static=yes --enable-shared=no \
 			CC="$CC" \
 			CFLAGS="$CFLAGS" \
 			CXXFLAGS="$CXXFLAGS" \


### PR DESCRIPTION
As @carthach pointed out in #3627, freetype might fail to work in some cases since an optional dependency to harfbuzz (a utility to parse extended OpenType features) has not been met. 

Since we haven't included & compiled harfbuzz in the past (and freetype for homebrew is fine without it) it seems a sensible choice to compile freetype without it.

If we wanted to include Harfbuzz, we'd need to add a dependency for harfbuzz 0.9.19 or newer: <http://sourceforge.net/projects/freetype/files/freetype2/2.5.3/> 

But this would create a catch22 while compiling, because harfbuzz, in turn, depends on Freetype.

We also have had a flag to exclude harfbuzz from android builds for a while. I wonder if we should exclude it from iOS builds, as well... 

ping @bakercp