### PR TITLE
Missing OpenSSL include OSX xconfig

### DIFF
--- a/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
@@ -26,6 +26,7 @@ HEADER_CAIRO = "$(OF_PATH)/libs/cairo/include/cairo"
 HEADER_RTAUDIO = "$(OF_PATH)/libs/rtAudio/include"
 HEADER_GLFW = "$(OF_PATH)/libs/glfw/include"
 HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
+HEADER_SSL = "$(OF_PATH)/libs/openssl/include"
 HEADER_URI = "$(OF_PATH)/libs/uri/include"
 HEADER_UTF8 = "$(OF_PATH)/libs/utf8cpp/include"
 
@@ -62,7 +63,7 @@ LIB_URI = "$(OF_PATH)/libs/uri/lib/osx/libnetwork-uri.a"
 
 OF_CORE_LIBS = $(LIB_POCO) $(LIB_TESS) $(LIB_GLEW) $(LIB_CAIRO1) $(LIB_CAIRO2) $(LIB_CAIRO3) $(LIB_FMODEX) $(LIB_RTAUDIO) $(LIB_OPENSSL1) $(LIB_OPENSSL2) $(LIB_GLFW) $(LIB_FREEIMAGE) $(LIB_FREETYPE) $(LIB_BOOST_FS) $(LIB_BOOST_SYSTEM) $(LIB_URI)
 
-OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_POCO) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_CAIRO) $(HEADER_RTAUDIO) $(HEADER_GLFW) $(HEADER_BOOST) $(HEADER_URI) $(HEADER_UTF8)
+OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_POCO) $(HEADER_FREETYPE) $(HEADER_FREETYPE2) $(HEADER_FMODEX) $(HEADER_GLEW) $(HEADER_FREEIMAGE) $(HEADER_TESS2) $(HEADER_CAIRO) $(HEADER_RTAUDIO) $(HEADER_GLFW) $(HEADER_BOOST) $(HEADER_URI) $(HEADER_UTF8) $(HEADER_SSL)
 
 OF_CORE_FRAMEWORKS = -framework Accelerate -framework AGL -framework AppKit -framework ApplicationServices -framework AudioToolbox -framework AVFoundation -framework Cocoa -framework CoreAudio -framework CoreFoundation -framework CoreMedia -framework CoreServices -framework CoreVideo -framework IOKit -framework OpenGL -framework QuartzCore -framework QuickTime -framework QTKit -framework GLUT
 


### PR DESCRIPTION
Fixes missing xconfig include for OpenSSL headers.