### PR TITLE
Travis Automated Testing of the Core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,10 @@
-language: node_js
-node_js: '0.10'
-env:
-  global:
-    - secure: kjz286d6rs2VHpv4WnxAOYXcdTIaTaABZ0SNXf27r5H+NDu5qx8ZSeCmj/9op/sDjTtpkLKhi2a0njUCWwak28RAWP3dNkT92MkUPVKBkevznSxWeqwLHoUos3AJnhPMB+cwrWvmRC+Ljt5K1q8SxQsS/HXM9pzKL3DG3qxM+eo=
-branches:
-  only:
-    - master
-notifications:
-  email:
-    - jonas@halfdanj.dk
-before_install:
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then sudo apt-get install python-software-properties; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then sudo apt-add-repository -y ppa:libreoffice/libreoffice-4-2; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then sudo apt-get update; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then sudo apt-get install doxygen; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then sudo apt-get install ncftp; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then gem install sass --version "=3.2.12"; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then gem install compass --version "=0.12.2"; fi'
+language: objective-c
+compiler: clang
 script:
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then cd scripts/; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then git clone https://github.com/halfdanJ/ofDocGenerator; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then cd ofDocGenerator; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then npm install; fi'
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then npm run start; fi'
+  scripts/osx/testTemplate.sh
+  scripts/ios/testTemplate.sh
 after_success:
-  - 'if [[ $TRAVIS_PULL_REQUEST == "false" && $FTP_USER ]]; then ncftpput -R -v -u $FTP_USER -p $FTP_PASSWORD 104.130.212.175 / output/*; fi'
+  echo "openFrameworks OSX and iOS Build Passing"
+git:
+    depth: 1
+

--- a/scripts/ios/testTemplate.sh
+++ b/scripts/ios/testTemplate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+OF_DIR=`pwd`;
+echo $OF_DIR;
+TEST_DIR="$OF_DIR/scripts/ios"
+cd $TEST_DIR
+  echo "Looking for iOS Template Project"
+  if [ ! -d template/bin/emptyExample.app ]; then
+      echo "-----------------------------------------------------------------"
+ 	    echo building emptyExample
+      if [ ! -e template/emptyExample.xcodeproj ]; then
+          echo "-----------------------------------------------------------------"
+          echo no xcode project for emptyExample
+      fi
+      echo "Building openFrameworks - iOS Template Project"
+      xcodebuild -configuration Release -target emptyExample -project template/emptyExample.xcodeproj
+      ret=$?
+      if [ $ret -ne 0 ]; then
+ 	        echo failed building emptyExample
+ 	        exit 1
+      fi
+      echo "-----------------------------------------------------------------"
+  fi
+cd $OF_DIR

--- a/scripts/osx/testTemplate.sh
+++ b/scripts/osx/testTemplate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+OF_DIR=`pwd`;
+echo $OF_DIR;
+TEST_DIR="$OF_DIR/scripts/osx"
+cd $TEST_DIR
+  echo "Looking for OSX Template Project"
+  if [ ! -d template/bin/emptyExample.app ]; then
+      echo "-----------------------------------------------------------------"
+ 	    echo building emptyExample
+      if [ ! -e template/emptyExample.xcodeproj ]; then
+          echo "-----------------------------------------------------------------"
+          echo no xcode project for emptyExample
+      fi
+      echo "Building openFrameworks - OSX Template Project"
+      xcodebuild -configuration Release -target emptyExample -project template/emptyExample.xcodeproj
+      ret=$?
+      if [ $ret -ne 0 ]; then
+ 	        echo failed building emptyExample
+ 	        exit 1
+      fi
+      echo "-----------------------------------------------------------------"
+  fi
+cd $OF_DIR


### PR DESCRIPTION
#### Automated PR / Commit and Merge testing of Core

Original Discussion here from 2012: ```Continuous integration/testing``` https://github.com/openframeworks/openFrameworks/issues/1068

- iOS Empty Example + openFrameworks Core iOS Build Testing

- OSX Empty Example + openFrameworks Core OSX Build Testing
- Adds a tick or cross to every PR for fail or success (once configured on Travis-ci website) (You may remember this happening a while ago when travis was added for documentation generation).

- Removes Documentation Automation - @HalfdanJ had some travis code to generate http://docs.openframeworks.cc automatically on merges. 
This should be done another way, travis is integration testing, even the Github API is designed for this.
