### PR TITLE
Making sure GL_COLOR_MATERIAL is disabled when using an ofMaterial

### DIFF
--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -24,6 +24,7 @@ ofGLRenderer::ofGLRenderer(const ofAppBaseWindow * _window)
 	linePoints.resize(2);
 	rectPoints.resize(4);
 	triPoints.resize(3);
+	colorMaterialEnabled = false;
 	normalsEnabled = false;
 	lightingEnabled = false;
 	alphaMaskTextureTarget = GL_TEXTURE_2D;
@@ -535,6 +536,9 @@ void ofGLRenderer::unbind(const ofFbo & fbo){
 
 //----------------------------------------------------------
 void ofGLRenderer::bind(const ofBaseMaterial & material){
+	colorMaterialEnabled = glIsEnabled(GL_COLOR_MATERIAL);
+	glDisable(GL_COLOR_MATERIAL);
+	
 	ofFloatColor diffuse = material.getDiffuseColor();
 	ofFloatColor specular = material.getSpecularColor();
 	ofFloatColor ambient = material.getAmbientColor();
@@ -586,6 +590,10 @@ void ofGLRenderer::unbind(const ofBaseMaterial & material){
 	glMaterialfv(GL_FRONT_AND_BACK, GL_EMISSION, &defaultData.emissive.r);
 	glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &defaultData.shininess);
 #endif
+	
+	if (colorMaterialEnabled) {
+		glEnable(GL_COLOR_MATERIAL);
+	}
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -230,6 +230,7 @@ private:
 	ofPolyline circlePolyline;
 
 	ofMatrixStack matrixStack;
+	bool colorMaterialEnabled;
 	bool normalsEnabled;
 	bool lightingEnabled;
 	set<int> textureLocationsEnabled;


### PR DESCRIPTION
I noticed that ofMaterial colours were not working when using the fixed pipeline. The idea for the fix is from [a comment](https://github.com/openframeworks/openFrameworks/issues/2475#issuecomment-26028340) by @julapy in #2475. It seems to be working fine now.