### PR TITLE
Working Apothecary Formula for OpenCV 2.4 - iOS and OS X

### DIFF
--- a/addons/ofxOpenCv/scripts/formulas/OpenCV.sh
+++ b/addons/ofxOpenCv/scripts/formulas/OpenCV.sh
@@ -34,11 +34,52 @@ function download() {
 # prepare the build environment, executed inside the lib src dir
 function prepare() {
   : # noop
+
+  # Patch for Clang for 2.4
+  # https://github.com/Itseez/opencv/commit/35f96d6da76099d80180439c857a4abe5cb17966
+  cd modules/legacy/src
+  if patch -p0 -u -N --dry-run --silent < $FORMULA_DIR/patch.calibfilter.cpp.patch 2>/dev/null ; then
+      patch -p0 -u < $FORMULA_DIR/patch.calibfilter.cpp.patch
+  fi
+  cd ../../../
 }
  
 function build_osx() {
+
+  SDKVERSION=`xcrun -sdk iphoneos --show-sdk-version` 
+  set -e
+  CURRENTPATH=`pwd`
+
+  echo "--------------------"
+  echo $CURRENTPATH
+  # Validate environment
+  case $XCODE_DEV_ROOT in  
+       *\ * )
+             echo "Your Xcode path contains whitespaces, which is not supported."
+             exit 1
+            ;;
+  esac
+  case $CURRENTPATH in  
+       *\ * )
+             echo "Your path contains whitespaces, which is not supported by 'make install'."
+             exit 1
+            ;;
+  esac 
+
+  mkdir -p "$CURRENTPATH/build/$TYPE/"
   
+  echo "--------------------"
+
+  isBuilding=true;
+ 
+
+  echo "Running cmake"
   if [ "$1" == "64" ] ; then
+    LOG="$CURRENTPATH/build/$TYPE/opencv2-x86_64-${VER}.log"
+    echo "Log:" >> "${LOG}" 2>&1
+    while $isBuilding; do theTail="$(tail -n 1 ${LOG})"; echo $theTail | cut -c -70 ; echo "...";sleep 30; done & # fix for 10 min time out travis
+
+    set +e
     cmake . -DCMAKE_INSTALL_PREFIX=$LIB_FOLDER64 \
       -DGLFW_BUILD_UNIVERSAL=ON \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 \
@@ -56,8 +97,12 @@ function build_osx() {
       -DBUILD_opencv_java=OFF \
       -DBUILD_opencv_python=OFF \
       -DBUILD_opencv_apps=OFF \
+      -DBUILD_JPEG=OFF \
+      -DBUILD_PNG=OFF \
       -DWITH_1394=OFF \
       -DWITH_CARBON=OFF \
+      -DWITH_JPEG=OFF \
+      -DWITH_PNG=OFF \
       -DWITH_FFMPEG=OFF \
       -DWITH_OPENCL=OFF \
       -DWITH_OPENCLAMDBLAS=OFF \
@@ -75,8 +120,22 @@ function build_osx() {
       -DWITH_V4L=OFF \
       -DWITH_PVAPI=OFF \
       -DBUILD_TESTS=OFF \
-      -DBUILD_PERF_TESTS=OFF
+      -DBUILD_PERF_TESTS=OFF >> "${LOG}" 2>&1
+
+      if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while CMAKE - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "CMAKE Successful for x86_64"
+      fi
   elif [ "$1" == "32" ] ; then
+    LOG="$CURRENTPATH/build/$TYPE/opencv2-i386-${VER}.log"
+    while $isBuilding; do theTail="$(tail -n 1 ${LOG})"; echo $theTail | cut -c -70 ; echo "...";sleep 30; done & # fix for 10 min time out travis
+    echo "Log:" >> "${LOG}" 2>&1
+    set +e
     # NB - using a special BUILD_ROOT_DIR
     cmake . -DCMAKE_INSTALL_PREFIX=$LIB_FOLDER32 \
       -DGLFW_BUILD_UNIVERSAL=ON \
@@ -95,6 +154,8 @@ function build_osx() {
       -DBUILD_opencv_java=OFF \
       -DBUILD_opencv_python=OFF \
       -DBUILD_opencv_apps=OFF \
+      -DBUILD_JPEG=OFF \
+      -DBUILD_PNG=OFF \
       -DWITH_1394=OFF \
       -DWITH_CARBON=OFF \
       -DWITH_FFMPEG=OFF \
@@ -105,6 +166,8 @@ function build_osx() {
       -DWITH_CUDA=OFF \
       -DWITH_CUFFT=OFF \
       -DWITH_JASPER=OFF \
+      -DWITH_JPEG=OFF \
+      -DWITH_PNG=OFF \
       -DWITH_LIBV4L=OFF \
       -DWITH_IMAGEIO=OFF \
       -DWITH_IPP=OFF \
@@ -114,89 +177,62 @@ function build_osx() {
       -DWITH_V4L=OFF \
       -DWITH_PVAPI=OFF \
       -DBUILD_TESTS=OFF \
-      -DBUILD_PERF_TESTS=OFF
+      -DBUILD_PERF_TESTS=OFF >> "${LOG}" 2>&1
+
+      if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while CMAKE - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "CMAKE Successful for i386"
+      fi
   fi
+
+  echo "--------------------"
+  echo "Running make clean"
  
-  make clean
-  make
-  make install
-}
-
-function build_ios() {
-
-  iosSDK="7.1"
-  iosPlatform="iPhoneOS"
-  arch="armv7"
-  isSimulator="FALSE";
-  effectivePlatforms="-iphoneos;"
-
-  targetFolder=$LIB_FOLDER_IOS
-
-  if [ "$1" == "i386" ] ; then
-    arch="i386"
-    iosPlatform="iPhoneSimulator"
-    targetFolder=$LIB_FOLDER_IOS_SIM
-    isSimulator="TRUE"
-    effectivePlatforms="-iphonesimulator;"
+  make clean >> "${LOG}" 2>&1
+  if [ $? != 0 ];
+    then
+      tail -n 10 "${LOG}"
+      echo "Problem while make clean- Please check ${LOG}"
+      exit 1
+    else
+      tail -n 10 "${LOG}"
+      echo "Make Clean Successful"
   fi
 
-  iosPlatSDK="$iosPlatform$iosSDK.sdk"
+  echo "--------------------"
+  echo "Running make"
+  make >> "${LOG}" 2>&1
+  if [ $? != 0 ];
+    then
+      tail -n 10 "${LOG}"
+      echo "Problem while make - Please check ${LOG}"
+      exit 1
+    else
+      tail -n 10 "${LOG}"
+      echo "Make  Successful"
+  fi
+  echo "--------------------"
+  echo "Running make install"
+  make install >> "${LOG}" 2>&1
+    if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while make install - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "Make install Successful"
+    fi
 
-  #-miphoneos-version-min is REALLY needed to cmake allows you to build for simulator
-
-    cmake . -DCMAKE_INSTALL_PREFIX=$targetFolder \
-      -DIOS=1 \
-      -DAPPLE=1 \
-      -DUNIX=1 \
-      -DIPHONESIMULATOR="TRUE" \
-      -DCMAKE_CXX_COMPILER_WORKS="TRUE" \
-      -DCMAKE_C_COMPILER_WORKS="TRUE" \
-      -DSDKVER="$iosSDK" \
-      -DCMAKE_IOS_DEVELOPER_ROOT="/Applications/Xcode.app/Contents/Developer/Platforms/$iosPlatform.platform/Developer" \
-      -DDEVROOT="/Applications/Xcode.app/Contents/Developer/Platforms/$iosPlatform.platform/Developer" \
-      -DSDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/$iosPlatform.platform/Developer/SDKs/$iosPlatSDK" \
-      -DCMAKE_OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/$iosPlatform.platform/Developer/SDKs/$iosPlatSDK" \
-      -DCMAKE_OSX_ARCHITECTURES="$arch" \
-      -DCMAKE_XCODE_EFFECTIVE_PLATFORMS="$effectivePlatforms" \
-      -DGLFW_BUILD_UNIVERSAL=ON \
-      -DENABLE_FAST_MATH=ON \
-      -DCMAKE_CXX_FLAGS="-stdlib=libc++ -fvisibility=hidden -fvisibility-inlines-hidden -DNDEBUG -O3 -fomit-frame-pointer -ffast-math -miphoneos-version-min=5.0" \
-      -DCMAKE_C_FLAGS="-stdlib=libc++ -fvisibility=hidden -fvisibility-inlines-hidden -DNDEBUG -O3 -fomit-frame-pointer -ffast-math -miphoneos-version-min=5.0" \
-      -DCMAKE_BUILD_TYPE="Release" \
-      -DBUILD_SHARED_LIBS=OFF \
-      -DBUILD_DOCS=OFF \
-      -DBUILD_EXAMPLES=OFF \
-      -DBUILD_FAT_JAVA_LIB=OFF \
-      -DBUILD_JASPER=OFF \
-      -DBUILD_PACKAGE=OFF \
-      -DBUILD_opencv_java=OFF \
-      -DBUILD_opencv_python=OFF \
-      -DBUILD_opencv_apps=OFF \
-      -DWITH_1394=OFF \
-      -DWITH_CARBON=OFF \
-      -DWITH_FFMPEG=OFF \
-      -DWITH_OPENCL=OFF \
-      -DWITH_OPENCLAMDBLAS=OFF \
-      -DWITH_OPENCLAMDFFT=OFF \
-      -DWITH_GIGEAPI=OFF \
-      -DWITH_CUDA=OFF \
-      -DWITH_CUFFT=OFF \
-      -DWITH_JASPER=OFF \
-      -DWITH_LIBV4L=OFF \
-      -DWITH_IMAGEIO=OFF \
-      -DWITH_IPP=OFF \
-      -DWITH_OPENNI=OFF \
-      -DWITH_QT=OFF \
-      -DWITH_QUICKTIME=OFF \
-      -DWITH_V4L=OFF \
-      -DWITH_PVAPI=OFF \
-      -DBUILD_TESTS=OFF \
-      -DBUILD_PERF_TESTS=OFF
-
-  make clean
-  make
-  make install
+    isBuilding=false;
 }
+
+
 
 
 function make_universal_binary() {
@@ -246,8 +282,8 @@ function build() {
     rm -f CMakeCache.txt
     build_osx "32";
 
-	mkdir -p $LIB_FOLDER/include
-	mkdir -p $LIB_FOLDER/lib
+	 mkdir -p $LIB_FOLDER/include
+	 mkdir -p $LIB_FOLDER/lib
  
     # lipo shit together
     make_universal_binary "$LIB_FOLDER64" "$LIB_FOLDER32" "$LIB_FOLDER" 
@@ -262,26 +298,245 @@ function build() {
     local LIB_FOLDER_IOS="$BUILD_ROOT_DIR/$TYPE/iOS/OpenCv"
     local LIB_FOLDER_IOS_SIM="$BUILD_ROOT_DIR/$TYPE/iOS_SIMULATOR/OpenCv"
 
-    # 64-bit OF transition, build x86-64 and i386 separately
-    rm -f CMakeCache.txt
-    build_ios "i386";
+
+    # This was quite helpful as a reference: https://github.com/x2on/OpenSSL-for-iPhone
+    # Refer to the other script if anything drastic changes for future versions
+    SDKVERSION=`xcrun -sdk iphoneos --show-sdk-version` 
+    set -e
+    CURRENTPATH=`pwd`
+    
+    DEVELOPER=$XCODE_DEV_ROOT
+    TOOLCHAIN=${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain
+    VERSION=$VER
+
+    local IOS_ARCHS="i386 x86_64 armv7 arm64" #armv7s
+    local STDLIB="libc++"
+    echo "--------------------"
+    echo $CURRENTPATH
+
+
+
+    # Validate environment
+    case $XCODE_DEV_ROOT in  
+         *\ * )
+               echo "Your Xcode path contains whitespaces, which is not supported."
+               exit 1
+              ;;
+    esac
+    case $CURRENTPATH in  
+         *\ * )
+               echo "Your path contains whitespaces, which is not supported by 'make install'."
+               exit 1
+              ;;
+    esac 
+
+
+
+    export THECOMPILER=$TOOLCHAIN/usr/bin
+     
+    
+
+      # loop through architectures! yay for loops!
+    for IOS_ARCH in ${IOS_ARCHS}
+    do
+      # make sure backed up
+       rm -f CMakeCache.txt
+      MIN_IOS_VERSION=$IOS_MIN_SDK_VER
+        # min iOS version for arm64 is iOS 7
+
+        if [[ "${IOS_ARCH}" == "arm64" || "${IOS_ARCH}" == "x86_64" ]]; then
+          MIN_IOS_VERSION=7.0 # 7.0 as this is the minimum for these architectures
+        elif [ "${IOS_ARCH}" == "i386" ]; then
+          MIN_IOS_VERSION=5.1 # 6.0 to prevent start linking errors
+        fi
+        export IPHONE_SDK_VERSION_MIN=$IOS_MIN_SDK_VER
+
+      
+      echo "The compiler: $THECOMPILER"
+      MIN_TYPE=-miphoneos-version-min=
+      if [[ "${IOS_ARCH}" == "i386" || "${IOS_ARCH}" == "x86_64" ]];
+      then
+        PLATFORM="iPhoneSimulator"
+        ISSIM="TRUE"
+        MIN_TYPE=-mios-simulator-version-min=
+      else
+        PLATFORM="iPhoneOS"
+        ISSIM="FALSE"
+      fi
+
+      
+      export CROSS_TOP="${DEVELOPER}/Platforms/${PLATFORM}.platform/Developer"
+      export CROSS_SDK="${PLATFORM}${SDKVERSION}.sdk"
+      export BUILD_TOOLS="${DEVELOPER}"
+
+      mkdir -p "$CURRENTPATH/build/$TYPE/$IOS_ARCH"
+      LOG="$CURRENTPATH/build/$TYPE/$IOS_ARCH/opencv2-$IOS_ARCH-${VER}.log"
+      set +e
+
+
+      isBuilding=true;
+      echo "Log:" >> "${LOG}" 2>&1
+      while $isBuilding; do theTail="$(tail -n 1 ${LOG})"; echo $theTail | cut -c -70 ; echo "...";sleep 30; done & # fix for 10 min time out travis
+
+
+
+      cmake . -DCMAKE_INSTALL_PREFIX="$CURRENTPATH/build/$TYPE/$IOS_ARCH" \
+      -DIOS=1 \
+      -DAPPLE=1 \
+      -DUNIX=1 \
+      -DCMAKE_CXX_COMPILER=$THECOMPILER/clang++ \
+      -DCMAKE_CC_COMPILER=$THECOMPILER/clang \
+      -DIPHONESIMULATOR=$ISSIM \
+      -DCMAKE_CXX_COMPILER_WORKS="TRUE" \
+      -DCMAKE_C_COMPILER_WORKS="TRUE" \
+      -DSDKVER="${SDKVERSION}" \
+      -DCMAKE_IOS_DEVELOPER_ROOT="${CROSS_TOP}" \
+      -DDEVROOT="${CROSS_TOP}" \
+      -DSDKROOT="${CROSS_SDK}" \
+      -DCMAKE_OSX_SYSROOT="${CROSS_TOP}/SDKs/${CROSS_SDK}" \
+      -DCMAKE_OSX_ARCHITECTURES="${IOS_ARCH}" \
+      -DCMAKE_XCODE_EFFECTIVE_PLATFORMS="-$PLATFORM" \
+      -DGLFW_BUILD_UNIVERSAL=ON \
+      -DENABLE_FAST_MATH=ON \
+      -DCMAKE_CXX_FLAGS="-stdlib=libc++ -fvisibility=hidden -fPIC -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -fvisibility-inlines-hidden -DNDEBUG -Os -fomit-frame-pointer -ffast-math $MIN_TYPE$IPHONE_SDK_VERSION_MIN" \
+      -DCMAKE_C_FLAGS="-stdlib=libc++ -fvisibility=hidden -fPIC -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -fvisibility-inlines-hidden -DNDEBUG -Os -fomit-frame-pointer -ffast-math $MIN_TYPE$IPHONE_SDK_VERSION_MIN"  \
+      -DCMAKE_BUILD_TYPE="Release" \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_DOCS=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_FAT_JAVA_LIB=OFF \
+      -DBUILD_JASPER=OFF \
+      -DBUILD_PACKAGE=OFF \
+      -DBUILD_opencv_java=OFF \
+      -DBUILD_opencv_python=OFF \
+      -DBUILD_opencv_apps=OFF \
+      -DBUILD_JPEG=OFF \
+      -DBUILD_PNG=OFF \
+      -DWITH_1394=OFF \
+      -DWITH_JPEG=OFF \
+      -DWITH_PNG=OFF \
+      -DWITH_CARBON=OFF \
+      -DWITH_FFMPEG=OFF \
+      -DWITH_OPENCL=OFF \
+      -DWITH_OPENCLAMDBLAS=OFF \
+      -DWITH_OPENCLAMDFFT=OFF \
+      -DWITH_GIGEAPI=OFF \
+      -DWITH_CUDA=OFF \
+      -DWITH_CUFFT=OFF \
+      -DWITH_JASPER=OFF \
+      -DWITH_LIBV4L=OFF \
+      -DWITH_IMAGEIO=OFF \
+      -DWITH_IPP=OFF \
+      -DWITH_OPENNI=OFF \
+      -DWITH_QT=OFF \
+      -DWITH_QUICKTIME=OFF \
+      -DWITH_V4L=OFF \
+      -DWITH_PVAPI=OFF \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_PERF_TESTS=OFF >> "${LOG}" 2>&1
+
+      if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while CMAKE - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "CMAKE Successful for ${IOS_ARCH}"
+      fi
+
+    echo "--------------------"
+    echo "Running make clean for ${IOS_ARCH}"
+    make clean >> "${LOG}" 2>&1
+    if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while make clean- Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "Make Clean Successful for ${IOS_ARCH}"
+    fi
+
+    echo "--------------------"
+    echo "Running make for ${IOS_ARCH}"
+    make >> "${LOG}" 2>&1
+    if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while make - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "Make  Successful for ${IOS_ARCH}"
+    fi
+
+    echo "--------------------"
+    echo "Running make install for ${IOS_ARCH}"
+    make install >> "${LOG}" 2>&1
+    if [ $? != 0 ];
+      then
+        tail -n 10 "${LOG}"
+        echo "Problem while make install - Please check ${LOG}"
+        exit 1
+      else
+        tail -n 10 "${LOG}"
+        echo "Make install Successful for ${IOS_ARCH}"
+    fi
 
     rm -f CMakeCache.txt
-    build_ios "armv7";
+    unset CROSS_TOP CROSS_SDK BUILD_TOOLS
+    isBuilding=false;
 
-	mkdir -p $LIB_FOLDER/include
-	mkdir -p $LIB_FOLDER/lib
 
-    make_universal_binary "$LIB_FOLDER_IOS" "$LIB_FOLDER_IOS_SIM" "$LIB_FOLDER"
+    done
 
-    # copy headers
-    cp -R $LIB_FOLDER_IOS/include/opencv $LIB_FOLDER/include/opencv
-    cp -R $LIB_FOLDER_IOS/include/opencv2 $LIB_FOLDER/include/opencv2
+    mkdir -p lib/$TYPE
+    echo "--------------------"
+    echo "Creating Fat Libs"
+    cd build/iOS
+    # link into universal lib, strip "lib" from filename
+    local lib
+    rm -rf i386/lib/pkgconfig
 
-  fi
+    for lib in $( ls -1 i386/lib) ; do
+      local renamedLib=$(echo $lib | sed 's|lib||')
+      if [ ! -e $renamedLib ] ; then
+        lipo -c armv7/lib/$lib arm64/lib/$lib i386/lib/$lib x86_64/lib/$lib -o "$CURRENTPATH/lib/$TYPE/$renamedLib"
+      fi
+    done
+
+    cd ../../
+    echo "--------------------"
+    echo "Copying includes"
+    cp -R "build/$TYPE/x86_64/include/" "lib/include/"
+
+    echo "--------------------"
+    echo "Stripping any lingering symbols"
+
+    cd lib/$TYPE
+    SLOG="$CURRENTPATH/lib/$TYPE-stripping.log"
+    local TOBESTRIPPED
+    for TOBESTRIPPED in $( ls -1) ; do
+      strip -x $TOBESTRIPPED >> "${SLOG}" 2>&1
+      if [ $? != 0 ];
+        then
+          tail -n 100 "${SLOG}"
+          echo "Problem while stripping lib - Please check ${SLOG}"
+          exit 1
+        else
+          echo "Strip Successful for ${SLOG}"
+        fi
+    done
+
+    cd ../../
+
+  # end if iOS
+  fi 
 
 }
- 
+
+
 # executed inside the lib src dir, first arg $1 is the dest libs dir root
 function copy() {
 
@@ -305,13 +560,13 @@ function copy() {
   if [ "$TYPE" == "ios" ] ; then
     # Standard *nix style copy.
     # copy headers
-    cp -R $LIB_FOLDER/include/ $1/include/
- 
-    # copy lib
-    cp -R $LIB_FOLDER/lib/opencv.a $1/lib/$TYPE/
+
+    cp -Rv lib/include/ $1/include/
+    mkdir -p $1/lib/$TYPE
+    cp -v lib/$TYPE/*.a $1/lib/$TYPE
   fi
 
-  # copy license files
+  # copy license file
   rm -rf $1/license # remove any older files if exists
   mkdir -p $1/license
   cp -v LICENSE $1/license/

--- a/addons/ofxOpenCv/scripts/formulas/patch.calibfilter.cpp.patch
+++ b/addons/ofxOpenCv/scripts/formulas/patch.calibfilter.cpp.patch
@@ -1,0 +1,145 @@
+--- calibfilter.cpp
++++ calibfilter.cpp
+@@ -95,11 +95,8 @@ bool CvCalibFilter::SetEtalon( CvCalibEtalonType type, double* params,
+ 
+     Stop();
+ 
+-    if (latestPoints != NULL)
+-    {
+-        for( i = 0; i < MAX_CAMERAS; i++ )
+-            cvFree( latestPoints + i );
+-    }
++    for( i = 0; i < MAX_CAMERAS; i++ )
++        cvFree( latestPoints + i );
+ 
+     if( type == CV_CALIB_ETALON_USER || type != etalonType )
+     {
+@@ -333,12 +330,6 @@ void CvCalibFilter::Stop( bool calibrate )
+                                    points[0],points[1],
+                                    buffer,
+                                    &stereo);
+-
+-                for( i = 0; i < 9; i++ )
+-                {
+-                    stereo.fundMatr[i] = stereo.fundMatr[i];
+-                }
+-
+             }
+ 
+         }
+@@ -529,64 +520,61 @@ void CvCalibFilter::DrawPoints( CvMat** dstarr )
+         return;
+     }
+ 
+-    if( latestCounts )
++    for( i = 0; i < cameraCount; i++ )
+     {
+-        for( i = 0; i < cameraCount; i++ )
++        if( dstarr[i] && latestCounts[i] )
+         {
+-            if( dstarr[i] && latestCounts[i] )
+-            {
+-                CvMat dst_stub, *dst;
+-                int count = 0;
+-                bool found = false;
+-                CvPoint2D32f* pts = 0;
++            CvMat dst_stub, *dst;
++            int count = 0;
++            bool found = false;
++            CvPoint2D32f* pts = 0;
+ 
+-                GetLatestPoints( i, &pts, &count, &found );
++            GetLatestPoints( i, &pts, &count, &found );
+ 
+-                dst = cvGetMat( dstarr[i], &dst_stub );
++            dst = cvGetMat( dstarr[i], &dst_stub );
+ 
+-                static const CvScalar line_colors[] =
+-                {
+-                    {{0,0,255}},
+-                    {{0,128,255}},
+-                    {{0,200,200}},
+-                    {{0,255,0}},
+-                    {{200,200,0}},
+-                    {{255,0,0}},
+-                    {{255,0,255}}
+-                };
+-
+-                const int colorCount = sizeof(line_colors)/sizeof(line_colors[0]);
+-                const int r = 4;
+-                CvScalar color = line_colors[0];
+-                CvPoint prev_pt = { 0, 0};
+-
+-                for( j = 0; j < count; j++ )
+-                {
+-                    CvPoint pt;
+-                    pt.x = cvRound(pts[j].x);
+-                    pt.y = cvRound(pts[j].y);
++            static const CvScalar line_colors[] =
++            {
++                {{0,0,255}},
++                {{0,128,255}},
++                {{0,200,200}},
++                {{0,255,0}},
++                {{200,200,0}},
++                {{255,0,0}},
++                {{255,0,255}}
++            };
++
++            const int colorCount = sizeof(line_colors)/sizeof(line_colors[0]);
++            const int r = 4;
++            CvScalar color = line_colors[0];
++            CvPoint prev_pt = { 0, 0};
++
++            for( j = 0; j < count; j++ )
++            {
++                CvPoint pt;
++                pt.x = cvRound(pts[j].x);
++                pt.y = cvRound(pts[j].y);
+ 
+-                    if( found )
+-                    {
+-                        if( etalonType == CV_CALIB_ETALON_CHESSBOARD )
+-                            color = line_colors[(j/cvRound(etalonParams[0]))%colorCount];
+-                        else
+-                            color = CV_RGB(0,255,0);
++                if( found )
++                {
++                    if( etalonType == CV_CALIB_ETALON_CHESSBOARD )
++                        color = line_colors[(j/cvRound(etalonParams[0]))%colorCount];
++                    else
++                        color = CV_RGB(0,255,0);
+ 
+-                        if( j != 0 )
+-                            cvLine( dst, prev_pt, pt, color, 1, CV_AA );
+-                    }
++                    if( j != 0 )
++                        cvLine( dst, prev_pt, pt, color, 1, CV_AA );
++                }
+ 
+-                    cvLine( dst, cvPoint( pt.x - r, pt.y - r ),
+-                            cvPoint( pt.x + r, pt.y + r ), color, 1, CV_AA );
++                cvLine( dst, cvPoint( pt.x - r, pt.y - r ),
++                        cvPoint( pt.x + r, pt.y + r ), color, 1, CV_AA );
+ 
+-                    cvLine( dst, cvPoint( pt.x - r, pt.y + r),
+-                            cvPoint( pt.x + r, pt.y - r), color, 1, CV_AA );
++                cvLine( dst, cvPoint( pt.x - r, pt.y + r),
++                        cvPoint( pt.x + r, pt.y - r), color, 1, CV_AA );
+ 
+-                    cvCircle( dst, pt, r+1, color, 1, CV_AA );
++                cvCircle( dst, pt, r+1, color, 1, CV_AA );
+ 
+-                    prev_pt = pt;
+-                }
++                prev_pt = pt;
+             }
+         }
+     }
+@@ -918,4 +906,4 @@ bool CvCalibFilter::Undistort( CvMat** srcarr, CvMat** dstarr )
+ 
+ 
+     return true;
+-}
++}
+


### PR DESCRIPTION
iOS : [![Build Status](https://travis-ci.org/danoli3/apothecary-den.svg?branch=opencv-ios)](https://travis-ci.org/danoli3/apothecary-den?branch=opencv-ios) https://travis-ci.org/danoli3/apothecary-den?branch=opencv-ios
OS X:  [![Build Status](https://travis-ci.org/danoli3/apothecary-den.svg?branch=opencv-osx)](https://travis-ci.org/danoli3/apothecary-den?branch=opencv-osx) https://travis-ci.org/danoli3/apothecary-den?branch=opencv-osx


- Works for iOS armv7, arm64, i386, x86_64 - clang with libc++
- OS X i386 libstdc++, OS X x86_64 with libc++

Fixed symbolic error conflicts with libPNG / libJPEG.
Implemented iOS build script

Tested and working with more recent 2.4 minor OpenCV versions as well with minimal changes from this.

Includes patch file for 2.4 that is required to compile under 3.3+ versions of stricter clang compiler. (patch derived from OpenCV pull request that is merged in more recent versions.