### PR TITLE
Add of fmod set buffersize

### DIFF
--- a/examples/sound/audioOutputExample/src/ofApp.cpp
+++ b/examples/sound/audioOutputExample/src/ofApp.cpp
@@ -29,6 +29,9 @@ void ofApp::setup(){
 
 	soundStream.setup(this, 2, 0, sampleRate, bufferSize, 4);
 
+	// on OSX: if you want to use ofSoundPlayer together with ofSoundStream you need to synchronize buffersizes.
+	// use ofFmodSetBuffersize(bufferSize) to set the buffersize in fmodx prior to loading a file.
+	
 	ofSetFrameRate(60);
 }
 

--- a/examples/sound/soundPlayerExample/src/ofApp.cpp
+++ b/examples/sound/soundPlayerExample/src/ofApp.cpp
@@ -2,6 +2,10 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
+	
+	// on OSX: if you want to use ofSoundPlayer together with ofSoundStream you need to synchronize buffersizes.
+	// use ofFmodSetBuffersize(bufferSize) to set the buffersize in fmodx prior to loading a file.
+	
 	synth.load("sounds/synth.wav");
 	beats.load("sounds/1085.mp3");
 	vocals.load("sounds/Violet.mp3");

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
@@ -4,11 +4,12 @@
 #include "ofUtils.h"
 
 
-bool bFmodInitialized_ = false;
-bool bUseSpectrum_ = false;
-float fftValues_[8192];			//
-float fftInterpValues_[8192];			//
-float fftSpectrum_[8192];		// maximum #ofFmodSoundPlayer is 8192, in fmodex....
+static bool bFmodInitialized_ = false;
+static bool bUseSpectrum_ = false;
+static float fftValues_[8192];			//
+static float fftInterpValues_[8192];			//
+static float fftSpectrum_[8192];		// maximum #ofFmodSoundPlayer is 8192, in fmodex....
+static unsigned int buffersize = 1024;
 
 
 // ---------------------  static vars
@@ -124,6 +125,10 @@ float * ofFmodSoundGetSpectrum(int nBands){
 	return fftInterpValues_;
 }
 
+void ofFmodSetBuffersize(unsigned int bs){
+	buffersize = bs;
+}
+
 // ------------------------------------------------------------
 // ------------------------------------------------------------
 
@@ -151,7 +156,12 @@ ofFmodSoundPlayer::~ofFmodSoundPlayer(){
 // this should only be called once
 void ofFmodSoundPlayer::initializeFmod(){
 	if(!bFmodInitialized_){
+		
 		FMOD_System_Create(&sys);
+		
+		// set buffersize
+		FMOD_System_SetDSPBufferSize (sys, buffersize, 4);
+
 		#ifdef TARGET_LINUX
 			FMOD_System_SetOutput(sys,FMOD_OUTPUTTYPE_ALSA);
 		#endif

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
@@ -159,8 +159,11 @@ void ofFmodSoundPlayer::initializeFmod(){
 		
 		FMOD_System_Create(&sys);
 		
-		// set buffersize
-		FMOD_System_SetDSPBufferSize (sys, buffersize, 4);
+		// set buffersize, keep number of buffers
+		unsigned int bsTmp;
+		int nbTmp;
+		FMOD_System_GetDSPBufferSize(sys, &bsTmp, &nbTmp);
+		FMOD_System_SetDSPBufferSize(sys, buffersize, nbTmp);
 
 		#ifdef TARGET_LINUX
 			FMOD_System_SetOutput(sys,FMOD_OUTPUTTYPE_ALSA);
@@ -170,6 +173,8 @@ void ofFmodSoundPlayer::initializeFmod(){
 		bFmodInitialized_ = true;
 	}
 }
+
+
 
 
 //---------------------------------------

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -29,6 +29,7 @@ void ofFmodSoundStopAll();
 void ofFmodSoundSetVolume(float vol);
 void ofFmodSoundUpdate();						// calls FMOD update.
 float * ofFmodSoundGetSpectrum(int nBands);		// max 512...
+void ofFmodSetBuffersize(unsigned int bs);
 
 
 // --------------------- player functions:

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -64,6 +64,7 @@ class ofFmodSoundPlayer : public ofBaseSoundPlayer {
 
 		static void initializeFmod();
 		static void closeFmod();
+	
 
 		bool isStreaming;
 		bool bMultiPlay;


### PR DESCRIPTION
adding `ofFmodSetBuffersize()` to set the buffersize of Fmodx before initialisation.
added `FMOD_System_SetDSPBufferSize` to `initializeFmod()`

allows to synchronize buffersizes of ofSoundStream and ofSoundPlayer.