### PR TITLE
Typo in ofParameter::setWithoutEventNotifcations

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -351,7 +351,7 @@ public:
 	ofParameter<ParameterType> & set(const string& name, const ParameterType & v);
 	ofParameter<ParameterType> & set(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
-    ofParameter<ParameterType> & setWithoutEventNotifcations(const ParameterType & v);
+    ofParameter<ParameterType> & setWithoutEventNotifications(const ParameterType & v);
 
 	void setMin(const ParameterType & min);
 	void setMax(const ParameterType & max);
@@ -475,7 +475,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::set(const string& name,
 }
 
 template<typename ParameterType>
-inline ofParameter<ParameterType> & ofParameter<ParameterType>::setWithoutEventNotifcations(const ParameterType & v){
+inline ofParameter<ParameterType> & ofParameter<ParameterType>::setWithoutEventNotifications(const ParameterType & v){
     noEventsSetValue(v);
     return *this;
 }


### PR DESCRIPTION
Just renamed setWithoutEventNotifcations to setWithoutEventNotifications.

It was added a few days ago: #4176 