### PR TITLE
refactor ofThread to use std::thread instead of Poco::Thread

### DIFF
--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -147,19 +147,6 @@ const std::thread & ofThread::getNativeThread() const{
 	return thread;
 }
 
-
-//-------------------------------------------------
-bool ofThread::isMainThread(){
-    return false;
-}
-
-
-//-------------------------------------------------
-std::thread * ofThread::getCurrentNativeThread(){
-	return nullptr;
-}
-
-
 //-------------------------------------------------
 void ofThread::threadedFunction(){
 	ofLogWarning("ofThread") << "- name: " << getThreadName() << " - Override ofThread::threadedFunction() in your ofThread subclass.";

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -105,7 +105,8 @@ void ofThread::waitForThread(bool callStopThread, long milliseconds){
 		}
 
         if (INFINITE_JOIN_TIMEOUT == milliseconds){
-            thread.join();
+        	std::unique_lock<std::mutex> lck(mutex);
+        	timeoutJoin.wait(lck);
         }else{
             // Wait for "joinWaitMillis" milliseconds for thread to finish
         	std::unique_lock<std::mutex> lck(mutex);
@@ -187,6 +188,7 @@ void ofThread::run(){
 #ifdef TARGET_ANDROID
 	attachResult = ofGetJavaVMPtr()->DetachCurrentThread();
 #endif
+    std::unique_lock<std::mutex> lck(mutex);
 	threadRunning = false;
 	threadDone = true;
 	timeoutJoin.notify_all();

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -106,11 +106,11 @@ void ofThread::waitForThread(bool callStopThread, long milliseconds){
 
         if (INFINITE_JOIN_TIMEOUT == milliseconds){
         	std::unique_lock<std::mutex> lck(mutex);
-        	timeoutJoin.wait(lck);
+        	joinCondition.wait(lck);
         }else{
             // Wait for "joinWaitMillis" milliseconds for thread to finish
         	std::unique_lock<std::mutex> lck(mutex);
-            if(timeoutJoin.wait_for(lck,std::chrono::milliseconds(milliseconds))==std::cv_status::timeout){
+            if(joinCondition.wait_for(lck,std::chrono::milliseconds(milliseconds))==std::cv_status::timeout){
 				// unable to completely wait for thread
             }
         }
@@ -175,6 +175,7 @@ void ofThread::run(){
 		ofLogWarning() << "couldn't attach new thread to java vm";
 	}
 #endif
+
 	// user function
     // should loop endlessly.
 	try{
@@ -188,8 +189,9 @@ void ofThread::run(){
 #ifdef TARGET_ANDROID
 	attachResult = ofGetJavaVMPtr()->DetachCurrentThread();
 #endif
+
     std::unique_lock<std::mutex> lck(mutex);
 	threadRunning = false;
 	threadDone = true;
-	timeoutJoin.notify_all();
+	joinCondition.notify_all();
 }

--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -369,7 +369,7 @@ private:
 
     std::string name;
 
-    std::condition_variable timeoutJoin;
+    std::condition_variable joinCondition;
 
 };
 

--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -361,14 +361,13 @@ private:
     void run();
 
     ///< \brief Is the thread running?
-    std::atomic<std::pair<bool,bool>> threadRunningDone;
+    std::atomic<bool> threadRunning;
+    std::atomic<bool> threadDone;
 
     ///< \brief Should the mutex block?
     std::atomic<bool> mutexBlocks;
 
-    std::atomic<bool> threadBeingWaitedFor;
-
-    std::atomic<std::string> name;
+    std::string name;
 
     std::condition_variable timeoutJoin;
 

--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -270,35 +270,6 @@ public:
     /// \returns A reference to the backing Poco thread.
     const std::thread & getNativeThread() const;
 
-    /// \brief A query to see if the current thread is the main thread.
-    ///
-    /// Some functions (e.g. OpenGL calls) can only be executed
-    /// the main thread.  This static function will tell the user
-    /// what thread is currently active at the moment the method
-    /// is called.
-    ///
-    ///     if (ofThread::isMainThread())
-    ///     {
-    ///         ofLogNotice() << "This is the main thread!";
-    ///     }
-    ///     else
-    ///     {
-    ///         ofLogNotice() << "This is NOT the main thread.";
-    ///     }
-    ///
-    /// \returns true iff the current thread is the main thread.
-    static bool isMainThread();
-
-    /// \brief Get the current Poco thread.
-    ///
-    /// In most cases, it is more appropriate to query the current
-    /// thread by calling isCurrentThread() on an active thread or
-    /// by calling ofThread::isMainThread().  See the method
-    /// documentation for more information on those methods.
-    ///
-    /// \returns A pointer to the current active thread OR 0 iff the main
-    ///     application thread is active.
-    static std::thread * getCurrentNativeThread();
 
     enum {
         INFINITE_JOIN_TIMEOUT = -1

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -140,7 +140,7 @@ void ofURLFileLoaderImpl::stop() {
 }
 
 void ofURLFileLoaderImpl::threadedFunction() {
-	thread.setName("ofURLFileLoader " + thread.name());
+	setThreadName("ofURLFileLoader " + ofToString(getThreadId()));
 	while( isThreadRunning() ){
 		int cancelled;
 		while(cancelRequestQueue.tryReceive(cancelled)){


### PR DESCRIPTION
Solves #3999 but introducing std::thread in ofThread this late might be problematic, i don't mind moving #3999 and this PR back to next release.

This also removes some methods in ofThread which is not possible to implement with std::thread anymore like getting the current thread as an object or checking if the calling thread is the main thread. in any case using those methods were not very good practice i think.

std thread doesn't have a numeric id so this returns now std::thread::id instead of int we could keep track of each created thread using a static variable in the class but i think is better to just expose the native id