### PR TITLE
Add guard to avoid segfault on uninitialized Video Grabber

### DIFF
--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -334,5 +334,5 @@ float ofVideoGrabber::getWidth() const{
 
 //----------------------------------------------------------
 bool ofVideoGrabber::isInitialized() const{
-	return grabber->isInitialized() && (!bUseTexture || tex[0].isAllocated() || grabber->getTexturePtr());
+	return grabber && grabber->isInitialized() && (!bUseTexture || tex[0].isAllocated() || grabber->getTexturePtr());
 }


### PR DESCRIPTION
If the ofVideoGrabber is not initialized on application start the grabber member is null, resulting in a segmentation fault, if  we try to check for the initialization of object; The performance penality of this guard are negligible.