### PR TITLE
remove ofThreadLogger

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -69,7 +69,6 @@ void ofInit(){
 	static bool initialized = false;
 	if(initialized) return;
 	initialized = true;
-	Poco::ErrorHandler::set(new ofThreadErrorLogger);
 
 #if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
     // manage own exit

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -4,6 +4,10 @@
 #include "ofConstants.h"
 #include "ofFileUtils.h"
 #include "ofTypes.h"
+#ifdef TARGET_ANDROID
+#include <jni.h>
+JavaVM * ofGetJavaVMPtr();
+#endif
 
 /// \file
 /// ofLog provides an interface for writing text output from your app.
@@ -659,31 +663,6 @@ public:
 private:
 	ofFile file; ///< The location of the log file.
 	
-};
-
-
-/// \brief An error logger class used to catch exceptions inside of threads.
-class ofThreadErrorLogger: public Poco::ErrorHandler{
-public:
-	/// \brief Destroy the ofThreadErrorLogger.
-    virtual ~ofThreadErrorLogger(){}
-
-	/// \brief Catch an exception.
-	/// \param exc The exception.
-    virtual void exception(const Poco::Exception& exc){
-        ofLogFatalError("ofThreadErrorLogger::exception") << exc.displayText();
-    }
-
-	/// \brief Catch an exception.
-	/// \param exc The exception.
-    virtual void exception(const std::exception& exc){
-        ofLogFatalError("ofThreadErrorLogger::exception") << exc.what();
-    }
-
-	/// \brief Catch an exception.
-    virtual void exception(){
-        ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
-    }
 };
 
 /// \endcond

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -4,10 +4,6 @@
 #include "ofConstants.h"
 #include "ofFileUtils.h"
 #include "ofTypes.h"
-#ifdef TARGET_ANDROID
-#include <jni.h>
-JavaVM * ofGetJavaVMPtr();
-#endif
 
 /// \file
 /// ofLog provides an interface for writing text output from your app.

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -180,11 +180,19 @@ void ofThread::run(){
 #endif
 	// user function
     // should loop endlessly.
-	threadedFunction();
+	try{
+		threadedFunction();
+	}catch(const Poco::Exception& exc){
+        ofLogFatalError("ofThreadErrorLogger::exception") << exc.displayText();
+	}catch(const std::exception& exc){
+		ofLogFatalError("ofThreadErrorLogger::exception") << exc.what();
+	}catch(...){
+        ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
+	}
 
     _threadRunning = false;
 
-#if !defined(TARGET_WIN32) && !defined(TARGET_ANDROID)
+#if !defined(TARGET_WIN32)
 	// FIXME: this won't be needed once we update POCO https://github.com/pocoproject/poco/issues/79
 	if(!threadBeingWaitedFor){ //if threadedFunction() ended and the thread is not being waited for, detach it before exiting.
 		pthread_detach(pthread_self());

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -183,11 +183,11 @@ void ofThread::run(){
 	try{
 		threadedFunction();
 	}catch(const Poco::Exception& exc){
-        ofLogFatalError("ofThreadErrorLogger::exception") << exc.displayText();
+		ofLogFatalError("ofThreadErrorLogger::exception") << exc.displayText();
 	}catch(const std::exception& exc){
 		ofLogFatalError("ofThreadErrorLogger::exception") << exc.what();
 	}catch(...){
-        ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
+		ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
 	}
 
     _threadRunning = false;


### PR DESCRIPTION
instead catch the exceptions and log them locally on each thread.
simplifies the architecture and seems a better idea than having
some global state taking care of this.

i've just realized that ofThreadLogger and Poco's ErrorHandler is doing just this. i also wanted to make the thread detach itself if it failed which i would need to have done in ofThreadLogger.

i think this makes much more sense and simplifies things a bit but i might be missing something about what Poco's ErrorHandler is doing. ping @bakercp 