### PR TITLE
catch empty addon line in project generator

### DIFF
--- a/addons/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/addons/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -188,6 +188,7 @@ void baseProject::parseAddons(){
 	while(!addonsMakeMem.isLastLine()){
 	    string line = addonsMakeMem.getNextLine();
 	    if(line[0] == '#') continue;
+        if(ofTrim(line) == "") continue;
 		ofAddon addon;
 		cout << projectDir << endl;
 		addon.pathToOF = getOFRelPath(projectDir);


### PR DESCRIPTION
without this, I always end up with a line named "addons" in my addons.make