### PR TITLE
change valueChanged so that the sender is included

### DIFF
--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -50,6 +50,6 @@ bool ofxButton::mouseDragged(ofMouseEventArgs & args){
 
 void ofxButton::valueChanged(bool & v){
 	if(!v){
-		ofNotifyEvent(triggerEvent);
+		ofNotifyEvent(triggerEvent, this);
 	}
 }


### PR DESCRIPTION
add the ability to get access to the ofxButton in the ListenerMethod . 
Tested on Windows 8.  
