### PR TITLE
Adds GL_BGRA format

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -177,6 +177,8 @@ int ofGetGLFormatFromInternal(int glInternalFormat){
 #endif
 			case GL_ALPHA:
 				return GL_ALPHA;
+			case GL_BGRA:
+				return GL_BGRA;
 
 			default:
 				ofLogError("ofGLUtils") << "ofGetGLFormatFromInternal(): unknown internal format " << glInternalFormat << ", returning GL_RGBA";
@@ -253,6 +255,8 @@ int ofGetGlTypeFromInternal(int glInternalFormat){
 
 		case GL_STENCIL_INDEX:
 			return GL_UNSIGNED_BYTE;
+		case GL_BGRA:
+			return GL_BGRA;
 
 		default:
 			ofLogError("ofGLUtils") << "ofGetGlTypeFromInternal(): unknown internal format " << glInternalFormat << ", returning GL_UNSIGNED_BYTE";

--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -192,6 +192,7 @@ int ofGetGlTypeFromInternal(int glInternalFormat){
 	switch(glInternalFormat) {
 		case GL_RGB:
 		case GL_RGBA:
+		case GL_BGRA:
 		case GL_LUMINANCE:
 		case GL_LUMINANCE_ALPHA:
 		case GL_ALPHA:
@@ -255,8 +256,6 @@ int ofGetGlTypeFromInternal(int glInternalFormat){
 
 		case GL_STENCIL_INDEX:
 			return GL_UNSIGNED_BYTE;
-		case GL_BGRA:
-			return GL_BGRA;
 
 		default:
 			ofLogError("ofGLUtils") << "ofGetGlTypeFromInternal(): unknown internal format " << glInternalFormat << ", returning GL_UNSIGNED_BYTE";


### PR DESCRIPTION
Makes possible to draw Cairo or other BGRA swizzled images without calling super expensive `swapRgb` function.