### PR TITLE
iOS Core Config update for new libraries

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
@@ -11,6 +11,9 @@ HEADER_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/include"
 HEADER_TESS2 = "$(OF_PATH)/libs/tess2/include"
 HEADER_RTAUDIO = "$(OF_PATH)/libs/rtaudio/include"
 HEADER_SSL = "$(OF_PATH)/libs/openssl/include"
+HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
+HEADER_URI = "$(OF_PATH)/libs/uri/include"
+HEADER_UTF8 = "$(OF_PATH)/libs/utf8cpp/include"
 
 //------- Libraries
 LIB_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/lib/ios/freeimage.a"
@@ -30,12 +33,16 @@ LIB_POCO_7 = "$(OF_PATH)/libs/poco/lib/ios/PocoNetSSL.a"
 LIB_POCO_8 = "$(OF_PATH)/libs/poco/lib/ios/PocoZip.a"
 LIB_POCO_9 = "$(OF_PATH)/libs/poco/lib/ios/PocoFoundation.a"
 LIB_POCO = $(LIB_POCO_0) $(LIB_POCO_1) $(LIB_POCO_2) $(LIB_POCO_3) $(LIB_POCO_4) $(LIB_POCO_5) $(LIB_POCO_6) $(LIB_POCO_7) $(LIB_POCO_8) $(LIB_POCO_9)
+LIB_BOOST_SYSTEM = "$(OF_PATH)/libs/boost/lib/ios/boost_system.a"
+LIB_BOOST_FS = "$(OF_PATH)/libs/boost/lib/ios/boost_filesystem.a"
+LIB_BOOST = $(LIB_BOOST_SYSTEM) $(LIB_BOOST_FS)
+LIB_URI = "$(OF_PATH)/libs/uri/lib/ios/network-uri.a"
 
 
 MISC_FLAGS = "-ObjC"
 
-OF_CORE_LIBS = $(MISC_FLAGS) $(LIB_POCO) $(LIB_FREEIMAGE) $(LIB_FREETYPE) $(LIB_OPENSSL) $(LIB_TESS)
-OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_OFXIOS) $(HEADER_OFXMULTITOUCH) $(HEADER_OFXACCELEROMETER) $(HEADER_POCO) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_RTAUDIO) $(HEADER_SSL)
+OF_CORE_LIBS = $(MISC_FLAGS) $(LIB_POCO) $(LIB_BOOST) $(LIB_URI) $(LIB_FREEIMAGE) $(LIB_FREETYPE) $(LIB_OPENSSL) $(LIB_TESS)
+OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_OFXIOS) $(HEADER_OFXMULTITOUCH) $(HEADER_OFXACCELEROMETER) $(HEADER_POCO) $(HEADER_BOOST) $(HEADER_URI) $(HEADER_UTF8) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_RTAUDIO) $(HEADER_SSL)
  
 // once all libraries are compiled for libc++ / all architectures
 CLANG_CXX_LIBRARY = libc++


### PR DESCRIPTION
Changes applied to ios/CoreOF.xcconfig
- Adds the new libraries (boost, uri)
- Adds the new source headers (boost, uri, utf8)