### PR TITLE
Ability to specify an offset into the index buffer when calling drawElements.

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -436,7 +436,7 @@ void ofGLProgrammableRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, 
 		vbo.bind();
 		const_cast<ofGLProgrammableRenderer*>(this)->setAttributes(vbo.getUsingVerts(),vbo.getUsingColors(),vbo.getUsingTexCoords(),vbo.getUsingNormals());
 #ifdef TARGET_OPENGLES
-        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void*)offsetbytes));
+        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void*)offsetbytes);
 #else
         glDrawElements(drawMode, amt, GL_UNSIGNED_INT, (void*)offsetbytes);
 #endif

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -431,14 +431,14 @@ void ofGLProgrammableRenderer::draw(const ofVbo & vbo, GLuint drawMode, int firs
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, int amt) const{
+void ofGLProgrammableRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int offsetbytes) const{
 	if(vbo.getUsingVerts()) {
 		vbo.bind();
 		const_cast<ofGLProgrammableRenderer*>(this)->setAttributes(vbo.getUsingVerts(),vbo.getUsingColors(),vbo.getUsingTexCoords(),vbo.getUsingNormals());
 #ifdef TARGET_OPENGLES
-        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, nullptr);
+        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void*)offsetbytes));
 #else
-        glDrawElements(drawMode, amt, GL_UNSIGNED_INT, nullptr);
+        glDrawElements(drawMode, amt, GL_UNSIGNED_INT, (void*)offsetbytes);
 #endif
 		vbo.unbind();
 	}

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -43,7 +43,7 @@ public:
 	void draw(const ofTexture & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
     void draw(const ofBaseVideoDraws & video, float x, float y, float w, float h) const;
 	void draw(const ofVbo & vbo, GLuint drawMode, int first, int total) const;
-	void drawElements(const ofVbo & vbo, GLuint drawMode, int amt) const;
+	void drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int offsetbytes = 0) const;
 	void drawInstanced(const ofVbo & vbo, GLuint drawMode, int first, int total, int primCount) const;
 	void drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int amt, int primCount) const;
 	void draw(const ofVboMesh & mesh, ofPolyRenderMode renderType) const;

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -365,13 +365,13 @@ void ofGLRenderer::draw(const ofVbo & vbo, GLuint drawMode, int first, int total
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, int amt) const{
+void ofGLRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int offsetbytes) const{
 	if(vbo.getUsingVerts()) {
 		vbo.bind();
 #ifdef TARGET_OPENGLES
-        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, nullptr);
+        glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void *)offsetbytes));
 #else
-        glDrawElements(drawMode, amt, GL_UNSIGNED_INT, nullptr);
+        glDrawElements(drawMode, amt, GL_UNSIGNED_INT, (void *)offsetbytes);
 #endif
 		vbo.unbind();
 	}

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -40,7 +40,7 @@ public:
 	void draw(const ofTexture & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofBaseVideoDraws & video, float x, float y, float w, float h) const;
 	void draw(const ofVbo & vbo, GLuint drawMode, int first, int total) const;
-	void drawElements(const ofVbo & vbo, GLuint drawMode, int amt) const;
+	void drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int offsetbytes = 0) const;
 	void drawInstanced(const ofVbo & vbo, GLuint drawMode, int first, int total, int primCount) const;
 	void drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int amt, int primCount) const;
 	void draw(const ofVboMesh & mesh, ofPolyRenderMode renderType) const;

--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -906,8 +906,8 @@ void ofVbo::draw(int drawMode, int first, int total) const{
 }
 
 //--------------------------------------------------------------
-void ofVbo::drawElements(int drawMode, int amt) const{
-	ofGetGLRenderer()->drawElements(*this,drawMode,amt);
+void ofVbo::drawElements(int drawMode, int amt, int offsetbytes) const{
+	ofGetGLRenderer()->drawElements(*this,drawMode,amt,offsetbytes);
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -112,7 +112,7 @@ public:
 	bool getUsingIndices() const;
 	
 	void draw(int drawMode, int first, int total) const;
-	void drawElements(int drawMode, int amt) const;
+	void drawElements(int drawMode, int amt, int offsetbytes = 0) const;
 	
 	void drawInstanced(int drawMode, int first, int total, int primCount) const;
 	void drawElementsInstanced(int drawMode, int amt, int primCount) const;

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -791,7 +791,7 @@ public:
 	using ofBaseRenderer::draw;
 	virtual void draw(const ofTexture & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const=0;
 	virtual void draw(const ofVbo & vbo, GLuint drawMode, int first, int total) const=0;
-	virtual void drawElements(const ofVbo & vbo, GLuint drawMode, int amt) const=0;
+	virtual void drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int offsetbytes) const=0;
 	virtual void drawInstanced(const ofVbo & vbo, GLuint drawMode, int first, int total, int primCount) const=0;
 	virtual void drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int amt, int primCount) const=0;
 	virtual void draw(const ofVboMesh & mesh, ofPolyRenderMode renderType) const=0;


### PR DESCRIPTION

I have an index buffer into some particles that is sorted back to front, I'm trying to render the particles slice by slice and ran into some missing functionality, namely that there is no way to specify an offset into the index buffer that you want to use for drawing.

An example below:

```c++
#pragma once

#include "ofMain.h"

// ------------------------------------------------------------------------------------------------------------
//
class ofApp : public ofBaseApp
{
	public:
	
		// --------------------------------
		void setup()
		{
			camera.setAutoDistance( false );
			camera.setPosition( ofVec3f(0,1,8) );
			camera.setNearClip( 0.01 );
			camera.setFarClip( 64 );	

			int numParticles = 512 * 512; 

			ofVec3f size(12,3,6);
			for( int i = 0; i < numParticles; i++ )
			{
				ofVec4f p(0,0,0,1); 
				p.x = ofMap( i, 0, numParticles,		size.x * -0.5, size.x * 0.5 ); // not random, increases in X
				p.y = ofMap( ofRandom(1),	0, 1,		size.y *  0.0, size.y * 1.0 );
				p.z = ofMap( ofRandom(1),	0, 1,		size.z * -0.5, size.z * 0.5 );

				particleInitData.push_back( p );

				particleIndexInitData.push_back( i );
			}

			particleDataBuffer.allocate( particleInitData, GL_DYNAMIC_DRAW );
			particleIndexBuffer.allocate( particleIndexInitData, GL_DYNAMIC_DRAW );
		
			particlesVbo.setVertexBuffer( particleDataBuffer, 4, sizeof(ofVec4f) );
			particlesVbo.setIndexBuffer( particleIndexBuffer);
		}
	
		// --------------------------------
		void draw()
		{
			ofBackgroundGradient( ofColor(55), ofColor(0), OF_GRADIENT_CIRCULAR );		
	
			ofEnableDepthTest();
			ofEnableAlphaBlending();
			
			float t = ofGetElapsedTimef();

			camera.begin();
			
				// Grid
				ofSetColor( ofColor(60) );
				ofPushMatrix();
					ofRotate(90, 0, 0, -1);
					ofDrawGridPlane( 5, 5, false );
				ofPopMatrix();
			
				ofSetColor( ofColor::white );
				ofEnablePointSprites();

					//particlesVbo.drawElements( GL_POINTS, particleInitData.size() ); // draw the whole thing

					int perSliceAmount = particleInitData.size() / 20;
					int offsetBytes = sizeof(uint32_t) * (int)ofMap( sinf(t * 0.7), -1, 1, 0, particleInitData.size()-perSliceAmount );
					particlesVbo.drawElements( GL_POINTS, perSliceAmount, offsetBytes);

				ofDisablePointSprites();

			camera.end();
			
			ofDisableDepthTest();
		}

		ofEasyCam				camera;

		ofVbo					particlesVbo;

		vector<ofVec4f>			particleInitData;
		ofBufferObject			particleDataBuffer;

		vector<uint32_t>		particleIndexInitData;
		ofBufferObject			particleIndexBuffer;
};`
```