### PR TITLE
Fixes osx ofToDataPath. See openframeworks/projectGenerator#22

### DIFF
--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -325,6 +325,12 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 	if (settings.isPositionSet()) {
 		setWindowPosition(settings.getPosition().x,settings.getPosition().y);
 	}
+
+#ifdef TARGET_OSX
+	// The osx implementation of glut changes the cwd, this restores it
+	// to wherever it was when the app was started
+	ofRestoreWorkingDirectoryToDefault();
+#endif
 }
 
 #ifdef TARGET_LINUX

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -44,6 +44,7 @@ static bool & initialized(){
 
 void ofExitCallback();
 void ofURLFileLoaderShutdown();
+void ofSetWorkingDirectoryToDefault();
 
 #if defined(TARGET_LINUX) || defined(TARGET_OSX)
 	#include <signal.h>

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1455,20 +1455,7 @@ bool ofFilePath::isAbsolute(const std::string& path){
 
 //------------------------------------------------------------------------------------------------------------
 string ofFilePath::getCurrentWorkingDirectory(){
-	#ifdef TARGET_OSX
-		char pathOSX[FILENAME_MAX];
-		uint32_t size = sizeof(pathOSX);
-		if(_NSGetExecutablePath(pathOSX, &size) != 0){
-			ofLogError("ofFilePath") << "getCurrentWorkingDirectory(): path buffer too small, need size " <<  size;
-		}
-		string pathOSXStr = string(pathOSX);
-		string pathWithoutApp;
-		size_t found = pathOSXStr.find_last_of("/");
-		pathWithoutApp = pathOSXStr.substr(0, found);
-		return pathWithoutApp;
-	#else
-		return std::filesystem::current_path().string();
-	#endif
+	return std::filesystem::current_path().string();
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -268,13 +268,19 @@ void ofDisableDataPath(){
 //--------------------------------------------------
 string defaultDataPath(){
 #if defined TARGET_OSX
-	return string("../../../data/");
+    try{
+        return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
+    }catch(...){
+        return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
+    }
 #elif defined TARGET_ANDROID
 	return string("sdcard/");
-#elif defined(TARGET_LINUX) || defined(TARGET_WIN32)
-	return string(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/"));
 #else
-	return string("data/");
+	try{
+	    return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).string();
+	}catch(...){
+	    return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
+	}
 #endif
 }
 
@@ -292,20 +298,6 @@ static std::filesystem::path & dataPathRoot(){
 
 //--------------------------------------------------
 void ofSetWorkingDirectoryToDefault(){
-#ifdef TARGET_OSX
-	#ifndef TARGET_OF_IOS
-		char path[MAXPATHLEN];
-		uint32_t size = sizeof(path);
-		
-		if (_NSGetExecutablePath(path, &size) == 0){
-			std::filesystem::path classPath(path);
-			classPath = classPath.parent_path();
-			chdir( classPath.native().c_str() );
-		}else{
-			ofLogFatalError("ofUtils") << "ofSetDataPathRoot(): path buffer too small, need size " << (unsigned int) size;
-		}
-	#endif
-#endif
 	defaultWorkingDirectory() = std::filesystem::absolute(std::filesystem::current_path());
 }
 	

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -300,6 +300,16 @@ static std::filesystem::path & dataPathRoot(){
 void ofSetWorkingDirectoryToDefault(){
 	defaultWorkingDirectory() = std::filesystem::absolute(std::filesystem::current_path());
 }
+
+//--------------------------------------------------
+bool ofRestoreWorkingDirectoryToDefault(){
+    try{
+        std::filesystem::current_path(defaultWorkingDirectory());
+        return true;
+    }catch(...){
+        return false;
+    }
+}
 	
 //--------------------------------------------------
 void ofSetDataPathRoot(const string& newRoot){
@@ -315,8 +325,8 @@ string ofToDataPath(const string& path, bool makeAbsolute){
 #ifdef TARGET_WIN32
 	if (defaultWorkingDirectory() != std::filesystem::current_path()) {
 		// change our cwd back to where it was on app load
-		int ret = chdir(defaultWorkingDirectory().string().c_str());
-		if(ret==-1){
+		bool ret = ofRestoreWorkingDirectoryToDefault();
+		if(!ret){
 			ofLogWarning("ofUtils") << "ofToDataPath: error while trying to change back to default working directory " << defaultWorkingDirectory();
 		}
 	}

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -185,9 +185,12 @@ string ofToDataPath(const string& path, bool absolute=false);
 
 /// \brief Reset the working directory to the platform default.
 ///
-/// The default working directory is usually in a data/ folder next to the
-/// openFrameworks application.
-void ofSetWorkingDirectoryToDefault();
+/// The default working directory is where the application was started from
+/// or the exe directory in case of osx bundles. GLUT might change the default
+/// working directory to the resources directory in the bundle in osx. This
+/// will restore it to the exe dir or whatever was the current dir when the
+/// application was started
+bool ofRestoreWorkingDirectoryToDefault();
 
 /// \brief Set the relative path to the data/ folder from the executable.
 ///

--- a/tests/utils/fileUtils/src/main.cpp
+++ b/tests/utils/fileUtils/src/main.cpp
@@ -2,6 +2,8 @@
 #include "ofUtils.h"
 #include "ofxUnitTests.h"
 
+std::filesystem::path initial_cwd;
+
 class ofApp: public ofxUnitTestsApp{
 	void run(){
 		ofDirectory dir(".");
@@ -15,6 +17,9 @@ class ofApp: public ofxUnitTestsApp{
 		}
 		test(ofDirectory(".").getFiles().empty(),"removing old tests files","other tests will fail too");
 
+
+
+		//========================================================================
 		ofLogNotice() << "testing ofFile";
 		{
 			ofFile("test.txt").create();
@@ -66,6 +71,7 @@ class ofApp: public ofxUnitTestsApp{
 
 
 
+		//========================================================================
 		ofLogNotice() << "";
 		ofLogNotice() << "testing ofDirectory";
 		test_eq(ofDirectory(".").getFiles().size(),size_t(3),"ofDirectory::ofDirectory with path",ofToString(ofDirectory(".").getFiles().size()));
@@ -111,15 +117,8 @@ class ofApp: public ofxUnitTestsApp{
 		test(!ofDirectory("d4").exists(),"!ofDirectory::exists after remove");
 
 
-		ofLogNotice() << "";
-		ofLogNotice() << "tests #4285";
-		test(!ofDirectory::doesDirectoryExist("d5/d1"),"!ofDirectory::doesDirectoryExist");
-		test(ofDirectory::createDirectory("d5/d1",true,true),"ofDirectory::create recursive");
-		test(ofDirectory::createDirectory(ofToDataPath("d5/d2",true),false,true),"ofDirectory::create recursive");
-		test(ofDirectory::createDirectory(ofToDataPath("d5/d3"),false,true),"ofDirectory::create recursive");
 
-
-
+		//========================================================================
 		ofLogNotice() << "";
 		ofLogNotice() << "testing ofFilePath";
 		test_eq(ofFilePath::getFileExt("test.txt"),"txt","ofFilePath::getFileExt");
@@ -150,6 +149,26 @@ class ofApp: public ofxUnitTestsApp{
 		test(std::filesystem::exists(ofFile("test.txt")), "ofFile cast to filesystem::path");
 		test(std::filesystem::exists(ofDirectory("d1")), "ofDirectory cast to filesystem::path");
 
+
+
+
+
+		//========================================================================
+        ofLogNotice() << "";
+        ofLogNotice() << "tests #4285";
+        test(!ofDirectory::doesDirectoryExist("d5/d1"),"!ofDirectory::doesDirectoryExist");
+        test(ofDirectory::createDirectory("d5/d1",true,true),"ofDirectory::create recursive");
+        test(ofDirectory::createDirectory(ofToDataPath("d5/d2",true),false,true),"ofDirectory::create recursive");
+        test(ofDirectory::createDirectory(ofToDataPath("d5/d3"),false,true),"ofDirectory::create recursive");
+
+
+        //========================================================================
+        ofLogNotice() << "";
+        ofLogNotice() << "tests #4299";
+        test_eq(std::filesystem::path(ofFilePath::getCurrentWorkingDirectory()), initial_cwd, "ofFilePath::getCurrentWorkingDirectory()");
+
+
+        //========================================================================
 		// clean test files
 		dir.open(".");
 		for(auto f: dir){
@@ -167,7 +186,8 @@ class ofApp: public ofxUnitTestsApp{
 #include "ofAppNoWindow.h"
 #include "ofAppRunner.h"
 //========================================================================
-	int main( ){
+int main( ){
+    initial_cwd = std::filesystem::current_path();
 	auto window = std::make_shared<ofAppNoWindow>();
 	auto app = std::make_shared<ofApp>();
 	ofRunApp(window, app);


### PR DESCRIPTION
In osx when OF starts it sets the current directory to the directory
where the exe is located and then uses a relative path from there to
correctly find the data folder.

This has several problems:

- The current working directory is not correct anymore, mostly for command
line applications is useful to know where the command was run from. This is
for example making the command line PG fail in osx and would require a hack
like https://github.com/openframeworks/projectGenerator/pull/22, in general
people would need to know that OF internally changes the cwd but even with
that the actual cwd is totally lost so there's no way to recover it except
by queryng $PWD which is not multiplatform

- If someone changes the current working directory using setcwd or std::current_path
the data folder won't be found anymore

Instead of that this commit changes the data path to EXE_DIR/../../..data
which always works no matter if the cwd is changed by the application or
where the application is run.

This also changes `ofFilePath::getCurrentWorkingDir` which right now is returning
the exe dir instead of the cwd