### PR TITLE
return relative ofToDataPath

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1513,3 +1513,23 @@ string ofFilePath::getUserHomeDir(){
 		return "";
 	#endif
 }
+
+string ofFilePath::makeRelative(const std::string & from, const std::string & to){
+    auto pathFrom = std::filesystem::absolute( from );
+    auto pathTo = std::filesystem::absolute( to );
+    std::filesystem::path ret;
+    std::filesystem::path::const_iterator itrFrom( pathFrom.begin() ), itrTo( pathTo.begin() );
+    // Find common base
+    for( std::filesystem::path::const_iterator toEnd( pathTo.end() ), fromEnd( pathFrom.end() ) ; itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo; ++itrFrom, ++itrTo );
+    // Navigate backwards in directory to reach previously found base
+    for( std::filesystem::path::const_iterator fromEnd( pathFrom.end() ); itrFrom != fromEnd; ++itrFrom )
+    {
+        if( (*itrFrom) != "." )
+            ret /= "..";
+    }
+    // Now navigate down the directory branch
+    for( ; itrTo != pathTo.end() ; ++itrTo )
+        ret /= *itrTo;
+
+    return ret.string();
+}

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -129,6 +129,8 @@ public:
 	static string getCurrentExeDir();
 
 	static string getUserHomeDir();
+
+	static string makeRelative(const std::string & from, const std::string & to);
 };
 
 class ofFile: public fstream{

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -358,24 +358,31 @@ string ofToDataPath(const string& path, bool makeAbsolute){
 	// also, we strip the trailing slash from dataPath since `path` may be input as a file formatted path even if it is a folder (i.e. missing trailing slash)
 	strippedDataPath = ofFilePath::removeTrailingSlash(strippedDataPath);
 	
-	if (inputPath.string().find(strippedDataPath) != 0) {
+	auto relativeStrippedDataPath = ofFilePath::makeRelative(std::filesystem::current_path().string(),dataPath.string());
+	relativeStrippedDataPath  = ofFilePath::removeTrailingSlash(relativeStrippedDataPath);
+
+	if (inputPath.string().find(strippedDataPath) != 0 && inputPath.string().find(relativeStrippedDataPath)!=0) {
 		// inputPath doesn't contain data path already, so we build the output path as the inputPath relative to the dataPath
-		outputPath = dataPath / inputPath;
+	    if(makeAbsolute){
+	        outputPath = dataPath / inputPath;
+	    }else{
+	        outputPath = relativeStrippedDataPath / inputPath;
+	    }
 	} else {
 		// inputPath already contains data path, so no need to change
 		outputPath = inputPath;
 	}
-	
-	// finally, if we do want an absolute path and we don't already have one
-	if (makeAbsolute) {
-		// then we return the absolute form of the path
-		try {
-			return std::filesystem::canonical(std::filesystem::absolute(outputPath)).string();
-		}
-		catch (...) {
-			return std::filesystem::absolute(outputPath).string();
-		}
-	} else {
+
+    // finally, if we do want an absolute path and we don't already have one
+	if(makeAbsolute){
+	    // then we return the absolute form of the path
+	    try {
+	        return std::filesystem::canonical(std::filesystem::absolute(outputPath)).string();
+	    }
+	    catch (std::exception &) {
+	        return std::filesystem::absolute(outputPath).string();
+	    }
+	}else{
 		// or output the relative path
 		return outputPath.string();
 	}

--- a/tests/utils/fileUtils/src/main.cpp
+++ b/tests/utils/fileUtils/src/main.cpp
@@ -166,6 +166,11 @@ class ofApp: public ofxUnitTestsApp{
         ofLogNotice() << "";
         ofLogNotice() << "tests #4299";
         test_eq(std::filesystem::path(ofFilePath::getCurrentWorkingDirectory()), initial_cwd, "ofFilePath::getCurrentWorkingDirectory()");
+#ifdef TARGET_OSX
+        test_eq(ofToDataPath("",false),"../../../data","ofToDataPath relative");
+#else
+        test_eq(ofToDataPath("",false),"data","ofToDataPath relative");
+#endif
 
 
         //========================================================================


### PR DESCRIPTION
some fixes for https://github.com/openframeworks/openFrameworks/pull/4299 to keep returning relative paths on ofToDataPath

