### PR TITLE
fix state leak when recursively drawing MSAA fbos

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -934,16 +934,21 @@ void ofFbo::updateTexture(int attachmentPoint) {
 			glPushAttrib(GL_COLOR_BUFFER_BIT);
 		}
 
-		bind();
+		// Because we temporarily change global Fbo binding state
+		// when blitting from one framebuffer to the other, we first have 
+		// to query the renderer for its binding state, and store it.
+		GLuint rendererFboBindingState = ofGetGLRenderer()->getCurrentFramebufferId();
+		
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
 		glReadBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboTextures);
 		glDrawBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint); 
 		glBlitFramebuffer(0, 0, settings.width, settings.height, 0, 0, settings.width, settings.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
-		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0); // reset to defaults
-		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0); 
-		unbind(); // this will restore GL_FRAMEBUFFER to previousFramebufferBinding
-		
+		// Restore renderer Fbo binding state
+		glBindFramebuffer(GL_FRAMEBUFFER, rendererFboBindingState);
+
+		// Set ReadBuffer state to GL_BACK (default)
 		glReadBuffer(GL_BACK);
 
 		if(!ofIsGLProgrammableRenderer()){

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -94,11 +94,11 @@ public:
 
 	void flagDirty() const; ///< check whether attached MSAA buffers need updating
 
-	/// \brief    Explicityl resolve MSAA render buffers into textures 
-	/// \note     if using MSAA, we will have rendered into a colorbuffer, not directly 
-	///           into the texture call this to blit from the colorbuffer into the texture 
-	///           so we can use the results for rendering, or input to a shader etc.
-	/// \note     This will get called implicitly upon getTexture();
+	/// \brief    Explicitly resolve MSAA render buffers into textures 
+	/// \note     If using MSAA, we will have rendered into a colorbuffer, not directly 
+	///           into the texture. Call this to blit from the colorbuffer into the texture 
+	///           so you can use the results for rendering, or input to a shader etc.
+	/// \note     This is called implicitly upon getTexture();
 	void updateTexture(int attachmentPoint);
 
 


### PR DESCRIPTION
+ fixes #4096 

When resolving MSAA fbos, global fbo binding state must be
changed, because the resolve is a blit from one fbo into
another.

This PR makes sure to correctly keep track of the global
renderer FBO binding state and to restore it after the
blitting operation has completed.

+ Also includes some minor typo fixes for the doxygen
documentation of the updateTexture() method.