### PR TITLE
fix ofParameter - extra template<>

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -248,7 +248,6 @@ struct ofTypeInfo <ofVec4f> {
     static ofVec4f max() { return ofVec4f(std::numeric_limits<float>::max()); };
 };
 
-template<>
 template<typename T>
 struct ofTypeInfo <ofColor_<T>> {
     static ofColor_<T> min() { return ofColor_<T>(0,0); };


### PR DESCRIPTION
  * removes an extra template<> line which was causing
    compiler errors since then the template could not be
    specialised.

    To specialise a template which is already templated, the
    template typename has to be specified, as it is in the
    next line.