### PR TITLE
Closes #3883

### DIFF
--- a/libs/openFrameworks/graphics/ofTessellator.cpp
+++ b/libs/openFrameworks/graphics/ofTessellator.cpp
@@ -62,12 +62,18 @@ ofTessellator::~ofTessellator(){
 
 //----------------------------------------------------------
 ofTessellator::ofTessellator(const ofTessellator & mom){
-	if(&mom != this) init();
+	if(&mom != this){
+		if(cacheTess) tessDeleteTess(cacheTess);
+		init();
+	}
 }
 
 //----------------------------------------------------------
 ofTessellator & ofTessellator::operator=(const ofTessellator & mom){
-	if(&mom != this) init();
+	if(&mom != this){
+		if(cacheTess) tessDeleteTess(cacheTess);
+		init();
+	}
 	return *this;
 }
 

--- a/libs/openFrameworks/graphics/ofTessellator.cpp
+++ b/libs/openFrameworks/graphics/ofTessellator.cpp
@@ -52,7 +52,7 @@ void memFree( void *userData, void *ptr ){
 
 //----------------------------------------------------------
 ofTessellator::ofTessellator()
-  : cacheTess(nullptr)
+  : cacheTess(NULL)
 {
 	init();
 }
@@ -64,7 +64,7 @@ ofTessellator::~ofTessellator(){
 
 //----------------------------------------------------------
 ofTessellator::ofTessellator(const ofTessellator & mom)
-  : cacheTess(nullptr)
+  : cacheTess(NULL)
 {
 	if(&mom != this){
 		if(cacheTess) tessDeleteTess(cacheTess);

--- a/libs/openFrameworks/graphics/ofTessellator.cpp
+++ b/libs/openFrameworks/graphics/ofTessellator.cpp
@@ -51,7 +51,9 @@ void memFree( void *userData, void *ptr ){
 }
 
 //----------------------------------------------------------
-ofTessellator::ofTessellator(){
+ofTessellator::ofTessellator()
+  : cacheTess(nullptr)
+{
 	init();
 }
 
@@ -61,7 +63,9 @@ ofTessellator::~ofTessellator(){
 }
 
 //----------------------------------------------------------
-ofTessellator::ofTessellator(const ofTessellator & mom){
+ofTessellator::ofTessellator(const ofTessellator & mom)
+  : cacheTess(nullptr)
+{
 	if(&mom != this){
 		if(cacheTess) tessDeleteTess(cacheTess);
 		init();


### PR DESCRIPTION
Destruction of `cacheTess` is required before new initialization, otherwise `tessNewTess` will override used address and its resources will never be freed.