### PR TITLE
Modified ofxTCPServer to use std::unique_lock<std::mutex> instead of ScopedLock

### DIFF
--- a/addons/ofx3DModelLoader/src/3DS/texture3DS.cpp
+++ b/addons/ofx3DModelLoader/src/3DS/texture3DS.cpp
@@ -15,9 +15,29 @@ texture3DS::texture3DS(string filename, const int textureId){
 		ofLogError("texture3DS") << "couldn't open " << filename;
     }
 
-    m_width     = img.width;
-    m_height    = img.height;
-    m_bpp       = img.bpp;
+    m_width     = img.getWidth();
+    m_height    = img.getHeight();
+    switch( img.getImageType() ){
+        case OF_IMAGE_UNDEFINED:
+            m_bpp = 0;
+            break;
+            
+        case OF_IMAGE_GRAYSCALE:
+            m_bpp = 8;
+            break;
+            
+        case OF_IMAGE_COLOR:
+            m_bpp = 24;
+            break;
+            
+        case OF_IMAGE_COLOR_ALPHA:
+            m_bpp = 32;
+            break;
+            
+        default:
+            m_bpp = 0;
+            break;
+    }
 
     if( m_width <= 0 || m_height <= 0){
 		ofLogError("texture3DS") << "dimensions less than 0 \"" << filename << "\": " << m_width << "x" << m_height;

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -83,7 +83,7 @@ ofxTCPClient & ofxTCPServer::getClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::disconnectClient(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "disconnectClient(): client " << clientID << " doesn't exist";
 		return false;
@@ -96,7 +96,7 @@ bool ofxTCPServer::disconnectClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::send(int clientID, string message){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "send(): client " << clientID << " doesn't exist";
 		return false;
@@ -109,7 +109,7 @@ bool ofxTCPServer::send(int clientID, string message){
 
 //--------------------------
 bool ofxTCPServer::sendToAll(string message){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if(TCPConnections.size() == 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -126,7 +126,7 @@ bool ofxTCPServer::sendToAll(string message){
 
 //--------------------------
 string ofxTCPServer::receive(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receive(): client " << clientID << " doesn't exist";
 		return "client " + ofToString(clientID) + "doesn't exist";
@@ -142,7 +142,7 @@ string ofxTCPServer::receive(int clientID){
 
 //--------------------------
 bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawBytes(): client " << clientID << " doesn't exist";
 		
@@ -155,7 +155,7 @@ bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int n
 
 //--------------------------
 bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -168,7 +168,7 @@ bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawMsg(): client " << clientID << " doesn't exist";
 		return false;
@@ -180,7 +180,7 @@ bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int num
 
 //--------------------------
 bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -192,7 +192,7 @@ bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 int ofxTCPServer::getNumReceivedBytes(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getNumReceivedBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -203,7 +203,7 @@ int ofxTCPServer::getNumReceivedBytes(int clientID){
 
 //--------------------------
 int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -215,7 +215,7 @@ int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numByt
 
 //--------------------------
 int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLog(OF_LOG_WARNING, "ofxTCPServer: client " + ofToString(clientID) + " doesn't exist");
 		return 0;
@@ -226,7 +226,7 @@ int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int nu
 
 //--------------------------
 int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawMsg(): client " << clientID << " doesn't exist";
 		return 0;
@@ -237,7 +237,7 @@ int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes
 
 //--------------------------
 int ofxTCPServer::getClientPort(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientPort(): client " << clientID << " doesn't exist";
 		return 0;
@@ -247,7 +247,7 @@ int ofxTCPServer::getClientPort(int clientID){
 
 //--------------------------
 string ofxTCPServer::getClientIP(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientIP(): client " << clientID << " doesn't exist";
 		return "000.000.000.000";
@@ -257,7 +257,7 @@ string ofxTCPServer::getClientIP(int clientID){
 
 //--------------------------
 int ofxTCPServer::getNumClients(){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	return TCPConnections.size();
 }
 
@@ -278,13 +278,13 @@ bool ofxTCPServer::isConnected(){
 
 //--------------------------
 bool ofxTCPServer::isClientSetup(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	return TCPConnections.find(clientID)!=TCPConnections.end();
 }
 
 //--------------------------
 bool ofxTCPServer::isClientConnected(int clientID){
-	ofMutex::ScopedLock Lock( mConnectionsLock );
+    std::unique_lock<std::mutex> Lock( mConnectionsLock );
 	return isClientSetup(clientID) && getClient(clientID).isConnected();
 }
 
@@ -315,7 +315,7 @@ void ofxTCPServer::threadedFunction(){
 		if( !TCPServer.Accept( client->TCPClient ) ){
 			if(isThreadRunning()) ofLogError("ofxTCPServer") << "couldn't accept client " << acceptId;
 		}else{
-			ofMutex::ScopedLock Lock( mConnectionsLock );
+            std::unique_lock<std::mutex> Lock( mConnectionsLock );
 			//	take owenership of socket from NewClient
 			TCPConnections[acceptId] = client;
 			TCPConnections[acceptId]->setup(acceptId, bClientBlocking);


### PR DESCRIPTION
Proposed fix for https://github.com/openframeworks/openFrameworks/issues/3990 #3990 