### PR TITLE
Fixing Fontconfig memory leaks by destroying allocated FcPatterns

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -305,6 +305,8 @@ static string linuxFontPathByName(string fontname){
 
 	if(!fontMatch){
 		ofLogError() << "linuxFontPathByName(): couldn't match font file or system font with name \"" << fontname << "\"";
+		FcPatternDestroy(fontMatch);
+		FcPatternDestroy(pattern);
 		return "";
 	}
 	FcChar8	*file;
@@ -312,8 +314,12 @@ static string linuxFontPathByName(string fontname){
 		filename = (const char*)file;
 	}else{
 		ofLogError() << "linuxFontPathByName(): couldn't find font match for \"" << fontname << "\"";
+		FcPatternDestroy(fontMatch);
+		FcPatternDestroy(pattern);
 		return "";
 	}
+	FcPatternDestroy(fontMatch);
+	FcPatternDestroy(pattern);
 	return filename;
 }
 #endif


### PR DESCRIPTION
Clang's Leak Sanitizer found these