### PR TITLE
remove method signature for setCurrentFBO

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -30,8 +30,6 @@ public:
     void startRender();
     void finishRender();
 
-	void setCurrentFBO(const ofFbo * fbo);
-    
 	using ofBaseRenderer::draw;
 	using ofBaseGLRenderer::draw;
 	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;


### PR DESCRIPTION
+ since the implementation for ofGLProgrammableRenderer::setCurrentFBO has
been removed in 94cb65672e92dc33dc67733f4397699f15a41399 the signature for
the method should probably go away, too.

setCurrentFBO is not used anywhere within oF core, which is why probably
nobody noticed the missing implementation.

Addresses #2738