### PR TITLE
fix issue #4155

### DIFF
--- a/addons/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/addons/ofxProjectGenerator/src/utils/Utils.cpp
@@ -60,8 +60,9 @@ string generateUUID(string input){
     HMACEngine<MD5Engine> hmac(passphrase); // we'll compute a MD5 Hash
     hmac.update(input);
 
-    const DigestEngine::Digest& digest = hmac.digest(); // finish HMAC computation and obtain digest
-    std::string digestString(DigestEngine::digestToHex(digest)); // convert to a string of hexadecimal numbers
+	const DigestEngine::Digest& digest = hmac.digest(); // finish HMAC computation and obtain digest
+	std::string digestString;
+	digestString = DigestEngine::digestToHex(digest); // convert to a string of hexadecimal numbers
 
     digestString = digestString.substr(0,24);
     digestString = StringToUpper(digestString);


### PR DESCRIPTION
For some obscure reason the VS2015 compiler seems to want to
optimise away digestString when compiling in optimised
Release mode.

This leads to a crash as reported by @DomAmato in #4155

Initialising `digestString`, then setting its value explicitly
appears to make it change its mind about the apparent
uselessness of the return value.

From the code in Utils.cpp#generateUUID I can't see an apparent reason
for the compiler to get so overzealous.