### PR TITLE
Fix ofToBinary

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -3,7 +3,6 @@
 #include "ofConstants.h"
 #include "utf8.h"
 #include <bitset> // For ofToBinary.
-#include <limits.h>
 
 #include "ofLog.h"
 
@@ -735,7 +734,7 @@ char ofToChar(const string& charString);
 /// \returns a binary string.
 template <class T>
 string ofToBinary(const T& value) {
-	return std::bitset<CHAR_BIT * sizeof(T)>(*reinterpret_cast<const uint64_t*>(&value)).to_string();
+	return std::bitset<8 * sizeof(T)>(*reinterpret_cast<const uint64_t*>(&value)).to_string();
 }
 
 /// \brief Converts a string value to a string of only 1s and 0s.

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -734,16 +734,7 @@ char ofToChar(const string& charString);
 /// \returns a binary string.
 template <class T>
 string ofToBinary(const T& value) {
-	ostringstream out;
-	const uint64_t* data = static_cast<uint64_t*>(&value);
-	// the number of bytes is determined by the datatype
-	std::size_t numBytes = sizeof(T);
-	// the bytes are stored backwards (least significant first)
-	for (std::size_t i = numBytes; i-- > 0;){
-		std::bitset<8> cur(data[i]);
-		out << cur;
-	}
-	return out.str();
+	return std::bitset<8 * sizeof(T)>(value).to_string();
 }
 
 /// \brief Converts a string value to a string of only 1s and 0s.

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -3,6 +3,7 @@
 #include "ofConstants.h"
 #include "utf8.h"
 #include <bitset> // For ofToBinary.
+#include <limits.h>
 
 #include "ofLog.h"
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -734,7 +734,7 @@ char ofToChar(const string& charString);
 /// \returns a binary string.
 template <class T>
 string ofToBinary(const T& value) {
-	return std::bitset<8 * sizeof(T)>(value).to_string();
+	return std::bitset<CHAR_BIT * sizeof(T)>(*reinterpret_cast<const uint64_t*>(&value)).to_string();
 }
 
 /// \brief Converts a string value to a string of only 1s and 0s.


### PR DESCRIPTION
I introduced a regression into ofToBinary when attempting to get rid of warnings.  The current version in the repo is wrong and doesn't make sense.  This is a fix that matches the old functionality.