### PR TITLE
fixes for adding frameworks to osx projects

### DIFF
--- a/addons/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/addons/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -371,6 +371,7 @@ void ofAddon::fromFS(string path, string platform){
     	srcFiles[i] = pathToOF + srcFiles[i];
     	filesToFolders[srcFiles[i]] = folder;
     }
+    
 
     string libsPath = path + "/libs";
     vector < string > libFiles;
@@ -424,19 +425,50 @@ void ofAddon::fromFS(string path, string platform){
 
     for (int i = 0; i < (int)frameworks.size(); i++){
 
-        // does libs[] have any path ? let's fix if so.
-#ifdef TARGET_WIN32
-    	int end = frameworks[i].rfind("\\");
-#else
-        int end = frameworks[i].rfind("/");
-#endif
-        if (end > 0){
-
-            frameworks[i].erase (frameworks[i].begin(), frameworks[i].begin()+ofRootPath.length());
-            frameworks[i] = pathToOF + frameworks[i];
+        // knowing if we are system framework or not is important....
+        
+        bool bIsSystemFramework = false;
+        size_t foundUnixPath = frameworks[i].find('/');
+        size_t foundWindowsPath = frameworks[i].find('\\');
+        if (foundUnixPath==std::string::npos &&
+            foundWindowsPath==std::string::npos){
+            bIsSystemFramework = true;                  // we have no "path" so we are system
         }
+        
+        if (bIsSystemFramework){
+            
+            ; // do we need to do anything here?
+            
+        } else {
+            
+            
+           
+            // erease out the OF root path.  this assumes the frames is *in* the OF folder....
+            frameworks[i].erase (frameworks[i].begin(), frameworks[i].begin()+ofRootPath.length());
+            
+            
+            
+            int init = 0;
+#ifdef TARGET_WIN32
+            int end = frameworks[i].rfind("\\");
+#else
+            int end = frameworks[i].rfind("/");
+#endif
+            
+            string folder = frameworks[i].substr(init,end);
+            frameworks[i] = pathToOF + frameworks[i];
+            filesToFolders[frameworks[i]] = folder;
+            
+            
+            
+        }
+        
+       
 
     }
+
+
+
 
 
 

--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -1104,12 +1104,22 @@ void xcodeProject::addAddon(ofAddon & addon){
              addFramework( addon.frameworks[i] + ".framework", "/System/Library/Frameworks/" + addon.frameworks[i] + ".framework", "");
         } else {
             
-            vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
+            if (ofIsStringInString(addon.frameworks[i], "/System/Library")){
+                
+                vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
+                
+                addFramework(pathSplit[pathSplit.size()-1],
+                             addon.frameworks[i],
+                             "");
+                
+            } else {
             
-            addFramework(pathSplit[pathSplit.size()-1],
-                         addon.frameworks[i],
-                         addon.filesToFolders[addon.frameworks[i]]);
-            
+                vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
+                
+                addFramework(pathSplit[pathSplit.size()-1],
+                             addon.frameworks[i],
+                             addon.filesToFolders[addon.frameworks[i]]);
+            }
         }
                                                                                             
                                                                                             //

--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -72,6 +72,26 @@ STRINGIFY(
 
 );
 
+//-----------------------------------------------------------------
+const char PBXFileReferenceWithoutEncoding[] =
+STRINGIFY(
+          
+          <key>FILEUUID</key>
+          <dict>
+          <key>explicitFileType</key>
+          <string>FILETYPE</string>
+          <key>isa</key>
+          <string>PBXFileReference</string>
+          <key>name</key>
+          <string>FILENAME</string>
+          <key>path</key>
+          <string>FILEPATH</string>
+          <key>sourceTree</key>
+          <string>SOURCE_ROOT</string>
+          </dict>
+          
+          );
+
 
 //-----------------------------------------------------------------
 const char PBXFileReferenceXib[] =
@@ -173,8 +193,8 @@ void xcodeProject::setup(){
 		addonUUID		= "BB4B014C10F69532006C3DED";
 		buildPhaseUUID	= "E4B69E200A3A1BDC003C02F2";
 		resourcesUUID	= "";
-        frameworksUUID  = "E7E077E715D3B6510020DFD4";   //PBXFrameworksBuildPhase
-	}else{
+        frameworksUUID  = "E4328149138ABC9F0047C5CB";   //PBXFrameworksBuildPhase
+    }else{
 		srcUUID			= "E4D8936A11527B74007E1F53";
 		addonUUID		= "BB16F26B0F2B646B00518274";
 		buildPhaseUUID	= "E4D8936E11527B74007E1F53";
@@ -349,6 +369,7 @@ bool xcodeProject::saveProjectFile(){
 }
 
 
+
 bool xcodeProject::findArrayForUUID(string UUID, pugi::xml_node & nodeMe){
     char query[255];
     sprintf(query, "//string[contains(.,'%s')]", UUID.c_str());
@@ -437,7 +458,7 @@ pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vec
         nodeWithThisName = doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(pbxDoc.first_child().next_sibling());
         doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(pbxDoc.first_child());
 
-
+        
 
         // add to array
         char queryArray[255];
@@ -464,70 +485,26 @@ pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vec
 
 // todo: frameworks
 //
-void xcodeProject::addFramework(string name, string path){
+void xcodeProject::addFramework(string name, string path, string folder){
     
-    
-    /*
-    //-----------------------------------------------------------------
-    const char PBXFileReference[] =
-    STRINGIFY(
-              
-              <key>FILEUUID</key>
-              <dict>
-              <key>explicitFileType</key>
-              <string>FILETYPE</string>
-              <key>fileEncoding</key>
-              <string>30</string>
-              <key>isa</key>
-              <string>PBXFileReference</string>
-              <key>name</key>
-              <string>FILENAME</string>
-              <key>path</key>
-              <string>FILEPATH</string>
-              <key>sourceTree</key>
-              <string>SOURCE_ROOT</string>
-              </dict>
-              
-              );
-    */
-    
-//    <key>FDA58C7417AD2D5A00BC9CD1</key>
-//    <dict>
-//    <key>isa</key>
-//    <string>PBXFileReference</string>
-//    <key>lastKnownFileType</key>
-//    <string>wrapper.framework</string>
-//    <key>name</key>
-//    <string>AudioToolbox.framework</string>
-//    <key>path</key>
-//    <string>../../../../../../../../System/Library/Frameworks/AudioToolbox.framework</string>
-//    <key>sourceTree</key>
-//    <string>&lt;group&gt;</string>
-//    </dict>
-//    <key>FDA58C7517AD2D5A00BC9CD1</key>
-//    <dict>
-//    <key>fileRef</key>
-//    <string>FDA58C7417AD2D5A00BC9CD1</string>
-//    <key>isa</key>
-//    <string>PBXBuildFile</string>
-//    </dict>
-//     
-    
-    
-    string buildUUID;
+    // name = name of the framework
+    // path = the full path (w name) of this framework
+    // folder = the path in the addon (in case we want to add this to the file browser -- we don't do that for system libs);
     
     //-----------------------------------------------------------------
     // based on the extension make some choices about what to do:
     //-----------------------------------------------------------------
     
-    //bool addToResources = true;
-    bool addToBuild = true;
-   
     //-----------------------------------------------------------------
     // (A) make a FILE REF
     //-----------------------------------------------------------------
     
-    string pbxfileref = string(PBXFileReference);
+    // encoding may be messing up for frameworks... so I switched to a pbx file ref without encoding fields
+    
+    string pbxfileref = string(PBXFileReferenceWithoutEncoding);
+    
+    // make a uuid for the framework file.
+    
     string UUID = generateUUID( name );
 
     findandreplace( pbxfileref, "FILEUUID", UUID);
@@ -540,12 +517,13 @@ void xcodeProject::addFramework(string name, string path){
     pugi::xml_document fileRefDoc;
     pugi::xml_parse_result result = fileRefDoc.load_buffer(pbxfileref.c_str(), strlen(pbxfileref.c_str()));
     
-    // insert it at <plist><dict><dict>
+    // insert near the top of the file <plist><dict><dict>
     doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child().next_sibling());   // UUID FIRST
     doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child());                  // DICT SECOND
     
+    // files need build refs, here we make 2....
 
-    buildUUID = generateUUID(name + "-build");
+    string buildUUID = generateUUID(name + "-build");
     string pbxbuildfile = string(PBXBuildFile);
     findandreplace( pbxbuildfile, "FILEUUID", UUID);
     findandreplace( pbxbuildfile, "BUILDUUID", buildUUID);
@@ -553,16 +531,104 @@ void xcodeProject::addFramework(string name, string path){
     doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child().next_sibling());   // UUID FIRST
     doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child());                  // DICT SECOND
     
+    string buildUUID2 = generateUUID(name + "-build2");
+    pbxbuildfile = string(PBXBuildFile);
+    findandreplace( pbxbuildfile, "FILEUUID", UUID);
+    findandreplace( pbxbuildfile, "BUILDUUID", buildUUID2);
+    fileRefDoc.load_buffer(pbxbuildfile.c_str(), strlen(pbxbuildfile.c_str()));
+    doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child().next_sibling());   // UUID FIRST
+    doc.select_single_node("/plist[1]/dict[1]/dict[2]").node().prepend_copy(fileRefDoc.first_child());                  // DICT SECOND
     
-    // add it to the system frameworks array....
+    // we add one of the build refs to the list of frameworks
+    
     pugi::xml_node array;
     findArrayForUUID(frameworksUUID, array);    // this is the build array (all build refs get added here)
-    array.append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
+    array.append_child("string").append_child(pugi::node_pcdata).set_value(buildUUID.c_str());
 
+    // we add the second to a final build phase for copying the framework into app.   we need to make sure we *don't* do this for system frameworks
+    
+    if (folder.size() != 0){
+        pugi::xpath_node xpathResult = doc.select_node("//string[contains(.,'PBXCopyFilesBuildPhase')]/../array");
+        pugi::xml_node node = xpathResult.node();
+        node.append_child("string").append_child(pugi::node_pcdata).set_value(buildUUID2.c_str());
+    }
+    
+    // now, we get the path for this framework without the name
+
+    string pathWithoutName;
+    vector < string > pathSplit = ofSplitString(path, "/");
+    for (int i = 0; i < pathSplit.size()-1; i++){
+        if (i != 0) pathWithoutName += "/";
+        pathWithoutName += pathSplit[i];
+    }
+    
+    // then, we are going to add this to "FRAMEWORK_SEARCH_PATHS" -- we do this twice, once for debug once for release.
+    
+    pugi::xpath_node_set frameworkSearchPaths = doc.select_nodes("//string[contains(.,'FRAMEWORK_SEARCH_PATHS')]/..");
+    
+    if (frameworkSearchPaths.size() > 0){
+        for (pugi::xpath_node_set::const_iterator it = frameworkSearchPaths.begin(); it != frameworkSearchPaths.end(); ++it){
+            pugi::xpath_node xpathNode = *it;
+            pugi::xml_node  xmlNode = xpathNode.node();
+            xmlNode.append_child("string").append_child(pugi::node_pcdata).set_value(pathWithoutName.c_str());
+        }
+    }
+    
+    // finally, this is for making folders based on the frameworks position in the addon. so it can appear in the sidebar / file explorer
+    
+    if (folder.size() > 0){
+        
+        vector < string > folders = ofSplitString(folder, "/", true);
+        
+        if (folders.size() > 1){
+            if (folders[0] == "src"){
+                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                
+                folders.erase(folders.begin());
+                pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
+                pugi::xml_node nodeToAddTo = findOrMakeFolderSet( node, folders, "src");
+                nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
+                
+            } else if (folders[0] == "addons"){
+                string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
+                
+                folders.erase(folders.begin());
+                pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
+                pugi::xml_node nodeToAddTo = findOrMakeFolderSet( node, folders, "addons");
+                
+                nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
+                
+            } else {
+                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                
+                pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
+                
+                // I'm not sure the best way to proceed;
+                // we should maybe find the rootest level and add it there.
+                // TODO: fix this.
+            }
+        };
+        
+    } else {
+        
+        
+        pugi::xml_node array;
+		string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+        pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
+        node.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
+        //nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
+        
+    }
+
+    
+    
+    //PBXCopyFilesBuildPhase
+    
+    
     // add it to the build phases...
-    pugi::xml_node arrayBuild;
-    findArrayForUUID(frameworksBuildPhaseUUID, arrayBuild);    // this is the build array (all build refs get added here)
-    arrayBuild.append_child("string").append_child(pugi::node_pcdata).set_value(buildUUID.c_str());
+//    pugi::xml_node arrayBuild;
+//    findArrayForUUID(frameworksBuildPhaseUUID, arrayBuild);    // this is the build array (all build refs get added here)
+//    arrayBuild.append_child("string").append_child(pugi::node_pcdata).set_value(buildUUID.c_str());
 
 }
 
@@ -1035,11 +1101,18 @@ void xcodeProject::addAddon(ofAddon & addon){
         
         size_t found=addon.frameworks[i].find('/');
         if (found==std::string::npos){
-             addFramework( addon.frameworks[i] + ".framework", "/System/Library/Frameworks/" + addon.frameworks[i] + ".framework");
+             addFramework( addon.frameworks[i] + ".framework", "/System/Library/Frameworks/" + addon.frameworks[i] + ".framework", "");
         } else {
+            
             vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
-            addFramework(pathSplit[pathSplit.size()-1], addon.frameworks[i]);
+            
+            addFramework(pathSplit[pathSplit.size()-1],
+                         addon.frameworks[i],
+                         addon.filesToFolders[addon.frameworks[i]]);
+            
         }
+                                                                                            
+                                                                                            //
             
     }
     

--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -200,7 +200,7 @@ void xcodeProject::setup(){
 		buildPhaseUUID	= "E4D8936E11527B74007E1F53";
 		resourcesUUID   = "BB24DD8F10DA77E000E9C588";
         buildPhaseResourcesUUID = "BB24DDCA10DA781C00E9C588";
-        frameworksUUID  = "E7E077E715D3B6510020DFD4";   //PBXFrameworksBuildPhase  // todo: check this?
+        frameworksUUID  = "E41D421413B3A95300A75A5D";   //PBXFrameworksBuildPhase  // todo: check this?
 	}
 }
 
@@ -208,7 +208,10 @@ void xcodeProject::setup(){
 void xcodeProject::saveScheme(){
 
 	string schemeFolder = projectDir + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/";
-    ofDirectory::removeDirectory(schemeFolder, true);
+    
+    if (ofDirectory::doesDirectoryExist(schemeFolder)){
+        ofDirectory::removeDirectory(schemeFolder, true);
+    }
 	ofDirectory::createDirectory(schemeFolder, false, true);
     
 	string schemeToD = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + " Debug.xcscheme";
@@ -232,8 +235,15 @@ void xcodeProject::saveWorkspaceXML(){
 	string workspaceFolder = projectDir + projectName + ".xcodeproj" + "/project.xcworkspace/";
 	string xcodeProjectWorkspace = workspaceFolder + "contents.xcworkspacedata";    
 
-	ofFile::removeFile(xcodeProjectWorkspace);
-	ofDirectory::removeDirectory(workspaceFolder, true);
+    
+    if (ofFile::doesFileExist(xcodeProjectWorkspace)){
+        ofFile::removeFile(xcodeProjectWorkspace);
+    }
+    
+    if (ofDirectory::doesDirectoryExist(workspaceFolder)){
+        ofDirectory::removeDirectory(workspaceFolder, true);
+    }
+    
 	ofDirectory::createDirectory(workspaceFolder, false, true);
     ofFile::copyFromTo(templatePath + "/emptyExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata", xcodeProjectWorkspace);
     findandreplaceInTexfile(xcodeProjectWorkspace, "PROJECTNAME", projectName);
@@ -253,7 +263,10 @@ bool xcodeProject::createProjectFile(){
     // todo: some error checking.
 
     string xcodeProject = ofFilePath::join(projectDir , projectName + ".xcodeproj");
-    ofDirectory::removeDirectory(xcodeProject, true);
+    
+    if (ofDirectory::doesDirectoryExist(xcodeProject)){
+        ofDirectory::removeDirectory(xcodeProject, true);
+    }
    
 	ofDirectory xcodeDir(xcodeProject);
 	xcodeDir.create(true);
@@ -1101,7 +1114,7 @@ void xcodeProject::addAddon(ofAddon & addon){
         
         size_t found=addon.frameworks[i].find('/');
         if (found==std::string::npos){
-             addFramework( addon.frameworks[i] + ".framework", "/System/Library/Frameworks/" + addon.frameworks[i] + ".framework", "");
+             addFramework( addon.frameworks[i] + ".framework", "/System/Library/Frameworks/" + addon.frameworks[i] + ".framework", "addons/" + addon.name + "/frameworks");
         } else {
             
             if (ofIsStringInString(addon.frameworks[i], "/System/Library")){
@@ -1110,7 +1123,7 @@ void xcodeProject::addAddon(ofAddon & addon){
                 
                 addFramework(pathSplit[pathSplit.size()-1],
                              addon.frameworks[i],
-                             "");
+                             "addons/" + addon.name + "/frameworks");
                 
             } else {
             

--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -200,7 +200,7 @@ void xcodeProject::setup(){
 		buildPhaseUUID	= "E4D8936E11527B74007E1F53";
 		resourcesUUID   = "BB24DD8F10DA77E000E9C588";
         buildPhaseResourcesUUID = "BB24DDCA10DA781C00E9C588";
-        frameworksUUID  = "E41D421413B3A95300A75A5D";   //PBXFrameworksBuildPhase  // todo: check this?
+        frameworksUUID  = "E41D421413B3A95300A75A5D";   //PBXFrameworksBuildPhase
 	}
 }
 

--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -29,7 +29,7 @@ public:
     void addCPPFLAG(string cppflag, LibType libType = RELEASE_LIB); // Other C++ Flags
     
     // specific to OSX
-    void addFramework(string name, string path);
+    void addFramework(string name, string path, string folder="");  // folder if for non system frameworks
     
         
     

--- a/addons/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/addons/ofxProjectGenerator/src/utils/Utils.cpp
@@ -194,7 +194,7 @@ void getFilesRecursively(const string & path, vector < string > & fileNames){
     for (int i = 0; i < dir.size(); i++){
         ofFile temp(dir.getFile(i));
         if (dir.getName(i) == ".svn") continue; // ignore svn
-        if (ofIsStringInString(dir.getName(i),".framework")) continue; // ignore svn
+        if (ofIsStringInString(dir.getName(i),".framework")) continue; // ignore frameworks
         
         if (temp.isFile()){
             fileNames.push_back(dir.getPath(i));

--- a/addons/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/addons/ofxProjectGenerator/src/utils/Utils.cpp
@@ -194,6 +194,8 @@ void getFilesRecursively(const string & path, vector < string > & fileNames){
     for (int i = 0; i < dir.size(); i++){
         ofFile temp(dir.getFile(i));
         if (dir.getName(i) == ".svn") continue; // ignore svn
+        if (ofIsStringInString(dir.getName(i),".framework")) continue; // ignore svn
+        
         if (temp.isFile()){
             fileNames.push_back(dir.getPath(i));
         } else if (temp.isDirectory()){
@@ -241,14 +243,17 @@ void splitFromFirst(string toSplit, string deliminator, string & first, string &
 
 void getFoldersRecursively(const string & path, vector < string > & folderNames, string platform){
     ofDirectory dir;
-    dir.listDir(path);
-    for (int i = 0; i < dir.size(); i++){
-        ofFile temp(dir.getFile(i));
-        if (temp.isDirectory() && isFolderNotCurrentPlatform(temp.getFileName(), platform) == false ){
-            getFoldersRecursively(dir.getPath(i), folderNames, platform);
+    
+    if (!ofIsStringInString(path, ".framework")){
+        dir.listDir(path);
+        for (int i = 0; i < dir.size(); i++){
+            ofFile temp(dir.getFile(i));
+            if (temp.isDirectory() && isFolderNotCurrentPlatform(temp.getFileName(), platform) == false ){
+                getFoldersRecursively(dir.getPath(i), folderNames, platform);
+            }
         }
+        folderNames.push_back(path);
     }
-    folderNames.push_back(path);
 }
 
 


### PR DESCRIPTION
this is a fix for #3774, adding non system frameworks to osx projects.   It works for syphon which is the test case. 

I haven't tested system level frameworks (side note, is there a good addon that adds other system frameworks to test on?)  fixed also an issue where the framework was getting parsed recursively (since it is a folder) and added to header search paths. 

ping @bangnoise @martialgallorini