### PR TITLE
Apothecary - FreeImage Formula Updated with NDEBUG (No Assertions).

### DIFF
--- a/scripts/apothecary/formulas/FreeImage/FreeImage.sh
+++ b/scripts/apothecary/formulas/FreeImage/FreeImage.sh
@@ -191,7 +191,7 @@ function build() {
 			export EXTRA_PLATFORM_LDFLAGS="$EXTRA_PLATFORM_LDFLAGS -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -Wl,-dead_strip -I${CROSS_TOP}/SDKs/${CROSS_SDK}/usr/include/ $MIN_TYPE$MIN_IOS_VERSION "
 
 		   	EXTRA_LINK_FLAGS="-arch $IOS_ARCH -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -Wno-trigraphs -fpascal-strings -Os -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-shorten-64-to-32 -Wno-newline-eof -Wno-c++11-extensions -DHAVE_UNISTD_H=1 -DOPJ_STATIC -DNO_LCMS -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -DLIBRAW_NODLL -DLIBRAW_LIBRARY_BUILD -DFREEIMAGE_LIB -fexceptions -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -Winvalid-offsetof -Wno-sign-conversion -Wmost -Wno-four-char-constants -Wno-unknown-pragmas -DNDEBUG -fPIC -fexceptions -fvisibility=hidden"
-			EXTRA_FLAGS="$EXTRA_LINK_FLAGS -ffast-math -DPNG_ARM_NEON_OPT=0 -DDISABLE_PERF_MEASUREMENT $MIN_TYPE$MIN_IOS_VERSION -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -I${CROSS_TOP}/SDKs/${CROSS_SDK}/usr/include/"
+			EXTRA_FLAGS="$EXTRA_LINK_FLAGS -DNDEBUG -ffast-math -DPNG_ARM_NEON_OPT=0 -DDISABLE_PERF_MEASUREMENT $MIN_TYPE$MIN_IOS_VERSION -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -I${CROSS_TOP}/SDKs/${CROSS_SDK}/usr/include/"
 
 		    export CC="$CC $EXTRA_FLAGS"
 			export CFLAGS="-arch $IOS_ARCH $EXTRA_FLAGS"

--- a/scripts/apothecary/formulas/FreeImage/Makefile.osx.patch
+++ b/scripts/apothecary/formulas/FreeImage/Makefile.osx.patch
@@ -27,7 +27,7 @@
 +CPP_I386 = $(shell xcrun -find clang++)
 +CPP_X86_64 = $(shell xcrun -find clang++)
 +
-+COMPILERFLAGS = -Os -fexceptions -fvisibility=hidden -DNO_LCMS -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -mmacosx-version-min=$(MACOSX_MIN_SDK)
++COMPILERFLAGS = -Os -fexceptions -fvisibility=hidden -DNO_LCMS -DNDEBUG -D__ANSI__ -DDISABLE_PERF_MEASUREMENT -mmacosx-version-min=$(MACOSX_MIN_SDK)
 +
  COMPILERFLAGS_I386 = -arch i386
  COMPILERFLAGS_X86_64 = -arch x86_64


### PR DESCRIPTION
Fixes: "Git Master, not able to load TIF files. #3832"

- Problem: Assertions were not being turned off for compilation of static library.
- Affected Versions: OS X x86(32 bit).

- Will PR static libs for iOS / OS X for FreeImage with this change.