### PR TITLE
Fixes compiler errors for win32 version of ofxOSC.

### DIFF
--- a/addons/ofxOsc/libs/oscpack/src/ip/win32/UdpSocket.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/ip/win32/UdpSocket.cpp
@@ -114,8 +114,8 @@ public:
         }
 
         if( UdpSocket::maxBufferSize > 0 ){
-            setsockopt(socket_, SOL_SOCKET, SO_SNDBUF, &UdpSocket::maxBufferSize, sizeof(UdpSocket::maxBufferSize));
-            setsockopt(socket_, SOL_SOCKET, SO_RCVBUF, &UdpSocket::maxBufferSize, sizeof(UdpSocket::maxBufferSize));
+            setsockopt(socket_, SOL_SOCKET, SO_SNDBUF, (const char*)&UdpSocket::maxBufferSize, sizeof(UdpSocket::maxBufferSize));
+            setsockopt(socket_, SOL_SOCKET, SO_RCVBUF, (const char*)&UdpSocket::maxBufferSize, sizeof(UdpSocket::maxBufferSize));
         }
         
 		std::memset( &sendToAddr_, 0, sizeof(sendToAddr_) );
@@ -452,7 +452,7 @@ public:
                 maxSize = 4098;
             }
             const unsigned long MAX_BUFFER_SIZE = maxSize;
-            data = new char[ MAX_BUFFER_SIZE ];
+            char * data = new char[ MAX_BUFFER_SIZE ];
 		IpEndpointName remoteEndpoint;
 
 		while( !break_ ){


### PR DESCRIPTION
+ Does not affect posix systems (linux, OSX), since these compile against the `/posix` version of the affected `.cpp` file.

This adds a missing declaration and a (char *) cast to make the windows compiler happy. Otherwise apps using ofxOSC will not compile on Windows.