### PR TITLE
Fixing compile-time errors in examples

### DIFF
--- a/examples/events/simpleEventsExample/src/Circle.cpp
+++ b/examples/events/simpleEventsExample/src/Circle.cpp
@@ -56,6 +56,8 @@ void Circle::mouseReleased(ofMouseEventArgs & args){
     }
 }
 void Circle::mouseScrolled(ofMouseEventArgs & args){}
+void Circle::mouseEntered(ofMouseEventArgs & args){}
+void Circle::mouseExited(ofMouseEventArgs & args){}
 
 //this function checks if the passed arguments are inside the circle.
 bool Circle::inside(float _x, float _y ){

--- a/examples/events/simpleEventsExample/src/Circle.h
+++ b/examples/events/simpleEventsExample/src/Circle.h
@@ -37,6 +37,8 @@ public:
     void mousePressed(ofMouseEventArgs & args);
     void mouseReleased(ofMouseEventArgs & args);
     void mouseScrolled(ofMouseEventArgs & args);
+    void mouseEntered(ofMouseEventArgs & args);
+    void mouseExited(ofMouseEventArgs & args);
     
     //this function checks if the passed arguments are inside the circle.
     bool inside(float _x, float _y );

--- a/examples/gl/textureBufferInstancedExample/src/ofApp.cpp
+++ b/examples/gl/textureBufferInstancedExample/src/ofApp.cpp
@@ -113,6 +113,16 @@ void ofApp::mouseReleased(int x, int y, int button){
 }
 
 //--------------------------------------------------------------
+void ofApp::mouseEntered(int x, int y){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseExited(int x, int y){
+
+}
+
+//--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
 
 }


### PR DESCRIPTION
Adds missing `mouseEntered` / `mouseExited` callbacks