### PR TITLE
ofScopedLock and ofMutex deprecation

### DIFF
--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -38,7 +38,7 @@ static ofAppAndroidWindow * window;
 static ofOrientation orientation = OF_ORIENTATION_DEFAULT;
 
 static queue<ofTouchEventArgs> touchEventArgsQueue;
-static ofMutex mtx;
+static std::mutex mtx;
 static bool threadedTouchEvents = false;
 static bool appSetup = false;
 static bool accumulateTouchEvents = false;

--- a/addons/ofxNetwork/src/ofxTCPServer.h
+++ b/addons/ofxNetwork/src/ofxTCPServer.h
@@ -92,7 +92,7 @@ class ofxTCPServer : public ofThread{
 
 		ofxTCPManager			TCPServer;
 		map<int,ofPtr<ofxTCPClient> >	TCPConnections;
-		ofMutex					mConnectionsLock;
+		std::mutex					mConnectionsLock;
 
 		bool			connected;
 		string			str;

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -30,8 +30,8 @@ UInt32	numSounds;
 bool	mp3Loaded;
 
 
-static ofMutex& soundPlayerLock() {
-    static ofMutex* m = new ofMutex;
+static std::mutex& soundPlayerLock() {
+  static std::mutex* m = new std::mutex;
     return *m;
 }
 

--- a/examples/utils/threadExample/src/threadedObject.h
+++ b/examples/utils/threadExample/src/threadedObject.h
@@ -82,9 +82,9 @@ public:
     /// it includes OpenGL calls (ofDrawBitmapString).
     void draw()
     {
-        std::stringstream ss;
+        stringstream ss;
 
-        ss << "I am a slowly increasing thread. " << std::endl;
+        ss << "I am a slowly increasing thread. " << endl;
         ss << "My current count is: ";
 
         if(lock())
@@ -111,7 +111,7 @@ public:
     // Use unique_lock to protect a copy of count while getting a copy.
     int getCount()
     {
-        std::unique_lock<std::mutex> lock(mutex);
+        unique_lock<std::mutex> lock(mutex);
         return count;
     }
 

--- a/examples/utils/threadExample/src/threadedObject.h
+++ b/examples/utils/threadExample/src/threadedObject.h
@@ -108,10 +108,10 @@ public:
         ofDrawBitmapString(ss.str(), 50, 56);
     }
 
-    // Use ofScopedLock to protect a copy of count while getting a copy.
+    // Use unique_lock to protect a copy of count while getting a copy.
     int getCount()
     {
-        ofScopedLock lock(mutex);
+        std::unique_lock<std::mutex> lock(mutex);
         return count;
     }
 

--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -74,6 +74,7 @@ class ofSerialDeviceInfo{
 
 #include <mutex>
 /// \brief A typedef for a cross-platform mutex.
+/// \deprecated Please use std::mutex instead of ofMutex. See also the note below.
 ///
 /// A mutex is used to lock data when it is accessible from multiple threads.
 /// Locking data with a mutex prevents data-races, deadlocks and other problems
@@ -98,18 +99,19 @@ class ofSerialDeviceInfo{
 ///
 /// ~~~~
 ///
-/// \warning Currently ofMutex is a typedef for Poco::FastMutex a fast cross-
-/// platform mutex. In a future version of OF, Poco::FastMutex will be replaced
-/// by std::mutex.
+/// \note Currently ofMutex is a typedef for std::mutex. This is done
+/// to preserve backwards compatibility. Please use std::mutex for new
+/// code.
 ///
 /// \sa http://www.cplusplus.com/reference/mutex/mutex/
-/// \sa http://www.appinf.com/docs/poco/Poco.FastMutex.html
+/// \sa ofScopedLock
 #ifndef _MSC_VER
 [[deprecated("Use std::mutex instead")]]
 #endif
 typedef std::mutex ofMutex;
 
 /// \brief A typedef for a cross-platform scoped mutex.
+/// \deprecated Please use std::unique_lock<std::mutex> instead of ofScopedLock. See also the note below.
 ///
 /// Normally ofMutex requres explicit calls to ofMutex::lock() and
 /// ofMutex::unlock() to lock and release the mutex. Sometimes, despite best
@@ -138,12 +140,11 @@ typedef std::mutex ofMutex;
 ///
 /// ~~~~
 ///
-/// \warning Currently ofScopedLock is a typedef for Poco::FastMutex::ScopedLock
-/// a convenient wrapper fo Poco::FastMutex.  In a future version of OF,
-/// Poco::FastMutex::ScopedLock by std::lock_guard.
+/// \warning Currently ofScopedLock is a typedef for std::unique_lock<std::mutex>.
+/// This is done to preserve backwards compatibility. Please use
+/// std::unique_lock<std::mutex> for new code.
 ///
-/// \sa http://en.cppreference.com/w/cpp/thread/lock_guard
-/// \sa http://www.appinf.com/docs/poco/Poco.ScopedLock.html
+/// \sa http://en.cppreference.com/w/cpp/thread/unique_lock
 /// \sa ofMutex
 #ifndef _MSC_VER
 [[deprecated("use std::unique_lock instead")]]

--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -1249,7 +1249,7 @@ GstFlowReturn ofGstVideoUtils::process_sample(shared_ptr<GstSample> sample){
 			bufferQueue.push(sample);
 			gst_buffer_unmap(_buffer, &mapinfo);
 			bool newTexture=false;
-			ofScopedLock lock(mutex);
+			std::unique_lock<std::mutex> lock(mutex);
 			while(bufferQueue.size()>2){
 				backBuffer = bufferQueue.front();
 				bufferQueue.pop();


### PR DESCRIPTION
Hi,

i replaced all occurences of `ofMutex` and `ofScopedLock` since they are deprecated. The documentation is also updated. This should be merged in conjunction with #4012.
Cheers
tpltnt