### PR TITLE
fix ofVbo copy constructor

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -230,10 +230,11 @@ ofVbo::ofVbo(const ofVbo & mom){
 	totalIndices = mom.totalIndices;
 	indexAttribute = mom.indexAttribute;
 
+	vaoChanged = mom.vaoChanged;
+	vaoID = mom.vaoID;
+
 	if(ofIsGLProgrammableRenderer()){
-		vaoID	   = mom.vaoID;
 		retainVAO(vaoID);
-		vaoChanged = mom.vaoChanged;
 	}
 }
 
@@ -257,10 +258,11 @@ ofVbo & ofVbo::operator=(const ofVbo& mom){
 	totalIndices = mom.totalIndices;
 	indexAttribute = mom.indexAttribute;
 
+	vaoChanged = mom.vaoChanged;
+	vaoID = mom.vaoID;
+
 	if(ofIsGLProgrammableRenderer()){
-		vaoID	   = mom.vaoID;
 		retainVAO(vaoID);
-		vaoChanged = mom.vaoChanged;
 	}
 	return *this;
 }


### PR DESCRIPTION
This patch fixes ofVbo copy and assignment constructors when not using the programmable pipeline.

Without it vaoID will be garbage and 'clear' tries to release it.