### PR TITLE
fix 4282

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -382,7 +382,7 @@ void ofShader::checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLeve
 		GLchar* infoBuffer = new GLchar[infoLength];
 		glGetShaderInfoLog(shader, infoLength, &infoLength, infoBuffer);
 		ofLog(logLevel, "ofShader: %s shader reports:\n%s", nameForType(type).c_str(), infoBuffer);
-#ifndef TARGET_RASPBERRY_PI
+#if (!defined(TARGET_LINUX) || defined(GCC_HAS_REGEX))
 		if (shaderSource.find(type) != shaderSource.end()) {
 			// The following regexp should match shader compiler error messages by Nvidia and ATI.
 			// Unfortunately, each vendor's driver formats error messages slightly different.

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -236,18 +236,55 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 	stringstream output;
 	stringstream input;
 	input << source;
+
+	auto match_pragma_include = [](const std::string& s_, std::string& filename_) -> bool {
+		filename_ = "";
+		std::istringstream s(s_);
+		s >> std::ws; // eat up any leading whitespace.
+		
+		if (s.peek() != '#') return false;
+		// -----| invariant: found '#'
+		s.seekg(1, std::ios::cur); // move forward one character
+		
+		std::string p, i, f;
+		
+		// while skipping whitespace, read in tokens for: pragma, include, and filename
+		s >> std::skipws >> p >> i >> f;
+		
+		if (p.empty() || i.empty() || (f.size() < 2) ) return false;
+		// -----| invariant: all tokens have values
+		
+		if (p != "pragma") return false;
+		if (i != "include") return false;
+		
+		// first and last character of filename token must match and be either
+		// '<' and '>', or '"
+		
+		if (f[0] == '<' && f[f.size()-1] != '>') return false; //< mismatching brackets
+		
+		if ((f[0] == '"' || f[0] == '\'') && (f[0] != f[f.size()-1])) return false; // mismatching quotes
+		
+		// invariant: filename properly quoted.
+		
+		filename_ = f.substr(1,f.size()-2);
+		
+		return true;
+	};
 	
-	std::regex re("^\\s*#\\s*pragma\\s+include\\s+[\"<](.*)[\">].*");
-	std::smatch matches;
+	// once std::regex is available across the board, use this regex in favour of the above lambda:
+	// std::regex re("^\\s*#\\s*pragma\\s+include\\s+[\"<](.*)[\">].*");
+	
 	string line;
 	while( std::getline( input, line ) ) {
-		std::regex_match( line, matches, re );
-		if ( matches.size() < 2 ) {
+
+		string include;
+		
+		if (!match_pragma_include(line, include)){
 			output << line << endl;
 			continue;
-		}
+		};
 		
-		string include = matches[1];
+		// --------| invariant: '#pragma include' has been requested
 		
 		if ( std::find( included.begin(), included.end(), include ) != included.end() ) {
 			ofLogVerbose("ofShader") << include << " already included";
@@ -258,7 +295,6 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 		
 		include = ofFile(ofFilePath::join(sourceDirectoryPath, include)).getAbsolutePath();
 		included.push_back( include );
-		
 		
 		ofBuffer buffer = ofBufferFromFile( include );
 		if ( !buffer.size() ) {
@@ -346,6 +382,7 @@ void ofShader::checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLeve
 		GLchar* infoBuffer = new GLchar[infoLength];
 		glGetShaderInfoLog(shader, infoLength, &infoLength, infoBuffer);
 		ofLog(logLevel, "ofShader: %s shader reports:\n%s", nameForType(type).c_str(), infoBuffer);
+#ifndef TARGET_RASPBERRY_PI
 		if (shaderSource.find(type) != shaderSource.end()) {
 			// The following regexp should match shader compiler error messages by Nvidia and ATI.
 			// Unfortunately, each vendor's driver formats error messages slightly different.
@@ -370,6 +407,15 @@ void ofShader::checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLeve
 				ofLog(logLevel) << shaderSource[type];
 			}
 		}
+#else
+		// Raspberry pi gcc is assumed to be < 4.9, which does not support std::regex.
+		// see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
+		// Also, it appears that RPi only reports shader errors whilst linking, so
+		// the check here might be superfluous.
+		if (shaderSource.find(type) != shaderSource.end()) {
+			ofLog(logLevel) << shaderSource[type];
+		}
+#endif
 		delete [] infoBuffer;
 	}
 }
@@ -381,29 +427,13 @@ void ofShader::checkProgramInfoLog(GLuint program) {
 	if (infoLength > 1) {
 		GLchar* infoBuffer = new GLchar[infoLength];
 		glGetProgramInfoLog(program, infoLength, &infoLength, infoBuffer);
+		// TODO: it appears that Raspberry Pi only reports shader errors whilst linking,
+		// but then it becomes hard to figure out whether the fragment or the
+		// vertex shader caused the error.
+		// We need to find a robust way of extracing this information from
+		// the log, and unfortunately can't use regex whilst gcc on RPi is assumed to
+		// be < 4.9, which is the first version fully supporting this c++11 feature.
 		string msg = "ofShader: program reports:\n";
-#ifdef TARGET_RASPBERRYPI
-		if (shaderSource.find(GL_FRAGMENT_SHADER) != shaderSource.end()) {
-			std::regex re(",.line.([^\\)]*)");
-			std::smatch matches;
-			string infoString = (infoBuffer != nullptr) ? string(infoBuffer): "";
-			std::regex_match(infoString, matches, re);
-			ofBuffer buf = shaderSource[GL_FRAGMENT_SHADER];
-			ofBuffer::Line line = buf.getLines().begin();
-			if (!matches.empty()){
-			int  offendingLineNumber = ofToInt(infoString.substr(matches[1].offset, matches[1].length));
-				ostringstream msg;
-				msg << "ofShader: " + nameForType(GL_FRAGMENT_SHADER) + ", offending line " << offendingLineNumber << " :"<< endl;
-				for(int i=0; line != buf.getLines().end(); line++, i++ ){
-					string s = *line;
-					if ( i >= offendingLineNumber -3 && i < offendingLineNumber + 2 ){
-						msg << "\t" << setw(5) << (i+1) << "\t" << s << endl;
-					}
-				}
-				ofLogError("ofShader") << msg.str();
-			}
-		}
-#endif
 		ofLogError("ofShader", msg + infoBuffer);
 		delete [] infoBuffer;
 	}

--- a/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
@@ -131,7 +131,7 @@ ifeq ($(CXX),g++)
 			PLATFORM_CFLAGS = -Wall -std=c++0x -DHAS_TLS=0
 		else
 			ifeq ("$(GCC_MINOR_GTEQ_9)","1")
-				PLATFORM_CFLAGS = -Wall -std=c++14
+				PLATFORM_CFLAGS = -Wall -std=c++14 -DGCC_HAS_REGEX
 			else
 				PLATFORM_CFLAGS = -Wall -std=c++11
 			endif

--- a/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
@@ -142,10 +142,10 @@ ifeq ($(CXX),g++)
 	endif
 else
 	ifeq ($(CXX),g++-5)
-		PLATFORM_CFLAGS = -Wall -std=c++14 -D_GLIBCXX_USE_CXX11_ABI=0
+		PLATFORM_CFLAGS = -Wall -std=c++14 -D_GLIBCXX_USE_CXX11_ABI=0 -DGCC_HAS_REGEX
 	else
 	    ifeq ($(CXX),g++-4.9)
-		    PLATFORM_CFLAGS = -Wall -std=c++14
+		    PLATFORM_CFLAGS = -Wall -std=c++14 -DGCC_HAS_REGEX
 	    else
 	        ifeq ($(CXX),g++-4.8)
 		        PLATFORM_CFLAGS = -Wall -std=c++11


### PR DESCRIPTION
* implements "#pragma include" parsing using stream ops to be independent of `std::regex` which is not yet implemented in gcc < 4.9. 

* remove raspberry pi specific shader linker error parsing until we have found the right compiler switches - it seems that the gcc version needs to be set in a -D flag in the makefiles - @arturoc could this affect the android target, too? The main thing I couldn't get my head around with the RPi error log parser is that it seemed to assume (hardcoded) that any error found must have occurred in the fragment shader - which may or may not be the case, and so the listing printed out might be for the wrong file if a compile error happened in the vertex shader for example

* exclude raspberry from targets where shader compiler error logs are parsed for error line number. It might be worth checking on other linux targets whether gcc >=4.9, so that regex was properly supported. 

I've written a test case as a main.cpp to test the includes parser, you can find it here: https://gist.github.com/tgfrerer/61c352b8fe8d2269ede6