### PR TITLE
Fix rtaudio gnome-shell

### DIFF
--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -63,34 +63,34 @@ vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList() const{
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::setDeviceID(int _deviceID) {
+void ofRtAudioSoundStream::setDeviceID(int _deviceID){
 	inDeviceID = outDeviceID = _deviceID;
 }
 
-int ofRtAudioSoundStream::getDeviceID()  const {
+int ofRtAudioSoundStream::getDeviceID()  const{
 	return inDeviceID;
 }
 
-void ofRtAudioSoundStream::setInDeviceID(int _deviceID) {
+void ofRtAudioSoundStream::setInDeviceID(int _deviceID){
 	inDeviceID = _deviceID;
 }
 
-void ofRtAudioSoundStream::setOutDeviceID(int _deviceID) {
+void ofRtAudioSoundStream::setOutDeviceID(int _deviceID){
 	outDeviceID = _deviceID;
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::setInput(ofBaseSoundInput * soundInput) {
+void ofRtAudioSoundStream::setInput(ofBaseSoundInput * soundInput){
 	soundInputPtr		= soundInput;
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::setOutput(ofBaseSoundOutput * soundOutput) {
+void ofRtAudioSoundStream::setOutput(ofBaseSoundOutput * soundOutput){
 	soundOutputPtr		= soundOutput;
 }
 
 //------------------------------------------------------------------------------
-bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers) {
+bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers){
 	if( audio != nullptr ){
 		close();
 	}
@@ -172,7 +172,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 }
 
 //------------------------------------------------------------------------------
-bool ofRtAudioSoundStream::setup(ofBaseApp * app, int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers) {
+bool ofRtAudioSoundStream::setup(ofBaseApp * app, int outChannels, int inChannels, int sampleRate, int bufferSize, int nBuffers){
 	setInput(app);
 	setOutput(app);
 	return setup(outChannels,inChannels,sampleRate,bufferSize,nBuffers);

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -118,7 +118,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 				if(std::find(apis.begin(), apis.end(), RtAudio::Api::LINUX_PULSE) != apis.end()){
 					//use pulseaudio
 					rApi = RtAudio::Api::LINUX_PULSE;
-				} else {
+				}else{
 					ofLogWarning() << "Using RtAudio on gnome shell, may require the linux pulse API. This API could not be found. If you run into any problems, configure and recompile rtAudio using --with-pulse .";
 				}
 			}
@@ -136,7 +136,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 	if(nInputChannels>0) {
 		if( inDeviceID >= 0 ){
 			inputParameters.deviceId = inDeviceID;
-		} else {
+		}else{
 			inputParameters.deviceId = audio->getDefaultInputDevice();
 		}
 		inputParameters.nChannels = nInputChannels;
@@ -145,7 +145,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 	if(nOutputChannels>0) {
 		if( outDeviceID >= 0 ){
 			outputParameters.deviceId = outDeviceID;
-		} else {
+		}else{
 			outputParameters.deviceId = audio->getDefaultOutputDevice();
 		}
 		outputParameters.nChannels = nOutputChannels;

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -28,7 +28,7 @@ ofRtAudioSoundStream::~ofRtAudioSoundStream(){
 }
 
 //------------------------------------------------------------------------------
-vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList() const {
+vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList() const{
 	shared_ptr<RtAudio> audioTemp;
 	try {
 		audioTemp = shared_ptr<RtAudio>(new RtAudio());
@@ -219,27 +219,27 @@ void ofRtAudioSoundStream::close(){
 }
 
 //------------------------------------------------------------------------------
-long unsigned long ofRtAudioSoundStream::getTickCount() const {
+long unsigned long ofRtAudioSoundStream::getTickCount() const{
 	return tickCount;
 }
 
 //------------------------------------------------------------------------------
-int ofRtAudioSoundStream::getNumInputChannels() const {
+int ofRtAudioSoundStream::getNumInputChannels() const{
 	return nInputChannels;
 }
 
 //------------------------------------------------------------------------------
-int ofRtAudioSoundStream::getNumOutputChannels() const {
+int ofRtAudioSoundStream::getNumOutputChannels() const{
 	return nOutputChannels;
 }
 
 //------------------------------------------------------------------------------
-int ofRtAudioSoundStream::getSampleRate() const {
+int ofRtAudioSoundStream::getSampleRate() const{
 	return sampleRate;
 }
 
 //------------------------------------------------------------------------------
-int ofRtAudioSoundStream::getBufferSize() const {
+int ofRtAudioSoundStream::getBufferSize() const{
 	return bufferSize;
 }
 

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -9,7 +9,7 @@
 
 
 //------------------------------------------------------------------------------
-ofRtAudioSoundStream::ofRtAudioSoundStream() {
+ofRtAudioSoundStream::ofRtAudioSoundStream(){
 	outDeviceID		= -1;
 	inDeviceID		= -1;
 	soundOutputPtr	= nullptr;
@@ -22,7 +22,7 @@ ofRtAudioSoundStream::ofRtAudioSoundStream() {
 }
 
 //------------------------------------------------------------------------------
-ofRtAudioSoundStream::~ofRtAudioSoundStream() {
+ofRtAudioSoundStream::~ofRtAudioSoundStream(){
 	stop();
 	close();
 }
@@ -39,7 +39,7 @@ vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList() const {
 	int deviceCount = audioTemp->getDeviceCount();
 	RtAudio::DeviceInfo info;
 	vector<ofSoundDevice> deviceList;
-	for (int i=0; i< deviceCount; i++) {
+	for (int i=0; i< deviceCount; i++){
 		try {
 			info = audioTemp->getDeviceInfo(i);
 		} catch (std::exception &error) {
@@ -91,7 +91,7 @@ void ofRtAudioSoundStream::setOutput(ofBaseSoundOutput * soundOutput) {
 
 //------------------------------------------------------------------------------
 bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRate, int _bufferSize, int nBuffers) {
-	if( audio != nullptr ) {
+	if( audio != nullptr ){
 		close();
 	}
 
@@ -108,14 +108,14 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 
 #ifdef TARGET_LINUX
 		//get available APIs
-		if(const char* currrentDesktop = std::getenv("XDG_CURRENT_DESKTOP")) {
+		if(const char* currrentDesktop = std::getenv("XDG_CURRENT_DESKTOP")){
 			//detect GNOME and use pulseaudio API
 			if(strcmp(currrentDesktop, "GNOME") == 0) {
 
 				//check if the pulseaudio api is available
 				std::vector<RtAudio::Api> apis;
 				RtAudio::getCompiledApi(apis);
-				if(std::find(apis.begin(), apis.end(), RtAudio::Api::LINUX_PULSE) != apis.end()) {
+				if(std::find(apis.begin(), apis.end(), RtAudio::Api::LINUX_PULSE) != apis.end()){
 					//use pulseaudio
 					rApi = RtAudio::Api::LINUX_PULSE;
 				} else {
@@ -134,7 +134,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 	RtAudio::StreamParameters outputParameters;
 	RtAudio::StreamParameters inputParameters;
 	if(nInputChannels>0) {
-		if( inDeviceID >= 0 ) {
+		if( inDeviceID >= 0 ){
 			inputParameters.deviceId = inDeviceID;
 		} else {
 			inputParameters.deviceId = audio->getDefaultInputDevice();
@@ -143,7 +143,7 @@ bool ofRtAudioSoundStream::setup(int outChannels, int inChannels, int _sampleRat
 	}
 
 	if(nOutputChannels>0) {
-		if( outDeviceID >= 0 ) {
+		if( outDeviceID >= 0 ){
 			outputParameters.deviceId = outDeviceID;
 		} else {
 			outputParameters.deviceId = audio->getDefaultOutputDevice();
@@ -179,7 +179,7 @@ bool ofRtAudioSoundStream::setup(ofBaseApp * app, int outChannels, int inChannel
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::start() {
+void ofRtAudioSoundStream::start(){
 	if( audio == nullptr ) return;
 
 	try {
@@ -190,11 +190,11 @@ void ofRtAudioSoundStream::start() {
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::stop() {
+void ofRtAudioSoundStream::stop(){
 	if( audio == nullptr ) return;
 
 	try {
-		if(audio->isStreamRunning()) {
+		if(audio->isStreamRunning()){
 			audio->stopStream();
 		}
 	} catch (std::exception &error) {
@@ -203,11 +203,11 @@ void ofRtAudioSoundStream::stop() {
 }
 
 //------------------------------------------------------------------------------
-void ofRtAudioSoundStream::close() {
+void ofRtAudioSoundStream::close(){
 	if( audio == nullptr ) return;
 
 	try {
-		if(audio->isStreamOpen()) {
+		if(audio->isStreamOpen()){
 			audio->closeStream();
 		}
 	} catch (std::exception &error) {
@@ -247,7 +247,7 @@ int ofRtAudioSoundStream::getBufferSize() const {
 int ofRtAudioSoundStream::rtAudioCallback(void *outputBuffer, void *inputBuffer, unsigned int nFramesPerBuffer, double streamTime, RtAudioStreamStatus status, void *data) {
 	ofRtAudioSoundStream * rtStreamPtr = (ofRtAudioSoundStream *)data;
 
-	if ( status ) {
+	if ( status ){
 		ofLogWarning("ofRtAudioSoundStream") << "stream over/underflow detected";
 	}
 
@@ -266,7 +266,7 @@ int ofRtAudioSoundStream::rtAudioCallback(void *outputBuffer, void *inputBuffer,
 	unsigned int nOutputChannels = rtStreamPtr->getNumOutputChannels();
 
 	if(nInputChannels > 0) {
-		if( rtStreamPtr->soundInputPtr != nullptr ) {
+		if( rtStreamPtr->soundInputPtr != nullptr ){
 			rtStreamPtr->inputBuffer.copyFrom(fPtrIn, nFramesPerBuffer, nInputChannels, rtStreamPtr->getSampleRate());
 			rtStreamPtr->inputBuffer.setTickCount(rtStreamPtr->tickCount);
 			rtStreamPtr->soundInputPtr->audioIn(rtStreamPtr->inputBuffer);
@@ -276,9 +276,9 @@ int ofRtAudioSoundStream::rtAudioCallback(void *outputBuffer, void *inputBuffer,
 	}
 
 	if (nOutputChannels > 0) {
-		if( rtStreamPtr->soundOutputPtr != nullptr ) {
+		if( rtStreamPtr->soundOutputPtr != nullptr ){
 
-			if ( rtStreamPtr->outputBuffer.size() != nFramesPerBuffer*nOutputChannels || rtStreamPtr->outputBuffer.getNumChannels()!=nOutputChannels ) {
+			if ( rtStreamPtr->outputBuffer.size() != nFramesPerBuffer*nOutputChannels || rtStreamPtr->outputBuffer.getNumChannels()!=nOutputChannels ){
 				rtStreamPtr->outputBuffer.setNumChannels(nOutputChannels);
 				rtStreamPtr->outputBuffer.resize(nFramesPerBuffer*nOutputChannels);
 			}


### PR DESCRIPTION
On my arch system running gnome shell, I get some warnings and the audioReceived callback does not get triggered when using the default rtaudio API. This PR will check for GNOME and tries to use pulseaudio which integrates the app better into the os. 
This also fixes some inconsistencies with the tab spacing.