### PR TITLE
Extending ofxBaseGui and ofxGuiGroup

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -5,8 +5,8 @@
 using namespace std;
 
 
-void ofxGuiSetFont(const string & fontPath,int fontsize, bool _bAntiAliased, bool _bFullCharacterSet, int dpi){
-	ofxBaseGui::loadFont(fontPath,fontsize,_bAntiAliased,_bFullCharacterSet,dpi);
+void ofxGuiSetFont(const string & fontPath, int fontsize, bool _bAntiAliased, bool _bFullCharacterSet, int dpi){
+	ofxBaseGui::loadFont(fontPath, fontsize, _bAntiAliased, _bFullCharacterSet, dpi);
 }
 
 void ofxGuiSetBitmapFont(){
@@ -49,7 +49,7 @@ void ofxGuiSetDefaultHeight(int height){
 ofColor
 ofxBaseGui::headerBackgroundColor(64),
 ofxBaseGui::backgroundColor(0),
-ofxBaseGui::borderColor(120,100),
+ofxBaseGui::borderColor(120, 100),
 ofxBaseGui::textColor(255),
 ofxBaseGui::fillColor(128);
 
@@ -63,35 +63,35 @@ bool ofxBaseGui::useTTF = false;
 ofBitmapFont ofxBaseGui::bitmapFont;
 
 ofxBaseGui::ofxBaseGui(){
-    parent = NULL;
+	parent = NULL;
 	currentFrame = ofGetFrameNum();
-	serializer = std::shared_ptr<ofBaseFileSerializer>(new ofXml);
+	serializer = std::shared_ptr <ofBaseFileSerializer>(new ofXml);
 
-	thisHeaderBackgroundColor=headerBackgroundColor;
-	thisBackgroundColor=backgroundColor;
-	thisBorderColor=borderColor;
-	thisTextColor=textColor;
-	thisFillColor=fillColor;
+	thisHeaderBackgroundColor = headerBackgroundColor;
+	thisBackgroundColor = backgroundColor;
+	thisBorderColor = borderColor;
+	thisTextColor = textColor;
+	thisFillColor = fillColor;
 
 	bRegisteredForMouseEvents = false;
 	needsRedraw = true;
 
 	/*if(!fontLoaded){
-		loadFont(OF_TTF_MONO,10,true,true);
-		useTTF=false;
+	    loadFont(OF_TTF_MONO,10,true,true);
+	    useTTF=false;
 	}*/
 
 }
 
 void ofxBaseGui::loadFont(string filename, int fontsize, bool _bAntiAliased, bool _bFullCharacterSet, int dpi){
-	font.load(filename,fontsize,_bAntiAliased,_bFullCharacterSet,dpi);
+	font.load(filename, fontsize, _bAntiAliased, _bFullCharacterSet, dpi);
 	fontLoaded = true;
 	useTTF = true;
 }
 
 void ofxBaseGui::setUseTTF(bool bUseTTF){
 	if(bUseTTF && !fontLoaded){
-		loadFont(OF_TTF_MONO,10,true,true);
+		loadFont(OF_TTF_MONO, 10, true, true);
 	}
 	useTTF = bUseTTF;
 }
@@ -101,7 +101,7 @@ ofxBaseGui::~ofxBaseGui(){
 }
 
 void ofxBaseGui::registerMouseEvents(){
-	if(bRegisteredForMouseEvents == true) {
+	if(bRegisteredForMouseEvents == true){
 		return; // already registered.
 	}
 	bRegisteredForMouseEvents = true;
@@ -109,7 +109,7 @@ void ofxBaseGui::registerMouseEvents(){
 }
 
 void ofxBaseGui::unregisterMouseEvents(){
-	if(bRegisteredForMouseEvents == false) {
+	if(bRegisteredForMouseEvents == false){
 		return; // not registered.
 	}
 	ofUnregisterMouseEvents(this, OF_EVENT_ORDER_BEFORE_APP);
@@ -117,18 +117,19 @@ void ofxBaseGui::unregisterMouseEvents(){
 }
 
 void ofxBaseGui::draw(){
-    if(needsRedraw){
-        generateDraw();
-        needsRedraw = false;
-    }
+	if(needsRedraw){
+		generateDraw();
+		needsRedraw = false;
+	}
 	currentFrame = ofGetFrameNum();
 	render();
 }
 
 bool ofxBaseGui::isGuiDrawing(){
-	if( ofGetFrameNum() - currentFrame > 1 ){
+	if(ofGetFrameNum() - currentFrame > 1){
 		return false;
-	}else{
+	}
+	else{
 		return true;
 	}
 }
@@ -136,7 +137,8 @@ bool ofxBaseGui::isGuiDrawing(){
 void ofxBaseGui::bindFontTexture(){
 	if(useTTF){
 		font.getFontTexture().bind();
-	}else{
+	}
+	else{
 		bitmapFont.getTexture().bind();
 	}
 }
@@ -144,7 +146,8 @@ void ofxBaseGui::bindFontTexture(){
 void ofxBaseGui::unbindFontTexture(){
 	if(useTTF){
 		font.getFontTexture().unbind();
-	}else{
+	}
+	else{
 		bitmapFont.getTexture().unbind();
 	}
 }
@@ -152,42 +155,44 @@ void ofxBaseGui::unbindFontTexture(){
 
 ofMesh ofxBaseGui::getTextMesh(const string & text, float x, float y){
 	if(useTTF){
-		return font.getStringMesh(text,x,y);
-	}else{
-		return bitmapFont.getMesh(text,x,y);
+		return font.getStringMesh(text, x, y);
+	}
+	else{
+		return bitmapFont.getMesh(text, x, y);
 	}
 }
 
-ofRectangle ofxBaseGui::getTextBoundingBox(const string & text,float x, float y){
+ofRectangle ofxBaseGui::getTextBoundingBox(const string & text, float x, float y){
 	if(useTTF){
-		return font.getStringBoundingBox(text,x,y);
-	}else{
-		return bitmapFont.getBoundingBox(text,x,y);
+		return font.getStringBoundingBox(text, x, y);
+	}
+	else{
+		return bitmapFont.getBoundingBox(text, x, y);
 	}
 }
 
-void ofxBaseGui::saveToFile(string filename) {
+void ofxBaseGui::saveToFile(string filename){
 	serializer->load(filename);
 	saveTo(*serializer);
 	serializer->save(filename);
 }
 
-void ofxBaseGui::loadFromFile(string filename) {
+void ofxBaseGui::loadFromFile(string filename){
 	serializer->load(filename);
 	loadFrom(*serializer);
 }
 
 
-void ofxBaseGui::saveTo(ofBaseSerializer& serializer){
+void ofxBaseGui::saveTo(ofBaseSerializer & serializer){
 	serializer.serialize(getParameter());
 }
 
-void ofxBaseGui::loadFrom(ofBaseSerializer& serializer){
+void ofxBaseGui::loadFrom(ofBaseSerializer & serializer){
 	serializer.deserialize(getParameter());
 }
 
 
-void ofxBaseGui::setDefaultSerializer(std::shared_ptr<ofBaseFileSerializer> _serializer){
+void ofxBaseGui::setDefaultSerializer(std::shared_ptr <ofBaseFileSerializer> _serializer){
 	serializer = _serializer;
 }
 
@@ -200,7 +205,7 @@ void ofxBaseGui::setName(string _name){
 }
 
 void ofxBaseGui::setPosition(ofPoint p){
-	setPosition(p.x,p.y);
+	setPosition(p.x, p.y);
 }
 
 void ofxBaseGui::setPosition(float x, float y){
@@ -212,21 +217,21 @@ void ofxBaseGui::setPosition(float x, float y){
 void ofxBaseGui::setSize(float w, float h){
 	b.width = w;
 	b.height = h;
-    sizeChangedCB();
+	sizeChangedCB();
 }
 
 void ofxBaseGui::setShape(ofRectangle r){
 	b = r;
-    sizeChangedCB();
+	sizeChangedCB();
 }
 
 void ofxBaseGui::setShape(float x, float y, float w, float h){
-	b.set(x,y,w,h);
-    sizeChangedCB();
+	b.set(x, y, w, h);
+	sizeChangedCB();
 }
 
 ofPoint ofxBaseGui::getPosition(){
-	return ofPoint(b.x,b.y);
+	return ofPoint(b.x, b.y);
 }
 
 ofRectangle ofxBaseGui::getShape(){
@@ -262,27 +267,27 @@ ofColor ofxBaseGui::getFillColor(){
 }
 
 void ofxBaseGui::setHeaderBackgroundColor(const ofColor & color){
-    setNeedsRedraw();
+	setNeedsRedraw();
 	thisHeaderBackgroundColor = color;
 }
 
 void ofxBaseGui::setBackgroundColor(const ofColor & color){
-    setNeedsRedraw();
+	setNeedsRedraw();
 	thisBackgroundColor = color;
 }
 
 void ofxBaseGui::setBorderColor(const ofColor & color){
-    setNeedsRedraw();
+	setNeedsRedraw();
 	thisBorderColor = color;
 }
 
 void ofxBaseGui::setTextColor(const ofColor & color){
-    setNeedsRedraw();
+	setNeedsRedraw();
 	thisTextColor = color;
 }
 
 void ofxBaseGui::setFillColor(const ofColor & color){
-    setNeedsRedraw();
+	setNeedsRedraw();
 	thisFillColor = color;
 }
 
@@ -319,15 +324,17 @@ void ofxBaseGui::setDefaultHeight(int height){
 }
 
 void ofxBaseGui::setNeedsRedraw(){
-    needsRedraw = true;
+	needsRedraw = true;
 }
 
 void ofxBaseGui::sizeChangedCB(){
-    if(parent) parent->sizeChangedCB();
-    setNeedsRedraw();
+	if(parent){
+		parent->sizeChangedCB();
+	}
+	setNeedsRedraw();
 }
 
-string ofxBaseGui::saveStencilToHex(ofImage& img) {
+string ofxBaseGui::saveStencilToHex(ofImage & img){
 	stringstream strm;
 	int width = img.getWidth();
 	int height = img.getHeight();
@@ -335,19 +342,20 @@ string ofxBaseGui::saveStencilToHex(ofImage& img) {
 	unsigned char cur = 0;
 	int shift = 0;
 	strm << "{";
-	for(int i = 0; i < n;) {
-		if(img.getPixels()[i * 4 + 3] > 0) {
+	for(int i = 0; i < n;){
+		if(img.getPixels()[i * 4 + 3] > 0){
 			cur |= 1 << shift;
 		}
 		i++;
-		if(i % 8 == 0) {
-			strm << "0x" << hex << (unsigned int) cur;
+		if(i % 8 == 0){
+			strm << "0x" << hex << (unsigned int)cur;
 			cur = 0;
 			shift = 0;
-			if(i < n) {
+			if(i < n){
 				strm << ",";
 			}
-		} else {
+		}
+		else{
 			shift++;
 		}
 	}
@@ -355,14 +363,14 @@ string ofxBaseGui::saveStencilToHex(ofImage& img) {
 	return strm.str();
 }
 
-void ofxBaseGui::loadStencilFromHex(ofImage& img, unsigned char* data) {
+void ofxBaseGui::loadStencilFromHex(ofImage & img, unsigned char * data){
 	int width = img.getWidth();
 	int height = img.getHeight();
 	int i = 0;
 	ofColor on(255, 255);
 	ofColor off(255, 0);
-	for(int y = 0; y < height; y++) {
-		for(int x = 0; x < width; x++) {
+	for(int y = 0; y < height; y++){
+		for(int x = 0; x < width; x++){
 			int shift = i % 8;
 			int offset = i / 8;
 			bool cur = (data[offset] >> shift) & 1;
@@ -373,10 +381,10 @@ void ofxBaseGui::loadStencilFromHex(ofImage& img, unsigned char* data) {
 	img.update();
 }
 
-void ofxBaseGui::setParent(ofxBaseGui *parent) {
-    this->parent = parent;
+void ofxBaseGui::setParent(ofxBaseGui * parent){
+	this->parent = parent;
 }
 
-ofxBaseGui* ofxBaseGui::getParent() {
-    return parent;
+ofxBaseGui * ofxBaseGui::getParent(){
+	return parent;
 }

--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -63,6 +63,7 @@ bool ofxBaseGui::useTTF = false;
 ofBitmapFont ofxBaseGui::bitmapFont;
 
 ofxBaseGui::ofxBaseGui(){
+    parent = NULL;
 	currentFrame = ofGetFrameNum();
 	serializer = std::shared_ptr<ofBaseFileSerializer>(new ofXml);
 
@@ -211,17 +212,17 @@ void ofxBaseGui::setPosition(float x, float y){
 void ofxBaseGui::setSize(float w, float h){
 	b.width = w;
 	b.height = h;
-	setNeedsRedraw();
+    sizeChangedCB();
 }
 
 void ofxBaseGui::setShape(ofRectangle r){
 	b = r;
-	setNeedsRedraw();
+    sizeChangedCB();
 }
 
 void ofxBaseGui::setShape(float x, float y, float w, float h){
 	b.set(x,y,w,h);
-	setNeedsRedraw();
+    sizeChangedCB();
 }
 
 ofPoint ofxBaseGui::getPosition(){
@@ -321,6 +322,11 @@ void ofxBaseGui::setNeedsRedraw(){
     needsRedraw = true;
 }
 
+void ofxBaseGui::sizeChangedCB(){
+    if(parent) parent->sizeChangedCB();
+    setNeedsRedraw();
+}
+
 string ofxBaseGui::saveStencilToHex(ofImage& img) {
 	stringstream strm;
 	int width = img.getWidth();
@@ -365,4 +371,12 @@ void ofxBaseGui::loadStencilFromHex(ofImage& img, unsigned char* data) {
 		}
 	}
 	img.update();
+}
+
+void ofxBaseGui::setParent(ofxBaseGui *parent) {
+    this->parent = parent;
+}
+
+ofxBaseGui* ofxBaseGui::getParent() {
+    return parent;
 }

--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -128,8 +128,7 @@ void ofxBaseGui::draw(){
 bool ofxBaseGui::isGuiDrawing(){
 	if(ofGetFrameNum() - currentFrame > 1){
 		return false;
-	}
-	else{
+	} else{
 		return true;
 	}
 }
@@ -137,8 +136,7 @@ bool ofxBaseGui::isGuiDrawing(){
 void ofxBaseGui::bindFontTexture(){
 	if(useTTF){
 		font.getFontTexture().bind();
-	}
-	else{
+	} else{
 		bitmapFont.getTexture().bind();
 	}
 }
@@ -146,8 +144,7 @@ void ofxBaseGui::bindFontTexture(){
 void ofxBaseGui::unbindFontTexture(){
 	if(useTTF){
 		font.getFontTexture().unbind();
-	}
-	else{
+	} else{
 		bitmapFont.getTexture().unbind();
 	}
 }
@@ -156,8 +153,7 @@ void ofxBaseGui::unbindFontTexture(){
 ofMesh ofxBaseGui::getTextMesh(const string & text, float x, float y){
 	if(useTTF){
 		return font.getStringMesh(text, x, y);
-	}
-	else{
+	} else{
 		return bitmapFont.getMesh(text, x, y);
 	}
 }
@@ -165,8 +161,7 @@ ofMesh ofxBaseGui::getTextMesh(const string & text, float x, float y){
 ofRectangle ofxBaseGui::getTextBoundingBox(const string & text, float x, float y){
 	if(useTTF){
 		return font.getStringBoundingBox(text, x, y);
-	}
-	else{
+	} else{
 		return bitmapFont.getBoundingBox(text, x, y);
 	}
 }
@@ -354,8 +349,7 @@ string ofxBaseGui::saveStencilToHex(ofImage & img){
 			if(i < n){
 				strm << ",";
 			}
-		}
-		else{
+		} else{
 			shift++;
 		}
 	}

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -6,118 +6,120 @@
 #include "ofTrueTypeFont.h"
 #include "ofBitmapFont.h"
 
-class ofxBaseGui{
-public:
-	ofxBaseGui();
-	
-	virtual ~ofxBaseGui();
-	void draw();
-	
-	void saveToFile(std::string filename);
-	void loadFromFile(std::string filename);
-	
-	void setDefaultSerializer(std::shared_ptr<ofBaseFileSerializer> serializer);
+class ofxBaseGui {
+	public:
+		ofxBaseGui();
 
-	virtual void saveTo(ofBaseSerializer& serializer);
-	virtual void loadFrom(ofBaseSerializer& serializer);
-	
-	std::string getName();
-	void setName(std::string name);
+		virtual ~ofxBaseGui();
+		void draw();
 
-	virtual void setPosition(ofPoint p);
-	virtual void setPosition(float x, float y);
-	virtual void setSize(float w, float h);
-	virtual void setShape(ofRectangle r);
-	virtual void setShape(float x, float y, float w, float h);
+		void saveToFile(std::string filename);
+		void loadFromFile(std::string filename);
 
-	ofPoint getPosition();
-	ofRectangle getShape();
-	float getWidth();
-	float getHeight();
+		void setDefaultSerializer(std::shared_ptr <ofBaseFileSerializer> serializer);
 
-	ofColor getHeaderBackgroundColor();
-	ofColor getBackgroundColor();
-	ofColor getBorderColor();
-	ofColor getTextColor();
-	ofColor getFillColor();
+		virtual void saveTo(ofBaseSerializer & serializer);
+		virtual void loadFrom(ofBaseSerializer & serializer);
 
-	void setHeaderBackgroundColor(const ofColor & color);
-	void setBackgroundColor(const ofColor & color);
-	void setBorderColor(const ofColor & color);
-	void setTextColor(const ofColor & color);
-	void setFillColor(const ofColor & color);
+		std::string getName();
+		void setName(std::string name);
 
-	static void setDefaultHeaderBackgroundColor(const ofColor & color);
-	static void setDefaultBackgroundColor(const ofColor & color);
-	static void setDefaultBorderColor(const ofColor & color);
-	static void setDefaultTextColor(const ofColor & color);
-	static void setDefaultFillColor(const ofColor & color);
+		virtual void setPosition(ofPoint p);
+		virtual void setPosition(float x, float y);
+		virtual void setSize(float w, float h);
+		virtual void setShape(ofRectangle r);
+		virtual void setShape(float x, float y, float w, float h);
 
-	static void setDefaultTextPadding(int padding);
-	static void setDefaultWidth(int width);
-	static void setDefaultHeight(int height);
+		ofPoint getPosition();
+		ofRectangle getShape();
+		float getWidth();
+		float getHeight();
 
-	virtual ofAbstractParameter & getParameter() = 0;
-	static void loadFont(std::string filename, int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=false, int dpi=0);
-	static void setUseTTF(bool bUseTTF);
-    
-    void registerMouseEvents();
-    void unregisterMouseEvents();
+		ofColor getHeaderBackgroundColor();
+		ofColor getBackgroundColor();
+		ofColor getBorderColor();
+		ofColor getTextColor();
+		ofColor getFillColor();
 
-	virtual bool mouseMoved(ofMouseEventArgs & args) = 0;
-	virtual bool mousePressed(ofMouseEventArgs & args) = 0;
-	virtual bool mouseDragged(ofMouseEventArgs & args) = 0;
-	virtual bool mouseReleased(ofMouseEventArgs & args) = 0;
-	virtual bool mouseScrolled(ofMouseEventArgs & args) = 0;
-	virtual void mouseEntered(ofMouseEventArgs & args){}
-	virtual void mouseExited(ofMouseEventArgs & args){}
+		void setHeaderBackgroundColor(const ofColor & color);
+		void setBackgroundColor(const ofColor & color);
+		void setBorderColor(const ofColor & color);
+		void setTextColor(const ofColor & color);
+		void setFillColor(const ofColor & color);
 
-    virtual void sizeChangedCB();
-    void setParent(ofxBaseGui* parent);
-    ofxBaseGui* getParent();
+		static void setDefaultHeaderBackgroundColor(const ofColor & color);
+		static void setDefaultBackgroundColor(const ofColor & color);
+		static void setDefaultBorderColor(const ofColor & color);
+		static void setDefaultTextColor(const ofColor & color);
+		static void setDefaultFillColor(const ofColor & color);
 
-protected:
-	virtual void render()=0;
-	bool isGuiDrawing();
-	virtual bool setValue(float mx, float my, bool bCheckBounds) = 0;
-	void bindFontTexture();
-	void unbindFontTexture();
-	ofMesh getTextMesh(const std::string & text, float x, float y);
-	ofRectangle getTextBoundingBox(const std::string & text,float x, float y);
+		static void setDefaultTextPadding(int padding);
+		static void setDefaultWidth(int width);
+		static void setDefaultHeight(int height);
 
-	ofRectangle b;
-	static ofTrueTypeFont font;
-	static bool fontLoaded;
-	static bool useTTF;
-	static ofBitmapFont bitmapFont;
-	std::shared_ptr<ofBaseFileSerializer> serializer;
+		virtual ofAbstractParameter & getParameter() = 0;
+		static void loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, int dpi = 0);
+		static void setUseTTF(bool bUseTTF);
 
-	static ofColor headerBackgroundColor;
-	static ofColor backgroundColor;
-	static ofColor borderColor;
-	static ofColor textColor;
-	static ofColor fillColor;
+		void registerMouseEvents();
+		void unregisterMouseEvents();
 
-	ofColor thisHeaderBackgroundColor;
-	ofColor thisBackgroundColor;
-	ofColor thisBorderColor;
-	ofColor thisTextColor;
-	ofColor thisFillColor;
+		virtual bool mouseMoved(ofMouseEventArgs & args) = 0;
+		virtual bool mousePressed(ofMouseEventArgs & args) = 0;
+		virtual bool mouseDragged(ofMouseEventArgs & args) = 0;
+		virtual bool mouseReleased(ofMouseEventArgs & args) = 0;
+		virtual bool mouseScrolled(ofMouseEventArgs & args) = 0;
+		virtual void mouseEntered(ofMouseEventArgs & args){
+		}
+		virtual void mouseExited(ofMouseEventArgs & args){
+		}
 
-	static int textPadding;
-	static int defaultWidth;
-	static int defaultHeight;
+		virtual void sizeChangedCB();
+		void setParent(ofxBaseGui * parent);
+		ofxBaseGui * getParent();
 
-    ofxBaseGui * parent;
+	protected:
+		virtual void render() = 0;
+		bool isGuiDrawing();
+		virtual bool setValue(float mx, float my, bool bCheckBounds) = 0;
+		void bindFontTexture();
+		void unbindFontTexture();
+		ofMesh getTextMesh(const std::string & text, float x, float y);
+		ofRectangle getTextBoundingBox(const std::string & text, float x, float y);
 
-	static std::string saveStencilToHex(ofImage& img);
-	static void loadStencilFromHex(ofImage& img, unsigned char* data) ;
+		ofRectangle b;
+		static ofTrueTypeFont font;
+		static bool fontLoaded;
+		static bool useTTF;
+		static ofBitmapFont bitmapFont;
+		std::shared_ptr <ofBaseFileSerializer> serializer;
 
-	void setNeedsRedraw();
-	virtual void generateDraw()=0;
+		static ofColor headerBackgroundColor;
+		static ofColor backgroundColor;
+		static ofColor borderColor;
+		static ofColor textColor;
+		static ofColor fillColor;
 
-private:
-	bool needsRedraw;
-	unsigned long currentFrame;
-    bool bRegisteredForMouseEvents;
-}; 
+		ofColor thisHeaderBackgroundColor;
+		ofColor thisBackgroundColor;
+		ofColor thisBorderColor;
+		ofColor thisTextColor;
+		ofColor thisFillColor;
+
+		static int textPadding;
+		static int defaultWidth;
+		static int defaultHeight;
+
+		ofxBaseGui * parent;
+
+		static std::string saveStencilToHex(ofImage & img);
+		static void loadStencilFromHex(ofImage & img, unsigned char * data);
+
+		void setNeedsRedraw();
+		virtual void generateDraw() = 0;
+
+	private:
+		bool needsRedraw;
+		unsigned long currentFrame;
+		bool bRegisteredForMouseEvents;
+};

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -71,6 +71,11 @@ public:
 	virtual bool mouseScrolled(ofMouseEventArgs & args) = 0;
 	virtual void mouseEntered(ofMouseEventArgs & args){}
 	virtual void mouseExited(ofMouseEventArgs & args){}
+
+    virtual void sizeChangedCB();
+    void setParent(ofxBaseGui* parent);
+    ofxBaseGui* getParent();
+
 protected:
 	virtual void render()=0;
 	bool isGuiDrawing();
@@ -102,6 +107,8 @@ protected:
 	static int textPadding;
 	static int defaultWidth;
 	static int defaultHeight;
+
+    ofxBaseGui * parent;
 
 	static std::string saveStencilToHex(ofImage& img);
 	static void loadStencilFromHex(ofImage& img, unsigned char* data) ;

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -89,7 +89,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, string _f
 	return this;
 }
 
-void ofxGuiGroup::add(ofxBaseGui * element){
+ofxBaseGui* ofxGuiGroup::add(ofxBaseGui * element){
 	collection.push_back( element );
 
 	element->setPosition(b.x, b.y + b.height  + spacing);
@@ -114,6 +114,7 @@ void ofxGuiGroup::add(ofxBaseGui * element){
     
 	parameters.add(element->getParameter());
 	setNeedsRedraw();
+    return element;
 }
 
 void ofxGuiGroup::setWidthElements(float w){
@@ -129,50 +130,50 @@ void ofxGuiGroup::setWidthElements(float w){
 	setNeedsRedraw();
 }
 
-void ofxGuiGroup::add(const ofParameterGroup & parameters){
+ofxBaseGui* ofxGuiGroup::add(const ofParameterGroup & parameters){
 	ofxGuiGroup * panel = new ofxGuiGroup(parameters);
 	panel->parent = this;
-	add(panel);
+    return add(panel);
 }
 
-void ofxGuiGroup::add(ofParameter<float> & parameter){
-	add(new ofxFloatSlider(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<float> & parameter){
+    return add(new ofxFloatSlider(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<int> & parameter){
-	add(new ofxIntSlider(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<int> & parameter){
+    return add(new ofxIntSlider(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<bool> & parameter){
-	add(new ofxToggle(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<bool> & parameter){
+    return add(new ofxToggle(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<string> & parameter){
-	add(new ofxLabel(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<string> & parameter){
+    return add(new ofxLabel(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofVec2f> & parameter){
-	add(new ofxVecSlider_<ofVec2f>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec2f> & parameter){
+    return add(new ofxVecSlider_<ofVec2f>(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofVec3f> & parameter){
-	add(new ofxVecSlider_<ofVec3f>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec3f> & parameter){
+    return add(new ofxVecSlider_<ofVec3f>(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofVec4f> & parameter){
-	add(new ofxVecSlider_<ofVec4f>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec4f> & parameter){
+    return add(new ofxVecSlider_<ofVec4f>(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofColor> & parameter){
-	add(new ofxColorSlider_<unsigned char>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofColor> & parameter){
+    return add(new ofxColorSlider_<unsigned char>(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofShortColor> & parameter){
-	add(new ofxColorSlider_<unsigned short>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofShortColor> & parameter){
+    return add(new ofxColorSlider_<unsigned short>(parameter,b.width));
 }
 
-void ofxGuiGroup::add(ofParameter<ofFloatColor> & parameter){
-	add(new ofxColorSlider_<float>(parameter,b.width));
+ofxBaseGui* ofxGuiGroup::add(ofParameter<ofFloatColor> & parameter){
+    return add(new ofxColorSlider_<float>(parameter,b.width));
 }
 
 void ofxGuiGroup::clear(){

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -7,7 +7,6 @@ using namespace std;
 
 ofxGuiGroup::ofxGuiGroup(){
 	minimized = false;
-	parent = NULL;
 	spacing  = 1;
 	spacingNextElement = 3;
 	header = defaultHeight;
@@ -99,11 +98,12 @@ ofxBaseGui* ofxGuiGroup::add(ofxBaseGui * element){
 	//if(b.width<element->getWidth()) b.width = element->getWidth();
     
     element->unregisterMouseEvents();
+
+    element->setParent(this);
     
 	ofxGuiGroup * subgroup = dynamic_cast<ofxGuiGroup*>(element);
 	if(subgroup!=NULL){
 		subgroup->filename = filename;
-		subgroup->parent = this;
 		subgroup->setWidthElements(b.width*.98);
 	}else{
 		if(parent!=NULL){

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -32,8 +32,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, string _f
 	spacingNextElement = 3;
 	if(parent != NULL){
 		b.width = parent->getWidth();
-	}
-	else{
+	} else{
 		b.width = defaultWidth;
 	}
 	clear();
@@ -45,49 +44,38 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, string _f
 		if(type == typeid(ofParameter <int> ).name()){
 			ofParameter <int> p = _parameters.getInt(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <float> ).name()){
+		} else if(type == typeid(ofParameter <float> ).name()){
 			ofParameter <float> p = _parameters.getFloat(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <bool> ).name()){
+		} else if(type == typeid(ofParameter <bool> ).name()){
 			ofParameter <bool> p = _parameters.getBool(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofVec2f> ).name()){
+		} else if(type == typeid(ofParameter <ofVec2f> ).name()){
 			ofParameter <ofVec2f> p = _parameters.getVec2f(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofVec3f> ).name()){
+		} else if(type == typeid(ofParameter <ofVec3f> ).name()){
 			ofParameter <ofVec3f> p = _parameters.getVec3f(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofVec4f> ).name()){
+		} else if(type == typeid(ofParameter <ofVec4f> ).name()){
 			ofParameter <ofVec4f> p = _parameters.getVec4f(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofColor> ).name()){
+		} else if(type == typeid(ofParameter <ofColor> ).name()){
 			ofParameter <ofColor> p = _parameters.getColor(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofShortColor> ).name()){
+		} else if(type == typeid(ofParameter <ofShortColor> ).name()){
 			ofParameter <ofShortColor> p = _parameters.getShortColor(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <ofFloatColor> ).name()){
+		} else if(type == typeid(ofParameter <ofFloatColor> ).name()){
 			ofParameter <ofFloatColor> p = _parameters.getFloatColor(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameter <string> ).name()){
+		} else if(type == typeid(ofParameter <string> ).name()){
 			ofParameter <string> p = _parameters.getString(i);
 			add(p);
-		}
-		else if(type == typeid(ofParameterGroup).name()){
+		} else if(type == typeid(ofParameterGroup).name()){
 			ofParameterGroup p = _parameters.getGroup(i);
 			ofxGuiGroup * panel = new ofxGuiGroup(p);
 			add(panel);
-		}
-		else{
+		} else{
 			ofLogWarning() << "ofxBaseGroup; no control for parameter of type " << type;
 		}
 	}
@@ -117,8 +105,7 @@ ofxBaseGui * ofxGuiGroup::add(ofxBaseGui * element){
 	if(subgroup != NULL){
 		subgroup->filename = filename;
 		subgroup->setWidthElements(b.width * .98);
-	}
-	else{
+	} else{
 		if(parent != NULL){
 			element->setSize(b.width * .98, element->getHeight());
 			element->setPosition(b.x + b.width - element->getWidth(), element->getPosition().y);
@@ -205,8 +192,7 @@ bool ofxGuiGroup::mouseMoved(ofMouseEventArgs & args){
 	}
 	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}
-	else{
+	} else{
 		return false;
 	}
 }
@@ -251,8 +237,7 @@ bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
 	}
 	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}
-	else{
+	} else{
 		return false;
 	}
 }
@@ -266,8 +251,7 @@ bool ofxGuiGroup::mouseScrolled(ofMouseEventArgs & args){
 	}
 	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}
-	else{
+	} else{
 		return false;
 	}
 }
@@ -287,8 +271,7 @@ void ofxGuiGroup::generateDraw(){
 	textMesh = getTextMesh(getName(), textPadding + b.x, header / 2 + 4 + b.y + spacingNextElement);
 	if(minimized){
 		textMesh.append(getTextMesh("+", b.width - textPadding - 8 + b.x, header / 2 + 4 + b.y + spacingNextElement));
-	}
-	else{
+	} else{
 		textMesh.append(getTextMesh("-", b.width - textPadding - 8 + b.x, header / 2 + 4 + b.y + spacingNextElement));
 	}
 }
@@ -374,8 +357,7 @@ bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){
 				minimized = !minimized;
 				if(minimized){
 					minimize();
-				}
-				else{
+				} else{
 					maximize();
 				}
 				return true;
@@ -428,8 +410,7 @@ void ofxGuiGroup::sizeChangedCB(){
 	float y;
 	if(parent){
 		y = b.y  + header + spacing + spacingNextElement;
-	}
-	else{
+	} else{
 		y = b.y  + header + spacing;
 	}
 	for(int i = 0; i < (int)collection.size(); i++){
@@ -451,8 +432,7 @@ int ofxGuiGroup::getNumControls(){
 ofxBaseGui * ofxGuiGroup::getControl(int num){
 	if(num < (int)collection.size()){
 		return collection[num];
-	}
-	else{
+	} else{
 		return NULL;
 	}
 }

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 ofxGuiGroup::ofxGuiGroup(){
 	minimized = false;
-	spacing  = 1;
+	spacing = 1;
 	spacingNextElement = 3;
 	header = defaultHeight;
 	bGuiActive = false;
@@ -16,181 +16,197 @@ ofxGuiGroup::ofxGuiGroup(){
 ofxGuiGroup::ofxGuiGroup(const ofParameterGroup & parameters, string filename, float x, float y){
 	minimized = false;
 	parent = NULL;
-    setup(parameters, filename, x, y);
+	setup(parameters, filename, x, y);
 }
 
 ofxGuiGroup * ofxGuiGroup::setup(string collectionName, string filename, float x, float y){
 	parameters.setName(collectionName);
-	return setup(parameters,filename,x,y);
+	return setup(parameters, filename, x, y);
 }
 
 ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, string _filename, float x, float y){
 	b.x = x;
 	b.y = y;
 	header = defaultHeight;
-	spacing  = 1;
+	spacing = 1;
 	spacingNextElement = 3;
-	if(parent!=NULL){
+	if(parent != NULL){
 		b.width = parent->getWidth();
-	}else{
+	}
+	else{
 		b.width = defaultWidth;
 	}
-    clear();
+	clear();
 	filename = _filename;
 	bGuiActive = false;
-    
-	for(int i=0;i<_parameters.size();i++){
+
+	for(int i = 0; i < _parameters.size(); i++){
 		string type = _parameters.getType(i);
-		if(type==typeid(ofParameter<int>).name()){
-			ofParameter<int> p = _parameters.getInt(i);
+		if(type == typeid(ofParameter <int> ).name()){
+			ofParameter <int> p = _parameters.getInt(i);
 			add(p);
-		}else if(type==typeid(ofParameter<float>).name()){
-			ofParameter<float> p = _parameters.getFloat(i);
+		}
+		else if(type == typeid(ofParameter <float> ).name()){
+			ofParameter <float> p = _parameters.getFloat(i);
 			add(p);
-		}else if(type==typeid(ofParameter<bool>).name()){
-			ofParameter<bool> p = _parameters.getBool(i);
+		}
+		else if(type == typeid(ofParameter <bool> ).name()){
+			ofParameter <bool> p = _parameters.getBool(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofVec2f>).name()){
-			ofParameter<ofVec2f> p = _parameters.getVec2f(i);
+		}
+		else if(type == typeid(ofParameter <ofVec2f> ).name()){
+			ofParameter <ofVec2f> p = _parameters.getVec2f(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofVec3f>).name()){
-			ofParameter<ofVec3f> p = _parameters.getVec3f(i);
+		}
+		else if(type == typeid(ofParameter <ofVec3f> ).name()){
+			ofParameter <ofVec3f> p = _parameters.getVec3f(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofVec4f>).name()){
-			ofParameter<ofVec4f> p = _parameters.getVec4f(i);
+		}
+		else if(type == typeid(ofParameter <ofVec4f> ).name()){
+			ofParameter <ofVec4f> p = _parameters.getVec4f(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofColor>).name()){
-			ofParameter<ofColor> p = _parameters.getColor(i);
+		}
+		else if(type == typeid(ofParameter <ofColor> ).name()){
+			ofParameter <ofColor> p = _parameters.getColor(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofShortColor>).name()){
-			ofParameter<ofShortColor> p = _parameters.getShortColor(i);
+		}
+		else if(type == typeid(ofParameter <ofShortColor> ).name()){
+			ofParameter <ofShortColor> p = _parameters.getShortColor(i);
 			add(p);
-		}else if(type==typeid(ofParameter<ofFloatColor>).name()){
-			ofParameter<ofFloatColor> p = _parameters.getFloatColor(i);
+		}
+		else if(type == typeid(ofParameter <ofFloatColor> ).name()){
+			ofParameter <ofFloatColor> p = _parameters.getFloatColor(i);
 			add(p);
-		}else if(type==typeid(ofParameter<string>).name()){
-        		ofParameter<string> p = _parameters.getString(i);
+		}
+		else if(type == typeid(ofParameter <string> ).name()){
+			ofParameter <string> p = _parameters.getString(i);
 			add(p);
-		}else if(type==typeid(ofParameterGroup).name()){
+		}
+		else if(type == typeid(ofParameterGroup).name()){
 			ofParameterGroup p = _parameters.getGroup(i);
 			ofxGuiGroup * panel = new ofxGuiGroup(p);
 			add(panel);
-		}else{
+		}
+		else{
 			ofLogWarning() << "ofxBaseGroup; no control for parameter of type " << type;
 		}
 	}
 
 	parameters = _parameters;
-    registerMouseEvents();
+	registerMouseEvents();
 
 	setNeedsRedraw();
-    
+
 	return this;
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofxBaseGui * element){
-	collection.push_back( element );
+ofxBaseGui * ofxGuiGroup::add(ofxBaseGui * element){
+	collection.push_back(element);
 
 	element->setPosition(b.x, b.y + b.height  + spacing);
 
 	b.height += element->getHeight() + spacing;
 
 	//if(b.width<element->getWidth()) b.width = element->getWidth();
-    
-    element->unregisterMouseEvents();
 
-    element->setParent(this);
-    
-	ofxGuiGroup * subgroup = dynamic_cast<ofxGuiGroup*>(element);
-	if(subgroup!=NULL){
+	element->unregisterMouseEvents();
+
+	element->setParent(this);
+
+	ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(element);
+	if(subgroup != NULL){
 		subgroup->filename = filename;
-		subgroup->setWidthElements(b.width*.98);
-	}else{
-		if(parent!=NULL){
-			element->setSize(b.width*.98,element->getHeight());
-			element->setPosition(b.x + b.width-element->getWidth(),element->getPosition().y);
+		subgroup->setWidthElements(b.width * .98);
+	}
+	else{
+		if(parent != NULL){
+			element->setSize(b.width * .98, element->getHeight());
+			element->setPosition(b.x + b.width - element->getWidth(), element->getPosition().y);
 		}
 	}
-    
+
 	parameters.add(element->getParameter());
 	setNeedsRedraw();
-    return element;
+	return element;
 }
 
 void ofxGuiGroup::setWidthElements(float w){
-	for(int i=0;i<(int)collection.size();i++){
-		collection[i]->setSize(w,collection[i]->getHeight());
-		collection[i]->setPosition(b.x + b.width-w,collection[i]->getPosition().y);
-		ofxGuiGroup * subgroup = dynamic_cast<ofxGuiGroup*>(collection[i]);
-		if(subgroup!=NULL){
-			subgroup->setWidthElements(w*.98);
+	for(int i = 0; i < (int)collection.size(); i++){
+		collection[i]->setSize(w, collection[i]->getHeight());
+		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
+		ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(collection[i]);
+		if(subgroup != NULL){
+			subgroup->setWidthElements(w * .98);
 		}
 	}
 	sizeChangedCB();
 	setNeedsRedraw();
 }
 
-ofxBaseGui* ofxGuiGroup::add(const ofParameterGroup & parameters){
+ofxBaseGui * ofxGuiGroup::add(const ofParameterGroup & parameters){
 	ofxGuiGroup * panel = new ofxGuiGroup(parameters);
 	panel->parent = this;
-    return add(panel);
+	return add(panel);
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<float> & parameter){
-    return add(new ofxFloatSlider(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <float> & parameter){
+	return add(new ofxFloatSlider(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<int> & parameter){
-    return add(new ofxIntSlider(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <int> & parameter){
+	return add(new ofxIntSlider(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<bool> & parameter){
-    return add(new ofxToggle(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <bool> & parameter){
+	return add(new ofxToggle(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<string> & parameter){
-    return add(new ofxLabel(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <string> & parameter){
+	return add(new ofxLabel(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec2f> & parameter){
-    return add(new ofxVecSlider_<ofVec2f>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofVec2f> & parameter){
+	return add(new ofxVecSlider_ <ofVec2f>(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec3f> & parameter){
-    return add(new ofxVecSlider_<ofVec3f>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofVec3f> & parameter){
+	return add(new ofxVecSlider_ <ofVec3f>(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofVec4f> & parameter){
-    return add(new ofxVecSlider_<ofVec4f>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofVec4f> & parameter){
+	return add(new ofxVecSlider_ <ofVec4f>(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofColor> & parameter){
-    return add(new ofxColorSlider_<unsigned char>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofColor> & parameter){
+	return add(new ofxColorSlider_ <unsigned char>(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofShortColor> & parameter){
-    return add(new ofxColorSlider_<unsigned short>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofShortColor> & parameter){
+	return add(new ofxColorSlider_ <unsigned short>(parameter, b.width));
 }
 
-ofxBaseGui* ofxGuiGroup::add(ofParameter<ofFloatColor> & parameter){
-    return add(new ofxColorSlider_<float>(parameter,b.width));
+ofxBaseGui * ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter){
+	return add(new ofxColorSlider_ <float>(parameter, b.width));
 }
 
 void ofxGuiGroup::clear(){
 	collection.clear();
 	parameters.clear();
-	b.height = header + spacing + spacingNextElement ;
+	b.height = header + spacing + spacingNextElement;
 	sizeChangedCB();
 }
 
 bool ofxGuiGroup::mouseMoved(ofMouseEventArgs & args){
 	ofMouseEventArgs a = args;
 	for(int i = 0; i < (int)collection.size(); i++){
-		if(collection[i]->mouseMoved(a)) return true;
+		if(collection[i]->mouseMoved(a)){
+			return true;
+		}
 	}
-	if(isGuiDrawing() && b.inside(ofPoint(args.x,args.y))){
+	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}else{
+	}
+	else{
 		return false;
 	}
 }
@@ -199,10 +215,12 @@ bool ofxGuiGroup::mousePressed(ofMouseEventArgs & args){
 	if(setValue(args.x, args.y, true)){
 		return true;
 	}
-	if( bGuiActive ){
+	if(bGuiActive){
 		ofMouseEventArgs a = args;
 		for(int i = 0; i < (int)collection.size(); i++){
-			if(collection[i]->mousePressed(a)) return true;
+			if(collection[i]->mousePressed(a)){
+				return true;
+			}
 		}
 	}
 	return false;
@@ -212,10 +230,12 @@ bool ofxGuiGroup::mouseDragged(ofMouseEventArgs & args){
 	if(setValue(args.x, args.y, false)){
 		return true;
 	}
-	if( bGuiActive ){
+	if(bGuiActive){
 		ofMouseEventArgs a = args;
 		for(int i = 0; i < (int)collection.size(); i++){
-			if(collection[i]->mouseDragged(a)) return true;
+			if(collection[i]->mouseDragged(a)){
+				return true;
+			}
 		}
 	}
 	return false;
@@ -225,11 +245,14 @@ bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
 	bGuiActive = false;
 	for(int k = 0; k < (int)collection.size(); k++){
 		ofMouseEventArgs a = args;
-		if(collection[k]->mouseReleased(a)) return true;
+		if(collection[k]->mouseReleased(a)){
+			return true;
+		}
 	}
-	if(isGuiDrawing() && b.inside(ofPoint(args.x,args.y))){
+	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}else{
+	}
+	else{
 		return false;
 	}
 }
@@ -237,32 +260,36 @@ bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
 bool ofxGuiGroup::mouseScrolled(ofMouseEventArgs & args){
 	ofMouseEventArgs a = args;
 	for(int i = 0; i < (int)collection.size(); i++){
-		if(collection[i]->mouseScrolled(a)) return true;
+		if(collection[i]->mouseScrolled(a)){
+			return true;
+		}
 	}
-	if(isGuiDrawing() && b.inside(ofPoint(args.x,args.y))){
+	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
 		return true;
-	}else{
+	}
+	else{
 		return false;
 	}
 }
 
 void ofxGuiGroup::generateDraw(){
 	border.clear();
-	border.setFillColor(ofColor(thisBorderColor,180));
+	border.setFillColor(ofColor(thisBorderColor, 180));
 	border.setFilled(true);
-	border.rectangle(b.x,b.y+ spacingNextElement,b.width+1,b.height);
+	border.rectangle(b.x, b.y + spacingNextElement, b.width + 1, b.height);
 
 
 	headerBg.clear();
 	headerBg.setFillColor(thisHeaderBackgroundColor);
 	headerBg.setFilled(true);
-	headerBg.rectangle(b.x,b.y +1 + spacingNextElement, b.width, header);
+	headerBg.rectangle(b.x, b.y + 1 + spacingNextElement, b.width, header);
 
-	textMesh = getTextMesh(getName(), textPadding + b.x, header / 2 + 4 + b.y+ spacingNextElement);
+	textMesh = getTextMesh(getName(), textPadding + b.x, header / 2 + 4 + b.y + spacingNextElement);
 	if(minimized){
-		textMesh.append(getTextMesh("+", b.width-textPadding-8 + b.x, header / 2 + 4+ b.y+ spacingNextElement));
-	}else{
-		textMesh.append(getTextMesh("-", b.width-textPadding-8 + b.x, header / 2 + 4 + b.y+ spacingNextElement));
+		textMesh.append(getTextMesh("+", b.width - textPadding - 8 + b.x, header / 2 + 4 + b.y + spacingNextElement));
+	}
+	else{
+		textMesh.append(getTextMesh("-", b.width - textPadding - 8 + b.x, header / 2 + 4 + b.y + spacingNextElement));
 	}
 }
 
@@ -271,7 +298,7 @@ void ofxGuiGroup::render(){
 	headerBg.draw();
 
 	ofBlendMode blendMode = ofGetStyle().blendingMode;
-	if(blendMode!=OF_BLENDMODE_ALPHA){
+	if(blendMode != OF_BLENDMODE_ALPHA){
 		ofEnableAlphaBlending();
 	}
 	ofColor c = ofGetStyle().color;
@@ -280,7 +307,7 @@ void ofxGuiGroup::render(){
 	bindFontTexture();
 	textMesh.draw();
 	unbindFontTexture();
-    
+
 	if(!minimized){
 		for(int i = 0; i < (int)collection.size(); i++){
 			collection[i]->draw();
@@ -288,42 +315,42 @@ void ofxGuiGroup::render(){
 	}
 
 	ofSetColor(c);
-	if(blendMode!=OF_BLENDMODE_ALPHA){
+	if(blendMode != OF_BLENDMODE_ALPHA){
 		ofEnableBlendMode(blendMode);
 	}
 }
 
-vector<string> ofxGuiGroup::getControlNames(){
-	vector<string> names;
-	for(int i=0; i<(int)collection.size(); i++){
+vector <string> ofxGuiGroup::getControlNames(){
+	vector <string> names;
+	for(int i = 0; i < (int)collection.size(); i++){
 		names.push_back(collection[i]->getName());
 	}
 	return names;
 }
 
 ofxIntSlider & ofxGuiGroup::getIntSlider(string name){
-	return getControlType<ofxIntSlider>(name);
+	return getControlType <ofxIntSlider>(name);
 }
 
 ofxFloatSlider & ofxGuiGroup::getFloatSlider(string name){
-	return getControlType<ofxFloatSlider>(name);
+	return getControlType <ofxFloatSlider>(name);
 }
 
 ofxToggle & ofxGuiGroup::getToggle(string name){
-	return getControlType<ofxToggle>(name);
+	return getControlType <ofxToggle>(name);
 }
 
 ofxButton & ofxGuiGroup::getButton(string name){
-	return getControlType<ofxButton>(name);
+	return getControlType <ofxButton>(name);
 }
 
 ofxGuiGroup & ofxGuiGroup::getGroup(string name){
-	return getControlType<ofxGuiGroup>(name);
+	return getControlType <ofxGuiGroup>(name);
 }
 
 ofxBaseGui * ofxGuiGroup::getControl(string name){
-	for(int i=0; i<(int)collection.size(); i++){
-		if(collection[i]->getName()==name){
+	for(int i = 0; i < (int)collection.size(); i++){
+		if(collection[i]->getName() == name){
 			return collection[i];
 		}
 	}
@@ -331,60 +358,69 @@ ofxBaseGui * ofxGuiGroup::getControl(string name){
 }
 
 bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){
-    
-	if( !isGuiDrawing() ){
+
+	if(!isGuiDrawing()){
 		bGuiActive = false;
 		return false;
 	}
 
 
-	if( bCheck ){
-		if( b.inside(mx, my) ){
+	if(bCheck){
+		if(b.inside(mx, my)){
 			bGuiActive = true;
 
-			ofRectangle minButton(b.x+b.width-textPadding*3,b.y,textPadding*3,header);
-			if(minButton.inside(mx,my)){
+			ofRectangle minButton(b.x + b.width - textPadding * 3, b.y, textPadding * 3, header);
+			if(minButton.inside(mx, my)){
 				minimized = !minimized;
 				if(minimized){
 					minimize();
-				}else{
+				}
+				else{
 					maximize();
 				}
 				return true;
 			}
-        }
+		}
 	}
 
 	return false;
 }
 
 void ofxGuiGroup::minimize(){
-	minimized=true;
+	minimized = true;
 	b.height = header + spacing + spacingNextElement + 1 /*border*/;
-	if(parent) parent->sizeChangedCB();
+	if(parent){
+		parent->sizeChangedCB();
+	}
 	setNeedsRedraw();
 }
 
 void ofxGuiGroup::maximize(){
-	minimized=false;
-	for(int i=0;i<(int)collection.size();i++){
+	minimized = false;
+	for(int i = 0; i < (int)collection.size(); i++){
 		b.height += collection[i]->getHeight() + spacing;
 	}
-	if(parent) parent->sizeChangedCB();
+	if(parent){
+		parent->sizeChangedCB();
+	}
 	setNeedsRedraw();
 }
 
 void ofxGuiGroup::minimizeAll(){
-	for(int i=0;i<(int)collection.size();i++){
-		ofxGuiGroup * group = dynamic_cast<ofxGuiGroup*>(collection[i]);
-		if(group)group->minimize();
+	for(int i = 0; i < (int)collection.size(); i++){
+		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(collection[i]);
+		if(group){
+			group->minimize();
+		}
 	}
 }
 
 void ofxGuiGroup::maximizeAll(){
-	for(int i=0;i<(int)collection.size();i++){
-		ofxGuiGroup * group = dynamic_cast<ofxGuiGroup*>(collection[i]);
-		if(group)group->maximize();
+	for(int i = 0; i < (int)collection.size(); i++){
+		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(collection[i]);
+		if(group){
+			group->maximize();
+		}
 	}
 }
 
@@ -392,15 +428,18 @@ void ofxGuiGroup::sizeChangedCB(){
 	float y;
 	if(parent){
 		y = b.y  + header + spacing + spacingNextElement;
-	}else{
+	}
+	else{
 		y = b.y  + header + spacing;
 	}
-	for(int i=0;i<(int)collection.size();i++){
-		collection[i]->setPosition(collection[i]->getPosition().x,y + spacing);
+	for(int i = 0; i < (int)collection.size(); i++){
+		collection[i]->setPosition(collection[i]->getPosition().x, y + spacing);
 		y += collection[i]->getHeight() + spacing;
 	}
 	b.height = y - b.y;
-	if(parent) parent->sizeChangedCB();
+	if(parent){
+		parent->sizeChangedCB();
+	}
 	setNeedsRedraw();
 }
 
@@ -410,10 +449,12 @@ int ofxGuiGroup::getNumControls(){
 }
 
 ofxBaseGui * ofxGuiGroup::getControl(int num){
-	if(num<(int)collection.size())
+	if(num < (int)collection.size()){
 		return collection[num];
-	else
+	}
+	else{
 		return NULL;
+	}
 }
 
 ofAbstractParameter & ofxGuiGroup::getParameter(){
@@ -423,8 +464,8 @@ ofAbstractParameter & ofxGuiGroup::getParameter(){
 void ofxGuiGroup::setPosition(ofPoint p){
 	ofVec2f diff = p - b.getPosition();
 
-	for(int i=0;i<(int)collection.size();i++){
-		collection[i]->setPosition(collection[i]->getPosition()+diff);
+	for(int i = 0; i < (int)collection.size(); i++){
+		collection[i]->setPosition(collection[i]->getPosition() + diff);
 	}
 
 	b.setPosition(p);
@@ -432,5 +473,5 @@ void ofxGuiGroup::setPosition(ofPoint p){
 }
 
 void ofxGuiGroup::setPosition(float x, float y){
-	setPosition(ofVec2f(x,y));
+	setPosition(ofVec2f(x, y));
 }

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -89,8 +89,7 @@ ControlType & ofxGuiGroup::getControlType(std::string name){
 	ControlType * control = dynamic_cast <ControlType *>(getControl(name));
 	if(control){
 		return *control;
-	}
-	else{
+	} else{
 		ofLogWarning() << "getControlType " << name << " not found, creating new";
 		control = new ControlType;
 		control->setName(name);

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -13,18 +13,18 @@ public:
     virtual ofxGuiGroup * setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
 	virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
     
-	void add(ofxBaseGui * element);
-    void add(const ofParameterGroup & parameters);
-	void add(ofParameter<float> & parameter);
-	void add(ofParameter<int> & parameter);
-	void add(ofParameter<bool> & parameter);
-	void add(ofParameter<std::string> & parameter);
-    void add(ofParameter<ofVec2f> & parameter);
-    void add(ofParameter<ofVec3f> & parameter);
-    void add(ofParameter<ofVec4f> & parameter);
-    void add(ofParameter<ofColor> & parameter);
-    void add(ofParameter<ofShortColor> & parameter);
-    void add(ofParameter<ofFloatColor> & parameter);
+    ofxBaseGui* add(ofxBaseGui * element);
+    ofxBaseGui* add(const ofParameterGroup & parameters);
+    ofxBaseGui* add(ofParameter<float> & parameter);
+    ofxBaseGui* add(ofParameter<int> & parameter);
+    ofxBaseGui* add(ofParameter<bool> & parameter);
+    ofxBaseGui* add(ofParameter<std::string> & parameter);
+    ofxBaseGui* add(ofParameter<ofVec2f> & parameter);
+    ofxBaseGui* add(ofParameter<ofVec3f> & parameter);
+    ofxBaseGui* add(ofParameter<ofVec4f> & parameter);
+    ofxBaseGui* add(ofParameter<ofColor> & parameter);
+    ofxBaseGui* add(ofParameter<ofShortColor> & parameter);
+    ofxBaseGui* add(ofParameter<ofFloatColor> & parameter);
 
     void minimize();
     void maximize();

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -6,6 +6,7 @@
 #include "ofParameterGroup.h"
 
 class ofxGuiGroup : public ofxBaseGui {
+
 public:
 	ofxGuiGroup();
 	ofxGuiGroup(const ofParameterGroup & parameters, std::string _filename="settings.xml", float x = 10, float y = 10);
@@ -61,7 +62,7 @@ public:
 protected:
 	virtual void render();
     virtual bool setValue(float mx, float my, bool bCheck);
-    void sizeChangedCB();
+    virtual void sizeChangedCB();
     
 	float spacing,spacingNextElement;
 	float header;
@@ -78,7 +79,6 @@ protected:
 	bool minimized;
 	bool bGuiActive;
 
-	ofxGuiGroup * parent;
 	ofPath border, headerBg;
 	ofVboMesh textMesh;
 };

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -7,88 +7,90 @@
 
 class ofxGuiGroup : public ofxBaseGui {
 
-public:
-	ofxGuiGroup();
-	ofxGuiGroup(const ofParameterGroup & parameters, std::string _filename="settings.xml", float x = 10, float y = 10);
-    virtual ~ofxGuiGroup() {}
-    virtual ofxGuiGroup * setup(std::string collectionName="", std::string filename="settings.xml", float x = 10, float y = 10);
-	virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, std::string filename="settings.xml", float x = 10, float y = 10);
-    
-    ofxBaseGui* add(ofxBaseGui * element);
-    ofxBaseGui* add(const ofParameterGroup & parameters);
-    ofxBaseGui* add(ofParameter<float> & parameter);
-    ofxBaseGui* add(ofParameter<int> & parameter);
-    ofxBaseGui* add(ofParameter<bool> & parameter);
-    ofxBaseGui* add(ofParameter<std::string> & parameter);
-    ofxBaseGui* add(ofParameter<ofVec2f> & parameter);
-    ofxBaseGui* add(ofParameter<ofVec3f> & parameter);
-    ofxBaseGui* add(ofParameter<ofVec4f> & parameter);
-    ofxBaseGui* add(ofParameter<ofColor> & parameter);
-    ofxBaseGui* add(ofParameter<ofShortColor> & parameter);
-    ofxBaseGui* add(ofParameter<ofFloatColor> & parameter);
+	public:
+		ofxGuiGroup();
+		ofxGuiGroup(const ofParameterGroup & parameters, std::string _filename = "settings.xml", float x = 10, float y = 10);
+		virtual ~ofxGuiGroup(){
+		}
+		virtual ofxGuiGroup * setup(std::string collectionName = "", std::string filename = "settings.xml", float x = 10, float y = 10);
+		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, std::string filename = "settings.xml", float x = 10, float y = 10);
 
-    void minimize();
-    void maximize();
-    void minimizeAll();
-    void maximizeAll();
+		ofxBaseGui * add(ofxBaseGui * element);
+		ofxBaseGui * add(const ofParameterGroup & parameters);
+		ofxBaseGui * add(ofParameter <float> & parameter);
+		ofxBaseGui * add(ofParameter <int> & parameter);
+		ofxBaseGui * add(ofParameter <bool> & parameter);
+		ofxBaseGui * add(ofParameter <std::string> & parameter);
+		ofxBaseGui * add(ofParameter <ofVec2f> & parameter);
+		ofxBaseGui * add(ofParameter <ofVec3f> & parameter);
+		ofxBaseGui * add(ofParameter <ofVec4f> & parameter);
+		ofxBaseGui * add(ofParameter <ofColor> & parameter);
+		ofxBaseGui * add(ofParameter <ofShortColor> & parameter);
+		ofxBaseGui * add(ofParameter <ofFloatColor> & parameter);
 
-	void setWidthElements(float w);
+		void minimize();
+		void maximize();
+		void minimizeAll();
+		void maximizeAll();
 
-	void clear();
-	
-	virtual bool mouseMoved(ofMouseEventArgs & args);
-	virtual bool mousePressed(ofMouseEventArgs & args);
-	virtual bool mouseDragged(ofMouseEventArgs & args);
-	virtual bool mouseReleased(ofMouseEventArgs & args);
-	virtual bool mouseScrolled(ofMouseEventArgs & args);
-	
-	
-	std::vector<std::string> getControlNames();
-	int getNumControls();
-    
-	ofxIntSlider & getIntSlider(std::string name);
-	ofxFloatSlider & getFloatSlider(std::string name);
-	ofxToggle & getToggle(std::string name);
-	ofxButton & getButton(std::string name);
-	ofxGuiGroup & getGroup(std::string name);
-    
-	ofxBaseGui * getControl(std::string name);
-	ofxBaseGui * getControl(int num);
-    
-	virtual ofAbstractParameter & getParameter();
+		void setWidthElements(float w);
 
-	virtual void setPosition(ofPoint p);
-	virtual void setPosition(float x, float y);
-protected:
-	virtual void render();
-    virtual bool setValue(float mx, float my, bool bCheck);
-    virtual void sizeChangedCB();
-    
-	float spacing,spacingNextElement;
-	float header;
-	
-    template<class ControlType>
-	ControlType & getControlType(std::string name);
+		void clear();
 
-    virtual void generateDraw();
+		virtual bool mouseMoved(ofMouseEventArgs & args);
+		virtual bool mousePressed(ofMouseEventArgs & args);
+		virtual bool mouseDragged(ofMouseEventArgs & args);
+		virtual bool mouseReleased(ofMouseEventArgs & args);
+		virtual bool mouseScrolled(ofMouseEventArgs & args);
 
-    std::vector <ofxBaseGui *> collection;
-	ofParameterGroup parameters;
-	
-	std::string filename;
-	bool minimized;
-	bool bGuiActive;
 
-	ofPath border, headerBg;
-	ofVboMesh textMesh;
+		std::vector <std::string> getControlNames();
+		int getNumControls();
+
+		ofxIntSlider & getIntSlider(std::string name);
+		ofxFloatSlider & getFloatSlider(std::string name);
+		ofxToggle & getToggle(std::string name);
+		ofxButton & getButton(std::string name);
+		ofxGuiGroup & getGroup(std::string name);
+
+		ofxBaseGui * getControl(std::string name);
+		ofxBaseGui * getControl(int num);
+
+		virtual ofAbstractParameter & getParameter();
+
+		virtual void setPosition(ofPoint p);
+		virtual void setPosition(float x, float y);
+	protected:
+		virtual void render();
+		virtual bool setValue(float mx, float my, bool bCheck);
+		virtual void sizeChangedCB();
+
+		float spacing, spacingNextElement;
+		float header;
+
+		template <class ControlType>
+		ControlType & getControlType(std::string name);
+
+		virtual void generateDraw();
+
+		std::vector <ofxBaseGui *> collection;
+		ofParameterGroup parameters;
+
+		std::string filename;
+		bool minimized;
+		bool bGuiActive;
+
+		ofPath border, headerBg;
+		ofVboMesh textMesh;
 };
 
-template<class ControlType>
+template <class ControlType>
 ControlType & ofxGuiGroup::getControlType(std::string name){
-	ControlType * control = dynamic_cast<ControlType*>(getControl(name));
+	ControlType * control = dynamic_cast <ControlType *>(getControl(name));
 	if(control){
 		return *control;
-	}else{
+	}
+	else{
 		ofLogWarning() << "getControlType " << name << " not found, creating new";
 		control = new ControlType;
 		control->setName(name);


### PR DESCRIPTION
Just a few small things:

 - the `parent` attribute is moved from `ofxGuiGroup` to `ofxBaseGui`: when a button or something else derived from ofxBaseGui changes size, the parent control should be updated, therefore ofxBaseGui needs a parent
 - `sizeChangedCB` moved to `ofxBaseGui`, gets called every time an element gets resized, is public to enable calling it even if the child has a different class (or is there another way without adding every possible child class as a friend class to `ofxBaseGui`?)


 - the `add`-functions of `ofxGuiGroup` return the new crontrol: allows visual changes to control element returned by the function:
```
ofxBaseGui* control = add(param.set(..));
control->setFillColor(..);
```
