### PR TITLE
fix addons.make not getting parsed properly

### DIFF
--- a/apps/devApps/projectGenerator/src/projects/baseProject.cpp
+++ b/apps/devApps/projectGenerator/src/projects/baseProject.cpp
@@ -173,16 +173,24 @@ void baseProject::addAddon(ofAddon & addon){
 
 void baseProject::parseAddons(){
 	ofFile addonsMake(ofFilePath::join(projectDir,"addons.make"));
-	ofBuffer addonsMakeMem;
-	addonsMake >> addonsMakeMem;
+    ofBuffer addonsMakeMem;
+    addonsMake >> addonsMakeMem;
+    
+    string line = addonsMakeMem.getFirstLine();
+    
 	while(!addonsMakeMem.isLastLine()){
-	    string line = addonsMakeMem.getNextLine();
-	    if(line[0] == '#') continue;
-		ofAddon addon;
-		cout << projectDir << endl;
-		addon.pathToOF = getOFRelPath(projectDir);
-		cout << addon.pathToOF << endl;
-		addon.fromFS(ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), line),target);
-		addAddon(addon);
+        
+        if (line.size() > 0){           // non empty line
+            if(line[0] != '#') {        // line is not a comment
+                ofAddon addon;
+                cout << projectDir << endl;
+                addon.pathToOF = getOFRelPath(projectDir);
+                cout << addon.pathToOF << endl;
+                addon.fromFS(ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), line),target);
+                addAddon(addon);
+            }
+        }
+        
+        line = addonsMakeMem.getNextLine();
 	}
 }

--- a/apps/devApps/projectGenerator/src/projects/baseProject.cpp
+++ b/apps/devApps/projectGenerator/src/projects/baseProject.cpp
@@ -183,9 +183,7 @@ void baseProject::parseAddons(){
         if (line.size() > 0){           // non empty line
             if(line[0] != '#') {        // line is not a comment
                 ofAddon addon;
-                cout << projectDir << endl;
                 addon.pathToOF = getOFRelPath(projectDir);
-                cout << addon.pathToOF << endl;
                 addon.fromFS(ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), line),target);
                 addAddon(addon);
             }

--- a/apps/devApps/projectGenerator/src/projects/xcodeProject.cpp
+++ b/apps/devApps/projectGenerator/src/projects/xcodeProject.cpp
@@ -128,6 +128,7 @@ STRINGIFY(
           <key>OTHER_LDFLAGS</key>
           <array>
           <string>$(OF_CORE_LIBS)</string>
+          <string>$(OF_CORE_FRAMEWORKS)</string>
           </array>
 
 );


### PR DESCRIPTION
I just pulled master and something seems broken with how the addons.make is getting parsed on OSX. 

@arturoc can you take a look at this small change (I wonder if any changes to ofBuffer line parsing might have contributed).  Essentially some OSX projects were generated without addons, because the iterating through ofBuffer was not totally working.  

happy to dig in further, I just did a minor re-write and this seems to help. 