### PR TITLE
Fix gst_element_query_duration argument type (int64_t to gint64).

### DIFF
--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -106,7 +106,7 @@ private:
 	GstElement 	*		gstPipeline;
 
 	float				speed;
-	mutable int64_t		durationNanos;
+	mutable gint64		durationNanos;
 	bool				isAppSink;
 	std::condition_variable		eosCondition;
 	std::mutex			eosMutex;


### PR DESCRIPTION
On Yosemite 10.10.4 with Clang 6.1, projects that use GStreamer fail to compile because of this type mismatch.