### PR TITLE
iOS Orientation Issues Fix

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -129,23 +129,18 @@
         
         ofOrientation defaultOrient = OF_ORIENTATION_UNKNOWN;
         if(bDoesHWOrientation) {
-            
             // update the window orientation based on the orientation of the device //
             switch (iOrient) {
                 case UIInterfaceOrientationPortrait:
-//                    NSLog(@"applicationDidFinishLaunnching :: portrait");
                     defaultOrient = OF_ORIENTATION_DEFAULT;
                     break;
                 case UIInterfaceOrientationPortraitUpsideDown:
-//                    NSLog(@"applicationDidFinishLaunnching :: upside down");
                     defaultOrient = OF_ORIENTATION_180;
                     break;
                 case UIInterfaceOrientationLandscapeLeft:
-//                    NSLog(@"applicationDidFinishLaunnching :: landscape left");
                     defaultOrient = OF_ORIENTATION_90_RIGHT;
                     break;
                 case UIInterfaceOrientationLandscapeRight:
-//                    NSLog(@"applicationDidFinishLaunnching :: landscape right");
                     defaultOrient = OF_ORIENTATION_90_LEFT;
                     break;
             }
@@ -159,30 +154,29 @@
         self.window.rootViewController = self.glViewController;
         
         ofOrientation requested = ofGetOrientation();
-        
+		UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationPortrait;
+		switch (requested) {
+			case OF_ORIENTATION_DEFAULT:
+				interfaceOrientation = UIInterfaceOrientationPortrait;
+				break;
+			case OF_ORIENTATION_180:
+				interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
+				break;
+			case OF_ORIENTATION_90_RIGHT:
+				interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
+				break;
+			case OF_ORIENTATION_90_LEFT:
+				interfaceOrientation = UIInterfaceOrientationLandscapeRight;
+				break;
+		}
+		
         if(!bDoesHWOrientation) {
+			//[[UIApplication sharedApplication] setStatusBarOrientation:interfaceOrientation animated:NO];
             [self.glViewController rotateToInterfaceOrientation:UIInterfaceOrientationPortrait animated:false];
-        } else {
-            UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationPortrait;
-            switch (requested) {
-                case OF_ORIENTATION_DEFAULT:
-                    interfaceOrientation = UIInterfaceOrientationPortrait;
-                    break;
-                case OF_ORIENTATION_180:
-                    interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
-                    break;
-                case OF_ORIENTATION_90_RIGHT:
-                    interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
-                    break;
-                case OF_ORIENTATION_90_LEFT:
-                    interfaceOrientation = UIInterfaceOrientationLandscapeRight;
-                    break;
-            }
-            
+			//ofSetOrientation(requested);
+		} else {
             [[UIApplication sharedApplication] setStatusBarOrientation:interfaceOrientation animated:NO];
-            //            self.glViewController.currentInterfaceOrientation = interfaceOrientation;
             [self.glViewController rotateToInterfaceOrientation:interfaceOrientation animated:false];
-            
             ofSetOrientation(requested);
         }
         
@@ -374,5 +368,6 @@
     
     return YES;
 }
+
 
 @end

--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -171,9 +171,7 @@
 		}
 		
         if(!bDoesHWOrientation) {
-			//[[UIApplication sharedApplication] setStatusBarOrientation:interfaceOrientation animated:NO];
             [self.glViewController rotateToInterfaceOrientation:UIInterfaceOrientationPortrait animated:false];
-			//ofSetOrientation(requested);
 		} else {
             [[UIApplication sharedApplication] setStatusBarOrientation:interfaceOrientation animated:NO];
             [self.glViewController rotateToInterfaceOrientation:interfaceOrientation animated:false];

--- a/addons/ofxiOS/src/core/ofxiOSViewController.mm
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.mm
@@ -144,7 +144,18 @@
     if(currentInterfaceOrientation == interfaceOrientation && !bFirstUpdate) {
         return;
     }
-    
+	
+	if(pendingInterfaceOrientation != interfaceOrientation) {
+		CGSize screenSize = [UIScreen mainScreen].bounds.size;
+		CGRect bounds = CGRectMake(0, 0, screenSize.width, screenSize.height);
+		if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
+			bounds.size.width   = screenSize.height;
+			bounds.size.height  = screenSize.width;
+		}
+		self.glView.bounds = bounds;
+		[self.glView updateDimensions];
+	}
+	
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     CGPoint center;
     CGRect bounds = CGRectMake(0, 0, screenSize.width, screenSize.height);
@@ -164,10 +175,19 @@
             bounds.size.height = screenSize.width;
         }
     } else {
-        center.x = screenSize.width * 0.5;
-        center.y = screenSize.height * 0.5;
+		if(UIInterfaceOrientationIsLandscape(self.interfaceOrientation)) {
+			center.x = screenSize.height * 0.5;
+			center.y = screenSize.width * 0.5;
+		} else {
+			center.x = screenSize.width * 0.5;
+			center.y = screenSize.height * 0.5;
+		}
+		if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
+			bounds.size.width = screenSize.height;
+			bounds.size.height = screenSize.width;
+		}
     }
-    
+	
     float rot1 = [self rotationForOrientation:currentInterfaceOrientation];
     float rot2 = [self rotationForOrientation:interfaceOrientation];
     float rot3 = rot2 - rot1;
@@ -263,25 +283,18 @@
 //-------------------------------------------------------------- iOS6.
 #ifdef __IPHONE_6_0
 - (NSUInteger)supportedInterfaceOrientations {
-    if(pendingInterfaceOrientation >= 0 && !bReadyToRotate) {
-        currentInterfaceOrientation = pendingInterfaceOrientation;
-    }
     switch (currentInterfaceOrientation) {
         case UIInterfaceOrientationPortrait:
-//            NSLog(@"ofxiPhoneViewController :: supportedInterfaceOrientations : UIInterfaceOrientationPortrait %i", currentInterfaceOrientation);
-            return UIInterfaceOrientationMaskPortrait;
+			return UIInterfaceOrientationMaskPortrait;
             break;
         case UIInterfaceOrientationPortraitUpsideDown:
-//            NSLog(@"ofxiPhoneViewController :: supportedInterfaceOrientations : UIInterfaceOrientationPortraitUpsideDown %i", currentInterfaceOrientation);
-            return UIInterfaceOrientationMaskPortraitUpsideDown;
+			return UIInterfaceOrientationMaskPortraitUpsideDown;
             break;
         case UIInterfaceOrientationLandscapeLeft:
-//            NSLog(@"ofxiPhoneViewController :: supportedInterfaceOrientations : UIInterfaceOrientationMaskLandscapeLeft %i", currentInterfaceOrientation);
-            return UIInterfaceOrientationMaskLandscapeLeft;
+			return UIInterfaceOrientationMaskLandscapeLeft;
             break;
         case UIInterfaceOrientationLandscapeRight:
-//            NSLog(@"ofxiPhoneViewController :: supportedInterfaceOrientations : UIInterfaceOrientationLandscapeRight %i", currentInterfaceOrientation);
-            return UIInterfaceOrientationMaskLandscapeRight;
+			return UIInterfaceOrientationMaskLandscapeRight;
             break;
         default:
             break;
@@ -297,6 +310,10 @@
 
 - (BOOL)isReadyToRotate {
     return bReadyToRotate;
+}
+
+-(BOOL)prefersStatusBarHidden{
+	return YES;
 }
 
 @end

--- a/addons/ofxiOS/src/core/ofxiOSViewController.mm
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.mm
@@ -13,6 +13,7 @@
     UIInterfaceOrientation pendingInterfaceOrientation;
     BOOL bReadyToRotate;
     BOOL bFirstUpdate;
+	BOOL bAnimated;
 }
 @end
 
@@ -26,6 +27,7 @@
         currentInterfaceOrientation = pendingInterfaceOrientation = self.interfaceOrientation;
         bReadyToRotate  = NO;
         bFirstUpdate    = NO;
+		bAnimated		= NO;
         
         self.glView = [[[ofxiOSEAGLView alloc] initWithFrame:frame andApp:app] autorelease];
         self.glView.delegate = self;
@@ -124,6 +126,7 @@
 
 - (void)rotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
                             animated:(BOOL)animated {
+	bAnimated = animated;
     if(bReadyToRotate == NO) {
         pendingInterfaceOrientation = interfaceOrientation;
         
@@ -159,34 +162,32 @@
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
     CGPoint center;
     CGRect bounds = CGRectMake(0, 0, screenSize.width, screenSize.height);
-
-    // Is the iOS version less than 8?
-    if( [[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending ) {
-        if(UIInterfaceOrientationIsLandscape(self.interfaceOrientation)) {
-            center.x = screenSize.height * 0.5;
-            center.y = screenSize.width * 0.5;
-        } else {
-            center.x = screenSize.width * 0.5;
-            center.y = screenSize.height * 0.5;
-        }
-
-        if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-            bounds.size.width = screenSize.height;
-            bounds.size.height = screenSize.width;
-        }
-    } else {
-		if(UIInterfaceOrientationIsLandscape(self.interfaceOrientation)) {
-			center.x = screenSize.height * 0.5;
-			center.y = screenSize.width * 0.5;
-		} else {
-			center.x = screenSize.width * 0.5;
-			center.y = screenSize.height * 0.5;
-		}
+	
+	if(UIInterfaceOrientationIsLandscape(self.interfaceOrientation)) {
+		center.x = screenSize.height * 0.5;
+		center.y = screenSize.width * 0.5;
+	} else {
+		center.x = screenSize.width * 0.5;
+		center.y = screenSize.height * 0.5;
+	}
+	
+	// Is the iOS version less than 8?
+	if( [[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending ) {
 		if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
 			bounds.size.width = screenSize.height;
 			bounds.size.height = screenSize.width;
 		}
-    }
+	} else {
+		// Fixes for iOS 8 Portrait to Landscape issues
+		if((UIInterfaceOrientationIsPortrait(interfaceOrientation) && screenSize.width >= screenSize.height) ||
+		   (UIInterfaceOrientationIsLandscape(interfaceOrientation) && screenSize.height >= screenSize.width)) {
+			bounds.size.width = screenSize.height;
+			bounds.size.height = screenSize.width;
+		} else {
+			bounds.size.width = screenSize.width;
+			bounds.size.height = screenSize.height;
+		}
+	}
 	
     float rot1 = [self rotationForOrientation:currentInterfaceOrientation];
     float rot2 = [self rotationForOrientation:interfaceOrientation];
@@ -229,6 +230,7 @@
     // The window calls the root view controller’s willRotateToInterfaceOrientation:duration: method.
     // Container view controllers forward this message on to the currently displayed content view controllers.
     // You can override this method in your custom content view controllers to hide views or make other changes to your view layout before the interface is rotated.
+	// Deprecated in iOS 8. See viewWillTransitionToSize below.
 }
 
 - (void)viewWillLayoutSubviews {
@@ -246,6 +248,7 @@
     // CALLBACK 3.
     // This method is called from within an animation block so that any property changes you make
     // are animated at the same time as other animations that comprise the rotation.
+	// Deprecated in iOS 8. See viewWillTransitionToSize below.
     
     CGSize screenSize = [UIScreen mainScreen].bounds.size;
 
@@ -264,9 +267,52 @@
         center.y = screenSize.height * 0.5;
     }
     
-    self.glView.center = center;
-    self.glView.transform = CGAffineTransformMakeRotation(0);
+	if(bAnimated) {
+		NSTimeInterval duration = 0.3;
+		[self.glView.layer removeAllAnimations];
+		[UIView animateWithDuration:duration animations:^{
+			self.glView.center = center;
+			self.glView.transform = CGAffineTransformMakeRotation(0);
+		}];
+	} else {
+		self.glView.center = center;
+		self.glView.transform = CGAffineTransformMakeRotation(0);
+	}
 }
+
+#ifdef __IPHONE_8_0
+// iOS8+ version of willAnimateRotationToInterfaceOrientation
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+	CGSize screenSize = size;
+	
+	CGPoint center;
+	// Is the iOS version less than 8?
+	if( [[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending ) {
+		if(UIInterfaceOrientationIsLandscape(self.interfaceOrientation)) {
+			center.x = screenSize.height * 0.5;
+			center.y = screenSize.width * 0.5;
+		} else {
+			center.x = screenSize.width * 0.5;
+			center.y = screenSize.height * 0.5;
+		}
+	} else {
+		center.x = screenSize.width * 0.5;
+		center.y = screenSize.height * 0.5;
+	}
+	
+	if(bAnimated) {
+		NSTimeInterval duration = 0.3;
+		[self.glView.layer removeAllAnimations];
+		[UIView animateWithDuration:duration animations:^{
+			self.glView.center = center;
+			self.glView.transform = CGAffineTransformMakeRotation(0);
+		}];
+	} else {
+		self.glView.center = center;
+		self.glView.transform = CGAffineTransformMakeRotation(0);
+	}
+}
+#endif
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
 
@@ -302,18 +348,19 @@
     // defaults to orientations selected in the .plist file ('Supported Interface Orientations' in the XCode Project)
     return -1; 
 }
-#endif
-
 - (BOOL)shouldAutorotate {
-    return YES;
+	return YES;
 }
+#endif
 
 - (BOOL)isReadyToRotate {
     return bReadyToRotate;
 }
 
+#ifdef __IPHONE_7_0
 -(BOOL)prefersStatusBarHidden{
 	return YES;
 }
+#endif
 
 @end


### PR DESCRIPTION
This PR contains fixes for the iOS Orientation issues

- iOS 8 orientation animation; excessive rotation & incorrect rotations - Fixes https://github.com/openframeworks/openFrameworks/issues/3336
- iOS 8.3 Landscape issues - Fixes https://github.com/openframeworks/openFrameworks/issues/3824
- iOS 8 breaks OF handling of Hardware Orientation - Fixes https://github.com/openframeworks/openFrameworks/issues/3158
- iOS 8 broken orientation with ofxiOSImagePicker - Fixes https://github.com/openframeworks/openFrameworks/issues/3474

----------------------------

- Fixes iOS 7 orientation issue of getting out of sync with preferred orientation
- Fixes issues related to ```settings.enableHardwareOrientation = false``` for iOS 8
- Fixed bounds issues mentioned here https://github.com/openframeworks/openFrameworks/issues/3158 (needed a more robust solution that mentioned, but it definitely showed one of the core issues with the bounds, however had to make custom fix rather than proposed)
- Working ofGetWidth() / ofGetHeight() regardless of orientation now (all working as intended).

#### Additions: 
- New iOS 8 function for automatic transitions (one of the reasons changing orientations by hardware was breaking it, old functions deprecated and ceased to work).
https://github.com/danoli3/openFrameworks/commit/f24d14c26bca9a94fa152761c974d5d06f0c2160#diff-8a28ee488dc73a25b3b1881fe20a027aR285
- Added animation to hardware rotations if setting is turned on for hardware animations https://github.com/danoli3/openFrameworks/commit/f24d14c26bca9a94fa152761c974d5d06f0c2160#diff-8a28ee488dc73a25b3b1881fe20a027aR270



- Tested iOS 8, iOS 8.3
- Tested iOS 7.1

- Tested all scenarios of Landscape, Portrait, Hardware Orientation on and off, animation on and off.