### PR TITLE
rename .glTypeInternal -> .glInternalFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ CORE
 	  `ofVbo::setAttributeData(ofShader::TEXCOORD_ATTRIBUTE, ...)` which allows
 	  for 3d texture coordinates.
 	/ Fix ofTexture::readToPixels for non RGBA or 4 aligned formats
+	/ Rename ofTextureData.glTypeInternal -> ofTextureDataData.glInternalFormat (this brings the parameter's name into sync with the OpenGL enum it represents)
 ### graphics
 	+ ofTruetypeFont: kerning and better hinting and spacing
 	+ ofDrawBitmapString: can draw any type not only strings

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -263,7 +263,7 @@ bool ofxAndroidVideoGrabber::setup(int w, int h){
 		td.tex_t = 1; // Hack!
 		td.tex_u = 1;
 		td.textureTarget = GL_TEXTURE_EXTERNAL_OES;
-		td.glTypeInternal = GL_RGBA;
+		td.glInternalFormat = GL_RGBA;
 		td.bFlipTexture = false;
 
 		// hack to initialize gl resources from outside ofTexture

--- a/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
@@ -137,7 +137,7 @@ bool ofxAndroidVideoPlayer::load(string fileName){
 	td.tex_t = 1; // Hack!
 	td.tex_u = 1;
 	td.textureTarget = GL_TEXTURE_EXTERNAL_OES;
-	td.glTypeInternal = GL_RGBA;
+	td.glInternalFormat = GL_RGBA;
 	td.bFlipTexture = false;
 
 	// hack to initialize gl resources from outside ofTexture

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -70,13 +70,13 @@ void ofxEmscriptenVideoGrabber::update(){
 			texture.texData.bFlipTexture = false;
 			switch(getPixelFormat()){
 			case OF_PIXELS_RGBA:
-				texture.texData.glTypeInternal = GL_RGBA;
+				texture.texData.glInternalFormat = GL_RGBA;
 				break;
 			case OF_PIXELS_RGB:
-				texture.texData.glTypeInternal = GL_RGB;
+				texture.texData.glInternalFormat = GL_RGB;
 				break;
 			case OF_PIXELS_MONO:
-				texture.texData.glTypeInternal = GL_LUMINANCE;
+				texture.texData.glInternalFormat = GL_LUMINANCE;
 				break;
 			default:
 				ofLogError() << "unknown pixel format, can't allocating texture";

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -343,7 +343,7 @@ void ofxiOSVideoPlayer::initTextureCache() {
                                                        imageBuffer,             // CVImageBufferRef sourceImage
                                                        NULL,                    // CFDictionaryRef textureAttributes
                                                        texData.textureTarget,   // GLenum target
-                                                       texData.glTypeInternal,  // GLint internalFormat
+                                                       texData.glInternalFormat,  // GLint internalFormat
                                                        texData.width,           // GLsizei width
                                                        texData.height,          // GLsizei height
                                                        GL_BGRA,                 // GLenum format

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -628,7 +628,7 @@ void ofFbo::createAndAttachTexture(GLenum internalFormat, GLenum attachmentPoint
 	texData.textureTarget = settings.textureTarget;
 	texData.width = settings.width;
 	texData.height = settings.height;
-	texData.glTypeInternal = internalFormat;
+	texData.glInternalFormat = internalFormat;
 	texData.bFlipTexture = false;
 	texData.wrapModeHorizontal = settings.wrapModeHorizontal;
 	texData.wrapModeVertical = settings.wrapModeVertical;
@@ -679,7 +679,7 @@ void ofFbo::createAndAttachDepthStencilTexture(GLenum target, GLint internalform
 
 
 	// allocate depthBufferTex as depth buffer;
-	depthBufferTex.texData.glTypeInternal = internalformat;
+	depthBufferTex.texData.glInternalFormat = internalformat;
 	depthBufferTex.texData.textureTarget = target;
 	depthBufferTex.texData.bFlipTexture = false;
 	depthBufferTex.texData.width = settings.width;
@@ -695,7 +695,7 @@ void ofFbo::createAndAttachDepthStencilTexture(GLenum target, GLint internalform
 void ofFbo::createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum  attachment){
 
 	// allocate depthBufferTex as depth buffer;
-	depthBufferTex.texData.glTypeInternal = internalformat;
+	depthBufferTex.texData.glInternalFormat = internalformat;
 	depthBufferTex.texData.textureTarget = target;
 	depthBufferTex.texData.bFlipTexture = false;
 	depthBufferTex.texData.width = settings.width;

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -259,18 +259,18 @@ void ofTexture::setUseExternalTextureID(GLuint externTexID){
 }
 
 //----------------------------------------------------------
-void ofTexture::allocate(int w, int h, int internalGlDataType){
-	allocate(w, h, internalGlDataType, ofGetUsingArbTex(), ofGetGLFormatFromInternal(internalGlDataType), ofGetGlTypeFromInternal(internalGlDataType));
+void ofTexture::allocate(int w, int h, int glInternalFormat){
+	allocate(w, h, glInternalFormat, ofGetUsingArbTex(), ofGetGLFormatFromInternal(glInternalFormat), ofGetGlTypeFromInternal(glInternalFormat));
 }
 
 //----------------------------------------------------------
-void ofTexture::allocate(int w, int h, int internalGlDataType, bool bUseARBExtension){
-	allocate(w, h, internalGlDataType, bUseARBExtension, ofGetGLFormatFromInternal(internalGlDataType), ofGetGlTypeFromInternal(internalGlDataType));
+void ofTexture::allocate(int w, int h, int glInternalFormat, bool bUseARBExtension){
+	allocate(w, h, glInternalFormat, bUseARBExtension, ofGetGLFormatFromInternal(glInternalFormat), ofGetGlTypeFromInternal(glInternalFormat));
 }
 
 //----------------------------------------------------------
-void ofTexture::allocate(int w, int h, int internalGlDataType, int glFormat, int pixelType){
-	allocate(w, h, internalGlDataType, ofGetUsingArbTex(), glFormat, pixelType);
+void ofTexture::allocate(int w, int h, int glInternalFormat, int glFormat, int pixelType){
+	allocate(w, h, glInternalFormat, ofGetUsingArbTex(), glFormat, pixelType);
 }
 
 //----------------------------------------------------------
@@ -313,7 +313,7 @@ void ofTexture::allocate(const ofFloatPixels& pix, bool bUseARBExtention){
 #ifndef TARGET_OPENGLES
 //----------------------------------------------------------
 void ofTexture::allocateAsBufferTexture(const ofBufferObject & buffer, int glInternalFormat){
-	texData.glTypeInternal = glInternalFormat;
+	texData.glInternalFormat = glInternalFormat;
 	texData.textureTarget = GL_TEXTURE_BUFFER;
 	allocate(texData);
 	glBindTexture(texData.textureTarget,texData.textureID);
@@ -323,11 +323,11 @@ void ofTexture::allocateAsBufferTexture(const ofBufferObject & buffer, int glInt
 #endif
 
 //----------------------------------------------------------
-void ofTexture::allocate(int w, int h, int internalGlDataType, bool bUseARBExtension, int glFormat, int pixelType){
+void ofTexture::allocate(int w, int h, int glInternalFormat, bool bUseARBExtension, int glFormat, int pixelType){
 	texData.width = w;
 	texData.height = h;
 	texData.bFlipTexture = false;
-	texData.glTypeInternal = internalGlDataType;
+	texData.glInternalFormat = glInternalFormat;
 	//our graphics card might not support arb so we have to see if it is supported.
 #ifndef TARGET_OPENGLES
 	if (bUseARBExtension && GL_ARB_texture_rectangle){
@@ -344,7 +344,7 @@ void ofTexture::allocate(int w, int h, int internalGlDataType, bool bUseARBExten
 //----------------------------------------------------------
 
 void ofTexture::allocate(const ofTextureData & textureData){
-	allocate(textureData,ofGetGLFormatFromInternal(textureData.glTypeInternal),ofGetGlTypeFromInternal(textureData.glTypeInternal));
+	allocate(textureData,ofGetGLFormatFromInternal(textureData.glInternalFormat),ofGetGlTypeFromInternal(textureData.glInternalFormat));
 }
 
 //----------------------------------------------------------
@@ -398,7 +398,7 @@ void ofTexture::allocate(const ofTextureData & textureData, int glFormat, int pi
 	if(texData.textureTarget == GL_TEXTURE_2D){
 #endif
 		glBindTexture(texData.textureTarget,texData.textureID);
-		glTexImage2D(texData.textureTarget, 0, texData.glTypeInternal, (GLint)texData.tex_w, (GLint)texData.tex_h, 0, glFormat, pixelType, 0);  // init to black...
+		glTexImage2D(texData.textureTarget, 0, texData.glInternalFormat, (GLint)texData.tex_w, (GLint)texData.tex_h, 0, glFormat, pixelType, 0);  // init to black...
 
 		glTexParameterf(texData.textureTarget, GL_TEXTURE_MAG_FILTER, texData.magFilter);
 		glTexParameterf(texData.textureTarget, GL_TEXTURE_MIN_FILTER, texData.minFilter);
@@ -425,32 +425,32 @@ void ofTexture::setRGToRGBASwizzles(bool rToRGBSwizzles){
 #ifndef TARGET_OPENGLES
 	glBindTexture(texData.textureTarget,texData.textureID);
 	if(rToRGBSwizzles){
-		if(texData.glTypeInternal==GL_R8 ||
-				texData.glTypeInternal==GL_R16 ||
-				texData.glTypeInternal==GL_R32F){
+		if(texData.glInternalFormat==GL_R8 ||
+				texData.glInternalFormat==GL_R16 ||
+				texData.glInternalFormat==GL_R32F){
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_R, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_G, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_B, GL_RED);
 
-		}else if(texData.glTypeInternal==GL_RG8 ||
-				texData.glTypeInternal==GL_RG16 ||
-				texData.glTypeInternal==GL_RG32F){
+		}else if(texData.glInternalFormat==GL_RG8 ||
+				texData.glInternalFormat==GL_RG16 ||
+				texData.glInternalFormat==GL_RG32F){
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_R, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_G, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_B, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_A, GL_GREEN);
 		}
 	}else{
-		if(texData.glTypeInternal==GL_R8 ||
-				texData.glTypeInternal==GL_R16 ||
-				texData.glTypeInternal==GL_R32F){
+		if(texData.glInternalFormat==GL_R8 ||
+				texData.glInternalFormat==GL_R16 ||
+				texData.glInternalFormat==GL_R32F){
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_R, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_G, GL_GREEN);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_B, GL_BLUE);
 
-		}else if(texData.glTypeInternal==GL_RG8 ||
-				texData.glTypeInternal==GL_RG16 ||
-				texData.glTypeInternal==GL_RG32F){
+		}else if(texData.glInternalFormat==GL_RG8 ||
+				texData.glInternalFormat==GL_RG16 ||
+				texData.glInternalFormat==GL_RG32F){
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_R, GL_RED);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_G, GL_GREEN);
 			 glTexParameteri(texData.textureTarget, GL_TEXTURE_SWIZZLE_B, GL_BLUE);
@@ -537,7 +537,7 @@ void ofTexture::loadData(const void * data, int w, int h, int glFormat, int glTy
 
 	if(w > texData.tex_w || h > texData.tex_h) {
 		if(isAllocated()){
-			allocate(w, h, texData.glTypeInternal, glFormat, glType);
+			allocate(w, h, texData.glInternalFormat, glFormat, glType);
 		}else{
 			// TODO: guess correct internal from glFormat
 			allocate(w, h, glFormat, glFormat, glType);
@@ -719,7 +719,7 @@ void ofTexture::unbind(int textureLocation) const{
 #if !defined(TARGET_OPENGLES) && defined(glBindImageTexture)
 //----------------------------------------------------------
 void ofTexture::bindAsImage(GLuint unit, GLenum access, GLint level, GLboolean layered, GLint layer){
-	glBindImageTexture(unit,texData.textureID,level,layered,layer,access,texData.glTypeInternal);
+	glBindImageTexture(unit,texData.textureID,level,layered,layer,access,texData.glInternalFormat);
 }
 #endif
 
@@ -1079,7 +1079,7 @@ ofMesh ofTexture::getQuad(const ofPoint & p1, const ofPoint & p2, const ofPoint 
 //----------------------------------------------------------
 void ofTexture::readToPixels(ofPixels & pixels) const {
 #ifndef TARGET_OPENGLES
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glInternalFormat));
 	ofSetPixelStoreiAlignment(GL_PACK_ALIGNMENT,pixels.getWidth(),pixels.getBytesPerChannel(),pixels.getNumChannels());
 	glBindTexture(texData.textureTarget,texData.textureID);
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_UNSIGNED_BYTE, pixels.getData());
@@ -1090,7 +1090,7 @@ void ofTexture::readToPixels(ofPixels & pixels) const {
 //----------------------------------------------------------
 void ofTexture::readToPixels(ofShortPixels & pixels) const {
 #ifndef TARGET_OPENGLES
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glInternalFormat));
 	ofSetPixelStoreiAlignment(GL_PACK_ALIGNMENT,pixels.getWidth(),pixels.getBytesPerChannel(),pixels.getNumChannels());
 	glBindTexture(texData.textureTarget,texData.textureID);
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_UNSIGNED_SHORT,pixels.getData());
@@ -1100,7 +1100,7 @@ void ofTexture::readToPixels(ofShortPixels & pixels) const {
 
 void ofTexture::readToPixels(ofFloatPixels & pixels) const {
 #ifndef TARGET_OPENGLES
-	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glTypeInternal));
+	pixels.allocate(texData.width,texData.height,ofGetImageTypeFromGLType(texData.glInternalFormat));
 	ofSetPixelStoreiAlignment(GL_PACK_ALIGNMENT,pixels.getWidth(),pixels.getBytesPerChannel(),pixels.getNumChannels());
 	glBindTexture(texData.textureTarget,texData.textureID);
 	glGetTexImage(texData.textureTarget,0,ofGetGlFormat(pixels),GL_FLOAT,pixels.getData());
@@ -1111,10 +1111,10 @@ void ofTexture::readToPixels(ofFloatPixels & pixels) const {
 #ifndef TARGET_OPENGLES
 //----------------------------------------------------------
 void ofTexture::copyTo(ofBufferObject & buffer) const{
-	ofSetPixelStoreiAlignment(GL_PACK_ALIGNMENT,getWidth(),ofGetBytesPerChannelFromGLType(ofGetGlTypeFromInternal(texData.glTypeInternal)),ofGetNumChannelsFromGLFormat(ofGetGLFormatFromInternal(texData.glTypeInternal)));
+	ofSetPixelStoreiAlignment(GL_PACK_ALIGNMENT,getWidth(),ofGetBytesPerChannelFromGLType(ofGetGlTypeFromInternal(texData.glInternalFormat)),ofGetNumChannelsFromGLFormat(ofGetGLFormatFromInternal(texData.glInternalFormat)));
 	buffer.bind(GL_PIXEL_PACK_BUFFER);
 	glBindTexture(texData.textureTarget,texData.textureID);
-	glGetTexImage(texData.textureTarget,0,ofGetGLFormatFromInternal(texData.glTypeInternal),ofGetGlTypeFromInternal(texData.glTypeInternal),0);
+	glGetTexImage(texData.textureTarget,0,ofGetGLFormatFromInternal(texData.glInternalFormat),ofGetGlTypeFromInternal(texData.glInternalFormat),0);
 	glBindTexture(texData.textureTarget,0);
 	buffer.unbind(GL_PIXEL_PACK_BUFFER);
 

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -159,10 +159,10 @@ public:
 	ofTextureData() {
 		textureID = 0;
 #ifndef TARGET_OPENGLES
-		glTypeInternal = GL_RGB8;
+		glInternalFormat = GL_RGB8;
 		textureTarget = GL_TEXTURE_RECTANGLE_ARB;
 #else
-		glTypeInternal = GL_RGB;
+		glInternalFormat = GL_RGB;
 		textureTarget = GL_TEXTURE_2D;
 #endif
 
@@ -191,7 +191,7 @@ public:
 	unsigned int textureID; ///< GL internal texture ID.
 	int textureTarget; ///< GL texture type, either GL_TEXTURE_2D or
 	                   ///< GL_TEXTURE_RECTANGLE_ARB.
-	int glTypeInternal; ///< GL internal format, e.g. GL_RGB8.
+	int glInternalFormat; ///< GL internal format, e.g. GL_RGB8.
                         ///< \sa http://www.opengl.org/wiki/Image_Format
 	
 	float tex_t; ///< Texture horizontal coordinate, ratio of width to display width.

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -948,8 +948,8 @@ void ofImage_<PixelType>::update(){
 	bpp = pixels.getBitsPerPixel();
 	type = pixels.getImageType();
 	if (pixels.isAllocated() && bUseTexture){
-		int glTypeInternal = ofGetGlInternalFormat(pixels);
-		if(!tex.isAllocated() || tex.getWidth() != width || tex.getHeight() != height || tex.getTextureData().glTypeInternal != glTypeInternal){
+		int glInternalFormat = ofGetGlInternalFormat(pixels);
+		if(!tex.isAllocated() || tex.getWidth() != width || tex.getHeight() != height || tex.getTextureData().glInternalFormat != glInternalFormat){
 			tex.allocate(pixels);
 			if(ofIsGLProgrammableRenderer() && (pixels.getPixelFormat()==OF_PIXELS_GRAY || pixels.getPixelFormat()==OF_PIXELS_GRAY_ALPHA)){
 				tex.setRGToRGBASwizzles(true);

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -444,7 +444,7 @@ void ofAVFoundationPlayer::initTextureCache() {
                                                        imageBuffer,             // CVImageBufferRef sourceImage
                                                        NULL,                    // CFDictionaryRef textureAttributes
                                                        texData.textureTarget,   // GLenum target
-                                                       texData.glTypeInternal,  // GLint internalFormat
+                                                       texData.glInternalFormat,  // GLint internalFormat
                                                        texData.width,           // GLsizei width
                                                        texData.height,          // GLsizei height
                                                        GL_BGRA,                 // GLenum format

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -228,7 +228,7 @@ void ofVideoGrabber::update(){
 			}
 			for(int i=0;i<grabber->getPixels().getNumPlanes();i++){
 				ofPixels plane = grabber->getPixels().getPlane(i);
-				bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glTypeInternal != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
+				bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glInternalFormat != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
 				if(bDiffPixFormat || !tex[i].isAllocated() ){
 					tex[i].allocate(plane);
 					if(ofIsGLProgrammableRenderer() && plane.getPixelFormat() == OF_PIXELS_GRAY){

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -208,7 +208,7 @@ void ofVideoPlayer::update(){
 				if(player->getWidth() != 0 && player->getHeight() != 0) {
 					for(int i=0;i<player->getPixels().getNumPlanes();i++){
 						ofPixels plane = player->getPixels().getPlane(i);
-						bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glTypeInternal != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
+						bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glInternalFormat != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
 						if(bDiffPixFormat || !tex[i].isAllocated() || tex[i].getWidth() != plane.getWidth() || tex[i].getHeight() != plane.getHeight()){
 							tex[i].allocate(plane);
 							if(ofIsGLProgrammableRenderer() && plane.getPixelFormat() == OF_PIXELS_GRAY){
@@ -375,7 +375,7 @@ void ofVideoPlayer::setUseTexture(bool bUse){
 	if(bUse && player && !player->getTexturePtr() && getWidth()!=0 && getHeight()!=0){
 		for(int i=0;i<player->getPixels().getNumPlanes();i++){
 			ofPixels plane = player->getPixels().getPlane(i);
-			bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glTypeInternal != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
+			bool bDiffPixFormat = ( tex[i].isAllocated() && tex[i].texData.glInternalFormat != ofGetGLInternalFormatFromPixelFormat(plane.getPixelFormat()) );
 			if(!tex[i].isAllocated() || bDiffPixFormat){
 				tex[i].allocate(plane);
 			}


### PR DESCRIPTION
rename `ofTextureData.glTypeInternal` to `ofTextureData.glInternalFormat` for naming consistency with
the underlying OpenGL enum.

Closes #4036

+ also updates CHANGELOG to highlight the change