### PR TITLE
Add mouseEntered/Exited events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CORE
 ### app
 	/ setupOpenGL and ofApp___Window use ofWindowMode instead of int
 	/ fix exit callbacks to allow for calling of the destructors, and better signal handling
+	/ changed windowEntry event to mouseEntered/mouseExted, added these callbacks when registering for mouse events
 
 ### 3d
 	/ ofEasyCam: removes roll rotation when rotating inside the arcball

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -919,9 +919,9 @@ void ofAppGLFWWindow::motion_cb(GLFWwindow* windowP_, double x, double y) {
 void ofAppGLFWWindow::entry_cb(GLFWwindow *windowP_, int entered) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
 	if(entered){
-		instance->events().notifyMouseEntered();
+		instance->events().notifyMouseEntered(instance->events().getMouseX(), instance->events().getMouseY());
 	}else{
-		instance->events().notifyMouseExited();
+		instance->events().notifyMouseExited(instance->events().getMouseX(), instance->events().getMouseY());
 	}
 }
 

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -269,6 +269,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
     setVerticalSync(true);
 	glfwSetMouseButtonCallback(windowP, mouse_cb);
 	glfwSetCursorPosCallback(windowP, motion_cb);
+	glfwSetCursorEnterCallback(windowP, entry_cb);
 	glfwSetKeyCallback(windowP, keyboard_cb);
 	glfwSetWindowSizeCallback(windowP, resize_cb);
 	glfwSetWindowCloseCallback(windowP, exit_cb);
@@ -911,6 +912,16 @@ void ofAppGLFWWindow::motion_cb(GLFWwindow* windowP_, double x, double y) {
 		instance->events().notifyMouseMoved(x*instance->pixelScreenCoordScale, y*instance->pixelScreenCoordScale);
 	}else{
 		instance->events().notifyMouseDragged(x*instance->pixelScreenCoordScale, y*instance->pixelScreenCoordScale, instance->buttonInUse);
+	}
+}
+
+//------------------------------------------------------------
+void ofAppGLFWWindow::entry_cb(GLFWwindow *windowP_, int entered) {
+	ofAppGLFWWindow * instance = setCurrent(windowP_);
+	if(entered){
+		instance->events().notifyMouseEntered();
+	}else{
+		instance->events().notifyMouseExited();
 	}
 }
 

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -203,6 +203,7 @@ private:
 	static ofAppGLFWWindow * setCurrent(GLFWwindow* windowP);
 	static void 	mouse_cb(GLFWwindow* windowP_, int button, int state, int mods);
 	static void 	motion_cb(GLFWwindow* windowP_, double x, double y);
+	static void 	entry_cb(GLFWwindow* windowP_, int entered);
 	static void 	keyboard_cb(GLFWwindow* windowP_, int key, int scancode, unsigned int codepoint, int action, int mods);
 	static void 	resize_cb(GLFWwindow* windowP_, int w, int h);
 	static void 	exit_cb(GLFWwindow* windowP_);

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -815,7 +815,11 @@ void ofAppGlutWindow::resize_cb(int w, int h) {
 
 //------------------------------------------------------------
 void ofAppGlutWindow::entry_cb(int state) {
-	instance->events().notifyWindowEntry( state );
+	if (state == GLUT_ENTERED){
+		instance->events().notifyMouseEntered(instance->events().getMouseX(), instance->events().getMouseY());
+	}else if (state == GLUT_LEFT){
+		instance->events().notifyMouseExited(instance->events().getMouseX(), instance->events().getMouseY());
+	}
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -29,6 +29,8 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void mousePressed( int x, int y, int button ){}
 		virtual void mouseReleased(int x, int y, int button ){}
 		virtual void mouseScrolled( float x, float y ){}
+		virtual void mouseEntered(){}
+		virtual void mouseExited(){}
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }
 		virtual void gotMessage(ofMessage msg){ }

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -34,8 +34,6 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }
 		virtual void gotMessage(ofMessage msg){ }
-	
-		virtual void windowEntry ( int state ) { }
 		
 		int mouseX, mouseY;			// for processing heads
 
@@ -91,9 +89,6 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		}
 		virtual void mouseExited( ofMouseEventArgs & mouse ){
 			mouseExited(mouse.x,mouse.y);
-		}
-		virtual void windowEntry(ofEntryEventArgs & entry){
-			windowEntry(entry.state);
 		}
 		virtual void dragged(ofDragInfo & drag){
 			dragEvent(drag);

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -29,8 +29,8 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void mousePressed( int x, int y, int button ){}
 		virtual void mouseReleased(int x, int y, int button ){}
 		virtual void mouseScrolled( float x, float y ){}
-		virtual void mouseEntered(){}
-		virtual void mouseExited(){}
+		virtual void mouseEntered( int x, int y ){}
+		virtual void mouseExited( int x, int y){}
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }
 		virtual void gotMessage(ofMessage msg){ }
@@ -85,6 +85,12 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		}
 		virtual void mouseScrolled( ofMouseEventArgs & mouse ){
 			mouseScrolled(mouse.x,mouse.y);
+		}
+		virtual void mouseEntered( ofMouseEventArgs & mouse ){
+			mouseEntered(mouse.x,mouse.y);
+		}
+		virtual void mouseExited( ofMouseEventArgs & mouse ){
+			mouseExited(mouse.x,mouse.y);
 		}
 		virtual void windowEntry(ofEntryEventArgs & entry){
 			windowEntry(entry.state);

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -24,12 +24,34 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void keyPressed( int key ){}
 		virtual void keyReleased( int key ){}
 
+		/// \brief Called on the active widow when the mouse is moved
 		virtual void mouseMoved( int x, int y ){}
+
+		/// \brief Called on the active widow when the mouse is dragged, i.e.
+		/// moved with a button pressed
 		virtual void mouseDragged( int x, int y, int button ){}
+
+		/// \brief Called on the active widow when a mouse button is pressed
 		virtual void mousePressed( int x, int y, int button ){}
+
+		/// \brief Called on the active widow when a mouse button is released
 		virtual void mouseReleased(int x, int y, int button ){}
+
+		/// \brief Called on the active widow when the mouse wheel is scrolled
 		virtual void mouseScrolled( float x, float y ){}
+
+		/// \brief Called on the active widow when the mouse cursor enters the
+		/// window area
+		///
+		/// Note that the mouse coordinates are the last known x/y before the
+		/// event occurred, i.e. from the previous frame
 		virtual void mouseEntered( int x, int y ){}
+
+		/// \brief Called on the active widow when the mouse cursor leaves the
+		/// window area
+		///
+		/// Note that the mouse coordinates are the last known x/y before the
+		/// event occurred, i.e. from the previous frame
 		virtual void mouseExited( int x, int y){}
 		
 		virtual void dragEvent(ofDragInfo dragInfo) { }

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -77,6 +77,8 @@ void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> a
 		ofAddListener(window->events().mousePressed,app.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().mouseReleased,app.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().mouseScrolled,app.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
+		ofAddListener(window->events().mouseEntered,app.get(),&ofBaseApp::mouseEntered,OF_EVENT_ORDER_APP);
+		ofAddListener(window->events().mouseExited,app.get(),&ofBaseApp::mouseExited,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().windowEntered,app.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().windowResized,app.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().messageEvent,app.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
@@ -153,6 +155,8 @@ void ofMainLoop::exit(){
 		ofRemoveListener(window->events().mousePressed,app.get(),&ofBaseApp::mousePressed,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().mouseReleased,app.get(),&ofBaseApp::mouseReleased,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().mouseScrolled,app.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseEntered,app.get(),&ofBaseApp::mouseEntered,OF_EVENT_ORDER_APP);
+		ofRemoveListener(window->events().mouseExited,app.get(),&ofBaseApp::mouseExited,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().windowEntered,app.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().windowResized,app.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().messageEvent,app.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -79,7 +79,6 @@ void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> a
 		ofAddListener(window->events().mouseScrolled,app.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().mouseEntered,app.get(),&ofBaseApp::mouseEntered,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().mouseExited,app.get(),&ofBaseApp::mouseExited,OF_EVENT_ORDER_APP);
-		ofAddListener(window->events().windowEntered,app.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().windowResized,app.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().messageEvent,app.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
 		ofAddListener(window->events().fileDragEvent,app.get(),&ofBaseApp::dragged,OF_EVENT_ORDER_APP);
@@ -157,7 +156,6 @@ void ofMainLoop::exit(){
 		ofRemoveListener(window->events().mouseScrolled,app.get(),&ofBaseApp::mouseScrolled,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().mouseEntered,app.get(),&ofBaseApp::mouseEntered,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().mouseExited,app.get(),&ofBaseApp::mouseExited,OF_EVENT_ORDER_APP);
-		ofRemoveListener(window->events().windowEntered,app.get(),&ofBaseApp::windowEntry,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().windowResized,app.get(),&ofBaseApp::windowResized,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().messageEvent,app.get(),&ofBaseApp::messageReceived,OF_EVENT_ORDER_APP);
 		ofRemoveListener(window->events().fileDragEvent,app.get(),&ofBaseApp::dragged,OF_EVENT_ORDER_APP);

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -84,6 +84,8 @@ void ofCoreEvents::disable(){
 	mousePressed.disable();
 	mouseMoved.disable();
 	mouseScrolled.disable();
+	mouseEntered.disable();
+	mouseExited.disable();
 	touchDown.disable();
 	touchUp.disable();
 	touchMoved.disable();
@@ -106,6 +108,8 @@ void ofCoreEvents::enable(){
 	mousePressed.enable();
 	mouseMoved.enable();
 	mouseScrolled.enable();
+	mouseEntered.enable();
+	mouseExited.enable();
 	touchDown.enable();
 	touchUp.enable();
 	touchMoved.enable();
@@ -385,6 +389,16 @@ void ofCoreEvents::notifyMouseMoved(int x, int y){
 
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Moved,x,y,0);
 	ofNotifyEvent( mouseMoved, mouseEventArgs );
+}
+
+//------------------------------------------
+void ofCoreEvents::notifyMouseEntered(){
+	ofNotifyEvent( mouseEntered );
+}
+
+//------------------------------------------
+void ofCoreEvents::notifyMouseExited(){
+	ofNotifyEvent( mouseExited );
 }
 
 //------------------------------------------

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -436,13 +436,6 @@ void ofCoreEvents::notifyDragEvent(ofDragInfo info){
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyWindowEntry( int state ) {
-	ofEntryEventArgs entryArgs(state);
-	ofNotifyEvent(windowEntered, entryArgs);
-
-}
-
-//------------------------------------------
 void ofSendMessage(ofMessage msg){
 	ofNotifyEvent(ofEvents().messageEvent, msg);
 }

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -313,6 +313,12 @@ void ofCoreEvents::notifyMouseEvent(const ofMouseEventArgs & mouseEvent){
 		case ofMouseEventArgs::Scrolled:
 			notifyMouseScrolled(mouseEvent.x,mouseEvent.y);
 			break;
+		case ofMouseEventArgs::Entered:
+			notifyMouseEntered(mouseEvent.x,mouseEvent.y);
+			break;
+		case ofMouseEventArgs::Exited:
+			notifyMouseExited(mouseEvent.x,mouseEvent.y);
+			break;
 	}
 }
 
@@ -392,16 +398,6 @@ void ofCoreEvents::notifyMouseMoved(int x, int y){
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseEntered(){
-	ofNotifyEvent( mouseEntered );
-}
-
-//------------------------------------------
-void ofCoreEvents::notifyMouseExited(){
-	ofNotifyEvent( mouseExited );
-}
-
-//------------------------------------------
 void ofCoreEvents::notifyMouseScrolled(float x, float y){
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Scrolled,x,y);
 
@@ -409,6 +405,18 @@ void ofCoreEvents::notifyMouseScrolled(float x, float y){
 	mouseEventArgs.y = y;
 	mouseEventArgs.type = ofMouseEventArgs::Scrolled;
 	ofNotifyEvent( mouseScrolled, mouseEventArgs );
+}
+
+//------------------------------------------
+void ofCoreEvents::notifyMouseEntered(int x, int y){
+	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Entered,x,y);
+	ofNotifyEvent( mouseEntered, mouseEventArgs );
+}
+
+//------------------------------------------
+void ofCoreEvents::notifyMouseExited(int x, int y){
+	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Exited,x,y);
+	ofNotifyEvent( mouseExited, mouseEventArgs );
 }
 
 //------------------------------------------

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -213,6 +213,8 @@ class ofCoreEvents {
 	ofEvent<ofMouseEventArgs> 	mousePressed;
 	ofEvent<ofMouseEventArgs> 	mouseReleased;
 	ofEvent<ofMouseEventArgs> 	mouseScrolled;
+	ofEvent<void>				mouseEntered;
+	ofEvent<void>				mouseExited;
 
 	ofEvent<ofTouchEventArgs>	touchDown;
 	ofEvent<ofTouchEventArgs>	touchUp;
@@ -253,6 +255,8 @@ class ofCoreEvents {
 	void notifyMouseDragged(int x, int y, int button);
 	void notifyMouseMoved(int x, int y);
 	void notifyMouseScrolled(float x, float y);
+	void notifyMouseEntered();
+	void notifyMouseExited();
 	void notifyMouseEvent(const ofMouseEventArgs & mouseEvent);
 
 	void notifyExit();
@@ -286,6 +290,8 @@ void ofRegisterMouseEvents(ListenerClass * listener, int prio=OF_EVENT_ORDER_AFT
 	ofAddListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed,prio);
 	ofAddListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased,prio);
 	ofAddListener(ofEvents().mouseScrolled,listener,&ListenerClass::mouseScrolled,prio);
+	ofAddListener(ofEvents().mouseEntered,listener,&ListenerClass::mouseEntered,prio);
+	ofAddListener(ofEvents().mouseExited,listener,&ListenerClass::mouseExited,prio);
 }
 
 template<class ListenerClass>
@@ -320,6 +326,8 @@ void ofUnregisterMouseEvents(ListenerClass * listener, int prio=OF_EVENT_ORDER_A
 	ofRemoveListener(ofEvents().mousePressed,listener,&ListenerClass::mousePressed,prio);
 	ofRemoveListener(ofEvents().mouseReleased,listener,&ListenerClass::mouseReleased,prio);
 	ofRemoveListener(ofEvents().mouseScrolled,listener,&ListenerClass::mouseScrolled,prio);
+	ofRemoveListener(ofEvents().mouseEntered,listener,&ListenerClass::mouseEntered,prio);
+	ofRemoveListener(ofEvents().mouseEntered,listener,&ListenerClass::mouseExited,prio);
 }
 
 template<class ListenerClass>

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -31,17 +31,6 @@ class ofDragInfo{
 
 class ofEventArgs{};
 
-class ofEntryEventArgs : public ofEventArgs {
-public:
-	ofEntryEventArgs()
-	:state(0){}
-
-	ofEntryEventArgs(int state)
-	:state(state){}
-
-	int state;
-};
-
 class ofKeyEventArgs : public ofEventArgs {
 public:
 	enum Type{
@@ -204,7 +193,6 @@ class ofCoreEvents {
 	ofEvent<ofEventArgs> 		draw;
 	ofEvent<ofEventArgs> 		exit;
 
-	ofEvent<ofEntryEventArgs>	windowEntered;
 	ofEvent<ofResizeEventArgs> 	windowResized;
 
 	ofEvent<ofKeyEventArgs> 	keyPressed;
@@ -263,7 +251,6 @@ class ofCoreEvents {
 
 	void notifyExit();
 	void notifyWindowResized(int width, int height);
-	void notifyWindowEntry(int state);
 
 	void notifyDragEvent(ofDragInfo info);
 

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -92,7 +92,9 @@ class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
 		Moved,
 		Released,
 		Dragged,
-		Scrolled
+		Scrolled,
+		Entered,
+		Exited
 	};
 
 	ofMouseEventArgs()
@@ -213,8 +215,8 @@ class ofCoreEvents {
 	ofEvent<ofMouseEventArgs> 	mousePressed;
 	ofEvent<ofMouseEventArgs> 	mouseReleased;
 	ofEvent<ofMouseEventArgs> 	mouseScrolled;
-	ofEvent<void>				mouseEntered;
-	ofEvent<void>				mouseExited;
+	ofEvent<ofMouseEventArgs> 	mouseEntered;
+	ofEvent<ofMouseEventArgs> 	mouseExited;
 
 	ofEvent<ofTouchEventArgs>	touchDown;
 	ofEvent<ofTouchEventArgs>	touchUp;
@@ -255,8 +257,8 @@ class ofCoreEvents {
 	void notifyMouseDragged(int x, int y, int button);
 	void notifyMouseMoved(int x, int y);
 	void notifyMouseScrolled(float x, float y);
-	void notifyMouseEntered();
-	void notifyMouseExited();
+	void notifyMouseEntered(int x, int y);
+	void notifyMouseExited(int x, int y);
 	void notifyMouseEvent(const ofMouseEventArgs & mouseEvent);
 
 	void notifyExit();


### PR DESCRIPTION
Replaces https://github.com/openframeworks/openFrameworks/pull/3162

Hi all. This looked like a relatively easy PR targeted for 0.9 so I figured I'd give it a shot. Based on @bakercp's original PR (linked above) plus comments in the discussion, I did the following things:
- added mouseEntered/mouseExited to ofEvents & ofBaseApp
- register/unregister these events in ofMainLoop
- added the GLFW callback

The events don't receive any arguments – no mouse x/y since it's a technically window event, and no state (ie entered vs left) since each state is broken out to a different event. We could pass the mouse x/y for convenience though using the last known values.

I tested this on OS X and it seems fine, though admittedly only with a single window app. Based on looking through the code, I noticed a few things:
- ofCoreEvents::notifyMouseEvent() looks like it isn't called from anywhere. Is this a remnant from the pre-multiwindow days? If so, does the same apply to notifyKeyEvent (and possibly others) and should they be removed?
- The existing windowEntry code is still in place for GLUT. Should it be updated to the mouseEntered/mouseExited paradigm as well? If so we can probably get rid of the ofEntryEventArgs class as well since this is the only place it's used.
- Does this mean the project templates & examples need to get updated with the addition of mouseEntered/Exited?