### PR TITLE
small updates: guiExample code consistency & OF_TTF string as static const

### DIFF
--- a/examples/gui/guiExample/src/ofApp.cpp
+++ b/examples/gui/guiExample/src/ofApp.cpp
@@ -1,23 +1,22 @@
 #include "ofApp.h"
 
-	
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofSetVerticalSync(true);
 
 	// we add this listener before setting up so the initial circle resolution is correct
 	circleResolution.addListener(this, &ofApp::circleResolutionChanged);
-	ringButton.addListener(this,&ofApp::ringButtonPressed);
+	ringButton.addListener(this, &ofApp::ringButtonPressed);
 
 	gui.setup(); // most of the time you don't need a name
 	gui.add(filled.setup("fill", true));
-	gui.add(radius.setup( "radius", 140, 10, 300 ));
-	gui.add(center.setup("center",ofVec2f(ofGetWidth()*.5,ofGetHeight()*.5),ofVec2f(0,0),ofVec2f(ofGetWidth(),ofGetHeight())));
-	gui.add(color.setup("color",ofColor(100,100,140),ofColor(0,0),ofColor(255,255)));
+	gui.add(radius.setup("radius", 140, 10, 300));
+	gui.add(center.setup("center", ofVec2f(ofGetWidth()*.5, ofGetHeight()*.5), ofVec2f(0, 0), ofVec2f(ofGetWidth(), ofGetHeight())));
+	gui.add(color.setup("color", ofColor(100, 100, 140), ofColor(0, 0), ofColor(255, 255)));
 	gui.add(circleResolution.setup("circle res", 5, 3, 90));
 	gui.add(twoCircles.setup("two circles"));
 	gui.add(ringButton.setup("ring"));
-	gui.add(screenSize.setup("screen size", ""));
+	gui.add(screenSize.setup("screen size", ofToString(ofGetWidth())+"x"+ofToString(ofGetHeight())));
 
 	bHide = false;
 
@@ -48,7 +47,7 @@ void ofApp::update(){
 void ofApp::draw(){
     ofBackgroundGradient(ofColor::white, ofColor::gray);
     
-	if( filled ){
+	if(filled){
 		ofFill();
 	}else{
 		ofNoFill();
@@ -56,31 +55,31 @@ void ofApp::draw(){
 
 	ofSetColor(color);
 	if(twoCircles){
-		ofDrawCircle(center->x-radius*.5, center->y, radius );
-		ofDrawCircle(center->x+radius*.5, center->y, radius );
+		ofCircle(center->x-radius*.5, center->y, radius );
+		ofCircle(center->x+radius*.5, center->y, radius );
 	}else{
-		ofDrawCircle((ofVec2f)center, radius );
+		ofCircle((ofVec2f)center, radius );
 	}
 	
 	// auto draw?
 	// should the gui control hiding?
-	if( !bHide ){
+	if(!bHide){
 		gui.draw();
 	}
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	if( key == 'h' ){
+	if(key == 'h'){
 		bHide = !bHide;
 	}
-	if(key == 's') {
+	else if(key == 's'){
 		gui.saveToFile("settings.xml");
 	}
-	if(key == 'l') {
+	else if(key == 'l'){
 		gui.loadFromFile("settings.xml");
 	}
-	if(key == ' '){
+	else if(key == ' '){
 		color = ofColor(255);
 	}
 }
@@ -92,11 +91,12 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
+
 }
 
 //--------------------------------------------------------------

--- a/examples/gui/guiExample/src/ofApp.cpp
+++ b/examples/gui/guiExample/src/ofApp.cpp
@@ -55,10 +55,10 @@ void ofApp::draw(){
 
 	ofSetColor(color);
 	if(twoCircles){
-		ofCircle(center->x-radius*.5, center->y, radius );
-		ofCircle(center->x+radius*.5, center->y, radius );
+		ofDrawCircle(center->x-radius*.5, center->y, radius );
+		ofDrawCircle(center->x+radius*.5, center->y, radius );
 	}else{
-		ofCircle((ofVec2f)center, radius );
+		ofDrawCircle((ofVec2f)center, radius );
 	}
 	
 	// auto draw?

--- a/examples/gui/guiExample/src/ofApp.cpp
+++ b/examples/gui/guiExample/src/ofApp.cpp
@@ -25,11 +25,11 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::exit(){
-	ringButton.removeListener(this,&ofApp::ringButtonPressed);
+	ringButton.removeListener(this, &ofApp::ringButtonPressed);
 }
 
 //--------------------------------------------------------------
-void ofApp::circleResolutionChanged(int & circleResolution){
+void ofApp::circleResolutionChanged(int &circleResolution){
 	ofSetCircleResolution(circleResolution);
 }
 

--- a/examples/gui/guiExample/src/ofApp.cpp
+++ b/examples/gui/guiExample/src/ofApp.cpp
@@ -20,7 +20,7 @@ void ofApp::setup(){
 
 	bHide = false;
 
-	ring.loadSound("ring.wav");
+	ring.load("ring.wav");
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -50,9 +50,9 @@ typedef struct FT_FaceRec_*  FT_Face;
 
 /// \name Fonts
 /// \{
-const static string OF_TTF_SANS = "sans-serif";
-const static string OF_TTF_SERIF = "serif";
-const static string OF_TTF_MONO = "monospace";
+static const string OF_TTF_SANS = "sans-serif";
+static const string OF_TTF_SERIF = "serif";
+static const string OF_TTF_MONO = "monospace";
 /// \}
 
 


### PR DESCRIPTION
**guiExample code consistency**: some small updates to resolve multiple coding styles and the use of multiple ifs instead of if else statements.

**OF_TTF string as static const**: this fixes a SWIG error when generating OF bindings (aka for ofxLua). Simply swapping "const static" with "static const" solves it. C++ doesn't care either way, so this change [shouldn't effect anything](http://stackoverflow.com/a/12006039/2146055). Besides, "static const" is the recommended order in C anyway.