### PR TITLE
rename ofTexture::allocate for texture buffers

### DIFF
--- a/examples/gl/textureBufferInstancedExample/src/ofApp.cpp
+++ b/examples/gl/textureBufferInstancedExample/src/ofApp.cpp
@@ -14,8 +14,10 @@ void ofApp::setup(){
 	buffer.setData(matrices,GL_STREAM_DRAW);
 
 	// using GL_RGBA32F allows to read each row of each matrix
-	// as a float vec4 from the shader
-	tex.allocate(buffer,GL_RGBA32F);
+	// as a float vec4 from the shader.
+	// Note that we're allocating the texture as a Buffer Texture:
+	// https://www.opengl.org/wiki/Buffer_Texture
+	tex.allocateAsBufferTexture(buffer,GL_RGBA32F);
 
 	// now we bind the texture to the shader as a uniform
 	// so we can read the texture buffer from it

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -312,7 +312,7 @@ void ofTexture::allocate(const ofFloatPixels& pix, bool bUseARBExtention){
 
 #ifndef TARGET_OPENGLES
 //----------------------------------------------------------
-void ofTexture::allocate(const ofBufferObject & buffer, int glInternalFormat){
+void ofTexture::allocateAsBufferTexture(const ofBufferObject & buffer, int glInternalFormat){
 	texData.glTypeInternal = glInternalFormat;
 	texData.textureTarget = GL_TEXTURE_BUFFER;
 	allocate(texData);

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -385,18 +385,21 @@ class ofTexture : public ofBaseDraws {
 	virtual void allocate(const ofFloatPixels& pix, bool bUseARBExtension);
 
 #ifndef TARGET_OPENGLES
-	/// \brief Allocate texture using an ofBufferObject instead of RAM memory.
+	/// \brief Allocate texture as a Buffer Texture.
 	///
-	/// Uses a gpu buffer as data for the texture instead of pixels in RAM
+	/// Uses a GPU buffer as data for the texture instead of pixels in RAM
 	/// Allows to use texture buffer objects (TBO) which make it easier to send big
 	/// amounts of data to a shader as a uniform.
+	/// 
+	/// Buffer textures are 1D textures, and may only be sampled using texelFetch 
+	/// in GLSL.
 	///
 	/// See textureBufferInstanceExample and https://www.opengl.org/wiki/Buffer_Texture
 	///
 	/// \sa allocate(const ofBufferObject & buffer, int glInternalFormat)
 	/// \param buffer Reference to ofBufferObject instance.
 	/// \param glInternalFormat Internal pixel format of the data.
-	void allocate(const ofBufferObject & buffer, int glInternalFormat);
+	void allocateAsBufferTexture(const ofBufferObject & buffer, int glInternalFormat);
 #endif
 
 


### PR DESCRIPTION
When allocating a texture as a texture buffer, the texture
cannot be used as a vanilla texture anymore, but must be
used as a buffer texture.

This name change in the hope it might help disambiguation.

Addresses #4035 

+ Also updated textureBufferInstancedExample so it uses the new signature