### PR TITLE
Const corrections and std::make_shared use.

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -63,9 +63,9 @@ bool ofxBaseGui::useTTF = false;
 ofBitmapFont ofxBaseGui::bitmapFont;
 
 ofxBaseGui::ofxBaseGui(){
-	parent = NULL;
+	parent = nullptr;
 	currentFrame = ofGetFrameNum();
-	serializer = std::shared_ptr <ofBaseFileSerializer>(new ofXml);
+    serializer = std::make_shared<ofXml>();
 
 	thisHeaderBackgroundColor = headerBackgroundColor;
 	thisBackgroundColor = backgroundColor;

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -15,7 +15,7 @@ ofxGuiGroup::ofxGuiGroup(){
 
 ofxGuiGroup::ofxGuiGroup(const ofParameterGroup & parameters, const std::string& filename, float x, float y){
 	minimized = false;
-	parent = NULL;
+	parent = nullptr;
 	setup(parameters, filename, x, y);
 }
 
@@ -30,7 +30,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	header = defaultHeight;
 	spacing = 1;
 	spacingNextElement = 3;
-	if(parent != NULL){
+	if(parent != nullptr){
 		b.width = parent->getWidth();
 	}else{
 		b.width = defaultWidth;
@@ -102,11 +102,11 @@ void ofxGuiGroup::add(ofxBaseGui * element){
 	element->setParent(this);
 
 	ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(element);
-	if(subgroup != NULL){
+	if(subgroup != nullptr){
 		subgroup->filename = filename;
 		subgroup->setWidthElements(b.width * .98);
 	}else{
-		if(parent != NULL){
+		if(parent != nullptr){
 			element->setSize(b.width * .98, element->getHeight());
 			element->setPosition(b.x + b.width - element->getWidth(), element->getPosition().y);
 		}
@@ -121,7 +121,7 @@ void ofxGuiGroup::setWidthElements(float w){
 		collection[i]->setSize(w, collection[i]->getHeight());
 		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
 		ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(collection[i]);
-		if(subgroup != NULL){
+		if(subgroup != nullptr){
 			subgroup->setWidthElements(w * .98);
 		}
 	}
@@ -336,7 +336,7 @@ ofxBaseGui * ofxGuiGroup::getControl(const std::string& name){
 			return collection[i];
 		}
 	}
-	return NULL;
+	return nullptr;
 }
 
 bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){
@@ -432,7 +432,7 @@ ofxBaseGui * ofxGuiGroup::getControl(std::size_t num){
 	if(num < collection.size()){
 		return collection[num];
 	}else{
-		return NULL;
+		return nullptr;
 	}
 }
 

--- a/addons/ofxOsc/src/ofxOscParameterSync.cpp
+++ b/addons/ofxOsc/src/ofxOscParameterSync.cpp
@@ -16,7 +16,7 @@ ofxOscParameterSync::~ofxOscParameterSync(){
 }
 
 
-void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, string host, int remotePort){
+void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const string& host, int remotePort){
 	syncGroup = group;
 	ofAddListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
 	sender.setup(host,remotePort);

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -18,7 +18,7 @@ public:
 	~ofxOscParameterSync();
 
 	/// the remote and local ports must be different to avoid collisions
-	void setup(ofParameterGroup & group, int localPort, string remoteHost, int remotePort);
+	void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
 	void update();
 
 private:

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -607,12 +607,12 @@ void ofParameter<ParameterType>::fromString(const string & str){
 
 template<typename ParameterType>
 void ofParameter<ParameterType>::enableEvents(){
-	setMethod = std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1);
+	setMethod = std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1);
 }
 
 template<typename ParameterType>
 void ofParameter<ParameterType>::disableEvents(){
-	setMethod = std::bind(&ofParameter<ParameterType>::noEventsSetValue,this, std::placeholders::_1);
+	setMethod = std::bind(&ofParameter<ParameterType>::noEventsSetValue, this, std::placeholders::_1);
 }
 
 template<typename ParameterType>

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -71,7 +71,7 @@ public:
 
 	template<typename ...Args>
 	ofParameterGroup(const string & name, Args&... p)
-	:obj(new Value){
+    :obj(std::make_shared<Value>()){
 		add(p...);
 		setName(name);
 	}
@@ -100,7 +100,7 @@ public:
 	ofParameter<ofShortColor> getShortColor(const string& name) const;
 	ofParameter<ofFloatColor> getFloatColor(const string& name) const;
 
-	ofParameterGroup getGroup(string name) const;
+	ofParameterGroup getGroup(const string& name) const;
 
 
 	ofParameter<bool> getBool(std::size_t pos) const;
@@ -417,22 +417,22 @@ private:
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter()
-:obj(new Value)
+:obj(std::make_shared<Value>())
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const ParameterType & v)
-:obj(shared_ptr<Value>(new Value(v)))
+:obj(std::make_shared<Value>(v))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)) {}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v)
-:obj(shared_ptr<Value>(new Value(name, v)))
+:obj(std::make_shared<Value>(name, v))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
-:obj(shared_ptr<Value>(new Value(name, v, min, max)))
+:obj(std::make_shared<Value>(name, v, min, max))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
 
 
@@ -693,7 +693,7 @@ void ofParameter<ParameterType>::makeReferenceTo(ofParameter<ParameterType> mom)
 
 template<typename ParameterType>
 shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::newReference() const{
-	return shared_ptr<ofAbstractParameter>(new ofParameter<ParameterType>(*this));
+    return std::make_shared<ofParameter<ParameterType>>(*this);
 }
 
 template<typename ParameterType>
@@ -1069,7 +1069,7 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::fromString(const string &
 
 template<typename ParameterType,typename Friend>
 shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType,Friend>::newReference() const{
-	return shared_ptr<ofAbstractParameter>(new ofReadOnlyParameter<ParameterType,Friend>(*this));
+	return shared_ptr<ofReadOnlyParameter<ParameterType,Friend>>(*this);
 }
 
 template<typename ParameterType,typename Friend>

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -273,7 +273,7 @@ namespace priv{
 /// ofParameter can be used as the value itself. For example an `ofParameter<int>`
 /// can be added, multiplied, substracted, etc with another number.
 ///
-/// An ofParameter with a custom object such as `ofParameter<MyObject> myObject`,
+/// For an ofParameter with a custom object such as `ofParameter<MyObject> myObject`,
 /// `MyObject`'s methods can be accessed using pointer syntax,
 /// e.g. `myObject->myMethod();`.
 ///

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -420,22 +420,22 @@ private:
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter()
 :obj(std::make_shared<Value>())
-,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const ParameterType & v)
 :obj(std::make_shared<Value>(v))
-,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)) {}
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)) {}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v)
 :obj(std::make_shared<Value>(name, v))
-,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
 :obj(std::make_shared<Value>(name, v, min, max))
-,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue,this, std::placeholders::_1)){}
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 
 template<typename ParameterType>

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -268,14 +268,16 @@ namespace priv{
 
 
 
-
-
-//----------------------------------------------------------------------
-/// Holds a value and notify it's listeners when it changes. Can be used as
-/// the value itself. For example an ofParameter<int> can be added, multiplied
-/// substracted... with another number.
-/// for ofParameter of other objects it's methods can be access using pointer
-/// syntax ->
+/// \brief ofParameter holds a value and notifies its listeners when it changes.
+///
+/// ofParameter can be used as the value itself. For example an `ofParameter<int>`
+/// can be added, multiplied, substracted, etc with another number.
+///
+/// An ofParameter with a custom object such as `ofParameter<MyObject> myObject`,
+/// `MyObject`'s methods can be accessed using pointer syntax,
+/// e.g. `myObject->myMethod();`.
+///
+/// \tparam ParameterType The data wrapped by the ofParameter.
 template<typename ParameterType>
 class ofParameter: public ofAbstractParameter{
 public:
@@ -703,12 +705,16 @@ void ofParameter<ParameterType>::setParent(ofParameterGroup & parent){
 
 
 
-
-
-
-//----------------------------------------------------------------------
-/// Same as ofParameter but can only be modified by a friend class specified
-/// as the second template argument
+/// \brief ofReadOnlyParameter holds a value and notifies its listeners when it changes.
+///
+/// ofReadOnlyParameter is a "read only" version of `ofPareameter`.  "Friend"
+/// classes specified in the template arguments allow other classes
+/// write-access to the internal data.  Otherwise, all other access is
+/// "read only".
+///
+/// \sa ofParameter
+/// \tparam ParameterType The data wrapped by the ofParameter.
+/// \tparam ParameterType The type of the "friend" class with write access.
 template<typename ParameterType,typename Friend>
 class ofReadOnlyParameter: public ofAbstractParameter{
 public:

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -91,8 +91,8 @@ public:
 	ofParameter<int> getInt(const string& name) const;
 	ofParameter<float> getFloat(const string& name) const;
 	ofParameter<char> getChar(const string& name) const;
-	ofParameter<string> getString(const string& name)	 const;
-	ofParameter<ofPoint> getPoint(const string& name)	 const;
+	ofParameter<string> getString(const string& name) const;
+	ofParameter<ofPoint> getPoint(const string& name) const;
 	ofParameter<ofVec2f> getVec2f(const string& name) const;
 	ofParameter<ofVec3f> getVec3f(const string& name) const;
 	ofParameter<ofVec4f> getVec4f(const string& name) const;
@@ -107,8 +107,8 @@ public:
 	ofParameter<int> getInt(std::size_t pos) const;
 	ofParameter<float> getFloat(std::size_t pos) const;
 	ofParameter<char> getChar(std::size_t pos) const;
-	ofParameter<string> getString(std::size_t pos)	 const;
-	ofParameter<ofPoint> getPoint(std::size_t pos)	 const;
+	ofParameter<string> getString(std::size_t pos) const;
+	ofParameter<ofPoint> getPoint(std::size_t pos) const;
 	ofParameter<ofVec2f> getVec2f(std::size_t pos) const;
 	ofParameter<ofVec3f> getVec3f(std::size_t pos) const;
 	ofParameter<ofVec4f> getVec4f(std::size_t pos) const;

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -2,7 +2,7 @@
 #include "ofParameter.h"
 
 ofParameterGroup::ofParameterGroup()
-:obj(new Value)
+:obj(std::make_shared<Value>())
 {
 
 }
@@ -67,7 +67,7 @@ ofParameter<ofFloatColor> ofParameterGroup::getFloatColor(const string& name) co
 	return get<ofFloatColor>(name);
 }
 
-ofParameterGroup ofParameterGroup::getGroup(string name) const{
+ofParameterGroup ofParameterGroup::getGroup(const string& name) const{
 	return static_cast<ofParameterGroup& >(get(name));
 }
 
@@ -274,7 +274,7 @@ bool ofParameterGroup::isReadOnly() const{
 }
 
 shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{
-	return shared_ptr<ofAbstractParameter>(new ofParameterGroup(*this));
+	return std::make_shared<ofParameterGroup>(*this);
 }
 
 void ofParameterGroup::setParent(ofParameterGroup & parent){


### PR DESCRIPTION
Getting rid of the "new" keyword in favor of std::make_shared when possible.

Clarify and document a complex ofParameter function that is efficient but difficult to grasp at first glance.