### PR TITLE
add locale to trim methods

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -686,7 +686,7 @@ string ofToUpper(const string & src, const string & locale){
 //--------------------------------------------------
 string ofTrimFront(const string & src, const string& locale_){
 	std::locale loc = getLocale(locale_);
-	auto front = std::find_if_not(src.begin(),src.end(),[&loc](int c){return std::isspace(c,loc);});
+	auto front = std::find_if_not(src.begin(),src.end(),[&loc](wchar_t c){return std::isspace(c,loc);});
 	return std::string(front,src.end());
 }
 
@@ -699,15 +699,15 @@ string ofTrimBack(const string & src, const string& locale_){
 	catch (...) {
 		ofLogWarning("ofToUpper") << "Couldn't create locale " << locale_ << " using default, " << loc.name();
 	}
-	auto back = std::find_if_not(src.rbegin(),src.rend(),[&loc](int c){return std::isspace(c,loc);}).base();
+	auto back = std::find_if_not(src.rbegin(),src.rend(),[&loc](wchar_t c){return std::isspace(c,loc);}).base();
 	return std::string(src.begin(),back);
 }
 
 //--------------------------------------------------
 string ofTrim(const string & src, const string& locale_){
 	std::locale loc = getLocale(locale_);
-	auto front = std::find_if_not(src.begin(),src.end(),[&loc](int c){return std::isspace(c,loc);});
-	auto back = std::find_if_not(src.rbegin(),src.rend(),[&loc](int c){return std::isspace(c,loc);}).base();
+	auto front = std::find_if_not(src.begin(),src.end(),[&loc](wchar_t c){return std::isspace(c,loc);});
+	auto back = std::find_if_not(src.rbegin(),src.rend(),[&loc](wchar_t c){return std::isspace(c,loc);}).base();
 	return (back<=front ? std::string() : std::string(front,back));
 }
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -432,9 +432,9 @@ string ofToLower(const string& src, const string & locale="");
 /// \returns the UTF-8 encoded string as all uppercase characters.
 string ofToUpper(const string& src, const string & locale="");
 
-string ofTrimFront(const string & src);
-string ofTrimBack(const string & src);
-string ofTrim(const string & src);
+string ofTrimFront(const string & src, const string & locale = "");
+string ofTrimBack(const string & src, const string & locale = "");
+string ofTrim(const string & src, const string & locale = "");
 
 void ofAppendUTF8(string & str, int utf8);
 


### PR DESCRIPTION
visual studio requires a locale to be given for std::isspace.

it seems that there are two signatures for std::isspace available, one in `<string>` and one in `<locale>`
but Visual Studio defaults to the one in `<locale>` 

http://en.cppreference.com/w/cpp/locale/isspace 
vs.
http://en.cppreference.com/w/cpp/string/byte/isspace

+ refactor getLocale to a helper method within `ofUtils.cpp` to keep things DRY

addresses #4042 