### PR TITLE
fix ofShader::load() return value

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -132,13 +132,23 @@ bool ofShader::load(string shaderName) {
 
 //--------------------------------------------------------------
 bool ofShader::load(string vertName, string fragName, string geomName) {
-	if(vertName.empty() == false) setupShaderFromFile(GL_VERTEX_SHADER, vertName);
-	if(fragName.empty() == false) setupShaderFromFile(GL_FRAGMENT_SHADER, fragName);
+	if(vertName.empty() == false) {
+		bool success = setupShaderFromFile(GL_VERTEX_SHADER, vertName);
+		if (success == false) return false;
+	}
+	if(fragName.empty() == false) {
+		bool success = setupShaderFromFile(GL_FRAGMENT_SHADER, fragName);
+		if (success == false) return false;
+	}
 #ifndef TARGET_OPENGLES
-	if(geomName.empty() == false) setupShaderFromFile(GL_GEOMETRY_SHADER_EXT, geomName);
+	if(geomName.empty() == false) {
+		bool success = setupShaderFromFile(GL_GEOMETRY_SHADER_EXT, geomName);
+		if (success == false) return false;
+	}
 #endif
 	if(ofIsGLProgrammableRenderer()){
-		bindDefaults();
+		bool success = bindDefaults();
+		if (success == false) return false;
 	}
 	return linkProgram();
 }
@@ -432,6 +442,7 @@ void ofShader::checkAndCreateProgram() {
 
 //--------------------------------------------------------------
 bool ofShader::linkProgram() {
+	bool linkStatus = false;
 	if(shaders.empty()) {
 		ofLogError("ofShader") << "linkProgram(): trying to link GLSL program, but no shaders created yet";
 	} else {
@@ -447,13 +458,16 @@ bool ofShader::linkProgram() {
 
 		glLinkProgram(program);
 
-		checkProgramLinkStatus(program);
+		linkStatus = checkProgramLinkStatus(program);
 
 		// bLoaded means we have loaded shaders onto the graphics card;
 		// it doesn't necessarily mean that these shaders have compiled and linked successfully.
 		bLoaded = true;
 	}
-	return bLoaded;
+	// only returns true if both values are true,
+	// that is, the shader has been loaded onto
+	// the graphics card and linking was successful.
+	return (bLoaded && linkStatus);
 }
 
 void ofShader::bindAttribute(GLuint location, const string & name) const{


### PR DESCRIPTION
Currently, `ofShader::load()` loads, compiles, and links GLSL shader source.

`ofShader::load()` returns a bool, which is set solely based on the current shader object's internal `bLoaded` variable, which does not say anything about whether the shader has been loaded, compiled and linked successfully.

It will also attempt to compile and link shader stages, even if an earlier shader stage compile or load failed.

---

This PR suggests the following changes:

* If an error is encountered in any of the stages of ofShader::load (`load`, `compile`, and `link`), return `false` early at the point of error, print an error messge, and do not continue processing this shader. This makes it easier to debug shader errors, since subsequent errors only fill up the log, and are most likely just results of the first error reported.

* ofShader::linkProgram only returns true if *both* load and `linkStatus`  were true, that is, when the shader was successfully linked.

With this, the return value of `ofShader::load()` is a reliable indicator of whether the shader was loaded, compiled, and linked properly.