### PR TITLE
fix ofVbo

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -950,6 +950,7 @@ void ofVbo::clear(){
 //--------------------------------------------------------------
 void ofVbo::clearVertices(){
 	positionAttribute = VertexAttribute();
+	positionAttribute.location = ofShader::POSITION_ATTRIBUTE;
 	bUsingVerts = false;
 	totalVerts = 0;
 }
@@ -957,12 +958,14 @@ void ofVbo::clearVertices(){
 //--------------------------------------------------------------
 void ofVbo::clearNormals(){
 	normalAttribute = VertexAttribute();
+	normalAttribute.location = ofShader::NORMAL_ATTRIBUTE;
 	bUsingNormals = false;
 }
 
 //--------------------------------------------------------------
 void ofVbo::clearColors(){
 	colorAttribute = VertexAttribute();
+	colorAttribute.location = ofShader::COLOR_ATTRIBUTE;
 	bUsingColors = false;
 	
 }
@@ -970,6 +973,7 @@ void ofVbo::clearColors(){
 //--------------------------------------------------------------
 void ofVbo::clearTexCoords(){
 	texCoordAttribute = VertexAttribute();
+	texCoordAttribute.location = ofShader::TEXCOORD_ATTRIBUTE;
 	bUsingTexCoords = false;
 }
 

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -133,10 +133,6 @@ public:
 	int getNumVertices() const;
 	int getNumIndices() const;
 	
-
-	static void disableVAOs();
-	static void enableVAOs();
-
 	bool hasAttribute(int attributePos_) const;
 
 private:


### PR DESCRIPTION
+ fixes an issue where `ofVbo::clear()` would invalidate an `ofVbo`.

`ofVbo::clear()` would not restore the default binding positions for position, color, normal and texture attributes.

This would lead to all these attributes being bound to location 0. Therefore, after calling `ofVbo::clear()`, it
was impossible to re-use that `ofVbo`, since all default attributes would map to location 0, and not, like in an initial ofVbo object, to the correct default attribute locations.

This PR fixes this by restoring the attribute binding locations for default attributes just after their buffers
have been reset, in each default attribute's clear method.

+ removes un-implemented static `ofVbo` methods from header file.

`static void disableVAOs()` and `static void enableVAOs()` were probably left orphaned after a refactor.