### PR TITLE
fix getTimestampString app crash on windows

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -156,7 +156,9 @@ void ofSleepMillis(int millis){
 //default ofGetTimestampString returns in this format: 2011-01-15-18-29-35-299
 //--------------------------------------------------
 string ofGetTimestampString(){
+
 	string timeFormat = "%Y-%m-%d-%H-%M-%S-%i";
+
 	return ofGetTimestampString(timeFormat);
 }
 
@@ -170,11 +172,18 @@ string ofGetTimestampString(const string& timestampFormat){
 	auto tm = *std::localtime(&t);
 	constexpr int bufsize = 256;
 	char buf[bufsize];
-	if (std::strftime(buf,bufsize,timestampFormat.c_str(),&tm) != 0){
+
+	// Beware! an invalid timestamp string crashes windows apps.
+	// so we have to filter out %i (which is not supported by vs)
+	// earlier.
+	auto tmpTimestampFormat = timestampFormat;
+	ofStringReplace(tmpTimestampFormat, "%i", ofToString(ms));
+	
+	if (strftime(buf,bufsize, tmpTimestampFormat.c_str(),&tm) != 0){
 		str << buf;
 	}
 	auto ret = str.str();
-	ofStringReplace(ret,"%i",ofToString(ms));
+	
 
     return ret;
 }

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -130,6 +130,7 @@ string ofGetTimestampString();
 ///
 /// \param timestampFormat The formatting pattern.
 /// \returns the formatted timestamp as a string.
+/// \warning an invalid timestampFormat may crash windows apps.
 string ofGetTimestampString(const string& timestampFormat);
 
 /// \brief Get the current year.


### PR DESCRIPTION
  * on windows, `strftime` called with an invalid formatting
    string will lead to an app crash.

  * since `ofGetTimestampString()`, when called without
    parameters, uses the parameters `%Y-%m-%d-%H-%M-%S-%i`,
    this would lead to a crash upon the first call of
    `ofGetTimeStampString` because of the non-standard `%i`
    formatter.

    https://msdn.microsoft.com/en-us/library/fe06s4ak(v=vs.140).aspx

Since the `%i` parameter is non-standard over probably all
implementations of `strftime`, and we manually replace it
anyways, i've re-arranged the replacement to happen before
the call to `strftime`.

This is not super optimised (and I believe this method
could be), but it doesn't crash anymore.