### PR TITLE
Bugfix avfvideo memleak

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -663,6 +663,9 @@ static const NSString * ItemStatusContext;
 			return;
 		}
 		
+		// release temp buffer
+		CFRelease(buffer);
+		
 		videoSampleTime = time;
 		
 		

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -881,7 +881,7 @@ static const NSString * ItemStatusContext;
 	if (frames < 0) {
 
 		double timeSec = CMTimeGetSeconds(currentTime) - (1.0/frameRate);
-		[self seekToTime:CMTimeMakeWithSeconds(timeSec, NSEC_PER_SEC)];
+		[self seekToTime:CMTimeMakeWithSeconds(timeSec, NSEC_PER_SEC) withTolerance:kCMTimeZero];
 		
 	} else if (![self isFinished] && frames > 0) {
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -664,7 +664,7 @@ static const NSString * ItemStatusContext;
 		}
 		
 		// release temp buffer
-		CFRelease(buffer);
+		CVBufferRelease(buffer);
 		
 		videoSampleTime = time;
 		


### PR DESCRIPTION
Two fixes for avfoundationvideplayer:

1. memory leak: https://github.com/openframeworks/openFrameworks/issues/4401
2. texture cache freeze: https://github.com/openframeworks/openFrameworks/issues/4384