### PR TITLE
fix vao not updated upon vertex buffer change

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -658,7 +658,7 @@ GLuint ofVbo::getAttributeId(int location) const {
 void ofVbo::setVertexBuffer(ofBufferObject & buffer, int numCoords, int stride, int offset){
 	positionAttribute.setBuffer(buffer, numCoords, stride, offset);
 	bUsingVerts = true;
-
+	vaoChanged = true;
 	// Calculate the total number of vertices based on what we know:
 	int tmpStride = stride;
 	if (tmpStride == 0) {


### PR DESCRIPTION
When an ofVbo is assigned a new buffer for vertex data, the
internal VAO was not flagged as dirty. This would lead to
the old buffer still being bound to the previous vertex
buffer, and the new vertex data not being displayed.

With this fix, the ofVbo's internal VAO is marked dirty
after the buffer has been assigned, and the VAO will be
re-submitted upon the next draw call, using the new buffer
for vertex data.