### PR TITLE
added getter for type long (ofXml & ofUtils)

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -475,9 +475,9 @@ double ofToDouble(const string& doubleString) {
 }
 
 //----------------------------------------
-long long ofToLong(const string& longString) {
-	long long x = 0;
-	istringstream cur(longString);
+int64_t ofToInt64(const string& intString) {
+	int64_t x = 0;
+	istringstream cur(intString);
 	cur >> x;
 	return x;
 }

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -475,6 +475,14 @@ double ofToDouble(const string& doubleString) {
 }
 
 //----------------------------------------
+long long ofToLong(const string& longString) {
+	long long x = 0;
+	istringstream cur(longString);
+	cur >> x;
+	return x;
+}
+
+//----------------------------------------
 bool ofToBool(const string& boolString) {
 	static const string trueString = "true";
 	static const string falseString = "false";

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -592,14 +592,14 @@ int ofToInt(const string& intString);
 /// \name Number conversion
 /// \{
 
-/// \brief Convert a string to a long long integer.
+/// \brief Convert a string to a int64_t.
 ///
-/// Converts a `std::string` representation of a long long integer
-/// (e.g., `"9223372036854775807"`) to an actual `long long int`.
+/// Converts a `std::string` representation of a long integer
+/// (e.g., `"9223372036854775807"`) to an actual `int64_t`.
 ///
-/// \param The string representation of the long long integer.
-/// \returns the long long integer represented by the string or 0 on failure.
-long long ofToLong(const string& intString);
+/// \param The string representation of the long integer.
+/// \returns the long integer represented by the string or 0 on failure.
+int64_t ofToInt64(const string& intString);
 
 /// \brief Convert a string to a float.
 ///

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -588,6 +588,19 @@ const char * ofFromString(const string & value);
 /// \returns the integer represented by the string or 0 on failure.
 int ofToInt(const string& intString);
 
+// --------------------------------------------
+/// \name Number conversion
+/// \{
+
+/// \brief Convert a string to a long long integer.
+///
+/// Converts a `std::string` representation of a long long integer
+/// (e.g., `"9223372036854775807"`) to an actual `long long int`.
+///
+/// \param The string representation of the long long integer.
+/// \returns the long long integer represented by the string or 0 on failure.
+long long ofToLong(const string& intString);
+
 /// \brief Convert a string to a float.
 ///
 /// Converts a std::string representation of a float (e.g., `"3.14"`) to an

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -98,10 +98,8 @@ void ofXml::deserialize(ofAbstractParameter & parameter){
 				parameter.cast<float>() = getFloatValue(name);
 			}else if(parameter.type()==typeid(ofParameter<bool>).name()){
 				parameter.cast<bool>() = getBoolValue(name);
-			}else if(parameter.type()==typeid(ofParameter<long>).name()){
-				parameter.cast<long>() = getLongValue(name);
-			}else if(parameter.type()==typeid(ofParameter<long long>).name()){
-				parameter.cast<long long>() = getLongValue(name);
+			}else if(parameter.type()==typeid(ofParameter<int64_t>).name()){
+				parameter.cast<int64_t>() = getInt64Value(name);
 			}else if(parameter.type()==typeid(ofParameter<string>).name()){
 				parameter.cast<string>() = getValue(name);
 			}else{
@@ -277,12 +275,12 @@ bool ofXml::getBoolValue(const string & path) const{
 	return getValue<bool>(path,false);
 }
 
-long long ofXml::getLongValue() const{
-	return ofToLong(getValue());
+int64_t ofXml::getInt64Value() const{
+	return ofToInt64(getValue());
 }
 
-long long ofXml::getLongValue(const string & path) const{
-	return getValue<long long>(path,0);
+int64_t ofXml::getInt64Value(const string & path) const{
+	return getValue<int64_t>(path,0);
 }
 
 

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -98,6 +98,10 @@ void ofXml::deserialize(ofAbstractParameter & parameter){
 				parameter.cast<float>() = getFloatValue(name);
 			}else if(parameter.type()==typeid(ofParameter<bool>).name()){
 				parameter.cast<bool>() = getBoolValue(name);
+			}else if(parameter.type()==typeid(ofParameter<long>).name()){
+				parameter.cast<long>() = getLongValue(name);
+			}else if(parameter.type()==typeid(ofParameter<long long>).name()){
+				parameter.cast<long long>() = getLongValue(name);
 			}else if(parameter.type()==typeid(ofParameter<string>).name()){
 				parameter.cast<string>() = getValue(name);
 			}else{
@@ -271,6 +275,14 @@ bool ofXml::getBoolValue() const{
 
 bool ofXml::getBoolValue(const string & path) const{
 	return getValue<bool>(path,false);
+}
+
+long long ofXml::getLongValue() const{
+	return ofToLong(getValue());
+}
+
+long long ofXml::getLongValue(const string & path) const{
+	return getValue<long long>(path,0);
 }
 
 

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -49,12 +49,12 @@ public:
     string          getValue(const string & path) const;
     int				getIntValue() const;
     int				getIntValue(const string & path) const;
+    int64_t getInt64Value() const;
+    int64_t getInt64Value(const string& path) const;
     float			getFloatValue() const;
     float			getFloatValue(const string & path) const;
     bool			getBoolValue() const;
     bool			getBoolValue(const string & path) const;
-    long long getLongValue() const;
-    long long getLongValue(const string& path) const;
 
     bool            setValue(const string& path, const string& value);
     

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -53,6 +53,8 @@ public:
     float			getFloatValue(const string & path) const;
     bool			getBoolValue() const;
     bool			getBoolValue(const string & path) const;
+    long long		getLongValue() const;
+    long long 		getLongValue(const string& path) const;
 
     bool            setValue(const string& path, const string& value);
     

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -53,8 +53,8 @@ public:
     float			getFloatValue(const string & path) const;
     bool			getBoolValue() const;
     bool			getBoolValue(const string & path) const;
-    long long		getLongValue() const;
-    long long 		getLongValue(const string& path) const;
+    long long getLongValue() const;
+    long long getLongValue(const string& path) const;
 
     bool            setValue(const string& path, const string& value);
     


### PR DESCRIPTION
Added getter methods for type long in ofXml (as in #3081 for ofxXmlSettings). 

I used long long instead of long for maximal value range.

Tested single methods + serialize and deserialize in combination with ofParameter (Ubuntu only).