### PR TITLE
ofXml: better parse error messages & file existence check

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -36,8 +36,12 @@ ofXml::ofXml() {
 }
 
 bool ofXml::load(const string & path){
-	ofFile xmlFile(path,ofFile::ReadOnly);
-	ofBuffer xmlBuffer(xmlFile);
+	ofFile file(path, ofFile::ReadOnly);
+	if(!file.exists()) {
+		ofLogError("ofxXml") << "couldn't load, \"" << file.getFileName() << "\" not found";
+		return false;
+	}
+	ofBuffer xmlBuffer(file);
 	return loadFromBuffer(xmlBuffer);
 }
 
@@ -775,12 +779,16 @@ bool ofXml::loadFromBuffer( const string& buffer )
     	element = (Poco::XML::Element*) document->firstChild();
     	document->normalize();
     	return true;
-    } catch( const exception & e ) {
-        short msg = atoi(e.what());
-        ofLogError("ofXml") << "loadFromBuffer(): " << DOMErrorMessage(msg);
+	} catch( const Poco::XML::SAXException & e ) {
+		ofLogError("ofXml") << "parse error: " << e.message();
         document = new Poco::XML::Document;
         element = document->documentElement();
-        //ofLogNotice("ofXml") << "element " << element;
+        return false;
+    } catch( const exception & e ) {
+        short msg = atoi(e.what());
+        ofLogError("ofXml") << "parse error: " << DOMErrorMessage(msg);
+        document = new Poco::XML::Document;
+        element = document->documentElement();
         return false;
     }
 }

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -38,7 +38,7 @@ ofXml::ofXml() {
 bool ofXml::load(const string & path){
 	ofFile file(path, ofFile::ReadOnly);
 	if(!file.exists()) {
-		ofLogError("ofxXml") << "couldn't load, \"" << file.getFileName() << "\" not found";
+		ofLogError("ofXml") << "couldn't load, \"" << file.getFileName() << "\" not found";
 		return false;
 	}
 	ofBuffer xmlBuffer(file);


### PR DESCRIPTION
* catch SAXException for better parse error info
* check if file exists before trying to load and print error if not

Now I get:

    [ error ]  ofXml: parse error: Tag mismatch in line 10 column 3

and:

    [ error ] ofxXml: couldn't load, "glslColorScheme.xml" not found

instead of:

    [ error ] ofXml: loadFromBuffer(): DOM ERROR