### PR TITLE
add ofThreadChannel.h to project view in VS

### DIFF
--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
@@ -192,6 +192,7 @@
     <ClInclude Include="..\..\..\openFrameworks\utils\ofNoise.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofSystemUtils.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofThread.h" />
+    <ClInclude Include="..\..\..\openFrameworks\utils\ofThreadChannel.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofTimer.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofURLFileLoader.h" />
     <ClInclude Include="..\..\..\openFrameworks\utils\ofUtils.h" />

--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj.filters
@@ -279,6 +279,9 @@
     <ClInclude Include="..\..\..\openFrameworks\events\ofEvent.h">
       <Filter>libs\openFrameworks\events</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\openFrameworks\utils\ofThreadChannel.h">
+      <Filter>libs\openFrameworks\utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\openFrameworks\app\ofAppGlutWindow.cpp">


### PR DESCRIPTION
ofThreadChannel, new with of 0.9, was not yet part of the
tree view in the VS project template.

This adds the file to the openFrameworks project file so it
shows up in the solution explorer view.