### PR TITLE
Fixed Android Studio tutorial for 0.9

### DIFF
--- a/docs/android_studio.md
+++ b/docs/android_studio.md
@@ -30,26 +30,22 @@ In the event that Android Studio does not come with an SDK, you can install it f
 
 ### Install the Android NDK
 
-For the current version of openFrameworks, you need to install Android NDK revision r10b or earlier. r10c breaks compatibility with some libraries, and should (at this time) be avoided.
-
-Here are download links for r9d, which has been tested and works fine:
-
-- Windows 32-bit: http://dl.google.com/android/ndk/android-ndk-r9d-windows-x86.zip
-- Windows 64-bit: http://dl.google.com/android/ndk/android-ndk-r9d-windows-x86_64.zip
-- Mac OS X 32-bit: http://dl.google.com/android/ndk/android-ndk-r9d-darwin-x86.tar.bz2
-- Mac OS X 64-bit: http://dl.google.com/android/ndk/android-ndk-r9d-darwin-x86_64.tar.bz2
-- Linux 32-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86.tar.bz2
-- Linux 64-bit (x86): http://dl.google.com/android/ndk/android-ndk-r9d-linux-x86_64.tar.bz2
+Download and Install the latest Android NDK for your plattform. Last known working version is r10e.
+https://developer.android.com/ndk/downloads/index.html
 
 On Windows, you will also need to install MinGW in order to build openFrameworks. MinGW provides some essential build tools which are not included in the NDK. Follow just the "Installing the MinGW and Msys" instructions on this page: http://www.multigesture.net/articles/how-to-install-mingw-msys-and-eclipse-on-windows/.
 
-### Download openFrameworks
+
+### Download openFrameworks 0.9.0 or later
 
 Download it from the downloads page:
 
 http://openframeworks.cc/download
 
 You may also check out the openFrameworks source from GitHub (under master branch): http://github.com/openframeworks/openFrameworks
+
+Or download the latest nightly:
+http://openframeworks.cc/download (bottom of the page)
 
 ### Import the project
 


### PR DESCRIPTION
The old NDK info doesn't work with 0.9 and some settings need to be changed with current releases of Android Studio in order to compile.

Changed according to https://github.com/openframeworks/openFrameworks/pull/4374#issuecomment-141001075

I only mentioned that 0.9 is a minimum requirement so people don't try it right now with 0.8.4