### PR TITLE
Print ofFbo id on warnings, add to bind() comments another possible warning trigger

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1317,8 +1317,8 @@ void ofGLProgrammableRenderer::end(const ofFbo & fbo){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::bind(const ofFbo & fbo){
 	if (currentFramebufferId == fbo.getId()){
-		ofLogWarning() << "Framebuffer with id:" << " cannot be bound onto itself. \n" <<
-			"Most probably you forgot to end() the current framebuffer before calling begin() again.";
+		ofLogWarning() << "Framebuffer with id: " << fbo.getId() << " cannot be bound onto itself. \n" <<
+			"Most probably you forgot to end() the current framebuffer before calling begin() again or you forgot to allocate() before calling begin().";
 		return;
 	}
 	// this method could just as well have been placed in ofBaseGLRenderer
@@ -1335,7 +1335,7 @@ void ofGLProgrammableRenderer::bind(const ofFbo & fbo){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::bindForBlitting(const ofFbo & fboSrc, ofFbo & fboDst, int attachmentPoint){
 	if (currentFramebufferId == fboSrc.getId()){
-		ofLogWarning() << "Framebuffer with id:" << " cannot be bound onto itself. \n" <<
+		ofLogWarning() << "Framebuffer with id: " << fboSrc.getId() << " cannot be bound onto itself. \n" <<
 			"Most probably you forgot to end() the current framebuffer before calling getTexture().";
 		return;
 	}

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -474,8 +474,8 @@ void ofGLRenderer::end(const ofFbo & fbo){
 //----------------------------------------------------------
 void ofGLRenderer::bind(const ofFbo & fbo){
 	if (currentFramebufferId == fbo.getId()){
-		ofLogWarning() << "Framebuffer with id:" << " cannot be bound onto itself. \n" <<
-			"Most probably you forgot to end() the current framebuffer before calling begin() again.";
+		ofLogWarning() << "Framebuffer with id: " << fbo.getId() << " cannot be bound onto itself. \n" <<
+			"Most probably you forgot to end() the current framebuffer before calling begin() again or you forgot to allocate() before calling begin().";
 		return;
 	}
 	// this method could just as well have been placed in ofBaseGLRenderer
@@ -492,7 +492,7 @@ void ofGLRenderer::bind(const ofFbo & fbo){
 //----------------------------------------------------------
 void ofGLRenderer::bindForBlitting(const ofFbo & fboSrc, ofFbo & fboDst, int attachmentPoint){
 	if (currentFramebufferId == fboSrc.getId()){
-		ofLogWarning() << "Framebuffer with id:" << " cannot be bound onto itself. \n" <<
+		ofLogWarning() << "Framebuffer with id: " << fboSrc.getId() << " cannot be bound onto itself. \n" <<
 			"Most probably you forgot to end() the current framebuffer before calling getTexture().";
 		return;
 	}


### PR DESCRIPTION
This PR adds missing ofFbo id printings and a comment in bind() for people like me who may wonder for half an hour why their fbo isn't drawing :)