### PR TITLE
Reallocating ofFbo on MRT, drawBuffers unable to attach.

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -364,6 +364,7 @@ void ofFbo::clear() {
 		releaseRB(colorBuffers[i]);
 	}
 	colorBuffers.clear();
+	activeDrawBuffers.clear();
 	bIsAllocated = false;
 #ifdef TARGET_ANDROID
 	ofRemoveListener(ofxAndroidEvents().reloadGL,this,&ofFbo::reloadFbo);


### PR DESCRIPTION
This problem occurs when reallocating ofFbo that is used on MRT. 
(such as resizing)

The fbo that attached to 1 or later , is always black.
This is probably because activeDrawBuffers has not been cleared.

When fbo is not the MRT, the attach_point is always 0.
So, it looks like there is no problem. But activeDrawBuffers will be incremented.