### PR TITLE
ignore linker warning 4099 for visual studio debug

### DIFF
--- a/libs/openFrameworksCompiled/project/vs/openFrameworksDebug.props
+++ b/libs/openFrameworksCompiled/project/vs/openFrameworksDebug.props
@@ -15,10 +15,12 @@
     <Link>
       <AdditionalLibraryDirectories>..\..\..\libs\glut\lib\vs\Win32;..\..\..\libs\glfw\lib\vs\Win32;..\..\..\libs\rtAudio\lib\vs\Win32;..\..\..\libs\FreeImage\lib\vs\Win32;..\..\..\libs\freetype\lib\vs\Win32;..\..\..\libs\quicktime\lib\vs\Win32;..\..\..\libs\fmodex\lib\vs\Win32;..\..\..\libs\videoInput\lib\vs\Win32;..\..\..\libs\cairo\lib\vs\Win32;..\..\..\libs\glew\lib\vs\Win32;..\..\..\libs\glu\lib\vs\Win32;..\..\..\libs\openssl\lib\vs\Win32;..\..\..\libs\Poco\lib\vs\Win32;..\..\..\libs\tess2\lib\vs\Win32;..\..\..\libs\uri\lib\vs\Win32;..\..\..\libs\boost\lib\vs\Win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>cairo-static.lib;pixman-1.lib;libpng.lib;msimg32.lib;OpenGL32.lib;GLu32.lib;kernel32.lib;setupapi.lib;Vfw32.lib;comctl32.lib;glut32.lib;rtAudioD.lib;videoInputD.lib;libfreetype.lib;FreeImage.lib;qtmlClient.lib;dsound.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;glew32s.lib;fmodex_vc.lib;glu32.lib;ssleay32MD.lib;libeay32MD.lib;crypt32.lib;PocoFoundationmdd.lib;PocoNetmdd.lib;PocoUtilmdd.lib;PocoXMLmdd.lib;Ws2_32.lib;tess2.lib;glfw3.lib;network-uri_debug.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
       <IgnoreSpecificDefaultLibraries>PocoFoundationmdd.lib;atlthunk.lib;msvcrt;libcmt;LIBC;LIBCMTD</IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
@@ -30,10 +32,12 @@
     <Link>
       <AdditionalLibraryDirectories>..\..\..\libs\glfw\lib\vs\x64;..\..\..\libs\rtAudio\lib\vs\x64;..\..\..\libs\FreeImage\lib\vs\x64;..\..\..\libs\freetype\lib\vs\x64;..\..\..\libs\fmodex\lib\vs\x64;..\..\..\libs\videoInput\lib\vs\x64;..\..\..\libs\cairo\lib\vs\x64;..\..\..\libs\glew\lib\vs\x64;..\..\..\libs\glu\lib\vs\x64;..\..\..\libs\openssl\lib\vs\x64;..\..\..\libs\Poco\lib\vs\x64;..\..\..\libs\tess2\lib\vs\x64;..\..\..\libs\uri\lib\vs\x64;..\..\..\libs\boost\lib\vs\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>cairo-static.lib;pixman-1.lib;libpng.lib;msimg32.lib;OpenGL32.lib;kernel32.lib;setupapi.lib;Vfw32.lib;comctl32.lib;rtAudioD.lib;videoInputD.lib;libfreetype.lib;FreeImage.lib;dsound.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;glew32s.lib;fmodex64_vc.lib;ssleay32MD.lib;libeay32MD.lib;crypt32.lib;PocoFoundationmdd.lib;PocoNetmdd.lib;PocoUtilmdd.lib;PocoXMLmdd.lib;Ws2_32.lib;tess2.lib;glfw3.lib;network-uri_debug.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
       <IgnoreSpecificDefaultLibraries>PocoFoundationmdd.lib;atlthunk.lib;msvcrt;libcmt;LIBC;LIBCMTD</IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/libs/openFrameworksCompiled/project/vs/openFrameworksRelease.props
+++ b/libs/openFrameworksCompiled/project/vs/openFrameworksRelease.props
@@ -18,7 +18,8 @@
       <IgnoreSpecificDefaultLibraries>PocoFoundationd.lib;atlthunk.lib;LIBC.lib;LIBCMT</IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
@@ -33,7 +34,8 @@
       <IgnoreSpecificDefaultLibraries>PocoFoundationd.lib;atlthunk.lib;LIBC.lib;LIBCMT</IgnoreSpecificDefaultLibraries>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /e /i /y "$(ProjectDir)..\..\..\export\vs\*.dll" "$(ProjectDir)bin"</Command>
+      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
+if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/scripts/vs/template/emptyExample.vcxproj
+++ b/scripts/vs/template/emptyExample.vcxproj
@@ -106,8 +106,6 @@
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
-if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -129,8 +127,6 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
-if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -154,8 +150,6 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
-if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -178,8 +172,6 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
-if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/scripts/vs/template/emptyExample.vcxproj
+++ b/scripts/vs/template/emptyExample.vcxproj
@@ -104,6 +104,7 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
@@ -127,6 +128,7 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes

--- a/scripts/vs/template/emptyExample.vcxproj
+++ b/scripts/vs/template/emptyExample.vcxproj
@@ -104,7 +104,6 @@
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes
@@ -128,7 +127,6 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>robocopy "$(ProjectDir)../../../export/vs/$(Platform_Actual)/" "$(ProjectDir)bin/" "*.dll" /njs /njh /np /fp /bytes


### PR DESCRIPTION
* when building an app in debug mode, visual studio tries to
  find linker symbol (*.pdb) files for libraries that ship
  with openframeworks.

  Since these libraries are shipped without debug symbol files
  (these files are huge) a warning is issued for almost
  every library that ships with openFrameworks whenever an
  app is built, or re-built. For oF, this meant scores of
  warnings on debug builds.

  In the past, it has been impossible to ignore this linker
  warning message, but it had been so nagging to not being
  able to ignore it that some people even had tutorials for
  binary patching the visual studio linker executable to be
  able to get rid of it.

  It seems that with Visual Studio2015 it is finally
  officially possible to ignore this (utterly useless in our
  case) warning.

  Let's.