### PR TITLE
ios fixes for multi window examples.

### DIFF
--- a/examples/ios/iosCustomSizeExample/src/main.mm
+++ b/examples/ios/iosCustomSizeExample/src/main.mm
@@ -15,8 +15,7 @@ int main(){
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
     settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
-    ofAppiOSWindow* window = static_cast<ofAppiOSWindow*>(windowBase.get());
+    ofAppiOSWindow * window = (ofAppiOSWindow *)(ofCreateWindow(settings).get());
     
     bool bUseNative = true;
     if (bUseNative){

--- a/examples/ios/iosNativeExample/src/main.mm
+++ b/examples/ios/iosNativeExample/src/main.mm
@@ -15,8 +15,7 @@ int main(){
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
     settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
-    ofAppiOSWindow * window = (ofAppiOSWindow *)(windowBase.get());
+    ofAppiOSWindow * window = (ofAppiOSWindow *)(ofCreateWindow(settings).get());
     
     bool bUseNative = true;
     if (bUseNative){

--- a/examples/ios/iosStoryboardExample/src/main.mm
+++ b/examples/ios/iosStoryboardExample/src/main.mm
@@ -15,8 +15,7 @@ int main(){
     settings.enableHardwareOrientationAnimation = false; // enables native orientation changes to be animated.
     settings.glesVersion = OFXIOS_RENDERER_ES1; // type of renderer to use, ES1, ES2, etc.
     
-    shared_ptr<ofAppBaseWindow> windowBase = ofCreateWindow(settings);
-    ofAppiOSWindow * window = (ofAppiOSWindow *)(windowBase.get());
+    ofAppiOSWindow * window = (ofAppiOSWindow *)(ofCreateWindow(settings).get());
     
     bool bUseNative = true;
     if (bUseNative){


### PR DESCRIPTION
making sure that a shared instance to the ofAppiOSWindow is not stored in the main.mm, since that prevents the window from being destroyed later in the app life cycle.