### PR TITLE
Adding gradle.properties file

### DIFF
--- a/libs/openFrameworksCompiled/project/android/gradle.properties
+++ b/libs/openFrameworksCompiled/project/android/gradle.properties
@@ -1,0 +1,1 @@
+android.useDeprecatedNdk=true


### PR DESCRIPTION
As reported in this issue https://github.com/openframeworks/ofSite/issues/315 a `gradle.properties` file is needed in the `/libs/openFrameworksCompiled/project/android` folder