### PR TITLE
Fix unused variable warning "targetFps".

### DIFF
--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -10,8 +10,7 @@ ofFpsCounter::ofFpsCounter()
 ,secsThen(0)
 ,nanosThen(0)
 ,fps(0)
-,lastFrameTime(0)
-,targetFps(60){
+,lastFrameTime(0){
 	ofGetMonotonicTime(secsThen,nanosThen);
 }
 
@@ -22,8 +21,7 @@ ofFpsCounter::ofFpsCounter(double targetFPS)
 ,secsThen(0)
 ,nanosThen(0)
 ,fps(targetFPS)
-,lastFrameTime(0)
-,targetFps(targetFPS){
+,lastFrameTime(0){
 	ofGetMonotonicTime(secsThen,nanosThen);
 }
 

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -27,5 +27,4 @@ private:
 	double fps;
 	uint64_t lastFrameTime;
 	queue<double> timestamps;
-	double targetFps;
 };


### PR DESCRIPTION
Fixing warnings.  `targetFps` is a private variable that is set but never accessed.