### PR TITLE
Fix a typo

### DIFF
--- a/examples/gl/glInfoExample/src/ofApp.cpp
+++ b/examples/gl/glInfoExample/src/ofApp.cpp
@@ -172,7 +172,7 @@ void printGLInfo(){
     vendor =      (char*)glGetString(GL_VENDOR);
     renderer =    (char*)glGetString(GL_RENDERER);
 
-    cout << "version=" << version << "\nvendor=" << vendor << "\nrenderer=" << renderer\n";
+    cout << "version=" << version << "\nvendor=" << vendor << "\nrenderer=" << renderer << "\n";
 
 }
 


### PR DESCRIPTION
A typo which causes a compile-time error on VS 2013.