### PR TITLE
Avoid Warning/Exception when Android video is playing and app is paused

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoPlayer.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoPlayer.java
@@ -24,6 +24,7 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 		bIsFrameNew = false;
 		bAutoResume = false;
 		bIsMoviedone = false;
+		bIsLooping = false;
 		
 		// TODO Get movie FPS to implement Frame methods
 		// movieFPS = 16;
@@ -74,6 +75,8 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 		try {
 			if(mediaPlayer == null) {
 				mediaPlayer = new MediaPlayer();
+				mediaPlayer.reset();
+				mediaPlayer.setLooping(bIsLooping);
 				mediaPlayer.setOnPreparedListener(new OnPreparedListener() {
 					public void onPrepared(MediaPlayer mp) {
 						bIsLoaded = true;
@@ -132,6 +135,7 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 	void unloadMovie(){
 		if(mediaPlayer!=null){
 			mediaPlayer.setSurface(null);
+			mediaPlayer.reset();
 			mediaPlayer.release();
 			mediaPlayer = null;
 		}
@@ -184,6 +188,7 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 	void setLoopState(boolean bL){
 		if(mediaPlayer==null) return;
 		mediaPlayer.setLooping(bL);
+		bIsLooping = bL;
 	}
 	
 	boolean getLoopState(){
@@ -326,6 +331,7 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 	private boolean bIsPaused;
 	private boolean bIsMoviedone;
 	private boolean bIsFrameNew;
+	private boolean bIsLooping;
 	
 	//private int movieFPS;
 	//private int nFrames;


### PR DESCRIPTION
…and resumed

By doing using reset() before releasing the media player we avoid the "mediaplayer went away with unhandled events" warning:

mediaPlayer.reset();
mediaPlayer.release();

Also by reseting the mediaplayer after creating it we avoid the internal/external state mismatch corrected exception when pausing resuming the app. Doing that forces us also to keep track of loop state when resuming the video.

06-02 18:05:37.195: E/MediaPlayer(30590): internal/external state mismatch corrected