### PR TITLE
iOS Template - Code Sign fix for simulator

### DIFF
--- a/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/ios/template/emptyExample.xcodeproj/project.pbxproj
@@ -682,6 +682,8 @@
 				<string>libc++</string>
 				<key>CODE_SIGN_IDENTITY</key>
 				<string></string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphonesimulator*]</key>
+				<string></string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
 				<string>iPhone Developer</string>
 				<key>COMPRESS_PNG_FILES</key>
@@ -735,6 +737,8 @@
 				<key>CLANG_CXX_LIBRARY</key>
 				<string>libc++</string>
 				<key>CODE_SIGN_IDENTITY</key>
+				<string></string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphonesimulator*]</key>
 				<string></string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
 				<string>iPhone Developer</string>


### PR DESCRIPTION
Fix for Xcode Template to fix the potential issues with code signing for the iOS simulator. 

### Problem
- If the developer does not have an active or any Apple Developer account associated with their account it has issues properly signing / deploying to Simulator
- By default deploying to the simulator does not require code signing however in the current project template setup it is attempting to code sign the simulator

### Solution
- Define different targets for iPhoneSimulator and iPhoneOS for Xcode under the code signing section.
- By adding iPhoneSimulator explicitly and defining this as Do not code sign. This error is fixed.