### PR TITLE
Revert "ofXml::setValue as int"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,6 @@ CORE
 	/ ofThread now uses Class name for logging channel (was thread name)
 	/ ofURLFileLoader: better shutdown, don't shutdown if it wasn't initialized + wait thread
 	/ ofXml: fixes crash on empty document
-	/ ofXml: added support for setValue as int
 	/ ofSystem: fix for second and later calls failing
 	+ ofThread argument for tryJoin time.
 	/ ofThread overall, documentation and example fixes

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -425,10 +425,6 @@ bool ofXml::setValue(const string& path, const string& value)
     }
 }
 
-bool ofXml::setValue(const string& path, const int& value){
-    return setValue(path, ofToString(value));
-}
-
 string ofXml::getAttribute(const string& path) const {
 
     Poco::XML::Node *e;

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -55,7 +55,6 @@ public:
     bool			getBoolValue(const string & path) const;
 
     bool            setValue(const string& path, const string& value);
-    bool            setValue(const string& path, const int& value);
     
     string          getAttribute(const string& path) const;
     bool            setAttribute(const string& path, const string& value);


### PR DESCRIPTION
Reverts openframeworks/openFrameworks#3711

The way it's implemented will cause ambiguity problems. we should have a templated version instead