### PR TITLE
Feature Request: Exposing Cairo context and surface internal variables for addons

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -1375,8 +1375,16 @@ cairo_t * ofCairoRenderer::getCairoContext(){
 	return cr;
 }
 
+void ofCairoRenderer::setCairoContext(cairo_t * _cr){
+  cr = _cr;
+}
+
 cairo_surface_t * ofCairoRenderer::getCairoSurface(){
 	return surface;
+}
+
+void ofCairoRenderer::setCairoSurface(cairo_surface_t * _surface){
+  surface = _surface;
 }
 
 ofPixels & ofCairoRenderer::getImageSurfacePixels(){

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -157,7 +157,9 @@ public:
 
 	// cairo specifics
 	cairo_t * getCairoContext();
+	void setCairoContext(cairo_t * cr);
 	cairo_surface_t * getCairoSurface();
+	void setCairoSurface(cairo_surface_t * surface);
 	ofPixels & getImageSurfacePixels();
 	ofBuffer & getContentBuffer();
 


### PR DESCRIPTION
I'm making an addon for Cairo which allows to override window's transparency and draw vector shapes more easily,  to make this happen and use `ofDraw...` commands I need to assign different surfaces and cairo contexts to internal variables which are currently not exposed.

To make addon work, either I need to completely duplicate functionality of `ofCairoRenderer` or with only two functions I propose here draw shapes directly with openFrameworks!

These two functions don't break anything, they're not even exposed to anyone except for people who can create a custom pointer to a renderer, i.e. advanced users.

Here's what will be possible :)

![](http://i.imgur.com/C2AWBZn.png)