### PR TITLE
Fix missing return in ofSoundPlayer::loadSound, update examples

### DIFF
--- a/examples/sound/soundPlayerExample/src/ofApp.cpp
+++ b/examples/sound/soundPlayerExample/src/ofApp.cpp
@@ -2,9 +2,9 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	synth.loadSound("sounds/synth.wav");
-	beats.loadSound("sounds/1085.mp3");
-	vocals.loadSound("sounds/Violet.mp3");
+	synth.load("sounds/synth.wav");
+	beats.load("sounds/1085.mp3");
+	vocals.load("sounds/Violet.mp3");
 	synth.setVolume(0.75f);
 	beats.setVolume(0.75f);
 	vocals.setVolume(0.5f);

--- a/examples/sound/soundPlayerFFTExample/src/ofApp.cpp
+++ b/examples/sound/soundPlayerFFTExample/src/ofApp.cpp
@@ -5,10 +5,10 @@
 void ofApp::setup(){	 
 
 	// load in sounds:
-	beat.loadSound("sounds/jdee_beat.mp3");
-	ow.loadSound("sounds/ow.mp3");	
-	dog.loadSound("sounds/dog.mp3");	
-	rooster.loadSound("sounds/rooster.mp3");
+	beat.load("sounds/jdee_beat.mp3");
+	ow.load("sounds/ow.mp3");
+	dog.load("sounds/dog.mp3");
+	rooster.load("sounds/rooster.mp3");
 	
 	// we will bounce a circle using these variables:
 	px = 300;

--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -83,7 +83,7 @@ bool ofSoundPlayer::load(string fileName, bool stream){
 
 //--------------------------------------------------------------------
 bool ofSoundPlayer::loadSound(string fileName, bool stream){
-	load(fileName,stream);
+	return load(fileName,stream);
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
This PR:

- Returns a bool from inside loadSound
- Updates the sound player examples to use the non-deprecated "load" syntax