### PR TITLE
Re-added TARGET_WIN32 guards around logger calls.

### DIFF
--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -160,7 +160,9 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	if (!Bind(usPort))
 	{
 #ifdef _DEBUG
+#ifdef TARGET_WIN32
 		ofLogError("ofxUDPManager") << "ConnectMcast(): couldn't bind to " << usPort<< ", err " << WSAGetLastError();
+#endif
 #endif
 		return false;
 	}
@@ -169,14 +171,18 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	if (!SetTTL(1))
 	{
 #ifdef _DEBUG
+#ifdef TARGET_WIN32
 		ofLogWarning("ofxUDPManager") << "ConnectMcast(): couldn't set TTL: err " << WSAGetLastError() << ", contining anyway";
+#endif
 #endif
 	}
 
 	if (!Connect(pMcast, usPort))
 	{
 #ifdef _DEBUG
+#ifdef TARGET_WIN32
 		ofLogError("ofxUDPManager") << " ConnectMcast(): couldn't connect to socket: err " << WSAGetLastError();
+#endif
 #endif
 		return false;
 	}
@@ -516,7 +522,9 @@ int ofxUDPManager::GetTTL()
 	if (getsockopt(m_hSocket, IPPROTO_IP, IP_MULTICAST_TTL, (char FAR *) &nTTL, &nSize) == SOCKET_ERROR)
 	{
 #ifdef _DEBUG
+#ifdef TARGET_WIN32
 		ofLogError("ofxUDPManager") << "GetTTL(): getsockopt failed: err " << WSAGetLastError();
+#endif
 #endif
 		ofxNetworkCheckError();
 		return -1;
@@ -534,7 +542,9 @@ bool ofxUDPManager::SetTTL(int nTTL)
 	if (setsockopt(m_hSocket, IPPROTO_IP, IP_MULTICAST_TTL, (char FAR *)&nTTL, sizeof (int)) == SOCKET_ERROR)
 	{
 #ifdef _DEBUG
+#ifdef TARGET_WIN32
 		ofLogError("ofxUDPManager") << "SetTTL(): setsockopt failed: err " << WSAGetLastError();
+#endif
 #endif
 		ofxNetworkCheckError();
 		return false;

--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -160,9 +160,8 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	if (!Bind(usPort))
 	{
 #ifdef _DEBUG
-#ifdef TARGET_WIN32
-		ofLogError("ofxUDPManager") << "ConnectMcast(): couldn't bind to " << usPort<< ", err " << WSAGetLastError();
-#endif
+		ofLogError("ofxUDPManager") << "ConnectMcast(): couldn't bind to " << usPort;
+		ofxNetworkCheckErrno();
 #endif
 		return false;
 	}
@@ -171,18 +170,16 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	if (!SetTTL(1))
 	{
 #ifdef _DEBUG
-#ifdef TARGET_WIN32
-		ofLogWarning("ofxUDPManager") << "ConnectMcast(): couldn't set TTL: err " << WSAGetLastError() << ", contining anyway";
-#endif
+		ofLogWarning("ofxUDPManager") << "ConnectMcast(): couldn't set TTL; continuing anyway"; 
+		ofxNetworkCheckErrno();
 #endif
 	}
 
 	if (!Connect(pMcast, usPort))
 	{
 #ifdef _DEBUG
-#ifdef TARGET_WIN32
-		ofLogError("ofxUDPManager") << " ConnectMcast(): couldn't connect to socket: err " << WSAGetLastError();
-#endif
+		ofLogError("ofxUDPManager") << " ConnectMcast(): couldn't connect to socket";
+		ofxNetworkCheckErrno();
 #endif
 		return false;
 	}
@@ -522,9 +519,8 @@ int ofxUDPManager::GetTTL()
 	if (getsockopt(m_hSocket, IPPROTO_IP, IP_MULTICAST_TTL, (char FAR *) &nTTL, &nSize) == SOCKET_ERROR)
 	{
 #ifdef _DEBUG
-#ifdef TARGET_WIN32
-		ofLogError("ofxUDPManager") << "GetTTL(): getsockopt failed: err " << WSAGetLastError();
-#endif
+		ofLogError("ofxUDPManager") << "GetTTL(): getsockopt failed";
+		ofxNetworkCheckErrno();
 #endif
 		ofxNetworkCheckError();
 		return -1;
@@ -542,9 +538,8 @@ bool ofxUDPManager::SetTTL(int nTTL)
 	if (setsockopt(m_hSocket, IPPROTO_IP, IP_MULTICAST_TTL, (char FAR *)&nTTL, sizeof (int)) == SOCKET_ERROR)
 	{
 #ifdef _DEBUG
-#ifdef TARGET_WIN32
-		ofLogError("ofxUDPManager") << "SetTTL(): setsockopt failed: err " << WSAGetLastError();
-#endif
+		ofLogError("ofxUDPManager") << "SetTTL(): setsockopt failed";
+		ofxNetworkCheckErrno();
 #endif
 		ofxNetworkCheckError();
 		return false;


### PR DESCRIPTION
The TARGET_WIN32 guard went missing in ofxUDPManager.cpp -- re-adding (otherwise compile fails in DEBUG mode). 

Tested on Android.