### PR TITLE
OSX -pthread template fix

### DIFF
--- a/scripts/osx/template/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/osx/template/emptyExample.xcodeproj/project.pbxproj
@@ -199,7 +199,6 @@
 				<key>OTHER_CPLUSPLUSFLAGS</key>
 				<array>
 					<string>-D__MACOSX_CORE__</string>
-					<string>-lpthread</string>
 					<string>-mtune=native</string>
 				</array>
 				<key>SDKROOT</key>
@@ -253,7 +252,6 @@
 				<key>OTHER_CPLUSPLUSFLAGS</key>
 				<array>
 					<string>-D__MACOSX_CORE__</string>
-					<string>-lpthread</string>
 					<string>-mtune=native</string>
 				</array>
 				<key>SDKROOT</key>


### PR DESCRIPTION
Fix pthread issues from Xcode OSX template.

As referenced: 
https://github.com/openframeworks/openFrameworks/issues/3980