### PR TITLE
ofNode orbit fix; Now uses quaternions to avoid Gimball Lock.

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -333,16 +333,13 @@ ofVec3f ofNode::getGlobalScale() const {
 
 //----------------------------------------
 void ofNode::orbit(float longitude, float latitude, float radius, const ofVec3f& centerPoint) {
-	ofMatrix4x4 m;
-
-	// find position
-	ofVec3f p(0, 0, radius);
-	p.rotate(ofClamp(latitude, -89, 89), ofVec3f(1, 0, 0));
-	p.rotate(longitude, ofVec3f(0, 1, 0));
-	p += centerPoint;
-	setPosition(p);
 	
-	lookAt(centerPoint);//, v - centerPoint);
+	ofQuaternion q(latitude, ofVec3f(1,0,0), longitude, ofVec3f(0,1,0), 0, ofVec3f(0,0,1));
+	setPosition((ofVec3f(0,0,radius)-centerPoint)*q +centerPoint);
+	setOrientation(q);
+	onOrientationChanged();
+	onPositionChanged();
+//	lookAt(centerPoint);//, v - centerPoint);
 }
 
 //----------------------------------------


### PR DESCRIPTION
closes https://github.com/openframeworks/openFrameworks/issues/4081