### PR TITLE
change denominator of ofRandomuf from float to double.

### DIFF
--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -46,24 +46,24 @@ void ofSeedRandom(int val) {
 
 //--------------------------------------------------
 float ofRandom(float max) {
-	return (max * (rand() / float(RAND_MAX))) * (1.0f - std::numeric_limits<float>::epsilon());
+	return (max * rand() / float(RAND_MAX)) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandom(float x, float y) {
 	float high = MAX(x, y);
 	float low = MIN(x, y);
-	return max(low, (low + ((high - low) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon()));
+	return max(low, (low + ((high - low) * rand() / float(RAND_MAX))) * (1.0f - std::numeric_limits<float>::epsilon()));
 }
 
 //--------------------------------------------------
 float ofRandomf() {
-	return -1.0f + 2.0f * (rand() / float(RAND_MAX)) * (1.0f - std::numeric_limits<float>::epsilon());
+	return -1.0f + (2.0f * rand() / float(RAND_MAX)) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandomuf() {
-	return rand() / float(RAND_MAX) * (1.0f - std::numeric_limits<float>::epsilon());
+	return (rand() / float(RAND_MAX)) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //---- new to 006

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -46,27 +46,24 @@ void ofSeedRandom(int val) {
 
 //--------------------------------------------------
 float ofRandom(float max) {
-	if(max == 0.0f) return 0.0f;
-	return MIN(0.0f, max) + ((fabs(max) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon());
+	return (max * (rand() / float(RAND_MAX))) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandom(float x, float y) {
-	// if there is no range, return the value
-	if (x == y) return x;           // float == ?, wise? epsilon?
-	float high = MAX(x,y);
-	float low = MIN(x,y);
-	return low + (((high - low) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon());
+	float high = MAX(x, y);
+	float low = MIN(x, y);
+	return max(low, (low + ((high - low) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon()));
 }
 
 //--------------------------------------------------
 float ofRandomf() {
-	return 2.0 * rand() / float(RAND_MAX) * (1.0f-std::numeric_limits<float>::epsilon()) - 1.0f;
+	return -1.0f + 2.0f * (rand() / float(RAND_MAX)) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandomuf() {
-	return rand() / float(RAND_MAX) * (1.0f-std::numeric_limits<float>::epsilon());
+	return rand() / float(RAND_MAX) * (1.0f - std::numeric_limits<float>::epsilon());
 }
 
 //---- new to 006

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -51,15 +51,15 @@ float ofRandom(float max) {
 
 //--------------------------------------------------
 float ofRandom(float x, float y) {
+    static constexpr float epsilon_smaller = 1.0f - FLT_EPSILON,
+                           float_rand_max = static_cast<float>(RAND_MAX);
 	// if there is no range, return the value
-	if (x == y) return x;
+	if (fabsf(x - y) < FLT_EPSILON) return x;
 	float high = MAX(x, y);
 	float low = MIN(x, y);
-	float range = high - low;
-	range -= std::numeric_limits<float>::epsilon();
-	float denominator = RAND_MAX / range;
-	float result = rand() / denominator;
-	result += low;
+    float range = high - low;
+	float result = rand() / float_rand_max * range;
+	result = result * epsilon_smaller + low;
 	return result;
 }
 

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -46,26 +46,31 @@ void ofSeedRandom(int val) {
 
 //--------------------------------------------------
 float ofRandom(float max) {
-	return max * ofRandomuf();
+	return ofRandom(0.0f, max);
 }
 
 //--------------------------------------------------
 float ofRandom(float x, float y) {
 	// if there is no range, return the value
-	if (x == y) return x; 			// float == ?, wise? epsilon?
-	float high = MAX(x,y);
-	float low = MIN(x,y);
-	return low + ((high - low) * ofRandomuf());
+	if (x == y) return x;
+	float high = MAX(x, y);
+	float low = MIN(x, y);
+	float range = high - low;
+	range -= std::numeric_limits<float>::epsilon();
+	float denominator = RAND_MAX / range;
+	float result = rand() / denominator;
+	result += low;
+	return result;
 }
 
 //--------------------------------------------------
 float ofRandomf() {
-	return ofRandomuf() * 2.0f - 1.0f;
+	return ofRandom(-1.0f, 1.0f);
 }
 
 //--------------------------------------------------
 float ofRandomuf() {
-	return rand() / (static_cast<double>(RAND_MAX) + 1.0);
+	return ofRandom(1.0f);
 }
 
 //---- new to 006

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -46,7 +46,7 @@ void ofSeedRandom(int val) {
 
 //--------------------------------------------------
 float ofRandom(float max) {
-	return max * rand() / (RAND_MAX + 1.0f);
+	return max * ofRandomuf();
 }
 
 //--------------------------------------------------
@@ -55,17 +55,17 @@ float ofRandom(float x, float y) {
 	if (x == y) return x; 			// float == ?, wise? epsilon?
 	float high = MAX(x,y);
 	float low = MIN(x,y);
-	return low + ((high - low) * rand() / (RAND_MAX + 1.0f));
+	return low + ((high - low) * ofRandomuf());
 }
 
 //--------------------------------------------------
 float ofRandomf() {
-	return rand() / (RAND_MAX + 1.0f) * 2.0f - 1.0f;
+	return ofRandomuf() * 2.0f - 1.0f;
 }
 
 //--------------------------------------------------
 float ofRandomuf() {
-	return rand() / (RAND_MAX + 1.0f);
+	return rand() / (static_cast<double>(RAND_MAX) + 1.0);
 }
 
 //---- new to 006

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -46,31 +46,27 @@ void ofSeedRandom(int val) {
 
 //--------------------------------------------------
 float ofRandom(float max) {
-	return ofRandom(0.0f, max);
+	if(max == 0.0f) return 0.0f;
+	return MIN(0.0f, max) + ((fabs(max) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandom(float x, float y) {
-    static constexpr float epsilon_smaller = 1.0f - FLT_EPSILON,
-                           float_rand_max = static_cast<float>(RAND_MAX);
 	// if there is no range, return the value
-	if (fabsf(x - y) < FLT_EPSILON) return x;
-	float high = MAX(x, y);
-	float low = MIN(x, y);
-    float range = high - low;
-	float result = rand() / float_rand_max * range;
-	result = result * epsilon_smaller + low;
-	return result;
+	if (x == y) return x;           // float == ?, wise? epsilon?
+	float high = MAX(x,y);
+	float low = MIN(x,y);
+	return low + (((high - low) * rand() / float(RAND_MAX))) * (1.0f-std::numeric_limits<float>::epsilon());
 }
 
 //--------------------------------------------------
 float ofRandomf() {
-	return ofRandom(-1.0f, 1.0f);
+	return 2.0 * rand() / float(RAND_MAX) * (1.0f-std::numeric_limits<float>::epsilon()) - 1.0f;
 }
 
 //--------------------------------------------------
 float ofRandomuf() {
-	return ofRandom(1.0f);
+	return rand() / float(RAND_MAX) * (1.0f-std::numeric_limits<float>::epsilon());
 }
 
 //---- new to 006


### PR DESCRIPTION
change from `(RAND_MAX + 1.0f)` to `(static_cast<double>(RAND_MAX) + 1.0)`.

Because, if RAND_MAX is sufficiently large as larger than float precision, then `RAND_MAX + 1.0f == RAND_MAX`.
In other words, often `rand() / (RAND_MAX + 1.0f)` returns `1.0f`

And, added `static_cast<double>` to clarify the meaning.

At the same time, replace same codes like `rand() / (RAND_MAX + 1.0f)` to `ofRandomuf()`.
Maybe this tiny code will be inline expanded automatically when compiling.

more discussion about this: please see #3762
