### PR TITLE
overloaded-virtual fixes for ofxCv example

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvContourFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.h
@@ -44,6 +44,7 @@ class ofxCvContourFinder : public ofBaseDraws {
 	virtual void  draw(const ofPoint & point) const;
 	virtual void  draw(const ofRectangle & rect) const;
 	virtual void setAnchorPercent(float xPct, float yPct);
+    using ofBaseDraws::setAnchorPoint;
     virtual void setAnchorPoint(int x, int y);
 	virtual void resetAnchor();      
     //virtual ofxCvBlob  getBlob(int num);

--- a/addons/ofxOpenCv/src/ofxCvContourFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.h
@@ -37,6 +37,7 @@ class ofxCvContourFinder : public ofBaseDraws {
                                // of the contour, if the contour runs
                                // along a straight line, for example...
 
+    using ofBaseDraws::draw;
     virtual void  draw() const { draw(0,0, _width, _height); };
     virtual void  draw( float x, float y ) const { draw(x,y, _width, _height); };
     virtual void  draw( float x, float y, float w, float h ) const;

--- a/addons/ofxOpenCv/src/ofxCvFloatImage.h
+++ b/addons/ofxOpenCv/src/ofxCvFloatImage.h
@@ -61,6 +61,7 @@ class ofxCvFloatImage : public ofxCvImage {
 	      
     virtual void  setFromPixels( const unsigned char* _pixels, int w, int h);
     virtual void  setFromPixels( float * _pixels, int w, int h );  //no scaling
+    using ofxCvImage::setRoiFromPixels;
     virtual void  setRoiFromPixels( const unsigned char* _pixels, int w, int h);
     virtual void  setRoiFromPixels( float * _pixels, int w, int h );  //no scaling
     virtual void  operator = ( unsigned char* _pixels );


### PR DESCRIPTION
Hi,

i fixed the overloaded-virtual warnings triggered by the openCV example.
Cheers
tpltnt