### PR TITLE
use robocopy instead of xcopy in post-build step

### DIFF
--- a/scripts/vs/template/emptyExample.vcxproj
+++ b/scripts/vs/template/emptyExample.vcxproj
@@ -106,7 +106,8 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\$(Platform_Actual)\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -128,7 +129,8 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\$(Platform_Actual)\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -152,7 +154,8 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\$(Platform_Actual)\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -175,7 +178,8 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\$(Platform_Actual)\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
  * xcopy overwrites all .dlls in the bin/ folder
    every time an app gets rebuilt. This leads to
    longer compile times, since about 20MB need to be
    overwritten in the bin/ folder everytime an app is
    built.

  * robocopy is similar to rsync and will only copy or
    overwrite a file if either a change was detected
    (i.e. the build target was changed from 32bit to
    64 bit) - or the directory is missing a file.

    Files which are already present and of the same
    size will not be copied.

    This speeds up app compile time. (And may also
    help towards longer SSD lifetime)

    ~~xcopy~~ robocopy is a default system tool, and available
    since Windows 7 onwards.

https://technet.microsoft.com/en-GB/library/cc733145.aspx