### PR TITLE
fix for deprecation attributes in vs2015

### DIFF
--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -104,7 +104,9 @@ class ofSerialDeviceInfo{
 ///
 /// \sa http://www.cplusplus.com/reference/mutex/mutex/
 /// \sa http://www.appinf.com/docs/poco/Poco.FastMutex.html
+#ifndef _MSC_VER
 [[deprecated("Use std::mutex instead")]]
+#endif
 typedef std::mutex ofMutex;
 
 /// \brief A typedef for a cross-platform scoped mutex.
@@ -143,7 +145,9 @@ typedef std::mutex ofMutex;
 /// \sa http://en.cppreference.com/w/cpp/thread/lock_guard
 /// \sa http://www.appinf.com/docs/poco/Poco.ScopedLock.html
 /// \sa ofMutex
+#ifndef _MSC_VER
 [[deprecated("use std::unique_lock instead")]]
+#endif
 typedef std::unique_lock<std::mutex> ofScopedLock;
 
 /// \brief Contains general information about the style of ofGraphics


### PR DESCRIPTION
+ vs2015RC does not yet implement the [[deprecated]] attribute:
  http://blogs.msdn.com/b/vcblog/archive/2014/11/17/c-11-14-17-features-in-vs-2015-preview.aspx

  Since our compiler-agnostic deprecation macro OF_DEPRECATED cannot add
  deprecation messages to typedefs, there appears no other option than to
  omit deprecation messages for these typedefs in visual studio for now.