### PR TITLE
Const and argument corrections in ofMath.h/.cpp.

### DIFF
--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -203,7 +203,7 @@ float ofNoise(float x, float y){
 }
 
 //--------------------------------------------------
-float ofNoise( ofVec2f p ){
+float ofNoise(const ofVec2f& p){
 	return ofNoise( p.x, p.y );
 }
 
@@ -213,7 +213,7 @@ float ofNoise(float x, float y, float z){
 }
 
 //--------------------------------------------------
-float ofNoise( ofVec3f p ){
+float ofNoise(const ofVec3f& p){
 	return ofNoise( p.x, p.y, p.z );
 }
 
@@ -223,7 +223,7 @@ float ofNoise(float x, float y, float z, float w){
 }
 
 //--------------------------------------------------
-float ofNoise( ofVec4f p ){
+float ofNoise(const ofVec4f& p){
 	return ofNoise( p.x, p.y, p.z, p.w );
 }
 
@@ -238,7 +238,7 @@ float ofSignedNoise(float x, float y){
 }
 
 //--------------------------------------------------
-float ofSignedNoise( ofVec2f p ){
+float ofSignedNoise(const ofVec2f& p){
 	return ofSignedNoise( p.x, p.y );
 }
 
@@ -248,7 +248,7 @@ float ofSignedNoise(float x, float y, float z){
 }
 
 //--------------------------------------------------
-float ofSignedNoise( ofVec3f p ){
+float ofSignedNoise(const ofVec3f& p){
 	return ofSignedNoise( p.x, p.y, p.z );
 }
 
@@ -258,22 +258,22 @@ float ofSignedNoise(float x, float y, float z, float w){
 }
 
 //--------------------------------------------------
-float ofSignedNoise( ofVec4f p ){
+float ofSignedNoise(const ofVec4f& p){
 	return ofSignedNoise( p.x, p.y, p.z, p.w );
 }
 
 //--------------------------------------------------
-bool ofInsidePoly(float x, float y, const vector<ofPoint> & polygon){
+bool ofInsidePoly(float x, float y, const vector<ofPoint>& polygon){
     return ofPolyline::inside(x,y, ofPolyline(polygon));
 }
 
 //--------------------------------------------------
-bool ofInsidePoly(const ofPoint & p, const vector<ofPoint> & poly){
+bool ofInsidePoly(const ofPoint& p, const vector<ofPoint>& poly){
     return ofPolyline::inside(p.x,p.y, ofPolyline(poly));
 }
 
 //--------------------------------------------------
-bool ofLineSegmentIntersection(ofPoint line1Start, ofPoint line1End, ofPoint line2Start, ofPoint line2End, ofPoint & intersection){
+bool ofLineSegmentIntersection(const ofPoint& line1Start, const ofPoint& line1End, const ofPoint& line2Start, const ofPoint& line2End, ofPoint& intersection){
 	ofPoint diffLA, diffLB;
 	float compareA, compareB;
 	diffLA = line1End - line1Start;
@@ -303,13 +303,13 @@ bool ofLineSegmentIntersection(ofPoint line1Start, ofPoint line1End, ofPoint lin
 }
 
 //--------------------------------------------------
-ofPoint ofBezierPoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t){
+ofPoint ofBezierPoint(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t){
     float tp = 1.0f - t;
     return a*tp*tp*tp + b*3*t*tp*tp + c*3*t*t*tp + d*t*t*t;
 }
 
 //--------------------------------------------------
-ofPoint ofCurvePoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t){
+ofPoint ofCurvePoint(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t){
     ofPoint pt;
     float t2 = t * t;
     float t3 = t2 * t;
@@ -325,12 +325,12 @@ ofPoint ofCurvePoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t){
 }
 
 //--------------------------------------------------
-ofPoint ofBezierTangent( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t){
+ofPoint ofBezierTangent(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t){
     return (d-a-c*3+b*3)*(t*t)*3 + (a+c-b*2)*t*6 - a*3+b*3;
 }
 
 //--------------------------------------------------
-ofPoint ofCurveTangent( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t){
+ofPoint ofCurveTangent(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t){
     ofPoint v0 = ( c - a )*0.5;
     ofPoint v1 = ( d - b )*0.5;
     return ( b*2 -c*2 + v0 + v1)*(3*t*t) + ( c*3 - b*3 - v1 - v0*2 )*( 2*t) + v0;

--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -387,19 +387,19 @@ float ofNoise(float x);
 float ofNoise(float x, float y);
 
 /// \brief Calculates a two dimensional Perlin noise value between 0.0...1.0.
-float ofNoise( ofVec2f p );
+float ofNoise(const ofVec2f& p);
 
 /// \brief Calculates a three dimensional Perlin noise value between 0.0...1.0.
 float ofNoise(float x, float y, float z);
 
 /// \brief Calculates a three dimensional Perlin noise value between 0.0...1.0.
-float ofNoise( ofVec3f p );
+float ofNoise(const ofVec3f& p);
 
 /// \brief Calculates a four dimensional Perlin noise value between 0.0...1.0.
 float ofNoise(float x, float y, float z, float w);
 
 /// \brief Calculates a four dimensional Perlin noise value between 0.0...1.0.
-float ofNoise( ofVec2f p );
+float ofNoise(const ofVec4f& p);
 
 /// \brief Calculates a one dimensional Perlin noise value between -1.0...1.0.
 float ofSignedNoise(float x);
@@ -408,19 +408,19 @@ float ofSignedNoise(float x);
 float ofSignedNoise(float x, float y);
 
 /// \brief Calculates a two dimensional Perlin noise value between -1.0...1.0.
-float ofSignedNoise( ofVec2f p );
+float ofSignedNoise(const ofVec2f& p);
 
 /// \brief Calculates a three dimensional Perlin noise value between -1.0...1.0.
 float ofSignedNoise(float x, float y, float z);
 
 /// \brief Calculates a three dimensional Perlin noise value between -1.0...1.0.
-float ofSignedNoise( ofVec3f p );
+float ofSignedNoise(const ofVec3f& p);
 
 /// \brief Calculates a four dimensional Perlin noise value between -1.0...1.0.
 float ofSignedNoise(float x, float y, float z, float w);
 
 /// \brief Calculates a four dimensional Perlin noise value between -1.0...1.0.
-float ofSignedNoise( ofVec4f p );
+float ofSignedNoise(const ofVec4f& p);
 
 /// \}
 
@@ -433,13 +433,13 @@ float ofSignedNoise( ofVec4f p );
 /// \param y The y dimension of the coordinate.
 /// \param poly a vector of ofPoints defining a polygon.
 /// \returns True if the point defined by the coordinates is enclosed, false otherwise.
-bool ofInsidePoly(float x, float y, const vector<ofPoint> & poly);
+bool ofInsidePoly(float x, float y, const vector<ofPoint>& poly);
 
 /// \brief Determine if an ofPoint is within the polygon defined by a vector of ofPoints.
 /// \param p A point to check.
 /// \param poly A vector of ofPoints defining a polygon.
 /// \returns True if the ofPoint is enclosed, false otherwise.
-bool ofInsidePoly(const ofPoint & p, const vector<ofPoint> & poly);
+bool ofInsidePoly(const ofPoint & p, const vector<ofPoint>& poly);
 
 /// \brief Determine the intersection between two lines.
 /// \param line1Start Starting point for first line.
@@ -448,7 +448,7 @@ bool ofInsidePoly(const ofPoint & p, const vector<ofPoint> & poly);
 /// \param line2End End point for second line.
 /// \param intersection ofPoint reference in which to store the computed intersection point.
 /// \returns True if the lines intersect.
-bool ofLineSegmentIntersection(ofPoint line1Start, ofPoint line1End, ofPoint line2Start, ofPoint line2End, ofPoint & intersection);
+bool ofLineSegmentIntersection(const ofPoint& line1Start, const ofPoint& line1End, const ofPoint& line2Start, const ofPoint& line2End, ofPoint& intersection);
 
 /// \brief Given the four points that determine a bezier curve, return an interpolated point on the curve.
 /// \param a The beginning point of the curve.
@@ -457,7 +457,7 @@ bool ofLineSegmentIntersection(ofPoint line1Start, ofPoint line1End, ofPoint lin
 /// \param d The end point of the curve.
 /// \param t an offset along the curve, normalized between 0 and 1.
 /// \returns A ofPoint on the curve.
-ofPoint ofBezierPoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
+ofPoint ofBezierPoint(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t);
 
 /// \brief Given the four points that determine a Catmull Rom curve, return an interpolated point on the curve.
 /// \param a The first control point.
@@ -466,7 +466,7 @@ ofPoint ofBezierPoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
 /// \param d The second control point.
 /// \param t an offset along the curve, normalized between 0 and 1.
 /// \returns A ofPoint on the curve.
-ofPoint ofCurvePoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
+ofPoint ofCurvePoint(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t);
 
 /// Given the four points that determine a bezier curve and an offset along the curve, return an tangent vector to a point on the curve.
 /// Currently this is not a normalized point, and will need to be normalized.
@@ -476,7 +476,7 @@ ofPoint ofCurvePoint( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
 /// \param d The end point of the curve.
 /// \param t an offset along the curve, normalized between 0 and 1.
 /// \returns A ofPoint on the curve.
-ofPoint ofBezierTangent( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
+ofPoint ofBezierTangent(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t);
 
 /// \brief Return a tangent point for an offset along a Catmull Rom curve.
 /// \param a The first control point.
@@ -485,18 +485,18 @@ ofPoint ofBezierTangent( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
 /// \param d The second control point.
 /// \param t an offset along the curve, normalized between 0 and 1.
 /// \returns A ofPoint on the curve.
-ofPoint ofCurveTangent( ofPoint a, ofPoint b, ofPoint c, ofPoint d, float t);
+ofPoint ofCurveTangent(const ofPoint& a, const ofPoint& b, const ofPoint& c, const ofPoint& d, float t);
 
 template<typename Type>
-Type ofInterpolateCosine(Type y1, Type y2, float pct);
+Type ofInterpolateCosine(const Type& y1, const Type& y2, float pct);
 template<typename Type>
-Type ofInterpolateCubic(Type y0, Type y1, Type y2, Type y3, float pct);
+Type ofInterpolateCubic(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct);
 template<typename Type>
-Type ofInterpolateCatmullRom(Type y0, Type y1, Type y2, Type y3, float pct);
+Type ofInterpolateCatmullRom(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct);
 template<typename Type>
-Type ofInterpolateHermite(Type y0, Type y1, Type y2, Type y3, float pct);
+Type ofInterpolateHermite(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct);
 template<typename Type>
-Type ofInterpolateHermite(Type y0, Type y1, Type y2, Type y3, float pct, float tension, float bias);
+Type ofInterpolateHermite(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct, float tension, float bias);
 
 /// \}
 
@@ -531,7 +531,7 @@ int ofSign(float n);
 // from http://paulbourke.net/miscellaneous/interpolation/
 //--------------------------------------------------
 template<typename Type>
-Type ofInterpolateCosine(Type y1, Type y2, float pct){
+Type ofInterpolateCosine(const Type& y1, const Type& y2, float pct){
 	float pct2;
 
 	pct2 = (1-cos(pct*PI))/2;
@@ -541,7 +541,7 @@ Type ofInterpolateCosine(Type y1, Type y2, float pct){
 // from http://paulbourke.net/miscellaneous/interpolation/
 //--------------------------------------------------
 template<typename Type>
-Type ofInterpolateCubic(Type y0, Type y1, Type y2, Type y3, float pct){
+Type ofInterpolateCubic(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct){
 	Type a0,a1,a2,a3;
 	float pct2;
 
@@ -557,7 +557,7 @@ Type ofInterpolateCubic(Type y0, Type y1, Type y2, Type y3, float pct){
 // from http://paulbourke.net/miscellaneous/interpolation/
 //--------------------------------------------------
 template<typename Type>
-Type ofInterpolateCatmullRom(Type y0, Type y1, Type y2, Type y3, float pct){
+Type ofInterpolateCatmullRom(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct){
 	Type a0,a1,a2,a3;
 	float pct2 = pct*pct;
 	a0 = -0.5*y0 + 1.5*y1 - 1.5*y2 + 0.5*y3;
@@ -571,7 +571,7 @@ Type ofInterpolateCatmullRom(Type y0, Type y1, Type y2, Type y3, float pct){
 // laurent de soras
 //--------------------------------------------------
 template<typename Type>
-inline Type ofInterpolateHermite(Type y0, Type y1, Type y2, Type y3, float pct){
+inline Type ofInterpolateHermite(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct){
 	const Type c = (y2 - y0) * 0.5f;
 	const Type v = y1 - y2;
 	const Type w = c + v;
@@ -584,7 +584,7 @@ inline Type ofInterpolateHermite(Type y0, Type y1, Type y2, Type y3, float pct){
 // from http://paulbourke.net/miscellaneous/interpolation/
 //--------------------------------------------------
 template<typename Type>
-Type ofInterpolateHermite(Type y0, Type y1, Type y2, Type y3, float pct, float tension, float bias){
+Type ofInterpolateHermite(const Type& y0, const Type& y1, const Type& y2, const Type& y3, float pct, float tension, float bias){
 	float pct2,pct3;
 	Type m0,m1;
 	Type a0,a1,a2,a3;


### PR DESCRIPTION
A few fixes for https://github.com/openframeworks/openFrameworks/pull/3699 related to const correctness + additional const corrections and a fix of an incorrect `ofNoise(const ofVec2f&)` signature.