### PR TITLE
adjusted error messages of ofxCvGrayscaleImage::absDiff()

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvGrayscaleImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvGrayscaleImage.cpp
@@ -249,11 +249,11 @@ void ofxCvGrayscaleImage::absDiff( ofxCvGrayscaleImage& mom,
                                    ofxCvGrayscaleImage& dad ) {
 
 	if( !mom.bAllocated ){
-		ofLogError("ofxCvGrayscaleImage") << "absDiff(): source image mom not allocated";	
+		ofLogError("ofxCvGrayscaleImage") << "absDiff(): first source image (mom) not allocated";
 		return;	
 	}
 	if( !dad.bAllocated ){
-		ofLogError("ofxCvGrayscaleImage") << "absDiff(): source image dad not allocated";
+		ofLogError("ofxCvGrayscaleImage") << "absDiff(): second source image (dad) not allocated";
 		return;	
 	}	
 	if( !bAllocated ){
@@ -271,7 +271,7 @@ void ofxCvGrayscaleImage::absDiff( ofxCvGrayscaleImage& mom,
         cvAbsDiff( mom.getCvImage(), dad.getCvImage(), cvImage );
         flagImageChanged();
     } else {
-        ofLogError("ofxCvGrayscaleImage") << "absDiff(): source image size mismatch between mom & dad";
+        ofLogError("ofxCvGrayscaleImage") << "absDiff(): source image size mismatch between first (mom) & second (dad) image";
     }
 
 }


### PR DESCRIPTION
Hi,

I received some error messages from ofxCvGrayscaleImage::absDiff() and could not figure out the `mom` and `dad` names from the message alone. I changed the  error messages to be more comprehensible (without needing to know the method signature).
Cheers,
tpltnt