### PR TITLE
oFAVFoundationPlayer gc and memory fixes

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -115,14 +115,15 @@ class ofAVFoundationGC : public ofThread {
 	
 public:
 	
-	static ofAVFoundationGC* instance();
+	~ofAVFoundationGC();
+	
+	static ofAVFoundationGC& instance();
 	void addToGarbageQueue(ofAVFoundationVideoPlayer*);
 	
 	
 private:
 	
-	ofAVFoundationGC(){}; //use instance()!
-	static ofAVFoundationGC*	singleton;
+	ofAVFoundationGC(); //use instance()!
 	
 	vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
 	

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -85,12 +85,12 @@ public:
     
 protected:
 	
-	bool loadPlayer(string name, bool bAsync);
+    bool loadPlayer(string name, bool bAsync);
 
 #ifdef __OBJC__
-	ofAVFoundationVideoPlayer * videoPlayer;
+    ofAVFoundationVideoPlayer * videoPlayer;
 #else
-	void * videoPlayer;
+    void * videoPlayer;
 #endif
     
     bool bFrameNew;
@@ -100,8 +100,8 @@ protected:
     bool bTextureCacheSupported;
 	
     ofPixels pixels;
-	ofPixelFormat pixelFormat;
-	ofTexture videoTexture;
+    ofPixelFormat pixelFormat;
+    ofTexture videoTexture;
 };
 
 
@@ -115,19 +115,19 @@ class ofAVFoundationGC : public ofThread {
 	
 public:
 	
-	~ofAVFoundationGC();
-	
-	static ofAVFoundationGC& instance();
-	void addToGarbageQueue(ofAVFoundationVideoPlayer*);
+    ~ofAVFoundationGC();
+
+    static ofAVFoundationGC& instance();
+    void addToGarbageQueue(ofAVFoundationVideoPlayer*);
 	
 	
 private:
 	
-	ofAVFoundationGC(); //use instance()!
-	
-	vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
-	dispatch_semaphore_t sema;
-	void threadedFunction();
+    ofAVFoundationGC(); //use instance()!
+
+    vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
+    dispatch_semaphore_t sema;
+    void threadedFunction();
 	
 };
 #endif

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -9,6 +9,7 @@
 #include "ofBaseTypes.h"
 #include "ofPixels.h"
 #include "ofTexture.h"
+#include "ofThread.h"
 
 #ifdef __OBJC__
 #import "ofAVFoundationVideoPlayer.h"
@@ -103,3 +104,29 @@ protected:
 	ofTexture videoTexture;
 };
 
+
+
+//--------------------------------------------------------------
+// garbage collector for videoplayers
+// destroying an AVAssetReader takes a while,
+// so do it on a thread
+#ifdef __OBJC__
+class ofAVFoundationGC : public ofThread {
+	
+public:
+	
+	static ofAVFoundationGC* instance();
+	void addToGarbageQueue(ofAVFoundationVideoPlayer*);
+	
+	
+private:
+	
+	ofAVFoundationGC(){}; //use instance()!
+	static ofAVFoundationGC*	singleton;
+	
+	vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
+	
+	void threadedFunction();
+	
+};
+#endif

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -47,6 +47,7 @@ public:
     ofPixels & getPixels();
     ofTexture * getTexturePtr();
     void initTextureCache();
+    void killTexture();
     void killTextureCache();
 	
     float getWidth() const;
@@ -90,6 +91,7 @@ public:
 protected:
 	
     bool loadPlayer(string name, bool bAsync);
+	void disposePlayer();
 
 #ifdef __OBJC__
     ofAVFoundationVideoPlayer * videoPlayer;

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -118,30 +118,3 @@ protected:
 #endif
 };
 
-
-
-//--------------------------------------------------------------
-// garbage collector for videoplayers
-// destroying an AVAssetReader takes a while,
-// so do it on a thread
-#ifdef __OBJC__
-class ofAVFoundationGC : public ofThread {
-	
-public:
-	
-    ~ofAVFoundationGC();
-
-    static ofAVFoundationGC& instance();
-    void addToGarbageQueue(ofAVFoundationVideoPlayer*);
-	
-	
-private:
-	
-    ofAVFoundationGC(); //use instance()!
-
-    vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
-    dispatch_semaphore_t sema;
-    void threadedFunction();
-	
-};
-#endif

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -126,7 +126,7 @@ private:
 	ofAVFoundationGC(); //use instance()!
 	
 	vector<ofAVFoundationVideoPlayer*> videosPendingDeletion;
-	
+	dispatch_semaphore_t sema;
 	void threadedFunction();
 	
 };

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -44,12 +44,8 @@ bool ofAVFoundationPlayer::load(string name) {
 //--------------------------------------------------------------
 bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
 	
-    if(videoPlayer != NULL) {
-        // throw this player away, add it to GC
-        ofAVFoundationGC::instance().addToGarbageQueue(videoPlayer);
-        videoPlayer = NULL;
-    }
-
+	// dispose videoplayer, texture and texture-caches
+	close();
 
     // create a new player
     videoPlayer = [[ofAVFoundationVideoPlayer alloc] init];

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -132,11 +132,14 @@ bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
     return bLoaded;
 }
 
+//--------------------------------------------------------------
 void ofAVFoundationPlayer::disposePlayer() {
 	
 	if (videoPlayer == NULL)
 		return;
 	
+	// pause player, stop updates
+	[videoPlayer pause];
 	
 	// dispose videoplayer
 	__block ofAVFoundationVideoPlayer *currentPlayer = videoPlayer;
@@ -160,12 +163,14 @@ void ofAVFoundationPlayer::close() {
 
 		disposePlayer();
 		
-        if(bTextureCacheSupported == true) {
-            killTextureCache();
-        }
+		videoPlayer = NULL;
     }
-    videoPlayer = NULL;
-    
+	
+	// in any case get rid of the textures
+	if(bTextureCacheSupported == true) {
+		killTextureCache();
+	}
+	
     bFrameNew = false;
     bResetPixels = false;
     bUpdatePixels = false;

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -144,8 +144,6 @@ void ofAVFoundationPlayer::disposePlayer() {
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
 		
 		@autoreleasepool {
-			// we always need to call cleanup before releasing the player!
-			[currentPlayer cleanup];
 			[currentPlayer autorelease];
 		}
 		
@@ -238,7 +236,9 @@ void ofAVFoundationPlayer::draw(const ofRectangle & rect) {
 }
 
 void ofAVFoundationPlayer::draw(float x, float y, float w, float h) {
-    getTexturePtr()->draw(x, y, w, h);
+	if(videoPlayer != NULL) {
+		getTexturePtr()->draw(x, y, w, h);
+	}
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -766,9 +766,7 @@ ofAVFoundationGC::ofAVFoundationGC(){
 
 void ofAVFoundationGC::threadedFunction(){
 
-
     ofAVFoundationVideoPlayer * toDel = NULL;
-
 
     while (isThreadRunning()) {
         
@@ -786,7 +784,7 @@ void ofAVFoundationGC::threadedFunction(){
             
             //should call a finalizer instead...
             @autoreleasepool {
-                [toDel release];
+                [toDel cleanupAndAutorelease];
                 toDel = NULL;
             }			
         }

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -756,6 +756,7 @@ ofAVFoundationGC& ofAVFoundationGC::instance(){
 void ofAVFoundationGC::addToGarbageQueue(ofAVFoundationVideoPlayer * p){
 	lock();
 	p.delegate = nil;
+	[p pause];
 	videosPendingDeletion.push_back(p);
 	unlock();
 	dispatch_semaphore_signal(sema);

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -20,7 +20,7 @@ CVOpenGLTextureRef _videoTextureRef = NULL;
 #endif
 
 ofAVFoundationPlayer::ofAVFoundationPlayer() {
-	videoPlayer = NULL;
+    videoPlayer = NULL;
     pixelFormat = OF_PIXELS_RGBA;
 	
     bFrameNew = false;
@@ -38,57 +38,57 @@ ofAVFoundationPlayer::ofAVFoundationPlayer() {
 
 //--------------------------------------------------------------
 ofAVFoundationPlayer::~ofAVFoundationPlayer() {
-	close();
+    close();
 }
 
 //--------------------------------------------------------------
 void ofAVFoundationPlayer::loadAsync(string name){
-	loadPlayer(name, true);
+    loadPlayer(name, true);
 }
 
 //--------------------------------------------------------------
 bool ofAVFoundationPlayer::load(string name) {
-	return loadPlayer(name, false);
+    return loadPlayer(name, false);
 }
 
 //--------------------------------------------------------------
 bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
 	
     if(videoPlayer != NULL) {
-		// throw this player away, add it to GC
-		ofAVFoundationGC::instance().addToGarbageQueue(videoPlayer);
-		videoPlayer = NULL;
-	}
-	
-	
-	// create a new player
-	videoPlayer = [[ofAVFoundationVideoPlayer alloc] init];
-	[videoPlayer setWillBeUpdatedExternally:YES];
+        // throw this player away, add it to GC
+        ofAVFoundationGC::instance().addToGarbageQueue(videoPlayer);
+        videoPlayer = NULL;
+    }
+
+
+    // create a new player
+    videoPlayer = [[ofAVFoundationVideoPlayer alloc] init];
+    [videoPlayer setWillBeUpdatedExternally:YES];
 
 
 	
     NSString * videoPath = [NSString stringWithUTF8String:name.c_str()];
-	NSString * videoLocalPath = [NSString stringWithUTF8String:ofToDataPath(name).c_str()];
+    NSString * videoLocalPath = [NSString stringWithUTF8String:ofToDataPath(name).c_str()];
 
-	BOOL bStream = NO;
-	
-	bStream = bStream || (ofIsStringInString(name, "http://"));
-	bStream = bStream || (ofIsStringInString(name, "https://"));
-	bStream = bStream || (ofIsStringInString(name, "rtsp://"));
-	
-	NSURL * url = nil;
-	if(bStream == YES) {
-		url = [NSURL URLWithString:videoPath];
-	} else {
-		url = [NSURL fileURLWithPath:videoLocalPath];
-	}
-	
-	bool bLoaded = [videoPlayer loadWithURL:url async:bAsync];
+    BOOL bStream = NO;
+
+    bStream = bStream || (ofIsStringInString(name, "http://"));
+    bStream = bStream || (ofIsStringInString(name, "https://"));
+    bStream = bStream || (ofIsStringInString(name, "rtsp://"));
+
+    NSURL * url = nil;
+    if(bStream == YES) {
+        url = [NSURL URLWithString:videoPath];
+    } else {
+        url = [NSURL fileURLWithPath:videoLocalPath];
+    }
+
+    bool bLoaded = [videoPlayer loadWithURL:url async:bAsync];
 	
     bResetPixels = true;
     bUpdatePixels = true;
     bUpdateTexture = true;
-    
+
     bool bCreateTextureCache = true;
     bCreateTextureCache = bCreateTextureCache && (bTextureCacheSupported == true);
     bCreateTextureCache = bCreateTextureCache && (_videoTextureCache == NULL);
@@ -132,23 +132,21 @@ bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
 
 //--------------------------------------------------------------
 void ofAVFoundationPlayer::close() {
-	if(videoPlayer != NULL) {
+    if(videoPlayer != NULL) {
 		
-		pixels.clear();
+        pixels.clear();
         
         videoTexture.clear();
 
-		// dispose videoplayer
-		ofAVFoundationGC& inst = ofAVFoundationGC::instance();
-		inst.addToGarbageQueue(videoPlayer);
-
-		videoPlayer = NULL;
+        // dispose videoplayer
+        ofAVFoundationGC::instance().addToGarbageQueue(videoPlayer);
+        videoPlayer = NULL;
 		
         if(bTextureCacheSupported == true) {
             killTextureCache();
         }
-	}
-	videoPlayer = NULL;
+    }
+    videoPlayer = NULL;
     
     bFrameNew = false;
     bResetPixels = false;
@@ -174,12 +172,12 @@ bool ofAVFoundationPlayer::setPixelFormat(ofPixelFormat value) {
     pixelFormat = value;
     bResetPixels = true;
     
-	return true;
+    return true;
 }
 
 //--------------------------------------------------------------
 ofPixelFormat ofAVFoundationPlayer::getPixelFormat() const{
-	return pixelFormat;
+    return pixelFormat;
 }
 
 //--------------------------------------------------------------
@@ -229,7 +227,7 @@ void ofAVFoundationPlayer::play() {
         ofLogWarning("ofxiOSVideoPlayer") << "play(): video not loaded";
     }
     
-	[videoPlayer play];
+    [videoPlayer play];
 }
 
 //--------------------------------------------------------------
@@ -749,65 +747,70 @@ ofTexture * ofAVFoundationPlayer::getTexture() {
 //--------------------------------------------------------------
 //--------------------------------------------------------------
 ofAVFoundationGC& ofAVFoundationGC::instance(){
-	static ofAVFoundationGC singleton;
-	return singleton;
+    static ofAVFoundationGC singleton;
+    return singleton;
 }
 
 void ofAVFoundationGC::addToGarbageQueue(ofAVFoundationVideoPlayer * p){
-	lock();
-	p.delegate = nil;
-	[p pause];
-	videosPendingDeletion.push_back(p);
-	unlock();
-	dispatch_semaphore_signal(sema);
+    lock();
+    p.delegate = nil;
+    [p pause];
+    videosPendingDeletion.push_back(p);
+    unlock();
+    dispatch_semaphore_signal(sema);
 }
 
 ofAVFoundationGC::~ofAVFoundationGC(){
-	// end thread and clean up
-	stopThread();
-	dispatch_semaphore_signal(sema);
-	waitForThread();
-	dispatch_release(sema);
+    // end thread and clean up
+    stopThread();
+    dispatch_semaphore_signal(sema);
+    waitForThread();
+    dispatch_release(sema);
 }
 
 // private constructor
 ofAVFoundationGC::ofAVFoundationGC(){
-	sema = dispatch_semaphore_create(0);
-	startThread();
+    sema = dispatch_semaphore_create(0);
+    startThread();
 }
 
 void ofAVFoundationGC::threadedFunction(){
-	
-	ofAVFoundationVideoPlayer * toDel = NULL;
-	
-	
-	while (isThreadRunning()) {
-		
-		// wait for signal
-		dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-		
-		lock();
-		if(videosPendingDeletion.size() > 0){
-			toDel = videosPendingDeletion[0];
-			videosPendingDeletion.erase(videosPendingDeletion.begin());
-		}
-		unlock();
-		if (toDel){ //we do this to avoid blocking the main thread inside the mutex
-			//as this is the "long" call
-			
-			//should call a finalizer instead...
-			[toDel release];
-			toDel = NULL;
-		}
-	}
 
-	// dispose all left over
-	while (videosPendingDeletion.size() > 0) {
-		toDel = videosPendingDeletion.front();
-		videosPendingDeletion.erase(videosPendingDeletion.begin());
-		if (toDel){
-			[toDel release];
-			toDel = NULL;
-		}
-	}
+
+    ofAVFoundationVideoPlayer * toDel = NULL;
+
+
+    while (isThreadRunning()) {
+        
+        // wait for signal
+        dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        
+        lock();
+        if(videosPendingDeletion.size() > 0){
+            toDel = videosPendingDeletion[0];
+            videosPendingDeletion.erase(videosPendingDeletion.begin());
+        }
+        unlock();
+        if (toDel){ //we do this to avoid blocking the main thread inside the mutex
+            //as this is the "long" call
+            
+            //should call a finalizer instead...
+            @autoreleasepool {
+                [toDel release];
+                toDel = NULL;
+            }			
+        }
+    }
+
+    // dispose all left over
+    @autoreleasepool {
+        while (videosPendingDeletion.size() > 0) {
+            toDel = videosPendingDeletion.front();
+            videosPendingDeletion.erase(videosPendingDeletion.begin());
+            if (toDel){
+                [toDel release];
+                toDel = NULL;
+            }
+        }
+    }
 }

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -138,5 +138,5 @@
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 
-- (void)cleanupAndAutorelease;
+- (void)cleanup;
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -138,5 +138,4 @@
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 
-- (void)cleanup;
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -138,5 +138,5 @@
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 
-- (void)finalize;
+- (void)cleanupAndAutorelease;
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -181,13 +181,11 @@ static const NSString * ItemStatusContext;
 	
 	dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 	dispatch_queue_t queue;
-//	if(bAsync == YES){
-//		queue = dispatch_get_main_queue();
-//	} else {
-//		
-//	}
-
-	queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+	if(bAsync == YES){
+		queue = dispatch_get_main_queue();
+	} else {
+		queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+	}
 	
 	dispatch_async(queue, ^{
 		[self.asset loadValuesAsynchronouslyForKeys:[NSArray arrayWithObject:kTracksKey] completionHandler:^{

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -123,6 +123,7 @@ static const NSString * ItemStatusContext;
 		[_player removeObserver:self forKeyPath:kRateKey];
 		
 		self.player = nil;
+		[_player release];
 	}
 	
 	if(self.assetReader != nil) {

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -153,11 +153,13 @@ static const NSString * ItemStatusContext;
 	
 	dispatch_semaphore_t sema = dispatch_semaphore_create(0);
 	dispatch_queue_t queue;
-	if(bAsync == YES){
-		queue = dispatch_get_main_queue();
-	} else {
-		queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-	}
+//	if(bAsync == YES){
+//		queue = dispatch_get_main_queue();
+//	} else {
+//		
+//	}
+
+	queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	
 	dispatch_async(queue, ^{
 		[self.asset loadValuesAsynchronouslyForKeys:[NSArray arrayWithObject:kTracksKey] completionHandler:^{
@@ -261,6 +263,13 @@ static const NSString * ItemStatusContext;
 	audioSampleTime = timeRange.start;
 	
 	NSError *error = nil;
+
+	// safety
+	if (self.assetReader != nil) {
+		[self.assetReader cancelReading];
+		self.assetReader = nil;
+	}
+	
 	self.assetReader = [AVAssetReader assetReaderWithAsset:self.asset error:&error];
 	
 	if(error) {
@@ -677,6 +686,8 @@ static const NSString * ItemStatusContext;
 		bFinished = NO;
 	}
 	
+	// expensive call?
+	// destroy it on a thread?
 	[self.assetReader cancelReading];
 	self.assetReader = nil;
 	self.assetReaderVideoTrackOutput = nil;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -78,7 +78,7 @@ static const NSString * ItemStatusContext;
 }
 
 //---------------------------------------------------------- cleanup / dispose.
-- (void)dealloc {
+- (void)cleanup {
 	
 	if(self.playerView != nil) {
 		[(ofAVFoundationVideoPlayerView *)self.playerView setPlayer:nil];
@@ -123,13 +123,6 @@ static const NSString * ItemStatusContext;
 		CFRelease(audioSampleBuffer);
 		audioSampleBuffer = nil;
 	}
-
-	
-	[super dealloc];
-}
-
-- (void)cleanup {
-	
 }
 
 //---------------------------------------------------------- position / size.

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -619,21 +619,22 @@ static const NSString * ItemStatusContext;
 		return;
 	}
 	
-	if(timeObserver){
+	if(timeObserver != nil){
 		return;
 	}
 	
 	double interval = 1.0 / (double)timeObserverFps;
 	
+	__block ofAVFoundationVideoPlayer* refToSelf = self;
 	timeObserver = [[_player addPeriodicTimeObserverForInterval:CMTimeMakeWithSeconds(interval, NSEC_PER_SEC)
 														  queue:dispatch_get_main_queue() usingBlock:
 					 ^(CMTime time) {
-						 [self update];
+						 [refToSelf update];
 					 }] retain];
 }
 
 - (void)removeTimeObserverFromPlayer {
-	if(timeObserver) {
+	if(timeObserver != nil) {
 		[_player removeTimeObserver:timeObserver];
 		[timeObserver release];
 		timeObserver = nil;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -89,10 +89,11 @@ static const NSString * ItemStatusContext;
 	
 	// safety
 	[self cleanup];
+	
 	[super dealloc];
 }
 
-- (void)finalize {
+- (void)cleanupAndAutorelease {
 	
 	[self cleanup];
 	[self autorelease];

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -14,13 +14,6 @@ static NSString * const kStatusKey = @"status";
 static NSString * const kRateKey = @"rate";
 static NSString * const kCurrentItemKey = @"currentItem";
 
-//---------------------------------------------------------- video player privates.
-@interface ofAVFoundationVideoPlayer()
-
-- (void)cleanup;
-
-@end
-
 //---------------------------------------------------------- video player.
 @implementation ofAVFoundationVideoPlayer
 
@@ -86,17 +79,9 @@ static const NSString * ItemStatusContext;
 
 //---------------------------------------------------------- cleanup / dispose.
 - (void)dealloc {
-	
 	// safety
 	[self cleanup];
-	
 	[super dealloc];
-}
-
-- (void)cleanupAndAutorelease {
-	
-	[self cleanup];
-	[self autorelease];
 }
 
 - (void)cleanup {
@@ -135,16 +120,15 @@ static const NSString * ItemStatusContext;
 	self.assetReaderAudioTrackOutput = nil;
 	self.asset = nil;
 	
-	if(videoSampleBuffer) {
+	if(videoSampleBuffer != nil) {
 		CFRelease(videoSampleBuffer);
 		videoSampleBuffer = nil;
 	}
 	
-	if(audioSampleBuffer) {
+	if(audioSampleBuffer != nil) {
 		CFRelease(audioSampleBuffer);
 		audioSampleBuffer = nil;
 	}
-
 }
 
 //---------------------------------------------------------- position / size.

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -79,12 +79,6 @@ static const NSString * ItemStatusContext;
 
 //---------------------------------------------------------- cleanup / dispose.
 - (void)dealloc {
-	// safety
-	[self cleanup];
-	[super dealloc];
-}
-
-- (void)cleanup {
 	
 	if(self.playerView != nil) {
 		[(ofAVFoundationVideoPlayerView *)self.playerView setPlayer:nil];
@@ -129,6 +123,13 @@ static const NSString * ItemStatusContext;
 		CFRelease(audioSampleBuffer);
 		audioSampleBuffer = nil;
 	}
+
+	
+	[super dealloc];
+}
+
+- (void)cleanup {
+	
 }
 
 //---------------------------------------------------------- position / size.

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -78,7 +78,9 @@ static const NSString * ItemStatusContext;
 }
 
 //---------------------------------------------------------- cleanup / dispose.
-- (void)cleanup {
+- (void)dealloc
+{
+	NSLog(@"dealloc");
 	
 	if(self.playerView != nil) {
 		[(ofAVFoundationVideoPlayerView *)self.playerView setPlayer:nil];
@@ -123,7 +125,10 @@ static const NSString * ItemStatusContext;
 		CFRelease(audioSampleBuffer);
 		audioSampleBuffer = nil;
 	}
+	
+	[super dealloc];
 }
+
 
 //---------------------------------------------------------- position / size.
 - (void)setVideoPosition:(CGPoint)position {

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -79,9 +79,7 @@ static const NSString * ItemStatusContext;
 
 //---------------------------------------------------------- cleanup / dispose.
 - (void)dealloc
-{
-	NSLog(@"dealloc");
-	
+{	
 	if(self.playerView != nil) {
 		[(ofAVFoundationVideoPlayerView *)self.playerView setPlayer:nil];
 		[self.playerView removeFromSuperview];


### PR DESCRIPTION
adding garbage collection for AVFoundationVideoPlayer disposal making movie loading faster.
also fixes some memory leaks reported here:
https://github.com/openframeworks/openFrameworks/issues/3704
https://github.com/openframeworks/openFrameworks/issues/3729
https://github.com/openframeworks/openFrameworks/issues/3715

might fix this as well: https://github.com/openframeworks/openFrameworks/issues/2530 (did not test)

also includes these pullrequests: 
https://github.com/openframeworks/openFrameworks/pull/3672: using a cleanup+release method for internal cleanup. refactored `finalize` to `cleanupAndAutorelease`
https://github.com/openframeworks/openFrameworks/pull/3670: making texture objects private