### PR TITLE
Fix ofxAndroidSoundPlayer getVolume

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
@@ -443,7 +443,7 @@ float ofxAndroidSoundPlayer::getVolume() const{
 		return 0;
 	}
 
-	jmethodID javaVolumeMethod = env->GetMethodID(javaClass,"getVolume","(V)F");
+	jmethodID javaVolumeMethod = env->GetMethodID(javaClass,"getVolume","()F");
 	if(!javaVolumeMethod){
 		ofLogError("ofxAndroidSoundPlayer") << "getVolume(): couldn't get java getVolume for SoundPlayer";
 		return 0;


### PR DESCRIPTION
getVolume was using an incorrect jni method signature. It was using "(V)F", when it should actually be "()F". getVolume was triggering a crash on Android devices.