### PR TITLE
ofxGui: improve inheritability of ofxSlider

### DIFF
--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -54,8 +54,8 @@ protected:
 	bool bGuiActive;
 	bool mouseInside;
 	bool setValue(float mx, float my, bool bCheck);
-	void generateDraw();
-	void generateText();
+	virtual void generateDraw();
+	virtual void generateText();
 	void valueChanged(Type & value);
 	ofPath bg, bar;
 	ofVboMesh textMesh;


### PR DESCRIPTION
splitting generateDraw()/generateText() and render() is nicely done but you can't really build on it in derived classes in the ofxGui context because of the missing virtual modifier in the base class. render() and mouse...() are virtual functions already.

(example: for a simple gui extension I tried to override generateText() to draw some labels instead of the actual value)