### PR TITLE
Refactor gui

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -63,7 +63,6 @@ bool ofxBaseGui::useTTF = false;
 ofBitmapFont ofxBaseGui::bitmapFont;
 
 ofxBaseGui::ofxBaseGui(){
-	parent = NULL;
 	currentFrame = ofGetFrameNum();
 	serializer = std::shared_ptr <ofBaseFileSerializer>(new ofXml);
 
@@ -212,17 +211,20 @@ void ofxBaseGui::setPosition(float x, float y){
 void ofxBaseGui::setSize(float w, float h){
 	b.width = w;
 	b.height = h;
-	sizeChangedCB();
+	sizeChangedE.notify(this);
+	setNeedsRedraw();
 }
 
 void ofxBaseGui::setShape(ofRectangle r){
 	b = r;
-	sizeChangedCB();
+	sizeChangedE.notify(this);
+	setNeedsRedraw();
 }
 
 void ofxBaseGui::setShape(float x, float y, float w, float h){
 	b.set(x, y, w, h);
-	sizeChangedCB();
+	sizeChangedE.notify(this);
+	setNeedsRedraw();
 }
 
 ofPoint ofxBaseGui::getPosition(){
@@ -318,13 +320,6 @@ void ofxBaseGui::setDefaultHeight(int height){
 	defaultHeight = height;
 }
 
-void ofxBaseGui::sizeChangedCB(){
-	if(parent){
-		parent->sizeChangedCB();
-	}
-	setNeedsRedraw();
-}
-
 void ofxBaseGui::setNeedsRedraw(){
 	needsRedraw = true;
 }
@@ -373,12 +368,4 @@ void ofxBaseGui::loadStencilFromHex(ofImage & img, unsigned char * data){
 		}
 	}
 	img.update();
-}
-
-void ofxBaseGui::setParent(ofxBaseGui * parent){
-	this->parent = parent;
-}
-
-ofxBaseGui * ofxBaseGui::getParent(){
-	return parent;
 }

--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -62,23 +62,31 @@ bool ofxBaseGui::fontLoaded = false;
 bool ofxBaseGui::useTTF = false;
 ofBitmapFont ofxBaseGui::bitmapFont;
 
-ofxBaseGui::ofxBaseGui(){
-	currentFrame = ofGetFrameNum();
-	serializer = std::shared_ptr <ofBaseFileSerializer>(new ofXml);
+ofxBaseGui::ofxBaseGui()
+:b(Config().shape)
+,serializer(new ofXml)
+,thisHeaderBackgroundColor(Config().headerBackgroundColor)
+,thisBackgroundColor(Config().backgroundColor)
+,thisBorderColor(Config().borderColor)
+,thisTextColor(Config().textColor)
+,thisFillColor(Config().fillColor)
+,needsRedraw(true)
+,currentFrame(ofGetFrameNum())
+,bRegisteredForMouseEvents(false){
 
-	thisHeaderBackgroundColor = headerBackgroundColor;
-	thisBackgroundColor = backgroundColor;
-	thisBorderColor = borderColor;
-	thisTextColor = textColor;
-	thisFillColor = fillColor;
+}
 
-	bRegisteredForMouseEvents = false;
-	needsRedraw = true;
-
-	/*if(!fontLoaded){
-	    loadFont(OF_TTF_MONO,10,true,true);
-	    useTTF=false;
-	}*/
+ofxBaseGui::ofxBaseGui(const Config & config)
+:b(config.shape)
+,serializer(new ofXml)
+,thisHeaderBackgroundColor(config.headerBackgroundColor)
+,thisBackgroundColor(config.backgroundColor)
+,thisBorderColor(config.borderColor)
+,thisTextColor(config.textColor)
+,thisFillColor(config.fillColor)
+,needsRedraw(true)
+,currentFrame(ofGetFrameNum())
+,bRegisteredForMouseEvents(false){
 
 }
 

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -9,6 +9,8 @@
 class ofxBaseGui {
 	public:
 		struct Config{
+			Config(){};
+			Config(const ofxBaseGui::Config & c){}
 			ofColor headerBackgroundColor = ofxBaseGui::headerBackgroundColor;
 			ofColor backgroundColor = ofxBaseGui::backgroundColor;
 			ofColor borderColor = ofxBaseGui::borderColor;

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -11,6 +11,9 @@ class ofxBaseGui {
 		ofxBaseGui();
 
 		virtual ~ofxBaseGui();
+		ofxBaseGui(const ofxBaseGui &) = delete;
+		ofxBaseGui & operator=(const ofxBaseGui &) = delete;
+
 		void draw();
 
 		void saveToFile(const std::string& filename);

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -64,10 +64,6 @@ class ofxBaseGui {
 		void registerMouseEvents();
 		void unregisterMouseEvents();
 
-		virtual void sizeChangedCB();
-		void setParent(ofxBaseGui * parent);
-		ofxBaseGui * getParent();
-
 		virtual bool mouseMoved(ofMouseEventArgs & args) = 0;
 		virtual bool mousePressed(ofMouseEventArgs & args) = 0;
 		virtual bool mouseDragged(ofMouseEventArgs & args) = 0;
@@ -78,6 +74,8 @@ class ofxBaseGui {
 		virtual void mouseExited(ofMouseEventArgs & args){
 		}
 
+		ofEvent<void> sizeChangedE;
+
 	protected:
 		virtual void render() = 0;
 		bool isGuiDrawing();
@@ -86,8 +84,6 @@ class ofxBaseGui {
 		void unbindFontTexture();
 		ofMesh getTextMesh(const std::string & text, float x, float y);
 		ofRectangle getTextBoundingBox(const std::string & text, float x, float y);
-
-		ofxBaseGui * parent;
 
 		ofRectangle b;
 		static ofTrueTypeFont font;

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -8,8 +8,16 @@
 
 class ofxBaseGui {
 	public:
+		struct Config{
+			ofColor headerBackgroundColor = ofxBaseGui::headerBackgroundColor;
+			ofColor backgroundColor = ofxBaseGui::backgroundColor;
+			ofColor borderColor = ofxBaseGui::borderColor;
+			ofColor textColor = ofxBaseGui::textColor;
+			ofColor fillColor = ofxBaseGui::fillColor;
+			ofRectangle shape{0.0f, 0.0f, (float)defaultWidth, (float)defaultHeight};
+		};
 		ofxBaseGui();
-
+		ofxBaseGui(const Config & config);
 		virtual ~ofxBaseGui();
 		ofxBaseGui(const ofxBaseGui &) = delete;
 		ofxBaseGui & operator=(const ofxBaseGui &) = delete;

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -1,8 +1,11 @@
 #include "ofxButton.h"
 using namespace std;
 
-ofxButton::ofxButton(){
+ofxButton::ofxButton(const Config & config)
+:ofxToggle(ofParameter<bool>{config.name,false}, config){
 	value.setSerializable(false);
+	registerMouseEvents();
+	value.addListener(this,&ofxButton::valueChanged);
 }
 
 ofxButton::~ofxButton(){

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -12,7 +12,7 @@ ofxButton::~ofxButton(){
 	//
 }
 
-ofxButton* ofxButton::setup(const std::string& toggleName, float width, float height){
+ofxButton & ofxButton::setup(const std::string& toggleName, float width, float height){
 	setName(toggleName);
 	b.x = 0;
 	b.y = 0;
@@ -26,7 +26,7 @@ ofxButton* ofxButton::setup(const std::string& toggleName, float width, float he
 
 	value.addListener(this,&ofxButton::valueChanged);
 
-	return this;
+	return *this;
 }
 
 bool ofxButton::mouseReleased(ofMouseEventArgs & args){

--- a/addons/ofxGui/src/ofxButton.h
+++ b/addons/ofxGui/src/ofxButton.h
@@ -14,7 +14,7 @@ public:
 
 	ofxButton(const Config & config = Config());
 	~ofxButton();
-    ofxButton* setup(const std::string& toggleName, float width = defaultWidth, float height = defaultHeight);
+    ofxButton & setup(const std::string& toggleName, float width = defaultWidth, float height = defaultHeight);
 
 	virtual bool mouseReleased(ofMouseEventArgs & args);
 	virtual bool mouseMoved(ofMouseEventArgs & args);

--- a/addons/ofxGui/src/ofxButton.h
+++ b/addons/ofxGui/src/ofxButton.h
@@ -4,11 +4,13 @@
 #include "ofParameter.h"
 
 class ofxButton : public ofxToggle{
-	friend class ofPanel;
-	
 public:
 	struct Config: public ofxToggle::Config{
-		typedef ofxButton ParentType;
+		Config(){}
+		Config(const ofxToggle::Config & c)
+		:ofxToggle::Config(c){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxToggle::Config(c){}
 		std::string name;
 	};
 

--- a/addons/ofxGui/src/ofxButton.h
+++ b/addons/ofxGui/src/ofxButton.h
@@ -7,7 +7,12 @@ class ofxButton : public ofxToggle{
 	friend class ofPanel;
 	
 public:
-	ofxButton();
+	struct Config: public ofxToggle::Config{
+		typedef ofxButton ParentType;
+		std::string name;
+	};
+
+	ofxButton(const Config & config = Config());
 	~ofxButton();
     ofxButton* setup(const std::string& toggleName, float width = defaultWidth, float height = defaultHeight);
 

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -84,44 +84,37 @@ ofxGuiGroup & ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 }
 
 
-void ofxGuiGroup::addParametersFrom(const ofParameterGroup & _parameters){
-	for(int i = 0; i < _parameters.size(); i++){
-		string type = _parameters.getType(i);
-		if(type == typeid(ofParameter <int> ).name()){
-			ofParameter <int> p = _parameters.getInt(i);
-			add(p);
-		}else if(type == typeid(ofParameter <float> ).name()){
-			ofParameter <float> p = _parameters.getFloat(i);
-			add(p);
-		}else if(type == typeid(ofParameter <bool> ).name()){
-			ofParameter <bool> p = _parameters.getBool(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofVec2f> ).name()){
-			ofParameter <ofVec2f> p = _parameters.getVec2f(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofVec3f> ).name()){
-			ofParameter <ofVec3f> p = _parameters.getVec3f(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofVec4f> ).name()){
-			ofParameter <ofVec4f> p = _parameters.getVec4f(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofColor> ).name()){
-			ofParameter <ofColor> p = _parameters.getColor(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofShortColor> ).name()){
-			ofParameter <ofShortColor> p = _parameters.getShortColor(i);
-			add(p);
-		}else if(type == typeid(ofParameter <ofFloatColor> ).name()){
-			ofParameter <ofFloatColor> p = _parameters.getFloatColor(i);
-			add(p);
-		}else if(type == typeid(ofParameter <string> ).name()){
-			ofParameter <string> p = _parameters.getString(i);
-			add(p);
+void ofxGuiGroup::addParametersFrom(const ofParameterGroup & parameters){
+	for(auto & p: parameters){
+		if(p->isReadOnly()){
+			ofLogWarning("ofxGui") << "Trying to add " << p->getName() << ": read only parameters not supported yet in ofxGui";
+			continue;
+		}
+		string type = p->type();
+		if(type == typeid(ofParameter<int>).name()){
+			add(p->cast<int>());
+		}else if(type == typeid(ofParameter<float>).name()){
+			add(p->cast<float>());
+		}else if(type == typeid(ofParameter<bool>).name()){
+			add(p->cast<bool>());
+		}else if(type == typeid(ofParameter<ofVec2f>).name()){
+			add(p->cast<ofVec2f>());
+		}else if(type == typeid(ofParameter<ofVec3f>).name()){
+			add(p->cast<ofVec3f>());
+		}else if(type == typeid(ofParameter<ofVec4f>).name()){
+			add(p->cast<ofVec4f>());
+		}else if(type == typeid(ofParameter<ofColor>).name()){
+			add(p->cast<ofColor>());
+		}else if(type == typeid(ofParameter<ofShortColor>).name()){
+			add(p->cast<ofShortColor>());
+		}else if(type == typeid(ofParameter<ofFloatColor>).name()){
+			add(p->cast<ofFloatColor>());
+		}else if(type == typeid(ofParameter<string>).name()){
+			add(p->cast<string>());
 		}else if(type == typeid(ofParameterGroup).name()){
-			ofParameterGroup p = _parameters.getGroup(i);
-			add(p);
+			add(p->castGroup());
 		}else{
-			ofLogWarning() << "ofxBaseGroup; no control for parameter of type " << type;
+			ofLogWarning("ofxGui") << "Trying to add " << p->getName() << ": ofxBaseGroup; no control for parameter of type " << type;
 		}
 	}
 }
@@ -166,9 +159,9 @@ void ofxGuiGroup::addOwned(ofxGuiGroup * element){
 }
 
 void ofxGuiGroup::setWidthElements(float w){
-    for(std::size_t i = 0; i < collection.size(); i++){
-		collection[i]->setSize(w, collection[i]->getHeight());
-		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
+    for(auto & e: collection){
+		e->setSize(w, e->getHeight());
+		e->setPosition(b.x + b.width - w, e->getPosition().y);
 	}
 	sizeChangedCB();
 	setNeedsRedraw();
@@ -227,8 +220,8 @@ void ofxGuiGroup::clear(){
 
 bool ofxGuiGroup::mouseMoved(ofMouseEventArgs & args){
 	ofMouseEventArgs a = args;
-	for(std::size_t i = 0; i < collection.size(); i++){
-		if(collection[i]->mouseMoved(a)){
+	for(auto & e: collection){
+		if(e->mouseMoved(a)){
 			return true;
 		}
 	}
@@ -245,8 +238,8 @@ bool ofxGuiGroup::mousePressed(ofMouseEventArgs & args){
 	}
 	if(bGuiActive){
 		ofMouseEventArgs a = args;
-		for(std::size_t i = 0; i < collection.size(); i++){
-			if(collection[i]->mousePressed(a)){
+		for(auto & e: collection){
+			if(e->mousePressed(a)){
 				return true;
 			}
 		}
@@ -260,8 +253,8 @@ bool ofxGuiGroup::mouseDragged(ofMouseEventArgs & args){
 	}
 	if(bGuiActive){
 		ofMouseEventArgs a = args;
-		for(std::size_t i = 0; i < collection.size(); i++){
-			if(collection[i]->mouseDragged(a)){
+		for(auto & e: collection){
+			if(e->mouseDragged(a)){
 				return true;
 			}
 		}
@@ -271,9 +264,9 @@ bool ofxGuiGroup::mouseDragged(ofMouseEventArgs & args){
 
 bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
 	bGuiActive = false;
-	for(std::size_t k = 0; k < collection.size(); k++){
+	for(auto & e: collection){
 		ofMouseEventArgs a = args;
-		if(collection[k]->mouseReleased(a)){
+		if(e->mouseReleased(a)){
 			return true;
 		}
 	}
@@ -286,8 +279,8 @@ bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
 
 bool ofxGuiGroup::mouseScrolled(ofMouseEventArgs & args){
 	ofMouseEventArgs a = args;
-	for(std::size_t i = 0; i < collection.size(); i++){
-		if(collection[i]->mouseScrolled(a)){
+	for(auto & e: collection){
+		if(e->mouseScrolled(a)){
 			return true;
 		}
 	}
@@ -347,8 +340,8 @@ void ofxGuiGroup::render(){
 
 vector <string> ofxGuiGroup::getControlNames() const{
 	vector <string> names;
-	for(std::size_t i = 0; i < collection.size(); i++){
-		names.push_back(collection[i]->getName());
+	for(auto & e: collection){
+		names.push_back(e->getName());
 	}
 	return names;
 }
@@ -374,16 +367,15 @@ ofxGuiGroup & ofxGuiGroup::getGroup(const std::string& name){
 }
 
 ofxBaseGui * ofxGuiGroup::getControl(const std::string& name){
-    for(std::size_t i = 0; i < collection.size(); i++){
-		if(collection[i]->getName() == name){
-			return collection[i];
+	for(auto & e: collection){
+		if(e->getName() == name){
+			return e;
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){
-
 	if(!isGuiDrawing()){
 		bGuiActive = false;
 		return false;
@@ -419,16 +411,16 @@ void ofxGuiGroup::minimize(){
 
 void ofxGuiGroup::maximize(){
 	minimized = false;
-    for(std::size_t i = 0; i < collection.size(); i++){
-		b.height += collection[i]->getHeight() + spacing;
+	for(auto & e: collection){
+		b.height += e->getHeight() + spacing;
 	}
 	sizeChangedE.notify(this);
 	setNeedsRedraw();
 }
 
 void ofxGuiGroup::minimizeAll(){
-	for(std::size_t i = 0; i < collection.size(); i++){
-		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(collection[i]);
+	for(auto & e: collection){
+		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(e);
 		if(group){
 			group->minimize();
 		}
@@ -436,8 +428,8 @@ void ofxGuiGroup::minimizeAll(){
 }
 
 void ofxGuiGroup::maximizeAll(){
-	for(std::size_t i = 0; i < collection.size(); i++){
-		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(collection[i]);
+	for(auto & e: collection){
+		ofxGuiGroup * group = dynamic_cast <ofxGuiGroup *>(e);
 		if(group){
 			group->maximize();
 		}
@@ -446,9 +438,9 @@ void ofxGuiGroup::maximizeAll(){
 
 void ofxGuiGroup::sizeChangedCB(){
 	float y = b.y  + header + spacing + spacingFirstElement;
-	for(std::size_t i = 0; i < collection.size(); i++){
-		collection[i]->setPosition(collection[i]->getPosition().x, y + spacing);
-		y += collection[i]->getHeight() + spacing;
+	for(auto & e: collection){
+		e->setPosition(e->getPosition().x, y + spacing);
+		y += e->getHeight() + spacing;
 	}
 	b.height = y - b.y;
 	sizeChangedE.notify(this);
@@ -475,8 +467,8 @@ ofAbstractParameter & ofxGuiGroup::getParameter(){
 void ofxGuiGroup::setPosition(ofPoint p){
 	ofVec2f diff = p - b.getPosition();
 
-	for(std::size_t i = 0; i < collection.size(); i++){
-		collection[i]->setPosition(collection[i]->getPosition() + diff);
+	for(auto & e: collection){
+		e->setPosition(e->getPosition() + diff);
 	}
 
 	b.setPosition(p);

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -61,12 +61,12 @@ ofxGuiGroup::~ofxGuiGroup(){
 	}
 }
 
-ofxGuiGroup * ofxGuiGroup::setup(const std::string& collectionName, const std::string& filename, float x, float y){
+ofxGuiGroup & ofxGuiGroup::setup(const std::string& collectionName, const std::string& filename, float x, float y){
 	parameters.setName(collectionName);
 	return setup(parameters, filename, x, y);
 }
 
-ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std::string& _filename, float x, float y){
+ofxGuiGroup & ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std::string& _filename, float x, float y){
 	b.x = x;
 	b.y = y;
 	spacing = 1;
@@ -80,7 +80,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	registerMouseEvents();
 	setNeedsRedraw();
 
-	return this;
+	return *this;
 }
 
 
@@ -126,9 +126,17 @@ void ofxGuiGroup::addParametersFrom(const ofParameterGroup & _parameters){
 	}
 }
 
+void ofxGuiGroup::add(ofxBaseGui & element){
+	add(&element);
+}
+
+
+void ofxGuiGroup::add(ofxGuiGroup & element){
+	add(&element);
+}
+
 void ofxGuiGroup::add(ofxBaseGui * element){
 	collection.push_back(element);
-
 	element->setPosition(b.x, b.y + b.height  + spacing);
 	element->setSize(getWidth(), element->getHeight());
 	b.height += element->getHeight() + spacing;
@@ -140,11 +148,21 @@ void ofxGuiGroup::add(ofxBaseGui * element){
 	setNeedsRedraw();
 }
 
-
 void ofxGuiGroup::add(ofxGuiGroup * element){
 	element->spacingFirstElement = 3;
 	element->filename = filename;
 	add(static_cast<ofxBaseGui*>(element));
+
+}
+
+void ofxGuiGroup::addOwned(ofxBaseGui * element){
+	collectionOwned.emplace_back(element);
+	add(element);
+}
+
+void ofxGuiGroup::addOwned(ofxGuiGroup * element){
+	collectionOwned.emplace_back(element);
+	add(element);
 }
 
 void ofxGuiGroup::setWidthElements(float w){
@@ -157,47 +175,47 @@ void ofxGuiGroup::setWidthElements(float w){
 }
 
 void ofxGuiGroup::add(const ofParameterGroup & parameters){
-	add(new ofxGuiGroup(parameters));
+	addOwned(new ofxGuiGroup(parameters));
 }
 
 void ofxGuiGroup::add(ofParameter <float> & parameter){
-	add(new ofxFloatSlider(parameter, b.width));
+	addOwned(new ofxFloatSlider(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <int> & parameter){
-	add(new ofxIntSlider(parameter, b.width));
+	addOwned(new ofxIntSlider(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <bool> & parameter){
-	add(new ofxToggle(parameter, b.width));
+	addOwned(new ofxToggle(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <string> & parameter){
-	add(new ofxLabel(parameter, b.width));
+	addOwned(new ofxLabel(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofVec2f> & parameter){
-	add(new ofxVecSlider_ <ofVec2f>(parameter, b.width));
+	addOwned(new ofxVecSlider_ <ofVec2f>(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofVec3f> & parameter){
-	add(new ofxVecSlider_ <ofVec3f>(parameter, b.width));
+	addOwned(new ofxVecSlider_ <ofVec3f>(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofVec4f> & parameter){
-	add(new ofxVecSlider_ <ofVec4f>(parameter, b.width));
+	addOwned(new ofxVecSlider_ <ofVec4f>(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofColor> & parameter){
-	add(new ofxColorSlider_ <unsigned char>(parameter, b.width));
+	addOwned(new ofxColorSlider_ <unsigned char>(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofShortColor> & parameter){
-	add(new ofxColorSlider_ <unsigned short>(parameter, b.width));
+	addOwned(new ofxColorSlider_ <unsigned short>(parameter, b.width));
 }
 
 void ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter){
-	add(new ofxColorSlider_ <float>(parameter, b.width));
+	addOwned(new ofxColorSlider_ <float>(parameter, b.width));
 }
 
 void ofxGuiGroup::clear(){
@@ -454,7 +472,7 @@ ofAbstractParameter & ofxGuiGroup::getParameter(){
 	return parameters;
 }
 
-void ofxGuiGroup::setPosition(const ofPoint& p){
+void ofxGuiGroup::setPosition(ofPoint p){
 	ofVec2f diff = p - b.getPosition();
 
 	for(std::size_t i = 0; i < collection.size(); i++){
@@ -482,5 +500,4 @@ void ofxGuiGroup::setShape(ofRectangle r){
 void ofxGuiGroup::setShape(float x, float y, float w, float h){
 	ofxBaseGui::setShape(x,y,w,h);
 	setWidthElements(w * .98);
-
 }

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -5,13 +5,45 @@
 #include "ofxLabel.h"
 using namespace std;
 
-ofxGuiGroup::ofxGuiGroup(){
-	minimized = false;
-	spacing = 1;
-	spacingNextElement = 3;
-	spacingFirstElement = 0;
-	header = defaultHeight;
-	bGuiActive = false;
+ofxGuiGroup::ofxGuiGroup()
+:ofxBaseGui(Config())
+,spacing(Config().spacing)
+,spacingNextElement(Config().spacingNextElement)
+,spacingFirstElement(Config().spacingFirstElement)
+,header(Config().header)
+,filename(Config().filename)
+,minimized(Config().minimized)
+,bGuiActive(false){
+}
+
+ofxGuiGroup::ofxGuiGroup(const ofParameterGroup & _parameters)
+:ofxBaseGui(Config())
+,spacing(Config().spacing)
+,spacingNextElement(Config().spacingNextElement)
+,spacingFirstElement(Config().spacingFirstElement)
+,header(Config().header)
+,filename(Config().filename)
+,minimized(Config().minimized)
+,bGuiActive(false){
+	addParametersFrom(_parameters);
+	parameters = _parameters;
+	registerMouseEvents();
+	setNeedsRedraw();
+}
+
+ofxGuiGroup::ofxGuiGroup(const ofParameterGroup & _parameters, const Config & config)
+:ofxBaseGui(config)
+,spacing(config.spacing)
+,spacingNextElement(config.spacingNextElement)
+,spacingFirstElement(config.spacingFirstElement)
+,header(config.header)
+,filename(config.filename)
+,minimized(config.minimized)
+,bGuiActive(false){
+	addParametersFrom(_parameters);
+	parameters = _parameters;
+	registerMouseEvents();
+	setNeedsRedraw();
 }
 
 ofxGuiGroup::ofxGuiGroup(const ofParameterGroup & parameters, const std::string& filename, float x, float y){
@@ -43,6 +75,16 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	filename = _filename;
 	bGuiActive = false;
 
+	addParametersFrom(_parameters);
+	parameters = _parameters;
+	registerMouseEvents();
+	setNeedsRedraw();
+
+	return this;
+}
+
+
+void ofxGuiGroup::addParametersFrom(const ofParameterGroup & _parameters){
 	for(int i = 0; i < _parameters.size(); i++){
 		string type = _parameters.getType(i);
 		if(type == typeid(ofParameter <int> ).name()){
@@ -77,19 +119,11 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 			add(p);
 		}else if(type == typeid(ofParameterGroup).name()){
 			ofParameterGroup p = _parameters.getGroup(i);
-			ofxGuiGroup * panel = new ofxGuiGroup(p);
-			add(panel);
+			add(p);
 		}else{
 			ofLogWarning() << "ofxBaseGroup; no control for parameter of type " << type;
 		}
 	}
-
-	parameters = _parameters;
-	registerMouseEvents();
-
-	setNeedsRedraw();
-
-	return this;
 }
 
 void ofxGuiGroup::add(ofxBaseGui * element){

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -96,41 +96,34 @@ void ofxGuiGroup::add(ofxBaseGui * element){
 	collection.push_back(element);
 
 	element->setPosition(b.x, b.y + b.height  + spacing);
-
+	element->setSize(getWidth(), element->getHeight());
 	b.height += element->getHeight() + spacing;
-
-	//if(b.width<element->getWidth()) b.width = element->getWidth();
 
 	element->unregisterMouseEvents();
 	ofAddListener(element->sizeChangedE,this,&ofxGuiGroup::sizeChangedCB);
 
-	ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(element);
-	if(subgroup != NULL){
-		subgroup->spacingFirstElement = 3;
-		subgroup->filename = filename;
-		subgroup->setWidthElements(b.width * .98);
-	}
-
 	parameters.add(element->getParameter());
 	setNeedsRedraw();
+}
+
+
+void ofxGuiGroup::add(ofxGuiGroup * element){
+	element->spacingFirstElement = 3;
+	element->filename = filename;
+	add(static_cast<ofxBaseGui*>(element));
 }
 
 void ofxGuiGroup::setWidthElements(float w){
 	for(int i = 0; i < (int)collection.size(); i++){
 		collection[i]->setSize(w, collection[i]->getHeight());
 		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
-		ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(collection[i]);
-		if(subgroup != NULL){
-			subgroup->setWidthElements(w * .98);
-		}
 	}
 	sizeChangedCB();
 	setNeedsRedraw();
 }
 
 void ofxGuiGroup::add(const ofParameterGroup & parameters){
-	ofxGuiGroup * panel = new ofxGuiGroup(parameters);
-	add(panel);
+	add(new ofxGuiGroup(parameters));
 }
 
 void ofxGuiGroup::add(ofParameter <float> & parameter){
@@ -440,4 +433,20 @@ void ofxGuiGroup::setPosition(ofPoint p){
 
 void ofxGuiGroup::setPosition(float x, float y){
 	setPosition(ofVec2f(x, y));
+}
+
+void ofxGuiGroup::setSize(float w, float h){
+	ofxBaseGui::setSize(w,h);
+	setWidthElements(w * .98);
+}
+
+void ofxGuiGroup::setShape(ofRectangle r){
+	ofxBaseGui::setShape(r);
+	setWidthElements(r.width * .98);
+}
+
+void ofxGuiGroup::setShape(float x, float y, float w, float h){
+	ofxBaseGui::setShape(x,y,w,h);
+	setWidthElements(w * .98);
+
 }

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -1,8 +1,7 @@
 #include "ofxGuiGroup.h"
 #include "ofxPanel.h"
-#include "ofxSliderGroup.h"
 #include "ofGraphics.h"
-#include "ofxLabel.h"
+#include "ofxSliderGroup.h"
 using namespace std;
 
 ofxGuiGroup::ofxGuiGroup()
@@ -165,50 +164,6 @@ void ofxGuiGroup::setWidthElements(float w){
 	}
 	sizeChangedCB();
 	setNeedsRedraw();
-}
-
-void ofxGuiGroup::add(const ofParameterGroup & parameters){
-	addOwned(new ofxGuiGroup(parameters));
-}
-
-void ofxGuiGroup::add(ofParameter <float> & parameter){
-	addOwned(new ofxFloatSlider(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <int> & parameter){
-	addOwned(new ofxIntSlider(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <bool> & parameter){
-	addOwned(new ofxToggle(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <string> & parameter){
-	addOwned(new ofxLabel(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofVec2f> & parameter){
-	addOwned(new ofxVecSlider_ <ofVec2f>(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofVec3f> & parameter){
-	addOwned(new ofxVecSlider_ <ofVec3f>(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofVec4f> & parameter){
-	addOwned(new ofxVecSlider_ <ofVec4f>(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofColor> & parameter){
-	addOwned(new ofxColorSlider_ <unsigned char>(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofShortColor> & parameter){
-	addOwned(new ofxColorSlider_ <unsigned short>(parameter, b.width));
-}
-
-void ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter){
-	addOwned(new ofxColorSlider_ <float>(parameter, b.width));
 }
 
 void ofxGuiGroup::clear(){

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -3,12 +3,16 @@
 
 #include "ofxSlider.h"
 #include "ofxButton.h"
+#include "ofxLabel.h"
 #include "ofParameterGroup.h"
 
 class ofxGuiGroup : public ofxBaseGui {
 	public:
 		struct Config: public ofxBaseGui::Config{
-			typedef ofxGuiGroup ParentType;
+			Config(){}
+			Config(const ofxBaseGui::Config & c)
+			:ofxBaseGui::Config(c){}
+
 			std::string filename = "settings.xml";
 			bool minimized = false;
 			float spacing = 1;
@@ -28,27 +32,42 @@ class ofxGuiGroup : public ofxBaseGui {
 
 		void add(ofxBaseGui & element);
 		void add(ofxGuiGroup & element);
-		void add(const ofParameterGroup & parameters);
-		void add(ofParameter <float> & parameter);
-		void add(ofParameter <int> & parameter);
-		void add(ofParameter <bool> & parameter);
-		void add(ofParameter <std::string> & parameter);
-		void add(ofParameter <ofVec2f> & parameter);
-		void add(ofParameter <ofVec3f> & parameter);
-		void add(ofParameter <ofVec4f> & parameter);
-		void add(ofParameter <ofColor> & parameter);
-		void add(ofParameter <ofShortColor> & parameter);
-		void add(ofParameter <ofFloatColor> & parameter);
 
-		template<class Config, typename Type>
-		void add(ofParameter<Type> p, const Config & config = Config()){
-			add(new typename Config::ParentType(p,config));
-		}
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <float> & parameter, const Config & config = Config());
 
-		template<class Config, typename Type>
-		void add(ofParameterGroup p, const Config & config = Config()){
-			add(new typename Config::ParentType(p,config));
-		}
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <int> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <bool> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <std::string> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofVec2f> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofVec3f> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofVec4f> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofColor> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofShortColor> & parameter, const Config & config = Config());
+
+		template<class Config = ofxBaseGui::Config>
+		void add(ofParameter <ofFloatColor> & parameter, const Config & config = Config());
+
+		template<class GuiType, typename Type, class Config = typename GuiType::Config>
+		void add(ofParameter<Type> p, const Config & config = Config());
+
+		template<class GuiType=ofxGuiGroup, class Config=ofxGuiGroup::Config>
+		void add(ofParameterGroup p, const Config & config = Config());
 
 		void minimize();
 		void maximize();
@@ -129,3 +148,34 @@ ControlType & ofxGuiGroup::getControlType(const std::string& name){
 		return *control;
 	}
 }
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <float> & parameter, const C & config){
+	add<ofxFloatSlider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <int> & parameter, const C & config){
+	add<ofxIntSlider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <bool> & parameter, const C & config){
+	add<ofxToggle>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <std::string> & parameter, const C & config){
+	add<ofxLabel>(parameter, config);
+}
+
+template<class GuiType, typename Type, class C>
+void ofxGuiGroup::add(ofParameter<Type> p, const C & config){
+	addOwned(new GuiType(p,config));
+}
+
+template<class GuiType, class C>
+void ofxGuiGroup::add(ofParameterGroup p, const C & config){
+	addOwned(new GuiType(p,config));
+}
+

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -23,11 +23,11 @@ class ofxGuiGroup : public ofxBaseGui {
 		ofxGuiGroup(const ofParameterGroup & parameters, const std::string& _filename, float x = 10, float y = 10);
 		virtual ~ofxGuiGroup();
 
-		virtual ofxGuiGroup * setup(const std::string& collectionName = "", const std::string& filename = "settings.xml", float x = 10, float y = 10);
-		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, const std::string& filename = "settings.xml", float x = 10, float y = 10);
+		virtual ofxGuiGroup & setup(const std::string& collectionName = "", const std::string& filename = "settings.xml", float x = 10, float y = 10);
+		virtual ofxGuiGroup & setup(const ofParameterGroup & parameters, const std::string& filename = "settings.xml", float x = 10, float y = 10);
 
-		void add(ofxBaseGui * element);
-		void add(ofxGuiGroup * element);
+		void add(ofxBaseGui & element);
+		void add(ofxGuiGroup & element);
 		void add(const ofParameterGroup & parameters);
 		void add(ofParameter <float> & parameter);
 		void add(ofParameter <int> & parameter);
@@ -80,7 +80,7 @@ class ofxGuiGroup : public ofxBaseGui {
 
 		virtual ofAbstractParameter & getParameter();
 
-		virtual void setPosition(const ofPoint& p);
+		virtual void setPosition(ofPoint p);
 		virtual void setPosition(float x, float y);
 		virtual void setSize(float w, float h);
 		virtual void setShape(ofRectangle r);
@@ -108,6 +108,12 @@ class ofxGuiGroup : public ofxBaseGui {
 
 		ofPath border, headerBg;
 		ofVboMesh textMesh;
+	private:
+		std::vector <std::unique_ptr<ofxBaseGui>> collectionOwned;
+		void add(ofxBaseGui * element);
+		void add(ofxGuiGroup * element);
+		void addOwned(ofxBaseGui * element);
+		void addOwned(ofxGuiGroup * element);
 };
 
 template <class ControlType>

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -10,6 +10,9 @@ class ofxGuiGroup : public ofxBaseGui {
 		ofxGuiGroup();
 		ofxGuiGroup(const ofParameterGroup & parameters, const std::string& _filename = "settings.xml", float x = 10, float y = 10);
 		virtual ~ofxGuiGroup();
+		ofxGuiGroup(const ofxGuiGroup &) = delete;
+		ofxGuiGroup & operator=(const ofxGuiGroup &) = delete;
+
 		virtual ofxGuiGroup * setup(const std::string& collectionName = "", const std::string& filename = "settings.xml", float x = 10, float y = 10);
 		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, const std::string& filename = "settings.xml", float x = 10, float y = 10);
 
@@ -26,6 +29,11 @@ class ofxGuiGroup : public ofxBaseGui {
 		void add(ofParameter <ofColor> & parameter);
 		void add(ofParameter <ofShortColor> & parameter);
 		void add(ofParameter <ofFloatColor> & parameter);
+
+		template<class GuiType, typename ...Args>
+		void add(Args... p){
+			add(new GuiType(p...));
+		}
 
 		void minimize();
 		void maximize();

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -14,6 +14,7 @@ class ofxGuiGroup : public ofxBaseGui {
 		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, std::string filename = "settings.xml", float x = 10, float y = 10);
 
 		void add(ofxBaseGui * element);
+		void add(ofxGuiGroup * element);
 		void add(const ofParameterGroup & parameters);
 		void add(ofParameter <float> & parameter);
 		void add(ofParameter <int> & parameter);
@@ -60,6 +61,9 @@ class ofxGuiGroup : public ofxBaseGui {
 
 		virtual void setPosition(ofPoint p);
 		virtual void setPosition(float x, float y);
+		virtual void setSize(float w, float h);
+		virtual void setShape(ofRectangle r);
+		virtual void setShape(float x, float y, float w, float h);
 	protected:
 		virtual void render();
 		virtual bool setValue(float mx, float my, bool bCheck);

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -9,8 +9,7 @@ class ofxGuiGroup : public ofxBaseGui {
 	public:
 		ofxGuiGroup();
 		ofxGuiGroup(const ofParameterGroup & parameters, std::string _filename = "settings.xml", float x = 10, float y = 10);
-		virtual ~ofxGuiGroup(){
-		}
+		virtual ~ofxGuiGroup();
 		virtual ofxGuiGroup * setup(std::string collectionName = "", std::string filename = "settings.xml", float x = 10, float y = 10);
 		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, std::string filename = "settings.xml", float x = 10, float y = 10);
 
@@ -65,7 +64,7 @@ class ofxGuiGroup : public ofxBaseGui {
 		virtual void render();
 		virtual bool setValue(float mx, float my, bool bCheck);
 
-		float spacing, spacingNextElement;
+		float spacing, spacingNextElement, spacingFirstElement;
 		float header;
 
 		template <class ControlType>

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -7,11 +7,21 @@
 
 class ofxGuiGroup : public ofxBaseGui {
 	public:
+		struct Config: public ofxBaseGui::Config{
+			typedef ofxGuiGroup ParentType;
+			std::string filename = "settings.xml";
+			bool minimized = false;
+			float spacing = 1;
+			float spacingNextElement = 3;
+			float spacingFirstElement = 0;
+			float header = defaultHeight;
+		};
+
 		ofxGuiGroup();
-		ofxGuiGroup(const ofParameterGroup & parameters, const std::string& _filename = "settings.xml", float x = 10, float y = 10);
+		ofxGuiGroup(const ofParameterGroup & parameters);
+		ofxGuiGroup(const ofParameterGroup & parameters, const Config & config);
+		ofxGuiGroup(const ofParameterGroup & parameters, const std::string& _filename, float x = 10, float y = 10);
 		virtual ~ofxGuiGroup();
-		ofxGuiGroup(const ofxGuiGroup &) = delete;
-		ofxGuiGroup & operator=(const ofxGuiGroup &) = delete;
 
 		virtual ofxGuiGroup * setup(const std::string& collectionName = "", const std::string& filename = "settings.xml", float x = 10, float y = 10);
 		virtual ofxGuiGroup * setup(const ofParameterGroup & parameters, const std::string& filename = "settings.xml", float x = 10, float y = 10);
@@ -30,17 +40,20 @@ class ofxGuiGroup : public ofxBaseGui {
 		void add(ofParameter <ofShortColor> & parameter);
 		void add(ofParameter <ofFloatColor> & parameter);
 
-		template<class GuiType, typename ...Args>
-		void add(Args... p){
-			add(new GuiType(p...));
+		template<class Config, typename Type>
+		void add(ofParameter<Type> p, const Config & config = Config()){
+			add(new typename Config::ParentType(p,config));
+		}
+
+		template<class Config, typename Type>
+		void add(ofParameterGroup p, const Config & config = Config()){
+			add(new typename Config::ParentType(p,config));
 		}
 
 		void minimize();
 		void maximize();
 		void minimizeAll();
 		void maximizeAll();
-
-		void setWidthElements(float w);
 
 		void clear();
 
@@ -75,6 +88,8 @@ class ofxGuiGroup : public ofxBaseGui {
 	protected:
 		virtual void render();
 		virtual bool setValue(float mx, float my, bool bCheck);
+		void setWidthElements(float w);
+		void addParametersFrom(const ofParameterGroup & parameters);
 
 		float spacing, spacingNextElement, spacingFirstElement;
 		float header;

--- a/addons/ofxGui/src/ofxLabel.cpp
+++ b/addons/ofxGui/src/ofxLabel.cpp
@@ -22,16 +22,16 @@ ofxLabel::~ofxLabel(){
     label.removeListener(this,&ofxLabel::valueChanged);
 }
 
-ofxLabel* ofxLabel::setup(ofParameter<string> _label, float width, float height) {
+ofxLabel & ofxLabel::setup(ofParameter<string> _label, float width, float height) {
     label.makeReferenceTo(_label);
     b.width  = width;
     b.height = height;
     setNeedsRedraw();
     label.addListener(this,&ofxLabel::valueChanged);
-    return this;
+    return *this;
 }
 
-ofxLabel* ofxLabel::setup(const std::string& labelName, string _label, float width, float height) {
+ofxLabel & ofxLabel::setup(const std::string& labelName, string _label, float width, float height) {
     label.set(labelName,_label);
     return setup(label,width,height);
 }

--- a/addons/ofxGui/src/ofxLabel.cpp
+++ b/addons/ofxGui/src/ofxLabel.cpp
@@ -2,6 +2,18 @@
 #include "ofGraphics.h"
 using namespace std;
 
+ofxLabel::ofxLabel()
+:ofxBaseGui(Config()){
+
+}
+
+ofxLabel::ofxLabel(ofParameter<std::string> _label, const Config & config)
+:ofxBaseGui(config){
+    label.makeReferenceTo(_label);
+    setNeedsRedraw();
+    label.addListener(this,&ofxLabel::valueChanged);
+}
+
 ofxLabel::ofxLabel(ofParameter<string> _label, float width, float height){
 	setup(_label,width,height);
 }

--- a/addons/ofxGui/src/ofxLabel.cpp
+++ b/addons/ofxGui/src/ofxLabel.cpp
@@ -14,7 +14,8 @@ ofxLabel::ofxLabel(ofParameter<std::string> _label, const Config & config)
     label.addListener(this,&ofxLabel::valueChanged);
 }
 
-ofxLabel::ofxLabel(ofParameter<string> _label, float width, float height){
+ofxLabel::ofxLabel(ofParameter<string> _label, float width, float height)
+:ofxBaseGui(Config()){
 	setup(_label,width,height);
 }
 

--- a/addons/ofxGui/src/ofxLabel.h
+++ b/addons/ofxGui/src/ofxLabel.h
@@ -5,8 +5,13 @@
 
 class ofxLabel: public ofxBaseGui {
 public:
-    ofxLabel(){}
-    ofxLabel(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight);
+	struct Config: public ofxBaseGui::Config{
+		typedef ofxLabel ParentType;
+	};
+
+    ofxLabel();
+    ofxLabel(ofParameter<std::string> _label, const Config & config = Config());
+    ofxLabel(ofParameter<std::string> _label, float width, float height = defaultHeight);
     virtual ~ofxLabel();
 
     ofxLabel * setup(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight);

--- a/addons/ofxGui/src/ofxLabel.h
+++ b/addons/ofxGui/src/ofxLabel.h
@@ -14,8 +14,8 @@ public:
     ofxLabel(ofParameter<std::string> _label, float width, float height = defaultHeight);
     virtual ~ofxLabel();
 
-    ofxLabel * setup(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight);
-    ofxLabel * setup(const std::string& labelName, std::string label, float width = defaultWidth, float height = defaultHeight);
+    ofxLabel & setup(ofParameter<std::string> _label, float width = defaultWidth, float height = defaultHeight);
+    ofxLabel & setup(const std::string& labelName, std::string label, float width = defaultWidth, float height = defaultHeight);
 
     // Abstract methods we must implement, but have no need for!
     virtual bool mouseMoved(ofMouseEventArgs & args){return false;}

--- a/addons/ofxGui/src/ofxLabel.h
+++ b/addons/ofxGui/src/ofxLabel.h
@@ -6,7 +6,9 @@
 class ofxLabel: public ofxBaseGui {
 public:
 	struct Config: public ofxBaseGui::Config{
-		typedef ofxLabel ParentType;
+		Config(){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxBaseGui::Config(c){}
 	};
 
     ofxLabel();

--- a/addons/ofxGui/src/ofxPanel.cpp
+++ b/addons/ofxGui/src/ofxPanel.cpp
@@ -30,20 +30,20 @@ ofxPanel::~ofxPanel(){
 	//
 }
 
-ofxPanel * ofxPanel::setup(const std::string& collectionName, const std::string& filename, float x, float y){
+ofxPanel & ofxPanel::setup(const std::string& collectionName, const std::string& filename, float x, float y){
 	if(!loadIcon.isAllocated() || !saveIcon.isAllocated()){
 		loadIcons();
 	}
 	registerMouseEvents();
-	return (ofxPanel*)ofxGuiGroup::setup(collectionName,filename,x,y);
+	return (ofxPanel&)ofxGuiGroup::setup(collectionName,filename,x,y);
 }
 
-ofxPanel * ofxPanel::setup(const ofParameterGroup & parameters, const std::string& filename, float x, float y){
+ofxPanel & ofxPanel::setup(const ofParameterGroup & parameters, const std::string& filename, float x, float y){
 	if(!loadIcon.isAllocated() || !saveIcon.isAllocated()){
 		loadIcons();
 	}
 	registerMouseEvents();
-	return (ofxPanel*)ofxGuiGroup::setup(parameters,filename,x,y);
+	return (ofxPanel&)ofxGuiGroup::setup(parameters,filename,x,y);
 }
 
 void ofxPanel::loadIcons(){

--- a/addons/ofxGui/src/ofxPanel.h
+++ b/addons/ofxGui/src/ofxPanel.h
@@ -10,8 +10,8 @@ public:
 	ofxPanel(const ofParameterGroup & parameters, const std::string& filename="settings.xml", float x = 10, float y = 10);
 	~ofxPanel();
 
-	ofxPanel * setup(const std::string& collectionName="", const std::string& filename="settings.xml", float x = 10, float y = 10);
-	ofxPanel * setup(const ofParameterGroup & parameters, const std::string& filename="settings.xml", float x = 10, float y = 10);
+	ofxPanel & setup(const std::string& collectionName="", const std::string& filename="settings.xml", float x = 10, float y = 10);
+	ofxPanel & setup(const ofParameterGroup & parameters, const std::string& filename="settings.xml", float x = 10, float y = 10);
 
 	bool mouseReleased(ofMouseEventArgs & args);
 

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -33,7 +33,7 @@ ofxSlider<Type>::ofxSlider(ofParameter<Type> _val, float width, float height){
 }
 
 template<typename Type>
-ofxSlider<Type>* ofxSlider<Type>::setup(ofParameter<Type> _val, float width, float height){
+ofxSlider<Type> & ofxSlider<Type>::setup(ofParameter<Type> _val, float width, float height){
 	bUpdateOnReleaseOnly = false;
 	value.makeReferenceTo(_val);
 	b.x = 0;
@@ -45,11 +45,11 @@ ofxSlider<Type>* ofxSlider<Type>::setup(ofParameter<Type> _val, float width, flo
 
 	value.addListener(this,&ofxSlider::valueChanged);
 	registerMouseEvents();
-	return this;
+	return *this;
 }
 
 template<typename Type>
-ofxSlider<Type>* ofxSlider<Type>::setup(const std::string& sliderName, Type _val, Type _min, Type _max, float width, float height){
+ofxSlider<Type> & ofxSlider<Type>::setup(const std::string& sliderName, Type _val, Type _min, Type _max, float width, float height){
 	value.set(sliderName,_val,_min,_max);
 	return setup(value,width,height);
 }

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -15,6 +15,19 @@ ofxSlider<Type>::~ofxSlider(){
 }
 
 template<typename Type>
+ofxSlider<Type>::ofxSlider(ofParameter<Type> _val, const Config & config)
+:ofxBaseGui(config)
+,bUpdateOnReleaseOnly(config.updateOnReleaseOnly)
+,bGuiActive(false)
+,mouseInside(false)
+{
+	value.makeReferenceTo(_val);
+	value.addListener(this,&ofxSlider::valueChanged);
+	setNeedsRedraw();
+	registerMouseEvents();
+}
+
+template<typename Type>
 ofxSlider<Type>::ofxSlider(ofParameter<Type> _val, float width, float height){
 	setup(_val,width,height);
 }

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -8,9 +8,15 @@ class ofxSlider : public ofxBaseGui{
 	friend class ofPanel;
 	
 public:	
+	struct Config: public ofxBaseGui::Config{
+		typedef ofxSlider<Type> ParentType;
+		bool updateOnReleaseOnly = false;
+	};
+
 	ofxSlider();
 	~ofxSlider();
-	ofxSlider(ofParameter<Type> _val, float width = defaultWidth, float height = defaultHeight);
+	ofxSlider(ofParameter<Type> _val, const Config & config = Config());
+	ofxSlider(ofParameter<Type> _val, float width, float height = defaultHeight);
 	ofxSlider* setup(ofParameter<Type> _val, float width = defaultWidth, float height = defaultHeight);
 	ofxSlider* setup(const std::string& sliderName, Type _val, Type _min, Type _max, float width = defaultWidth, float height = defaultHeight);
 	

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -7,7 +7,9 @@ template<typename Type>
 class ofxSlider : public ofxBaseGui{
 public:	
 	struct Config: public ofxBaseGui::Config{
-		typedef ofxSlider<Type> ParentType;
+		Config(){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxBaseGui::Config(c){}
 		bool updateOnReleaseOnly = false;
 	};
 

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -5,8 +5,6 @@
 
 template<typename Type>
 class ofxSlider : public ofxBaseGui{
-	friend class ofPanel;
-	
 public:	
 	struct Config: public ofxBaseGui::Config{
 		typedef ofxSlider<Type> ParentType;
@@ -17,8 +15,8 @@ public:
 	~ofxSlider();
 	ofxSlider(ofParameter<Type> _val, const Config & config = Config());
 	ofxSlider(ofParameter<Type> _val, float width, float height = defaultHeight);
-	ofxSlider* setup(ofParameter<Type> _val, float width = defaultWidth, float height = defaultHeight);
-	ofxSlider* setup(const std::string& sliderName, Type _val, Type _min, Type _max, float width = defaultWidth, float height = defaultHeight);
+	ofxSlider & setup(ofParameter<Type> _val, float width = defaultWidth, float height = defaultHeight);
+	ofxSlider & setup(const std::string& sliderName, Type _val, Type _min, Type _max, float width = defaultWidth, float height = defaultHeight);
 	
 	void setMin(Type min);
 	Type getMin();

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -2,6 +2,17 @@
 using namespace std;
 
 template<class VecType>
+ofxVecSlider_<VecType>::ofxVecSlider_()
+:sliderChanging(false){
+}
+
+template<class VecType>
+ofxVecSlider_<VecType>::ofxVecSlider_(ofParameter<VecType> value, const Config & config)
+:sliderChanging(false){
+    setup(value, config.shape.width, config.shape.height);
+}
+
+template<class VecType>
 ofxVecSlider_<VecType>::ofxVecSlider_(ofParameter<VecType> value, float width, float height){
 	sliderChanging = false;
     setup(value, width, height);
@@ -85,6 +96,18 @@ template class ofxVecSlider_<ofVec2f>;
 template class ofxVecSlider_<ofVec3f>;
 template class ofxVecSlider_<ofVec4f>;
 
+
+template<class ColorType>
+ofxColorSlider_<ColorType>::ofxColorSlider_()
+:sliderChanging(false){
+
+}
+
+template<class ColorType>
+ofxColorSlider_<ColorType>::ofxColorSlider_(ofParameter<ofColor_<ColorType>> value, const Config & config)
+:sliderChanging(false){
+    setup(value, config.shape.width, config.shape.height);
+}
 
 template<class ColorType>
 ofxColorSlider_<ColorType>::ofxColorSlider_(ofParameter<ofColor_<ColorType> > value, float width, float height){

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -19,7 +19,7 @@ ofxVecSlider_<VecType>::ofxVecSlider_(ofParameter<VecType> value, float width, f
 }
 
 template<class VecType>
-ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> value, float width, float height){
+ofxVecSlider_<VecType> & ofxVecSlider_<VecType>::setup(ofParameter<VecType> value, float width, float height){
     ofxGuiGroup::setup(value.getName(), "", 0, 0);
     
     parameters.clear();
@@ -32,20 +32,23 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     VecType val = value;
     VecType min = value.getMin();
     VecType max = value.getMax();
+    ofxFloatSlider::Config config;
+    config.shape.width = width;
+    config.shape.height = height;
     
     for (int i=0; i<VecType::DIM; i++) {
     	ofParameter<float> p(names[i], val[i], min[i], max[i]);
-        add(new ofxSlider<float>(p, width, height));
+        add(p,config);
         p.addListener(this, & ofxVecSlider_::changeSlider);
     }
 
     sliderChanging = false;
-    return this;
+    return *this;
 
 }
 
 template<class VecType>
-ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(const std::string& controlName, const VecType & v, const VecType & min, const VecType & max, float width, float height){
+ofxVecSlider_<VecType> & ofxVecSlider_<VecType>::setup(const std::string& controlName, const VecType & v, const VecType & min, const VecType & max, float width, float height){
 	value.set(controlName,v,min,max);
 	return setup(value,width,height);
 }
@@ -116,7 +119,7 @@ ofxColorSlider_<ColorType>::ofxColorSlider_(ofParameter<ofColor_<ColorType> > va
 }
 
 template<class ColorType>
-ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofColor_<ColorType> > value, float width, float height){
+ofxColorSlider_<ColorType> & ofxColorSlider_<ColorType>::setup(ofParameter<ofColor_<ColorType> > value, float width, float height){
     ofxGuiGroup::setup(value.getName(), "", 0, 0);
     parameters.clear();
 
@@ -128,21 +131,23 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
     ofColor_<ColorType> val = value;
     ofColor_<ColorType> min = value.getMin();
     ofColor_<ColorType> max = value.getMax();
-
+    typename ofxSlider<ColorType>::Config config;
+    config.shape.width = width;
+    config.shape.height = height;
     for (int i=0; i<4; i++) {
     	ofParameter<ColorType> p(names[i], val[i], min[i], max[i]);
-        add(new ofxSlider<ColorType>(p, width, height));
+        add(p,config);
         p.addListener(this, & ofxColorSlider_::changeSlider);
         collection[i]->setFillColor(value.get());
     }
 
     sliderChanging = false;
-    return this;
+    return *this;
 }
 
 
 template<class ColorType>
-ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(const std::string& controlName, const ofColor_<ColorType> & v, const ofColor_<ColorType> & min, const ofColor_<ColorType> & max, float width, float height){
+ofxColorSlider_<ColorType> & ofxColorSlider_<ColorType>::setup(const std::string& controlName, const ofColor_<ColorType> & v, const ofColor_<ColorType> & min, const ofColor_<ColorType> & max, float width, float height){
     value.set(controlName, v, min, max);
 	return setup(value,width,height);
 }

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -136,7 +136,7 @@ ofxColorSlider_<ColorType> & ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
     config.shape.height = height;
     for (int i=0; i<4; i++) {
     	ofParameter<ColorType> p(names[i], val[i], min[i], max[i]);
-        add(p,config);
+        add<ofxSlider<ColorType>>(p,config);
         p.addListener(this, & ofxColorSlider_::changeSlider);
         collection[i]->setFillColor(value.get());
     }

--- a/addons/ofxGui/src/ofxSliderGroup.h
+++ b/addons/ofxGui/src/ofxSliderGroup.h
@@ -13,8 +13,8 @@ public:
     ofxVecSlider_(ofParameter<VecType> value, const Config & config = Config());
     ofxVecSlider_(ofParameter<VecType> value, float width, float height = defaultHeight);
 
-    ofxVecSlider_ * setup(ofParameter<VecType> value, float width = defaultWidth, float height = defaultHeight);
-    ofxVecSlider_ * setup(const std::string& controlName, const VecType & value, const VecType & min, const VecType & max, float width = defaultWidth, float height = defaultHeight);
+    ofxVecSlider_ & setup(ofParameter<VecType> value, float width = defaultWidth, float height = defaultHeight);
+    ofxVecSlider_ & setup(const std::string& controlName, const VecType & value, const VecType & min, const VecType & max, float width = defaultWidth, float height = defaultHeight);
 
     ofAbstractParameter & getParameter();
 
@@ -45,8 +45,8 @@ public:
 	ofxColorSlider_(ofParameter<ofColor_<ColorType>> value, const Config & config = Config());
 	ofxColorSlider_(ofParameter<ofColor_<ColorType> > value, float width = defaultWidth, float height = defaultHeight);
 
-	ofxColorSlider_ * setup(ofParameter<ofColor_<ColorType> > value, float width = defaultWidth, float height = defaultHeight);
-	ofxColorSlider_ * setup(const std::string& controlName, const ofColor_<ColorType> & value, const ofColor_<ColorType> & min, const ofColor_<ColorType> & max, float width = defaultWidth, float height = defaultHeight);
+	ofxColorSlider_ & setup(ofParameter<ofColor_<ColorType> > value, float width = defaultWidth, float height = defaultHeight);
+	ofxColorSlider_ & setup(const std::string& controlName, const ofColor_<ColorType> & value, const ofColor_<ColorType> & min, const ofColor_<ColorType> & max, float width = defaultWidth, float height = defaultHeight);
 
 	ofAbstractParameter & getParameter();
 

--- a/addons/ofxGui/src/ofxSliderGroup.h
+++ b/addons/ofxGui/src/ofxSliderGroup.h
@@ -6,10 +6,12 @@
 template<class VecType>
 class ofxVecSlider_ : public ofxGuiGroup {
 public:
-    ofxVecSlider_(){
-        sliderChanging = false;
-    };
-    ofxVecSlider_(ofParameter<VecType> value, float width = defaultWidth, float height = defaultHeight);
+	struct Config: public ofxGuiGroup::Config{
+		typedef ofxVecSlider_ ParentType;
+	};
+	ofxVecSlider_();
+    ofxVecSlider_(ofParameter<VecType> value, const Config & config = Config());
+    ofxVecSlider_(ofParameter<VecType> value, float width, float height = defaultHeight);
 
     ofxVecSlider_ * setup(ofParameter<VecType> value, float width = defaultWidth, float height = defaultHeight);
     ofxVecSlider_ * setup(const std::string& controlName, const VecType & value, const VecType & min, const VecType & max, float width = defaultWidth, float height = defaultHeight);
@@ -35,9 +37,12 @@ template<typename ColorType>
 class ofxColorSlider_: public ofxGuiGroup{
 
 public:
-	ofxColorSlider_(){
-	    sliderChanging = false;
+	struct Config: public ofxGuiGroup::Config{
+		typedef ofxColorSlider_ ParentType;
 	};
+
+	ofxColorSlider_();
+	ofxColorSlider_(ofParameter<ofColor_<ColorType>> value, const Config & config = Config());
 	ofxColorSlider_(ofParameter<ofColor_<ColorType> > value, float width = defaultWidth, float height = defaultHeight);
 
 	ofxColorSlider_ * setup(ofParameter<ofColor_<ColorType> > value, float width = defaultWidth, float height = defaultHeight);

--- a/addons/ofxGui/src/ofxSliderGroup.h
+++ b/addons/ofxGui/src/ofxSliderGroup.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include "ofxGuiGroup.h"
-#include "ofxSlider.h"
+
 
 template<class VecType>
 class ofxVecSlider_ : public ofxGuiGroup {
 public:
 	struct Config: public ofxGuiGroup::Config{
-		typedef ofxVecSlider_ ParentType;
+		Config(){}
+		Config(const ofxGuiGroup::Config & c)
+		:ofxGuiGroup::Config(c){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxGuiGroup::Config(c){}
 	};
 	ofxVecSlider_();
     ofxVecSlider_(ofParameter<VecType> value, const Config & config = Config());
@@ -38,7 +42,11 @@ class ofxColorSlider_: public ofxGuiGroup{
 
 public:
 	struct Config: public ofxGuiGroup::Config{
-		typedef ofxColorSlider_ ParentType;
+		Config(){}
+		Config(const ofxGuiGroup::Config & c)
+		:ofxGuiGroup::Config(c){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxGuiGroup::Config(c){}
 	};
 
 	ofxColorSlider_();
@@ -62,3 +70,33 @@ protected:
 typedef ofxColorSlider_<unsigned char> ofxColorSlider;
 typedef ofxColorSlider_<unsigned short> ofxShortColorSlider;
 typedef ofxColorSlider_<float> ofxFloatColorSlider;
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofVec2f> & parameter, const C & config){
+	add<ofxVec2Slider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofVec3f> & parameter, const C & config){
+	add<ofxVec3Slider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofVec4f> & parameter, const C & config){
+	add<ofxVec4Slider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofColor> & parameter, const C & config){
+	add<ofxColorSlider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofShortColor> & parameter, const C & config){
+	add<ofxShortColorSlider>(parameter, config);
+}
+
+template<class C>
+void ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter, const C & config){
+	add<ofxFloatColorSlider>(parameter, config);
+}

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -2,6 +2,25 @@
 #include "ofGraphics.h"
 using namespace std;
 
+ofxToggle::ofxToggle()
+:ofxBaseGui(Config())
+,bGuiActive(false){
+	checkboxRect.set(1, 1, b.height - 2, b.height - 2);
+	value.addListener(this,&ofxToggle::valueChanged);
+	registerMouseEvents();
+	setNeedsRedraw();
+}
+
+ofxToggle::ofxToggle(ofParameter<bool> _bVal, const Config & config)
+:ofxBaseGui(config)
+,bGuiActive(false){
+	value.makeReferenceTo(_bVal);
+	checkboxRect.set(1, 1, b.height - 2, b.height - 2);
+	value.addListener(this,&ofxToggle::valueChanged);
+	registerMouseEvents();
+	setNeedsRedraw();
+}
+
 ofxToggle::ofxToggle(ofParameter<bool> _bVal, float width, float height){
 	setup(_bVal,width,height);
 }

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -29,7 +29,7 @@ ofxToggle::~ofxToggle(){
 	value.removeListener(this,&ofxToggle::valueChanged);
 }
 
-ofxToggle * ofxToggle::setup(ofParameter<bool> _bVal, float width, float height){
+ofxToggle & ofxToggle::setup(ofParameter<bool> _bVal, float width, float height){
 	b.x = 0;
 	b.y = 0;
 	b.width = width;
@@ -42,11 +42,11 @@ ofxToggle * ofxToggle::setup(ofParameter<bool> _bVal, float width, float height)
 	registerMouseEvents();
 	setNeedsRedraw();
 
-	return this;
+	return *this;
 
 }
 
-ofxToggle * ofxToggle::setup(const std::string& toggleName, bool _bVal, float width, float height){
+ofxToggle & ofxToggle::setup(const std::string& toggleName, bool _bVal, float width, float height){
 	value.set(toggleName,_bVal);
 	return setup(value,width,height);
 }

--- a/addons/ofxGui/src/ofxToggle.h
+++ b/addons/ofxGui/src/ofxToggle.h
@@ -5,9 +5,14 @@
 
 class ofxToggle : public ofxBaseGui{
 public:
-	ofxToggle(){};
+	struct Config: public ofxBaseGui::Config{
+		typedef ofxToggle ParentType;
+	};
+
+	ofxToggle();
+	ofxToggle(ofParameter<bool> _bVal, const Config & config = Config());
 	~ofxToggle();
-	ofxToggle(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
+	ofxToggle(ofParameter<bool> _bVal, float width, float height = defaultHeight);
 	ofxToggle * setup(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
 	ofxToggle * setup(const std::string& toggleName, bool _bVal, float width = defaultWidth, float height = defaultHeight);
 	

--- a/addons/ofxGui/src/ofxToggle.h
+++ b/addons/ofxGui/src/ofxToggle.h
@@ -13,8 +13,8 @@ public:
 	ofxToggle(ofParameter<bool> _bVal, const Config & config = Config());
 	~ofxToggle();
 	ofxToggle(ofParameter<bool> _bVal, float width, float height = defaultHeight);
-	ofxToggle * setup(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
-	ofxToggle * setup(const std::string& toggleName, bool _bVal, float width = defaultWidth, float height = defaultHeight);
+	ofxToggle & setup(ofParameter<bool> _bVal, float width = defaultWidth, float height = defaultHeight);
+	ofxToggle & setup(const std::string& toggleName, bool _bVal, float width = defaultWidth, float height = defaultHeight);
 	
 
 	virtual bool mouseMoved(ofMouseEventArgs & args);

--- a/addons/ofxGui/src/ofxToggle.h
+++ b/addons/ofxGui/src/ofxToggle.h
@@ -6,7 +6,9 @@
 class ofxToggle : public ofxBaseGui{
 public:
 	struct Config: public ofxBaseGui::Config{
-		typedef ofxToggle ParentType;
+		Config(){}
+		Config(const ofxBaseGui::Config & c)
+		:ofxBaseGui::Config(c){}
 	};
 
 	ofxToggle();

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -43,6 +43,15 @@ vector<string> ofAbstractParameter::getGroupHierarchyNames() const{
 	return hierarchy;
 }
 
+
+ofParameterGroup & ofAbstractParameter::castGroup(){
+	return static_cast<ofParameterGroup& >(*this);
+}
+
+const ofParameterGroup & ofAbstractParameter::castGroup() const{
+	return static_cast<const ofParameterGroup&>(*this);
+}
+
 ostream& operator<<(ostream& os, const ofAbstractParameter& p){
 	os << p.toString();
 	return os;

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -718,9 +718,9 @@ public:
 
 	string getName() const;
 
-	ParameterType getMin();
+	ParameterType getMin() const;
 
-	ParameterType getMax();
+	ParameterType getMax() const;
 
 	string toString() const;
 
@@ -841,13 +841,13 @@ inline string ofReadOnlyParameter<ParameterType,Friend>::getName() const{
 
 
 template<typename ParameterType,typename Friend>
-inline ParameterType ofReadOnlyParameter<ParameterType,Friend>::getMin(){
+inline ParameterType ofReadOnlyParameter<ParameterType,Friend>::getMin() const{
 	return parameter.getMin();
 }
 
 
 template<typename ParameterType,typename Friend>
-inline ParameterType ofReadOnlyParameter<ParameterType,Friend>::getMax(){
+inline ParameterType ofReadOnlyParameter<ParameterType,Friend>::getMax() const{
 	return parameter.getMax();
 }
 

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -42,10 +42,15 @@ public:
 		return static_cast<const ofParameter<ParameterType> &>(*this);
 	}
 
+	ofParameterGroup & castGroup();
+
+	const ofParameterGroup & castGroup() const;
+
 	friend ostream& operator<<(ostream& os, const ofAbstractParameter& p);
 	friend istream& operator>>(istream& is, ofAbstractParameter& p);
 
 	virtual bool isSerializable() const = 0;
+	virtual bool isReadOnly() const = 0;
 	virtual shared_ptr<ofAbstractParameter> newReference() const = 0;
 
 protected:
@@ -64,6 +69,7 @@ protected:
 class ofParameterGroup: public ofAbstractParameter {
 public:
 	ofParameterGroup();
+
 
 	template<typename ...Args>
 	ofParameterGroup(const string & name, Args&... p)
@@ -128,6 +134,7 @@ public:
 	int size() const;
 	string getName(int position) const;
 	string getType(int position) const;
+	bool getIsReadOnly(int position) const;
 	int getPosition(const string& name) const;
 
 	friend ostream& operator<<(ostream& os, const ofParameterGroup& group);
@@ -147,6 +154,7 @@ public:
 
 	void setSerializable(bool serializable);
 	bool isSerializable() const;
+	bool isReadOnly() const;
 	shared_ptr<ofAbstractParameter> newReference() const;
 
 	void setParent(ofParameterGroup & parent);
@@ -298,6 +306,7 @@ public:
 	void enableEvents();
 	void disableEvents();
 	bool isSerializable() const;
+	bool isReadOnly() const;
 
 	void makeReferenceTo(ofParameter<ParameterType> mom);
 
@@ -372,9 +381,9 @@ private:
 
 		Value(string name, ParameterType v)
 		:name(name)
+		,value(v)
 		,min(ofTypeInfo<ParameterType>::min())
 		,max(ofTypeInfo<ParameterType>::min())
-		,value(v)
 		,bInNotify(false)
 		,serializable(true){};
 
@@ -387,7 +396,7 @@ private:
 		,serializable(true){};
 
 		string name;
-		ParameterType value, prevValue;
+		ParameterType value;
 		ParameterType min, max;
 		ofEvent<ParameterType> changedE;
 		bool bInNotify;
@@ -500,6 +509,11 @@ bool ofParameter<ParameterType>::isSerializable() const{
 }
 
 template<typename ParameterType>
+bool ofParameter<ParameterType>::isReadOnly() const{
+	return false;
+}
+
+template<typename ParameterType>
 void ofParameter<ParameterType>::setMin(ParameterType min){
 	obj->min = min;
 }
@@ -557,7 +571,7 @@ void ofParameter<ParameterType>::disableEvents(){
 }
 
 template<typename ParameterType>
-ParameterType ofParameter<ParameterType>::operator++(int v){
+inline ParameterType ofParameter<ParameterType>::operator++(int v){
 	ParameterType r = obj->value;
 	obj->value++;
 	set(obj->value);
@@ -565,14 +579,14 @@ ParameterType ofParameter<ParameterType>::operator++(int v){
 }
 
 template<typename ParameterType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator++(){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator++(){
 	++obj->value;
 	set(obj->value);
 	return *this;
 }
 
 template<typename ParameterType>
-ParameterType ofParameter<ParameterType>::operator--(int v){
+inline ParameterType ofParameter<ParameterType>::operator--(int v){
 	ParameterType r = obj->value;
 	obj->value--;
 	set(obj->value);
@@ -580,7 +594,7 @@ ParameterType ofParameter<ParameterType>::operator--(int v){
 }
 
 template<typename ParameterType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator--(){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator--(){
 	--obj->value;
 	set(obj->value);
 	return *this;
@@ -588,7 +602,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator--(){
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator+=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator+=(const OtherType & v){
 	obj->value+=v;
 	set(obj->value);
 	return *this;
@@ -596,7 +610,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator+=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator-=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator-=(const OtherType & v){
 	obj->value-=v;
 	set(obj->value);
 	return *this;
@@ -604,7 +618,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator-=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator*=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator*=(const OtherType & v){
 	obj->value*=v;
 	set(obj->value);
 	return *this;
@@ -612,7 +626,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator*=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator/=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator/=(const OtherType & v){
 	obj->value/=v;
 	set(obj->value);
 	return *this;
@@ -620,7 +634,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator/=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator%=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator%=(const OtherType & v){
 	obj->value%=v;
 	set(obj->value);
 	return *this;
@@ -628,7 +642,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator%=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator&=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator&=(const OtherType & v){
 	obj->value&=v;
 	set(obj->value);
 	return *this;
@@ -644,7 +658,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator|=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator^=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator^=(const OtherType & v){
 	obj->value^=v;
 	set(obj->value);
 	return *this;
@@ -652,7 +666,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator^=(const OtherT
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator<<=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator<<=(const OtherType & v){
 	obj->value<<=v;
 	set(obj->value);
 	return *this;
@@ -660,7 +674,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::operator<<=(const Other
 
 template<typename ParameterType>
 template<typename OtherType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::operator>>=(const OtherType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator>>=(const OtherType & v){
 	obj->value>>=v;
 	set(obj->value);
 	return *this;
@@ -716,12 +730,13 @@ public:
 	template<class ListenerClass, typename ListenerMethod>
 	void removeListener(ListenerClass * listener, ListenerMethod method);
 	shared_ptr<ofAbstractParameter> newReference() const;
+	bool isSerializable() const;
+	bool isReadOnly() const;
 
 protected:
 	void setName(const string & name);
 	void enableEvents();
 	void disableEvents();
-	bool isSerializable() const;
 	void setSerializable(bool s);
 
 	void makeReferenceTo(ofReadOnlyParameter<ParameterType,Friend> mom);
@@ -779,6 +794,7 @@ protected:
 	ofParameter<ParameterType> parameter;
 	
 	friend class ofParameterGroup;
+	friend Friend;
 };
 
 
@@ -874,6 +890,11 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::disableEvents(){
 template<typename ParameterType,typename Friend>
 inline bool ofReadOnlyParameter<ParameterType,Friend>::isSerializable() const{
 	return parameter.isSerializable();
+}
+
+template<typename ParameterType,typename Friend>
+inline bool ofReadOnlyParameter<ParameterType,Friend>::isReadOnly() const{
+	return true;
 }
 
 template<typename ParameterType,typename Friend>
@@ -1041,7 +1062,7 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::fromString(const string &
 
 template<typename ParameterType,typename Friend>
 shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType,Friend>::newReference() const{
-	return shared_ptr<ofAbstractParameter>(new ofParameter<ParameterType>(*this));
+	return shared_ptr<ofAbstractParameter>(new ofReadOnlyParameter<ParameterType,Friend>(*this));
 }
 
 template<typename ParameterType,typename Friend>

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -151,6 +151,10 @@ string ofParameterGroup::getType(int position) const{
 	else return obj->parameters[position]->type();
 }
 
+bool ofParameterGroup::getIsReadOnly(int position) const{
+	if(position>=size()) return true;
+	else return obj->parameters[position]->isReadOnly();
+}
 
 int ofParameterGroup::getPosition(const string& name) const{
 	if(obj->parametersIndex.find(escape(name))!=obj->parametersIndex.end())
@@ -267,6 +271,10 @@ void ofParameterGroup::setSerializable(bool _serializable){
 
 bool ofParameterGroup::isSerializable() const{
 	return obj->serializable;
+}
+
+bool ofParameterGroup::isReadOnly() const{
+	return false;
 }
 
 shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{


### PR DESCRIPTION
this solves some problems with the current architecture of ofxGui:

- when ofxGuiGroup created a gui element it was leaked on it's destruction, now elements created internally are destroyed.
- elements passed from outside are now passed by reference to make clear that they need to live until the gui is destroyed, this will probably be deprecated later and leave only the option to add an element using a parameter.
- all elements now have a Config struct that allows to configure the gui element on creation instead of having to keep a reference later, the config structs follow the same inheritance hierarchy as it's class so we can pass a base gui config to any element like:

```cpp
ofxBaseGui::Config config;
config.backgroundColor = ofColor::blue;
gui.add(floatParameter, config);
gui.add(boolParameter, config);
```
- this PR also makes it easy to add new elements that are not in the official ofxGui: any new element needs to have an inner Config class and a constructor that receives an ofParameter or ofParameterGroup + a config:

```cpp
class CircularSlider: public ofxBaseGui{
    struct Config: public ofxBaseGui::Config{
        Config(){}
        Config(const ofxBaseGui::Config & c):ofxBaseGui::Config(c){}
        float innerRadius = 5;
        float outterRadius = 10;
    }
    CircularSlider(ofParameter<float> & p, const Config & config);
    ....
}
```
any element with such characteristics can be added to the gui using:

```cpp
gui.add<CircluarSlider>(floatParameter);
```
or

```cpp
CircularSlider::Config config;
config.backgroundColor = ofColor::blue;
gui.add<CircluarSlider>(floatParameter, config);
```

or

```cpp
ofxBaseGui::Config config;
config.backgroundColor = ofColor::blue;
gui.add<CircluarSlider>(floatParameter, config);
```

- before we had a parent pointer on every element which being a raw pointer could be problematic if the objects were put on vectors... now every object has a sizeChangedE ofEvent through which it can notify that it's size has changed (this is what the parent pointer was mostly used for before)

ping @frauzufall, this solves most of the problems you found i think, allows to config elements without needing to get a pointer to them after being added, frees the elements, removes the use of most raw pointers which makes the ownership of the elements less ambiguous, and allows to add custom elements from parameters. does this fit with your extensions? we could add more events like sizeChangedE to notify changes upwards if you are using something else.