### PR TITLE
ofFileUtils : Check if directory already exists before creating it

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -414,7 +414,9 @@ bool ofFile::openStream(Mode _mode, bool _binary){
 		case WriteOnly:
 		case ReadWrite:
 		case Append:
-			ofFilePath::createEnclosingDirectory(path());
+			if(!ofDirectory::doesDirectoryExist(path())){
+				ofFilePath::createEnclosingDirectory(path());
+			}
 			break;
 		case Reference:
 		case ReadOnly:


### PR DESCRIPTION
I was getting lots of console warnings on this; 
Not sure why you would need to createEnclosingDirectory() in ofFile:: openStream(), but if you are to create a directory, you should probably check if it already exists first.