### PR TITLE
Compatibility issue of ofGstUtils

### DIFF
--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -21,6 +21,10 @@
 #include <gst/gl/x11/gstgldisplay_x11.h>
 #include <gst/gl/egl/gstgldisplay_egl.h>
 #endif
+#ifdef TARGET_WIN32
+#include <winbase.h>	// to use SetEnvironmentVariableA
+#endif
+
 
 ofGstUtils::ofGstMainLoopThread * ofGstUtils::mainLoop;
 
@@ -118,7 +122,9 @@ ofGstUtils::ofGstUtils() {
 	if(!gst_inited){
 #ifdef TARGET_WIN32
 		string gst_path = g_getenv("GSTREAMER_1_0_ROOT_X86");
-		putenv(("GST_PLUGIN_PATH_1_0=" + ofFilePath::join(gst_path, "lib\\gstreamer-1.0") + ";.").c_str());
+		//putenv(("GST_PLUGIN_PATH_1_0=" + ofFilePath::join(gst_path, "lib\\gstreamer-1.0") + ";.").c_str());
+		// to make it compatible with gcc and C++11 standard
+		SetEnvironmentVariableA("GST_PLUGIN_PATH_1_0", ofFilePath::join(gst_path, "lib\\gstreamer-1.0").c_str());
 #endif
 		gst_init (NULL, NULL);
 		gst_inited=true;


### PR DESCRIPTION
I've had a compatibility issue using ofGstUtils in Windows environment (with ofxGstreamer add on), with Code::Block 13.12 (gcc 4.7.1) if I enable the C++11 standard option.
In this standard the putenv function is not defined, so I substitute the function with SetEnvironmentVariableA, including winbase.h