### PR TITLE
ofParameter: add ofParameter<void>

### DIFF
--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -54,3 +54,67 @@ istream& operator>>(istream& is, ofAbstractParameter& p){
 	p.fromString(str);
 	return is;
 }
+
+
+
+ofParameter<void>::ofParameter()
+:obj(new Value){
+
+}
+
+ofParameter<void>::ofParameter(const string& name)
+:obj(new Value(name)){
+
+}
+
+void ofParameter<void>::setName(const string & name){
+	obj->name = name;
+}
+
+string ofParameter<void>::getName() const{
+	return obj->name;
+}
+
+std::string ofParameter<void>::toString() const{
+	return "";
+}
+
+void ofParameter<void>::fromString(const std::string & name){
+
+}
+
+void ofParameter<void>::trigger(){
+	ofNotifyEvent(obj->changedE,this);
+}
+
+void ofParameter<void>::enableEvents(){
+	obj->changedE.enable();
+}
+
+void ofParameter<void>::disableEvents(){
+	obj->changedE.disable();
+}
+
+bool ofParameter<void>::isSerializable() const{
+	return obj->serializable;
+}
+
+bool ofParameter<void>::isReadOnly() const{
+	return false;
+}
+
+void ofParameter<void>::makeReferenceTo(ofParameter<void> & mom){
+	*this = mom;
+}
+
+void ofParameter<void>::setSerializable(bool serializable){
+	obj->serializable = serializable;
+}
+
+shared_ptr<ofAbstractParameter> ofParameter<void>::newReference() const{
+	return std::make_shared<ofParameter<void>>(*this);
+}
+
+void ofParameter<void>::setParent(ofParameterGroup & parent){
+	obj->parents.emplace_back(parent.obj);
+}

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -867,6 +867,68 @@ void ofParameter<ParameterType>::setParent(ofParameterGroup & parent){
 	obj->parents.emplace_back(parent.obj);
 }
 
+template<>
+class ofParameter<void>: public ofAbstractParameter{
+public:
+	ofParameter();
+	ofParameter(const string& name);
+
+	void setName(const string & name);
+	string getName() const;
+
+	std::string toString() const;
+    void fromString(const std::string & name);
+
+	template<class ListenerClass, typename ListenerMethod>
+	void addListener(ListenerClass * listener, ListenerMethod method, int prio=OF_EVENT_ORDER_AFTER_APP){
+		ofAddListener(obj->changedE,listener,method,prio);
+	}
+
+	template<class ListenerClass, typename ListenerMethod>
+	void removeListener(ListenerClass * listener, ListenerMethod method, int prio=OF_EVENT_ORDER_AFTER_APP){
+		ofRemoveListener(obj->changedE,listener,method,prio);
+	}
+
+	void trigger();
+
+	void enableEvents();
+	void disableEvents();
+	bool isSerializable() const;
+	bool isReadOnly() const;
+
+	void makeReferenceTo(ofParameter<void> & mom);
+
+	void setSerializable(bool serializable);
+	shared_ptr<ofAbstractParameter> newReference() const;
+
+	void setParent(ofParameterGroup & _parent);
+
+	const ofParameterGroup getFirstParent() const{
+		auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](weak_ptr<ofParameterGroup::Value> p){return p.lock()!=nullptr;});
+		if(first!=obj->parents.end()){
+			return first->lock();
+		}else{
+			return shared_ptr<ofParameterGroup::Value>(nullptr);
+		}
+	}
+private:
+	class Value{
+	public:
+		Value()
+		:serializable(false){};
+
+		Value(string name)
+		:name(name)
+		,serializable(false){};
+
+		string name;
+		ofEvent<void> changedE;
+		bool serializable;
+		vector<weak_ptr<ofParameterGroup::Value>> parents;
+	};
+	shared_ptr<Value> obj;
+};
+
 
 
 /// \brief ofReadOnlyParameter holds a value and notifies its listeners when it changes.


### PR DESCRIPTION
which it's pretty useless by itself but allows to add a parameter to
an `ofParameterGroup` that will end up represented as a button in an
ofxGui.

an `ofParameter<void>` can't be set or have operators... but has a
`trigger()` method that calls the corresponding event.

This still doesn't add the posibility to add an `ofParameter<void>` to
an `ofxPanel`.

ping @frauzufall 