### PR TITLE
bHide now means 'hidden', not 'shown'

### DIFF
--- a/examples/gui/guiExample/src/ofApp.cpp
+++ b/examples/gui/guiExample/src/ofApp.cpp
@@ -19,7 +19,7 @@ void ofApp::setup(){
 	gui.add(ringButton.setup("ring"));
 	gui.add(screenSize.setup("screen size", ""));
 
-	bHide = true;
+	bHide = false;
 
 	ring.loadSound("ring.wav");
 }
@@ -64,7 +64,7 @@ void ofApp::draw(){
 	
 	// auto draw?
 	// should the gui control hiding?
-	if( bHide ){
+	if( !bHide ){
 		gui.draw();
 	}
 }

--- a/examples/gui/guiFromParametersExample/src/ofApp.cpp
+++ b/examples/gui/guiFromParametersExample/src/ofApp.cpp
@@ -19,7 +19,7 @@ void ofApp::setup(){
 	gui.add(ringButton.setup("ring"));
 	gui.add(screenSize.set("screenSize", ""));
 	
-	bHide = true;
+	bHide = false;
 
 	ring.loadSound("ring.wav");
 }
@@ -61,7 +61,7 @@ void ofApp::draw(){
 		ofDrawCircle((ofVec2f)center, radius );
 	}
 	
-	if( bHide ){
+	if( !bHide ){
 		gui.draw();
 	}
 }


### PR DESCRIPTION
Small point I found confusing in the GUI examples. bHide meant "shown" or "not hidden". Still defaults on, but uses !bHide to draw.