### PR TITLE
Removed old debian gstreamer omx repo. fixes #3669

### DIFF
--- a/scripts/linux/debian_armv6l/install_dependencies.sh
+++ b/scripts/linux/debian_armv6l/install_dependencies.sh
@@ -1,7 +1,6 @@
 echo "inserting gstreamer 1.0 repository"
 rm /etc/apt/sources.list.d/gstreamer.list
 touch /etc/apt/sources.list.d/gstreamer.list
-echo "deb http://vontaene.de/raspbian-updates/ . main" > /etc/apt/sources.list.d/gstreamer.list
 echo "updating apt database"
 apt-get update
 


### PR DESCRIPTION
Gstreamer is now included in the default Raspbian