### PR TITLE
fixing error in install-dependencies.sh of cdee8cb

### DIFF
--- a/scripts/linux/archlinux/install_dependencies.sh
+++ b/scripts/linux/archlinux/install_dependencies.sh
@@ -44,5 +44,5 @@ if [ $GCC_MAJOR_GT_4 -eq 1 ]; then
 	
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     cd ${DIR}/../../apothecary
-    ./apothecary update poco -j${cores}
+    ./apothecary -j${cores} update poco
 fi

--- a/scripts/linux/archlinux_armv6/install_dependencies.sh
+++ b/scripts/linux/archlinux_armv6/install_dependencies.sh
@@ -36,5 +36,5 @@ if [ $GCC_MAJOR_GT_4 -eq 1 ]; then
 	
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     cd ${DIR}/../../apothecary
-    ./apothecary update poco -j${cores}
+    ./apothecary -j${cores} update poco
 fi

--- a/scripts/linux/debian/install_dependencies.sh
+++ b/scripts/linux/debian/install_dependencies.sh
@@ -87,5 +87,5 @@ if [ $GCC_MAJOR_GT_4 -eq 1 ]; then
 	
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     cd ${DIR}/../../apothecary
-    ./apothecary update poco -j${cores}
+    ./apothecary -j${cores} update poco
 fi

--- a/scripts/linux/fedora/install_dependencies.sh
+++ b/scripts/linux/fedora/install_dependencies.sh
@@ -36,5 +36,5 @@ if [ $GCC_MAJOR_GT_4 -eq 1 ]; then
 	
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     cd ${DIR}/../../apothecary
-    ./apothecary update poco -j${cores}
+    ./apothecary -j${cores} update poco
 fi

--- a/scripts/linux/ubuntu/install_dependencies.sh
+++ b/scripts/linux/ubuntu/install_dependencies.sh
@@ -115,5 +115,5 @@ if [ $GCC_MAJOR_GT_4 -eq 1 ]; then
 	
     DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
     cd ${DIR}/../../apothecary
-    ./apothecary update poco -j${cores}
+    ./apothecary -j${cores} update poco
 fi


### PR DESCRIPTION
Hi,

i fixed the error #4427 in install-dependecies.sh due to the argument order for apothecary in cdee8cb. 
Cheers,
ni-cc
