### PR TITLE
AVFoundationPlayer remove checks

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -103,7 +103,6 @@ protected:
     bool bResetPixels;
     bool bUpdatePixels;
     bool bUpdateTexture;
-    bool bTextureCacheSupported;
 	
     ofPixels pixels;
 	ofPixelFormat pixelFormat;


### PR DESCRIPTION
textureCaches are supported from OSX 10.4 and iOS 5, remove check for textureCache support.