### PR TITLE
fixes relative paths in osx templates project generation

### DIFF
--- a/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -299,7 +299,6 @@ bool xcodeProject::createProjectFile(){
         string relPath2 = relRoot;
         relPath2.erase(relPath2.end()-1);
         findandreplaceInTexfile(projectDir + projectName + ".xcodeproj/project.pbxproj", "../../..", relPath2);
-        findandreplaceInTexfile(projectDir + "Project.xcconfig", "../../../", relRoot);
         findandreplaceInTexfile(projectDir + "Project.xcconfig", "../../..", relPath2);
     }
 


### PR DESCRIPTION
this is a small fix which fixes a double parsing when find and replacing ../../.. paths inside the config file