### PR TITLE
Add isEnabled() and size() to ofBaseEvent.

### DIFF
--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -47,7 +47,7 @@ public:
     	enabled = false;
     }
 
-	bool isEnabled() {
+	bool isEnabled() const {
 		return enabled;
 	}
 

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -47,6 +47,14 @@ public:
     	enabled = false;
     }
 
+	bool isEnabled() {
+		return enabled;
+	}
+
+	std::size_t size() const {
+		return functions.size();
+	}
+
     class Function{
     public:
     	int priority;


### PR DESCRIPTION
I want to conditionally create a stack of events to be notified.  

Then I want to pass events through that stack.  Since the stack is linked in a sort of chain, I only want to include events in the stack that have subscribers and are enabled.  

Thus, it is important to be able to know if an event is enabled and if the event has subscribers.  These two accessors allow me to use the existing ofEvent system without extending ofEvent and adding these accessors to my own subclass.
