### PR TITLE
OpenGLES / iOS Fixes for recent Renderer changes.

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1350,12 +1350,15 @@ void ofGLProgrammableRenderer::bindForBlitting(const ofFbo & fboSrc, ofFbo & fbo
 	// I'm keeping it here, so that if we want to do more fancyful
 	// named framebuffers with GL 4.5+, we can have
 	// different implementations.
+#ifndef TARGET_OPENGLES
 	framebufferIdStack.push_back(currentFramebufferId);
 	currentFramebufferId = fboSrc.getId();
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, currentFramebufferId);
 	glReadBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboDst.getIdDrawBuffer());
 	glDrawBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint);
+#endif
+
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -88,7 +88,8 @@ void ofGLProgrammableRenderer::startRender() {
 	// can't trust ofFbo to have correctly tracked the bind
 	// state. Therefore, we are forced to use the slower glGet() method
 	// to be sure to get the correct default framebuffer.
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &defaultFramebufferId);
+	GLint defaultFramebufferBinding = defaultFramebufferId;
+	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &defaultFramebufferBinding);
 #endif
 	currentFramebufferId = defaultFramebufferId;
 	framebufferIdStack.push_back(defaultFramebufferId);

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -45,7 +45,8 @@ void ofGLRenderer::startRender(){
 	// can't trust ofFbo to have correctly tracked the bind
 	// state. Therefore, we are forced to use the slower glGet() method
 	// to be sure to get the correct default framebuffer.
-	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &defaultFramebufferId);
+	GLint defaultFramebufferBinding = defaultFramebufferId;
+	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &defaultFramebufferBinding);
 #endif
 	currentFramebufferId = defaultFramebufferId;
 	framebufferIdStack.push_back(defaultFramebufferId);
@@ -496,12 +497,14 @@ void ofGLRenderer::bindForBlitting(const ofFbo & fboSrc, ofFbo & fboDst, int att
 	// I'm keeping it here, so that if we want to do more fancyful
 	// named framebuffers with GL 4.5+, we can have
 	// different implementations.
+#ifndef TARGET_OPENGLES
 	framebufferIdStack.push_back(currentFramebufferId);
 	currentFramebufferId = fboSrc.getId();
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, currentFramebufferId);
 	glReadBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fboDst.getIdDrawBuffer());
 	glDrawBuffer(GL_COLOR_ATTACHMENT0 + attachmentPoint);
+#endif
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
Fixes some OpenGLES (iOS) errors caused by recent: 9988a637545e05d9c39f4d94710194be70c3bfde

@arturoc give this a quick look over. This just enables to compile again.

Xcode was very strict with needing to see an explicit definition of the GLuint which is why the following:

```
	GLint defaultFramebufferBinding = defaultFramebufferId;
	glGetIntegerv(GL_FRAMEBUFFER_BINDING, &defaultFramebufferBinding);
```

Aside from that, defined out the non-compatible OpenGL commands for OpenGLES in the new ```bindForBlitting``` function. I did a quick check and it seems those commands are only OpenGLES 3.0+.
Not sure what we can do for an alternative. Anyway this fixes it to compile.