### PR TITLE
Fix AVFoundationVideoPlayer warnings for OS X.

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -623,7 +623,7 @@ static const NSString * ItemStatusContext;
 			err = CMVideoFormatDescriptionCreateForImageBuffer(NULL, buffer, &_videoInfo);
 		}
 		if (err) {
-			NSLog(@"Error at CMVideoFormatDescriptionCreateForImageBuffer %ld", err);
+			NSLog(@"Error at CMVideoFormatDescriptionCreateForImageBuffer %ld", (long)err);
 			bNewFrame = NO;
 			return;
 		}
@@ -652,7 +652,7 @@ static const NSString * ItemStatusContext;
 												 &sampleTimingInfo,
 												 &videoSampleBuffer);
 		if (err) {
-			NSLog(@"Error at CMSampleBufferCreateForImageBuffer %ld", err);
+			NSLog(@"Error at CMSampleBufferCreateForImageBuffer %ld", (long)err);
 			bNewFrame = NO;
 			return;
 		}


### PR DESCRIPTION
Warning said to use an explicit cast to remove warning.