### PR TITLE
Fixes ofxOpenALSoundPlayer const issues

### DIFF
--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -223,15 +223,22 @@ void ofxOpenALSoundPlayer::setPaused(bool bP) {
 		return;
 	
 	if(iAmAnMp3)
-		cerr<<"error, cannot set pause on mp3s in openAL"<<endl; // TODO
+		ofLogError("Error, cannot set pause on mp3s in openAL"); // @todo
+		if(iAmAnMp3)
+			stopped = SoundEngine_getBackgroundMusicStopped();
+		if(!stopped) // if not stopped, run the update to see if maybe we should be...
+			update();
 	else {
-		bool isPlaying = isPlaying();
+		
+		bool isSoundPlaying = isPlaying();
 		bPaused = bP;
 		
-		if(bPaused && isPlaying)
+		if(bPaused && isSoundPlaying) {
 			SoundEngine_PauseEffect(myPrimedId);
-		else if(!bPaused && !isPlaying)
+			
+		} else if(!bPaused && !isSoundPlaying) {
 			play();
+		}
 	}
 }
 
@@ -303,7 +310,7 @@ float ofxOpenALSoundPlayer::getPosition() const {
 
 //--------------------------------------------------------------
 
-int ofxOpenALSoundPlayer::getPositionMS()  const{
+int ofxOpenALSoundPlayer::getPositionMS() const {
 	if ( !bLoadedOk ) 
 		return 0;
 
@@ -319,17 +326,15 @@ int ofxOpenALSoundPlayer::getPositionMS()  const{
 
 //--------------------------------------------------------------
 
-bool ofxOpenALSoundPlayer::isPlaying()  const{
+bool ofxOpenALSoundPlayer::isPlaying() const {
 	if ( !bLoadedOk ) 
 		return false;
-
+	
+	bool isMP3AndStopped = false;
 	if(iAmAnMp3)
-		stopped = SoundEngine_getBackgroundMusicStopped();
+		isMP3AndStopped = SoundEngine_getBackgroundMusicStopped();
 	
-	if(!stopped) // if not stopped, run the update to see if maybe we should be...
-		update();
-	
-	if(stopped || bPaused)
+	if(stopped || bPaused || isMP3AndStopped)
 		return false;
 	else
 		return true;


### PR DESCRIPTION
Fixes ofxOpenALSoundPlayer const issues associated with the new const changes for 0.9.

Picked up by Xcode under libc++. It has stricter compiler checking so this was an error.

Issue: Calling a non-const function (Update) and assigning a variable under a const function.

![openal](https://cloud.githubusercontent.com/assets/830748/7364295/48e01c8c-edc8-11e4-9a43-a682a8ea8de7.png)
