### PR TITLE
bugfix. stores circle resolution in current style. closes #4312

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -666,6 +666,7 @@ void ofGLProgrammableRenderer::setCircleResolution(int res){
 		circleMesh.getVertices() = circlePolyline.getVertices();
 		path.setCircleResolution(res);
 	}
+	currentStyle.circleResolution = res; 
 }
 
 void ofGLProgrammableRenderer::setPolyMode(ofPolyWindingMode mode){

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -837,6 +837,7 @@ void ofGLRenderer::setCircleResolution(int res){
 		circlePoints.resize(circlePolyline.size());
 		path.setCircleResolution(res);
 	}
+	currentStyle.circleResolution = res; 
 }
 
 void ofGLRenderer::setPolyMode(ofPolyWindingMode mode){
@@ -1268,7 +1269,7 @@ void ofGLRenderer::setBitmapTextMode(ofDrawBitmapMode mode){
 }
 
 ofStyle ofGLRenderer::getStyle() const{
-	return currentStyle;
+	return setCircle;
 }
 
 void ofGLRenderer::pushStyle(){

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -1269,7 +1269,7 @@ void ofGLRenderer::setBitmapTextMode(ofDrawBitmapMode mode){
 }
 
 ofStyle ofGLRenderer::getStyle() const{
-	return setCircle;
+	return currentStyle;
 }
 
 void ofGLRenderer::pushStyle(){


### PR DESCRIPTION
see the issue #4312 
@arturoc I think this should be good to merge - but maybe you could give the okay, just incase there was a reason the circle resolution wasn't being stored. 