### PR TITLE
Fix modal dialog focus problem on OSX

### DIFF
--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -616,6 +616,7 @@ string ofSystemTextBoxDialog(string question, string text){
 		// add text field to alert dialog
 		[alert setAccessoryView:label];
 		NSInteger returnCode = [alert runModal];
+		restoreAppWindowFocus();
 		// if OK was clicked, assign value to text
 		if ( returnCode == NSAlertFirstButtonReturn )
 			text = [[label stringValue] UTF8String];


### PR DESCRIPTION
Restored code from @admsyn's commit in 2013: https://github.com/admsyn/openFrameworks/commit/41048de13c8f8ae4cceb771765408f583b46ca50

@ofZach [of-dev mailing list]: «There's also some little things like on osx adding retina support __and getting focus back to the window after using a dialog prompt__, etc.»
See also http://forum.openframeworks.cc/t/using-ofsystemtextboxdialog-makes-window-lose-focus/19743

Only affects TARGET_OSX and I tested it on 10.10.2 with Xcode 6.3.1