### PR TITLE
Fix tcpserver deadlock w/ recursive mutex

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -53,7 +53,7 @@ bool ofxTCPServer::close(){
 
 	if(connected)
 	{
-		std::lock_guard<std::mutex> lock( mConnectionsLock );
+		std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 		map<int,ofPtr<ofxTCPClient> >::iterator it;
 		for(it=TCPConnections.begin(); it!=TCPConnections.end(); it++){
 			it->second->close();
@@ -82,7 +82,7 @@ ofxTCPClient & ofxTCPServer::getClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::disconnectClient(int clientID){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "disconnectClient(): client " << clientID << " doesn't exist";
 		return false;
@@ -95,7 +95,7 @@ bool ofxTCPServer::disconnectClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::send(int clientID, string message){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "send(): client " << clientID << " doesn't exist";
 		return false;
@@ -108,7 +108,7 @@ bool ofxTCPServer::send(int clientID, string message){
 
 //--------------------------
 bool ofxTCPServer::sendToAll(string message){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -125,7 +125,7 @@ bool ofxTCPServer::sendToAll(string message){
 
 //--------------------------
 string ofxTCPServer::receive(int clientID){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receive(): client " << clientID << " doesn't exist";
 		return "client " + ofToString(clientID) + "doesn't exist";
@@ -141,7 +141,7 @@ string ofxTCPServer::receive(int clientID){
 
 //--------------------------
 bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawBytes(): client " << clientID << " doesn't exist";
 		
@@ -154,7 +154,7 @@ bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int n
 
 //--------------------------
 bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -167,7 +167,7 @@ bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawMsg(): client " << clientID << " doesn't exist";
 		return false;
@@ -179,7 +179,7 @@ bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int num
 
 //--------------------------
 bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -191,7 +191,7 @@ bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 int ofxTCPServer::getNumReceivedBytes(int clientID){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getNumReceivedBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -202,7 +202,7 @@ int ofxTCPServer::getNumReceivedBytes(int clientID){
 
 //--------------------------
 int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -214,7 +214,7 @@ int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numByt
 
 //--------------------------
 int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLog(OF_LOG_WARNING, "ofxTCPServer: client " + ofToString(clientID) + " doesn't exist");
 		return 0;
@@ -225,7 +225,7 @@ int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int nu
 
 //--------------------------
 int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawMsg(): client " << clientID << " doesn't exist";
 		return 0;
@@ -236,7 +236,7 @@ int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes
 
 //--------------------------
 int ofxTCPServer::getClientPort(int clientID){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientPort(): client " << clientID << " doesn't exist";
 		return 0;
@@ -246,7 +246,7 @@ int ofxTCPServer::getClientPort(int clientID){
 
 //--------------------------
 string ofxTCPServer::getClientIP(int clientID){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientIP(): client " << clientID << " doesn't exist";
 		return "000.000.000.000";
@@ -256,7 +256,7 @@ string ofxTCPServer::getClientIP(int clientID){
 
 //--------------------------
 int ofxTCPServer::getNumClients(){
-	std::lock_guard<std::mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	return TCPConnections.size();
 }
 
@@ -277,13 +277,13 @@ bool ofxTCPServer::isConnected(){
 
 //--------------------------
 bool ofxTCPServer::isClientSetup(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	return TCPConnections.find(clientID)!=TCPConnections.end();
 }
 
 //--------------------------
 bool ofxTCPServer::isClientConnected(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	return isClientSetup(clientID) && getClient(clientID).isConnected();
 }
 
@@ -314,7 +314,7 @@ void ofxTCPServer::threadedFunction(){
 		if( !TCPServer.Accept( client->TCPClient ) ){
 			if(isThreadRunning()) ofLogError("ofxTCPServer") << "couldn't accept client " << acceptId;
 		}else{
-			std::lock_guard<std::mutex> lock( mConnectionsLock );
+			std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 			//	take owenership of socket from NewClient
 			TCPConnections[acceptId] = client;
 			TCPConnections[acceptId]->setup(acceptId, bClientBlocking);

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -53,16 +53,16 @@ bool ofxTCPServer::close(){
 
 	if(connected)
 	{
-		mConnectionsLock.lock();
+		std::lock_guard<std::mutex> lock( mConnectionsLock );
 		map<int,ofPtr<ofxTCPClient> >::iterator it;
 		for(it=TCPConnections.begin(); it!=TCPConnections.end(); it++){
 			it->second->close();
 		}
 		stopThread();
 		connected = false;
+		TCPConnections.clear();
 	}
-	TCPConnections.clear();
-	mConnectionsLock.unlock();	//	unlock for thread
+	
 	stopThread();
 
 	if( !TCPServer.Close() ){
@@ -83,7 +83,7 @@ ofxTCPClient & ofxTCPServer::getClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::disconnectClient(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "disconnectClient(): client " << clientID << " doesn't exist";
 		return false;
@@ -96,7 +96,7 @@ bool ofxTCPServer::disconnectClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::send(int clientID, string message){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "send(): client " << clientID << " doesn't exist";
 		return false;
@@ -109,7 +109,7 @@ bool ofxTCPServer::send(int clientID, string message){
 
 //--------------------------
 bool ofxTCPServer::sendToAll(string message){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -126,7 +126,7 @@ bool ofxTCPServer::sendToAll(string message){
 
 //--------------------------
 string ofxTCPServer::receive(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receive(): client " << clientID << " doesn't exist";
 		return "client " + ofToString(clientID) + "doesn't exist";
@@ -142,7 +142,7 @@ string ofxTCPServer::receive(int clientID){
 
 //--------------------------
 bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawBytes(): client " << clientID << " doesn't exist";
 		
@@ -155,7 +155,7 @@ bool ofxTCPServer::sendRawBytes(int clientID, const char * rawBytes, const int n
 
 //--------------------------
 bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -168,7 +168,7 @@ bool ofxTCPServer::sendRawBytesToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "sendRawMsg(): client " << clientID << " doesn't exist";
 		return false;
@@ -180,7 +180,7 @@ bool ofxTCPServer::sendRawMsg(int clientID, const char * rawBytes, const int num
 
 //--------------------------
 bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if(TCPConnections.size() == 0 || numBytes <= 0) return false;
 
 	map<int,ofPtr<ofxTCPClient> >::iterator it;
@@ -192,7 +192,7 @@ bool ofxTCPServer::sendRawMsgToAll(const char * rawBytes, const int numBytes){
 
 //--------------------------
 int ofxTCPServer::getNumReceivedBytes(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getNumReceivedBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -203,7 +203,7 @@ int ofxTCPServer::getNumReceivedBytes(int clientID){
 
 //--------------------------
 int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawBytes(): client " << clientID << " doesn't exist";
 		return 0;
@@ -215,7 +215,7 @@ int ofxTCPServer::receiveRawBytes(int clientID, char * receiveBytes,  int numByt
 
 //--------------------------
 int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLog(OF_LOG_WARNING, "ofxTCPServer: client " + ofToString(clientID) + " doesn't exist");
 		return 0;
@@ -226,7 +226,7 @@ int ofxTCPServer::peekReceiveRawBytes(int clientID, char * receiveBytes,  int nu
 
 //--------------------------
 int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "receiveRawMsg(): client " << clientID << " doesn't exist";
 		return 0;
@@ -237,7 +237,7 @@ int ofxTCPServer::receiveRawMsg(int clientID, char * receiveBytes,  int numBytes
 
 //--------------------------
 int ofxTCPServer::getClientPort(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientPort(): client " << clientID << " doesn't exist";
 		return 0;
@@ -247,7 +247,7 @@ int ofxTCPServer::getClientPort(int clientID){
 
 //--------------------------
 string ofxTCPServer::getClientIP(int clientID){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "getClientIP(): client " << clientID << " doesn't exist";
 		return "000.000.000.000";
@@ -257,7 +257,7 @@ string ofxTCPServer::getClientIP(int clientID){
 
 //--------------------------
 int ofxTCPServer::getNumClients(){
-	std::unique_lock<std::mutex> Lock( mConnectionsLock );
+	std::lock_guard<std::mutex> lock( mConnectionsLock );
 	return TCPConnections.size();
 }
 
@@ -315,7 +315,7 @@ void ofxTCPServer::threadedFunction(){
 		if( !TCPServer.Accept( client->TCPClient ) ){
 			if(isThreadRunning()) ofLogError("ofxTCPServer") << "couldn't accept client " << acceptId;
 		}else{
-			std::unique_lock<std::mutex> Lock( mConnectionsLock );
+			std::lock_guard<std::mutex> lock( mConnectionsLock );
 			//	take owenership of socket from NewClient
 			TCPConnections[acceptId] = client;
 			TCPConnections[acceptId]->setup(acceptId, bClientBlocking);

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -82,7 +82,7 @@ ofxTCPClient & ofxTCPServer::getClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::disconnectClient(int clientID){
-	std::lock_guard<recursive_mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "disconnectClient(): client " << clientID << " doesn't exist";
 		return false;
@@ -95,7 +95,7 @@ bool ofxTCPServer::disconnectClient(int clientID){
 
 //--------------------------
 bool ofxTCPServer::send(int clientID, string message){
-	std::lock_guard<recursive_mutex> lock( mConnectionsLock );
+	std::lock_guard<std::recursive_mutex> lock( mConnectionsLock );
 	if( !isClientSetup(clientID) ){
 		ofLogWarning("ofxTCPServer") << "send(): client " << clientID << " doesn't exist";
 		return false;

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -58,7 +58,6 @@ bool ofxTCPServer::close(){
 		for(it=TCPConnections.begin(); it!=TCPConnections.end(); it++){
 			it->second->close();
 		}
-		stopThread();
 		connected = false;
 		TCPConnections.clear();
 	}

--- a/addons/ofxNetwork/src/ofxTCPServer.h
+++ b/addons/ofxNetwork/src/ofxTCPServer.h
@@ -92,7 +92,7 @@ class ofxTCPServer : public ofThread{
 
 		ofxTCPManager			TCPServer;
 		map<int,ofPtr<ofxTCPClient> >	TCPConnections;
-		std::mutex					mConnectionsLock;
+		std::recursive_mutex					mConnectionsLock;
 
 		bool			connected;
 		string			str;


### PR DESCRIPTION
This is a bit of a band-aid fix to work around multiple member functions calling each other and trying to lock the same mutex, without reworking the call structure. It swaps the regular `std::mutex` for a `std::recursive_mutex`. If you're not familiar, it allows the same mutex to be locked multiple times from the same thread, blocking other threads until it's complete.

Also switched the `std::unique_lock` for the simpler `std::lock_guard`, since in all cases it's just being used as a simple automatic scoped lock.

There's a [bit of related weird logic in `ofxTCPServer::close()`](https://github.com/openframeworks/openFrameworks/blob/621876270b585498e4557eacddf8afc60ffdb8b5/addons/ofxNetwork/src/ofxTCPServer.cpp#L54-L66) that this addresses. There are redundant calls to `stopThread` and a manual `mConnectionsLock.unlock()` that was possible to be hit without a corresponding `mConnectionsLock.lock()`

Fixes #4329 and fixes #3580