### PR TITLE
fix hard-coded glInternalformat

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -317,7 +317,7 @@ void ofTexture::allocate(const ofBufferObject & buffer, int glInternalFormat){
 	texData.textureTarget = GL_TEXTURE_BUFFER;
 	allocate(texData);
 	glBindTexture(texData.textureTarget,texData.textureID);
-	glTexBuffer(GL_TEXTURE_BUFFER,GL_RGBA32F,buffer.getId());
+	glTexBuffer(GL_TEXTURE_BUFFER, glInternalFormat,buffer.getId());
 	glBindTexture(texData.textureTarget,0);
 }
 #endif


### PR DESCRIPTION
when allocating an ofTexture backed by an ofBufferObject, the glInternal format would always be hardcoded to GL_RGBA32F, regardless of the glInternalFormat parameter handed over through the method parameters.

This was probably accidentally leftover from a refactor.

ping @arturoc 