### PR TITLE
Addition of Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior includes the use of sexual language or imagery
 * Attempt collaboration before conflict.
 * Be mindful of other community members.
 
-Alert any one of the core members ([Zach](https://github.com/ofZach), [Theo](https://github.com/ofTheo), [Arturo](https://github.com/arturoc)) or the community organizer ([Kyle](https://github.com/kylemcdonald)) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Alert [the core](of@openframeworks.cc) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 One of the goals of openFrameworks is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, socioeconomic status, age, level of experience, personal appearance, ethnicity, religion or philosophy.
 
-As the openFrameworks community, we pledge to respect all members who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, engage in discussion on the forum, mailing list or IRC, participate in meetups and workshops, or who are involved in any way with openFrameworks.
+As the openFrameworks community, we pledge to respect both old and new members who post on the forum, chat on IRC, post on mailing lists, report issues, post feature requests, submit pull requests or patches, update documentation, participate in meetups and workshops, or are involved in any way with openFrameworks.
 
 Examples of unacceptable behavior include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, exclusion, or other disrespectful conduct. We promise each other to:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # openFrameworks Code of Conduct
 
-One of the goals of openFrameworks is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, socioeconomic status, age, level of experience, personal appearance, ethnicity, and religion (or lack thereof).
+One of the goals of openFrameworks is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, socioeconomic status, age, level of experience, personal appearance, ethnicity, religion or philosophy.
 
 As the openFrameworks community, we pledge to respect all members who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, engage in discussion on the forum, mailing list or IRC, participate in meetups and workshops, or who are involved in any way with openFrameworks.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior include the use of sexual language or imagery,
 * Attempt collaboration before conflict.
 * Be mindful of other community members.
 
-Alert [the core](mailto:of@openframeworks.cc) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Alert [the core](mailto:of@openframeworks.cc) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential. We'll treat reports as anonymous submissions, and do our best to work with everyone in private to resolve the conflict.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior include the use of sexual language or imagery,
 * Attempt collaboration before conflict.
 * Be mindful of other community members.
 
-Alert [the core](of@openframeworks.cc) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Alert [the core](mailto:of@openframeworks.cc) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@ One of the goals of openFrameworks is to be inclusive to the largest number of c
 
 As the openFrameworks community, we pledge to respect all members who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, engage in discussion on the forum, mailing list or IRC, participate in meetups and workshops, or who are involved in any way with openFrameworks.
 
-Examples of unacceptable behavior includes the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other disrespectful conduct. We promise each other to:
+Examples of unacceptable behavior include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, exclusion, or other disrespectful conduct. We promise each other to:
 
 * Participate in an authentic and active way. In doing so, we contribute to the health and longevity of this community.
 * Exercise consideration and respect in our speech and actions.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior includes the use of sexual language or imagery
 * Attempt collaboration before conflict.
 * Be mindful of other community members.
 
-Alert anyone of the core members ([Zach](https://github.com/ofZach), [Theo](https://github.com/ofTheo), [Arturo](https://github.com/arturoc)) or the community organizer ([Kyle](https://github.com/kylemcdonald)) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Alert any one of the core members ([Zach](https://github.com/ofZach), [Theo](https://github.com/ofTheo), [Arturo](https://github.com/arturoc)) or the community organizer ([Kyle](https://github.com/kylemcdonald)) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,20 @@
-# Contributor Code of Conduct
+# openFrameworks Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+One of the goals of openFrameworks is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, socioeconomic status, age, level of experience, personal appearance, ethnicity, and religion (or lack thereof).
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+As the openFrameworks community, we pledge to respect all members who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, engage in discussion on the forum, mailing list or IRC, participate in meetups and workshops, or who are involved in any way with openFrameworks.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+Examples of unacceptable behavior includes the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other disrespectful conduct. We promise each other to:
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+* Participate in an authentic and active way. In doing so, we contribute to the health and longevity of this community.
+* Exercise consideration and respect in our speech and actions.
+* Attempt collaboration before conflict.
+* Be mindful of other community members.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Alert anyone in [the core](https://github.com/orgs/openframeworks/teams/core) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the openFrameworks community.
+
+_This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org) and the [Berlin Code of Conduct](http://berlincodeofconduct.org/)_

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior includes the use of sexual language or imagery
 * Attempt collaboration before conflict.
 * Be mindful of other community members.
 
-Alert anyone in [the core](https://github.com/orgs/openframeworks/teams/core) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+Alert anyone of the core members ([Zach](https://github.com/ofZach), [Theo](https://github.com/ofTheo), [Arturo](https://github.com/arturoc)) or the community organizer ([Kyle](https://github.com/kylemcdonald)) if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Contributors who do not follow the Code of Conduct will be removed from the project team.
 


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md alongside the README.md and LICENSE.md. @ofZach mentioned this one on Twitter and I thought it was nice, so I thought I'd add it.

Probably more important than any code of conduct itself is the discussion that happens around it. I brought this up in October and some of the comments then were:

- Make the "Philosophy" section more prominent on the "About" page (it's been moved to the top).
- It'd be nice, but we already have a lot of text on the site. We should organize and consolidate the text in a smart way (@workergnome started working on this, but it's on hiatus).
- Changing the language a little bit. For example, "If you are not a part of the group, welcome!" got changed to "If you are not yet...". Changing "of-dev" to "of-contributors" could also be good.
- Making it more clear how people can get involved should go along with any code of conduct. There's a short "Contribute" section under the "Community" page that @caitlinmorris added, but as far as I can tell no one has acted on any of the suggestions listed there. I think it might be time to try a new approach where we just have a single link that says "if you're interested in contributing, send an email to this person" and then we work it out from there. More personal relationships are probably going to work better than more diverse descriptions of ways to contribute.

Anyway, I wanted to post this PR as a way to keep this discussion going :)