### PR TITLE
iOS header includes cleanup

### DIFF
--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -31,9 +31,8 @@
 
 #pragma once
 
-#import "ofAppBaseWindow.h"
+#include "ofAppBaseWindow.h"
 #include "ofxiOSConstants.h"
-#include "ofWindowSettings.h"
 
 class ofiOSWindowSettings: public ofGLESWindowSettings{
 public:

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -29,13 +29,12 @@
  *
  * ***********************************************************************/ 
 
-#import "ofMain.h"
-#import "ofGLProgrammableRenderer.h"
-#import "ofAppiOSWindow.h"
-#import "ofxiOSEAGLView.h"
-#import "ofxiOSAppDelegate.h"
-#import "ofxiOSViewController.h"
-#import "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
+#include "ofGLRenderer.h"
+#include "ofGLProgrammableRenderer.h"
+#include "ofxiOSAppDelegate.h"
+#include "ofxiOSViewController.h"
+#include "ofxiOSEAGLView.h"
 
 //----------------------------------------------------------------------------------- instance.
 static ofAppiOSWindow * _instance = NULL;

--- a/addons/ofxiOS/src/app/ofxiOSApp.h
+++ b/addons/ofxiOS/src/app/ofxiOSApp.h
@@ -9,11 +9,10 @@
 
 #pragma once
 
-#include "ofMain.h"
-#include "ofEvents.h"
+#include "ofBaseApp.h"
 #include "ofxiOSAlerts.h"
 
-class ofxiOSApp : public ofSimpleApp, public ofxiOSAlertsListener {
+class ofxiOSApp : public ofBaseApp, public ofxiOSAlertsListener {
 	
 public:
 	virtual void setup() {};

--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -29,11 +29,14 @@
  *
  * ***********************************************************************/
 
-#import "ofMain.h"
-#import "ofxiOSAppDelegate.h"
-#import "ofxiOSViewController.h"
-#import "ofxiOSExtras.h"
-#import "ofxiOSExternalDisplay.h"
+#include "ofxiOSAppDelegate.h"
+#include "ofxiOSViewController.h"
+#include "ofxiOSExternalDisplay.h"
+#include "ofxiOSExtras.h"
+#include "ofxiOSAlerts.h"
+#include "ofxiOSEAGLView.h"
+#include "ofAppiOSWindow.h"
+#include "ofAppRunner.h"
 
 @implementation ofxiOSAppDelegate
 

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.h
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.h
@@ -5,6 +5,8 @@
 //  Created by lukasz karluk on 5/07/12.
 //
 
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "EAGLView.h"
 

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -5,13 +5,11 @@
 //  Created by lukasz karluk on 5/07/12.
 //
 
-#import "ofxiOSEAGLView.h"
-
-#import "ofMain.h"
-#import "ofAppiOSWindow.h"
-#import "ofGLProgrammableRenderer.h"
-#import "ofxiOSApp.h"
-#import "ofxiOSExtensions.h"
+#include "ofxiOSEAGLView.h"
+#include "ofxiOSApp.h"
+#include "ofAppiOSWindow.h"
+#include "ofGLRenderer.h"
+#include "ofGLProgrammableRenderer.h"
 
 static ofxiOSEAGLView * _instanceRef = nil;
 

--- a/addons/ofxiOS/src/core/ofxiOSViewController.h
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.h
@@ -3,6 +3,8 @@
 //  Created by lukasz karluk on 12/12/11.
 //
 
+#pragma once
+
 #import <UIKit/UIKit.h>
 
 class ofxiOSApp;

--- a/addons/ofxiOS/src/core/ofxiOSViewController.mm
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.mm
@@ -5,8 +5,8 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-#import "ofxiOSViewController.h"
-#import "ofxiOSEAGLView.h"
+#include "ofxiOSViewController.h"
+#include "ofxiOSEAGLView.h"
 
 @interface ofxiOSViewController() <EAGLViewDelegate> {
     UIInterfaceOrientation currentInterfaceOrientation;

--- a/addons/ofxiOS/src/events/ofxiOSAccelerometer.mm
+++ b/addons/ofxiOS/src/events/ofxiOSAccelerometer.mm
@@ -30,9 +30,10 @@
  * ***********************************************************************/ 
 
 
-#import "ofxAccelerometer.h"
-#import "ofMain.h"
 #import <UIKit/UIKit.h>
+
+#include "ofUtils.h"
+#include "ofxAccelerometer.h"
 
 /************ Interface for iPhone Accelerometer Delegate ************/
 @interface ofxiOSAccelerometerDelegate : NSObject <UIAccelerometerDelegate> {

--- a/addons/ofxiOS/src/events/ofxiOSAlerts.h
+++ b/addons/ofxiOS/src/events/ofxiOSAlerts.h
@@ -30,8 +30,10 @@
 
 #pragma once
 
-#import "ofxiOSAlertsListener.h"
-#import <list>
+#include <list>
+#include "ofxiOSAlertsListener.h"
+
+using namespace std;
 
 class ofxiOSAlertsHandler : public ofxiOSAlertsListener {
 public:

--- a/addons/ofxiOS/src/events/ofxiOSAlertsListener.h
+++ b/addons/ofxiOS/src/events/ofxiOSAlertsListener.h
@@ -29,8 +29,10 @@
  * ***********************************************************************/ 
 
 #pragma once
-#include "ofMain.h"
 
+#include <string>
+
+using namespace std;
 
 /****** protocol, delegate, interface, whatever you want to call it ******/
 class ofxiOSAlertsListener {
@@ -41,7 +43,7 @@ public:
 	virtual void gotFocus(){};
 	virtual void gotMemoryWarning(){};
     virtual void deviceOrientationChanged(int newOrientation){};
-	virtual void launchedWithURL(string url){};
+	virtual void launchedWithURL(std::string url){};
 };
 
 #define ofxiPhoneAlertsListener ofxiOSAlertsListener

--- a/addons/ofxiOS/src/gl/EAGLView.h
+++ b/addons/ofxiOS/src/gl/EAGLView.h
@@ -29,6 +29,8 @@
  *
  * ***********************************************************************/ 
 
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import "ESRenderer.h"
 

--- a/addons/ofxiOS/src/gl/ES1Renderer.h
+++ b/addons/ofxiOS/src/gl/ES1Renderer.h
@@ -1,4 +1,5 @@
 
+#pragma once
 
 #import "ESRenderer.h"
 #import <OpenGLES/ES1/gl.h>

--- a/addons/ofxiOS/src/gl/ES2Renderer.h
+++ b/addons/ofxiOS/src/gl/ES2Renderer.h
@@ -1,4 +1,5 @@
 
+#pragma once
 
 #import "ESRenderer.h"
 #import <OpenGLES/ES2/gl.h>

--- a/addons/ofxiOS/src/gl/ESRenderer.h
+++ b/addons/ofxiOS/src/gl/ESRenderer.h
@@ -6,6 +6,8 @@
 //  Copyright MSA Visuals Ltd. 2010. All rights reserved.
 //
 
+#pragma once
+
 #import <QuartzCore/QuartzCore.h>
 
 #import <OpenGLES/EAGL.h>

--- a/addons/ofxiOS/src/ofxiOS.h
+++ b/addons/ofxiOS/src/ofxiOS.h
@@ -36,10 +36,13 @@
 
 #pragma once
 
-#import <OpenGLES/ES1/gl.h>
-#import <OpenGLES/ES1/glext.h>
-
-#import "ofxAccelerometer.h"
-#import "ofxiOSAlerts.h"
-#import "ofxiOSApp.h"
-
+#include "ofMain.h"
+#include "ofAppiOSWindow.h"
+#include "ofxiOSConstants.h"
+#include "ofxiOSExtensions.h"
+#include "ofxiOSAppDelegate.h"
+#include "ofxiOSViewController.h"
+#include "ofxiOSEAGLView.h"
+#include "ofxiOSApp.h"
+#include "ofxiOSExtras.h"
+#include "ofxAccelerometer.h"

--- a/addons/ofxiOS/src/ofxiOSExtensions.h
+++ b/addons/ofxiOS/src/ofxiOSExtensions.h
@@ -8,8 +8,6 @@
 #pragma once
 
 void ofReloadGLResources();
-
-void ofUpdateBitmapCharacterTexture();
 void ofReloadAllImageTextures();
 void ofReloadAllFontTextures();
 void ofUnloadAllFontTextures();

--- a/addons/ofxiOS/src/sound/AVSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/AVSoundPlayer.h
@@ -4,6 +4,8 @@
 //  http://julapy.com/blog
 //
 
+#pragma once
+
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 

--- a/addons/ofxiOS/src/sound/SoundInputStream.h
+++ b/addons/ofxiOS/src/sound/SoundInputStream.h
@@ -4,6 +4,8 @@
 //  http://julapy.com/blog
 //
 
+#pragma once
+
 #import "SoundStream.h"
 
 @interface SoundInputStream : SoundStream {

--- a/addons/ofxiOS/src/sound/SoundOutputStream.h
+++ b/addons/ofxiOS/src/sound/SoundOutputStream.h
@@ -4,6 +4,8 @@
 //  http://julapy.com/blog
 //
 
+#pragma once
+
 #import "SoundStream.h"
 
 @interface SoundOutputStream : SoundStream

--- a/addons/ofxiOS/src/sound/SoundStream.h
+++ b/addons/ofxiOS/src/sound/SoundStream.h
@@ -5,6 +5,8 @@
 //
 //
 
+#pragma once
+
 #import <UIKit/UIKit.h>
 #import <AudioToolbox/AudioToolbox.h>
 

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -23,6 +23,7 @@
  ************************************************************************/ 
 
 #import "ofxOpenALSoundPlayer.h"
+#include "ofUtils.h"
 
 bool SoundEngineInitialized = false;
 

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
@@ -38,10 +38,7 @@
 
 
 #include "SoundEngine.h"
-#include <CoreAudio/CoreAudioTypes.h>
 #include "ofBaseSoundPlayer.h"
-#include "ofUtils.h"
-#include "ofPoint.h"
 #include "ofTypes.h"
 
 //globals

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "ofMain.h"
+#include "ofBaseSoundPlayer.h"
 
 class ofxiOSSoundPlayer : public ofBaseSoundPlayer {
     

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
@@ -5,6 +5,7 @@
 //
 
 #include "ofxiOSSoundPlayer.h"
+#include "ofUtils.h"
 #import "AVSoundPlayer.h"
 
 ofxiOSSoundPlayer::ofxiOSSoundPlayer() {

--- a/addons/ofxiOS/src/sound/ofxiOSSoundStreamDelegate.h
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundStreamDelegate.h
@@ -4,6 +4,8 @@
 //  http://julapy.com/blog
 //
 
+#pragma once
+
 #import "SoundStream.h"
 
 class ofBaseSoundInput;

--- a/addons/ofxiOS/src/sound/ofxiOSSoundStreamDelegate.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundStreamDelegate.mm
@@ -4,9 +4,9 @@
 //  http://julapy.com/blog
 //
 
-#import "ofxiOSSoundStreamDelegate.h"
-#import "ofBaseTypes.h"
-#import "ofSoundBuffer.h"
+#include "ofxiOSSoundStreamDelegate.h"
+#include "ofBaseTypes.h"
+#include "ofSoundBuffer.h"
 
 @interface ofxiOSSoundStreamDelegate() {
 	ofBaseSoundInput * soundInputApp;

--- a/addons/ofxiOS/src/utils/ofxiOSCoreLocation.h
+++ b/addons/ofxiOS/src/utils/ofxiOSCoreLocation.h
@@ -6,10 +6,9 @@
  *
  */
 
-#import <UIKit/UIKit.h>
-#import <CoreLocation/CoreLocation.h>
-#import "ofMain.h"
 #pragma once
+
+#import <CoreLocation/CoreLocation.h>
 
 @interface ofxiOSCoreLocationDelegate : NSObject <CLLocationManagerDelegate>
 {

--- a/addons/ofxiOS/src/utils/ofxiOSCoreLocation.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSCoreLocation.mm
@@ -17,7 +17,7 @@
  *
  */
 
-#import "ofxiOSCoreLocation.h"
+#include "ofxiOSCoreLocation.h"
 
 //C++ class implementations
 

--- a/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#import "ofMain.h"
+#include "ofConstants.h"
 
 struct ofxiOSExternalDisplayMode{
     int width;

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -37,18 +37,14 @@
 #pragma once
 
 #import <UIKit/UIKit.h>
-#import "ofMain.h"
-#import "ofxiOS.h"
-#import "ofxiOSConstants.h"
-#import "ofAppiOSWindow.h"
-#import "ofxiOSAppDelegate.h"
-#import "ofxiOSEAGLView.h"
-#import "ofxiOSKeyboard.h"
-#import "ofxiOSCoreLocation.h"
-#import "ofxiOSImagePicker.h"
-#import "ofxiOSMapKit.h"
-#include <sys/sysctl.h>
 
+#include "ofBaseTypes.h"
+#include "ofxiOSConstants.h"
+
+class ofAppiOSWindow;
+@class ofxiOSAppDelegate;
+@class ofxiOSViewController;
+@class ofxiOSEAGLView;
 
 // this is the new way for getting device info.
 // we can add other parameters later.
@@ -79,22 +75,22 @@ string ofxiOSGetDeviceRevision();
 ofxiOSDeviceInfo ofxiOSGetDeviceInfo();
 
 // return application key UIWindow
-UIWindow *ofxiOSGetUIWindow();
+UIWindow * ofxiOSGetUIWindow();
 
 // return openglview
-ofxiOSEAGLView *ofxiOSGetGLView();
+ofxiOSEAGLView * ofxiOSGetGLView();
 
 // return opengl parent view
 UIView * ofxiOSGetGLParentView();
 
 // return OpenFrameworks iPhone Window
-ofAppiOSWindow* ofxiOSGetOFWindow();
+ofAppiOSWindow * ofxiOSGetOFWindow();
 
 // return application delegate
-ofxiOSAppDelegate *ofxiOSGetAppDelegate();
+ofxiOSAppDelegate * ofxiOSGetAppDelegate();
 
 // return iphone view controller.
-ofxiOSViewController *ofxiOSGetViewController();
+ofxiOSViewController * ofxiOSGetViewController();
 
 // brings the OpenGL view to the front of any other UIViews
 // the OpenGL view will receive touchXXXXX events, but other UIViews will not
@@ -145,12 +141,12 @@ OF_DEPRECATED_MSG("ofxiOSGetOrientation is deprecated, use ofGetOrientation inst
 // load an image from the app bundle into a texture
 // NOTE: renamed this function to something more clearer
 // WAS: void iPhoneLoadImageFromBundle(NSString *filename, GLuint *spriteTexture);
-bool ofxiOSBundleImageToGLTexture(NSString *filename, GLuint *spriteTexture);
+bool ofxiOSBundleImageToGLTexture(NSString * filename, GLuint * spriteTexture);
 
 // load an image from UIImage into an opengl texture
 // NOTE: renamed this function to something more clearer
 // WAS: void iPhoneLoadImageFromUIImage(UIImage *uiImage, GLuint *spriteTexture);
-bool ofxiOSUIImageToGLTexture(UIImage *uiImage, GLuint *spriteTexture);
+bool ofxiOSUIImageToGLTexture(UIImage * uiImage, GLuint * spriteTexture);
 
 
 // create an ofImage out of a UIImage
@@ -158,9 +154,9 @@ bool ofxiOSUIImageToGLTexture(UIImage *uiImage, GLuint *spriteTexture);
 // targetWidth, targetHeight are target dimensions (UIImage is resized to this size and ofImage is created)
 // .... omit targetWidth & targetHeight to use original image dimensions and not resize
 // TODO: take into consideration UI image orentation
-bool ofxiOSUIImageToOFImage(UIImage *uiImage, ofImage &outImage, int targetWidth = 0, int targetHeight = 0);
+bool ofxiOSUIImageToOFImage(UIImage * uiImage, ofImage & outImage, int targetWidth = 0, int targetHeight = 0);
 
-bool ofxiOSUIImageToOFTexture(UIImage *uiImage, ofTexture &outTexture, int targetWidth, int targetHeight);
+bool ofxiOSUIImageToOFTexture(UIImage * uiImage, ofTexture & outTexture, int targetWidth, int targetHeight);
 
 bool ofxiOSCGImageToPixels(CGImageRef & ref, unsigned char * pixels);
 

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.mm
@@ -30,7 +30,14 @@
  * ***********************************************************************/ 
 
 
-#import "ofxiOSExtras.h"
+#include "ofxiOSExtras.h"
+#include "ofxiOSAppDelegate.h"
+#include "ofxiOSViewController.h"
+#include "ofxiOSEAGLView.h"
+#include "ofAppiOSWindow.h"
+#include "ofAppRunner.h"
+#include "ofImage.h"
+#include <sys/sysctl.h>
 
 //--------------------------------------------------------------
 ofxiOSDeviceType ofxiOSGetDeviceType() {
@@ -117,13 +124,13 @@ ofxiOSDeviceInfo ofxiOSGetDeviceInfo(){
 }
 
 //--------------------------------------------------------------
-UIWindow *ofxiOSGetUIWindow() {
+UIWindow * ofxiOSGetUIWindow() {
 	return [[UIApplication sharedApplication] keyWindow];
 }
 
 
 //--------------------------------------------------------------
-ofxiOSEAGLView *ofxiOSGetGLView() {
+ofxiOSEAGLView * ofxiOSGetGLView() {
 	return [ofxiOSEAGLView getInstance];
 }
 
@@ -133,18 +140,18 @@ UIView * ofxiOSGetGLParentView() {
 }
 
 //--------------------------------------------------------------
-ofAppiOSWindow* ofxiOSGetOFWindow() {
+ofAppiOSWindow * ofxiOSGetOFWindow() {
 	return ofAppiOSWindow::getInstance();
 }
 
 
 //--------------------------------------------------------------
-ofxiOSAppDelegate *ofxiOSGetAppDelegate() {
+ofxiOSAppDelegate * ofxiOSGetAppDelegate() {
 	return [[UIApplication sharedApplication] delegate];
 }
 
 //--------------------------------------------------------------
-ofxiOSViewController *ofxiOSGetViewController() {
+ofxiOSViewController * ofxiOSGetViewController() {
 	return [ofxiOSGetAppDelegate() glViewController];
 }
 
@@ -217,18 +224,18 @@ UIDeviceOrientation ofxiOSGetOrientation() {
 
 
 //--------------------------------------------------------------
-bool ofxiOSBundleImageToGLTexture(NSString *filename, GLuint *spriteTexture) {
+bool ofxiOSBundleImageToGLTexture(NSString * filename, GLuint * spriteTexture) {
 	return ofxiOSUIImageToGLTexture([UIImage imageNamed:filename], spriteTexture);
 }
 
 
 //--------------------------------------------------------------
-bool ofxiOSUIImageToGLTexture(UIImage *uiImage, GLuint *spriteTexture) {
+bool ofxiOSUIImageToGLTexture(UIImage * uiImage, GLuint * spriteTexture) {
 	if(!uiImage) return false;
 	
 	CGImageRef cgImage;
 	CGContextRef spriteContext;
-	GLubyte *pixels;
+	GLubyte * pixels;
 	size_t	width, height;
 	
 	// Creates a Core Graphics image from an image file
@@ -264,7 +271,7 @@ bool ofxiOSUIImageToGLTexture(UIImage *uiImage, GLuint *spriteTexture) {
 
 
 //--------------------------------------------------------------
-bool ofxiOSUIImageToOFImage(UIImage *uiImage, ofImage &outImage, int targetWidth, int targetHeight) {
+bool ofxiOSUIImageToOFImage(UIImage * uiImage, ofImage & outImage, int targetWidth, int targetHeight) {
 	if(uiImage == nil) {
         return false;
     }
@@ -332,7 +339,7 @@ bool ofxiOSUIImageToOFImage(UIImage *uiImage, ofImage &outImage, int targetWidth
 }
 
 //--------------------------------------------------------------
-bool ofxiOSUIImageToOFTexture(UIImage *uiImage, ofTexture &outTexture, int targetWidth, int targetHeight) {
+bool ofxiOSUIImageToOFTexture(UIImage * uiImage, ofTexture & outTexture, int targetWidth, int targetHeight) {
 	if(!uiImage) return false;
 	
 	CGContextRef spriteContext;
@@ -345,7 +352,7 @@ bool ofxiOSUIImageToOFTexture(UIImage *uiImage, ofTexture &outTexture, int targe
 	int height			= targetHeight > 0 ? targetHeight : CGImageGetHeight(cgImage);
 	
 	// Allocated memory needed for the bitmap context
-	GLubyte *pixels		= (GLubyte *) malloc(width * height * bytesPerPixel);
+	GLubyte * pixels		= (GLubyte *) malloc(width * height * bytesPerPixel);
 	
 	// Uses the bitmap creation function provided by the Core Graphics framework. 
 	spriteContext = CGBitmapContextCreate(pixels, width, height, CGImageGetBitsPerComponent(cgImage), width * bytesPerPixel, CGImageGetColorSpace(cgImage), bytesPerPixel == 4 ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNone);
@@ -401,7 +408,7 @@ bool ofxiOSCGImageToPixels(CGImageRef & ref, unsigned char * pixels){
 	int h			= CGImageGetHeight(ref);
 	
 	// Allocated memory needed for the bitmap context
-	GLubyte *pixelsTmp	= (GLubyte *) malloc(w * h * bytesPerPixel);
+	GLubyte * pixelsTmp	= (GLubyte *) malloc(w * h * bytesPerPixel);
 	
 	// Uses the bitmap creation function provided by the Core Graphics framework. 
 	spriteContext = CGBitmapContextCreate(pixelsTmp, w, h, CGImageGetBitsPerComponent(ref), w * bytesPerPixel, CGImageGetColorSpace(ref), bytesPerPixel == 4 ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNone);

--- a/addons/ofxiOS/src/utils/ofxiOSImagePicker.h
+++ b/addons/ofxiOS/src/utils/ofxiOSImagePicker.h
@@ -6,11 +6,10 @@
  *
  */
 
+#pragma once
+
 #import <UIKit/UIKit.h>
-#import <OpenGLES/ES1/gl.h>
-#import "ofMain.h"
-#include <iostream>
-#include <Availability.h>
+#include "ofBaseTypes.h"
 
 #define OFX_IMG_PICKER_UP 1
 #define OFX_IMG_PICKER_DOWN 2

--- a/addons/ofxiOS/src/utils/ofxiOSImagePicker.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSImagePicker.mm
@@ -7,7 +7,7 @@
  *
  */
 
-#import "ofxiOSImagePicker.h"
+#include "ofxiOSImagePicker.h"
 
 //C++ class implementations
 

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -6,10 +6,10 @@
  *
  */
 
-#import <UIKit/UIKit.h>
-#import "ofMain.h"
-#import "ofxiOSExtras.h"
 #pragma once
+
+#import <UIKit/UIKit.h>
+#include "ofConstants.h"
 
 @interface ofxiOSKeyboardDelegate : NSObject <UITextFieldDelegate>
 {

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
@@ -7,7 +7,10 @@
  *
  */
 
-#import "ofxiOSKeyboard.h"
+#include "ofxiOSKeyboard.h"
+#include "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
+#include "ofAppRunner.h"
 
 //C++ class implementations
 

--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.h
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.h
@@ -30,12 +30,9 @@
 
 #pragma once
 
-#include <Availability.h>
-
-#include "ofMain.h"
-#include <MapKit/MapKit.h>
+#import <MapKit/MapKit.h>
+#include "ofBaseTypes.h"
 #include "ofxiOSMapKitListener.h"
-#include <list>
 
 // these are the types you can set for the map
 enum ofxiOSMapKitType {

--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
@@ -28,11 +28,10 @@
  *
  * ***********************************************************************/ 
 
-#include <Availability.h>
-
 #include "ofxiOSMapKit.h"
-#include "ofxiOSExtras.h"
 #include "ofxiOSMapKitDelegate.h"
+#include "ofxiOSExtras.h"
+#include "ofAppRunner.h"
 
 ofxiOSMapKit::ofxiOSMapKit() {
 	mapView = nil;

--- a/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.h
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.h
@@ -28,7 +28,7 @@
  *
  * ***********************************************************************/ 
 
-#include <Availability.h>
+#pragma once
 
 #import <MapKit/MapKit.h>
 

--- a/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.mm
@@ -28,11 +28,8 @@
  *
  * ***********************************************************************/ 
 
-#include <Availability.h>
-
-
-#import "ofxiOSMapKitDelegate.h"
-#import "ofxiOSMapKit.h"
+#include "ofxiOSMapKitDelegate.h"
+#include "ofxiOSMapKit.h"
 
 @implementation ofxiOSMapKitDelegate
 

--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
@@ -9,12 +9,10 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreVideo/CoreVideo.h>
 #import <CoreMedia/CoreMedia.h>
-#include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-
+#include "ofBaseTypes.h"
+#include "ofTexture.h"
 
 class AVFoundationVideoGrabber;
-
 
 @interface iOSVideoGrabber : UIViewController <AVCaptureVideoDataOutputSampleBufferDelegate> {
 

--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
@@ -3,13 +3,8 @@
  */
 
 #include "AVFoundationVideoGrabber.h"
-
-#import <UIKit/UIKit.h>
-#import <AVFoundation/AVFoundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 #include "ofxiOSExtras.h"
-#import <CoreVideo/CoreVideo.h>
-#import <CoreMedia/CoreMedia.h>
+#include "ofAppRunner.h"
 
 #define IS_IOS_7_OR_LATER    ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0)
 #define IS_IOS_6_OR_LATER    ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0)
@@ -247,7 +242,7 @@
 	NSArray * devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 	int i=0;
 	for (AVCaptureDevice * captureDevice in devices){
-        deviceNames.push_back(ofxNSStringToString(captureDevice.localizedName));
+        deviceNames.push_back([captureDevice.localizedName UTF8String]);
 		 ofLogNotice() << "Device: " << i << ": " << deviceNames.back();
 		i++;
     }

--- a/addons/ofxiOS/src/video/AVFoundationVideoPlayer.h
+++ b/addons/ofxiOS/src/video/AVFoundationVideoPlayer.h
@@ -5,8 +5,9 @@
 //  Created by lukasz karluk on 21/05/12.
 //
 
+#pragma once
+
 #import <UIKit/UIKit.h>
-#import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 #import <Accelerate/Accelerate.h>
 

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-class AVFoundationVideoGrabber;
+#include "ofBaseTypes.h"
 
-#include "ofVideoGrabber.h"
+class AVFoundationVideoGrabber;
 
 class ofxiOSVideoGrabber : public ofBaseVideoGrabber {
 	

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "ofPixels.h"
 #include "ofBaseTypes.h"
 #include "ofTexture.h"
-
-#include "ofVideoPlayer.h"
 
 class ofxiOSVideoPlayer : public ofBaseVideoPlayer {
 	

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -1,5 +1,6 @@
-#import "ofxiOSVideoPlayer.h"
-#import "ofxiOSExtras.h"
+#include "ofxiOSVideoPlayer.h"
+#include "ofxiOSExtras.h"
+#include "ofxiOSEAGLView.h"
 #import "AVFoundationVideoPlayer.h"
 
 CVOpenGLESTextureCacheRef _videoTextureCache = NULL;

--- a/examples/ios/CoreLocationExample/src/main.mm
+++ b/examples/ios/CoreLocationExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/CoreLocationExample/src/ofApp.h
+++ b/examples/ios/CoreLocationExample/src/ofApp.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
+#include "ofxiOSCoreLocation.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/ImagePickerExample/src/main.mm
+++ b/examples/ios/ImagePickerExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/ImagePickerExample/src/ofApp.h
+++ b/examples/ios/ImagePickerExample/src/ofApp.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
+#include "ofxiOSImagePicker.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/KeyboardExample/src/main.mm
+++ b/examples/ios/KeyboardExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/KeyboardExample/src/ofApp.h
+++ b/examples/ios/KeyboardExample/src/ofApp.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
+#include "ofxiOSKeyboard.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/MapKitExample/src/main.mm
+++ b/examples/ios/MapKitExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/MapKitExample/src/ofApp.h
+++ b/examples/ios/MapKitExample/src/ofApp.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ofMain.h"
-#include "ofxiOSExtras.h"
+#include "ofxiOS.h"
+#include "ofxiOSMapKit.h"
 
 class ofApp : public ofxiOSApp, ofxiOSMapKitListener{
 	

--- a/examples/ios/PrimitivesExample/src/main.mm
+++ b/examples/ios/PrimitivesExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/PrimitivesExample/src/ofApp.h
+++ b/examples/ios/PrimitivesExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/TouchAndAccelExample/src/main.mm
+++ b/examples/ios/TouchAndAccelExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/TouchAndAccelExample/src/ofApp.h
+++ b/examples/ios/TouchAndAccelExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #include "Ball.h"
 
 class ofApp : public ofxiOSApp{

--- a/examples/ios/advancedEventsExample/src/eventsObject.h
+++ b/examples/ios/advancedEventsExample/src/eventsObject.h
@@ -1,4 +1,5 @@
-#include "ofMain.h"
+#pragma once
+
 #include "ofEvents.h"
 
 class eventsObject{

--- a/examples/ios/advancedEventsExample/src/main.mm
+++ b/examples/ios/advancedEventsExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/advancedEventsExample/src/ofApp.h
+++ b/examples/ios/advancedEventsExample/src/ofApp.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-
 #include "eventsObject.h"
 
 class ofApp : public ofxiOSApp{

--- a/examples/ios/advancedGraphics/src/main.mm
+++ b/examples/ios/advancedGraphics/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/advancedGraphics/src/ofApp.h
+++ b/examples/ios/advancedGraphics/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
     

--- a/examples/ios/assimpExample/src/main.mm
+++ b/examples/ios/assimpExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/assimpExample/src/ofApp.h
+++ b/examples/ios/assimpExample/src/ofApp.h
@@ -1,12 +1,7 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-#include "ofMain.h"
-
 #include "ofxAssimpModelLoader.h"
-#include "ofVboMesh.h"
 
 class ofApp : public ofxiOSApp{
 

--- a/examples/ios/audioInputExample/src/main.mm
+++ b/examples/ios/audioInputExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/audioInputExample/src/ofApp.h
+++ b/examples/ios/audioInputExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/audioInputExample/src/ofApp.mm
+++ b/examples/ios/audioInputExample/src/ofApp.mm
@@ -1,6 +1,4 @@
 
-#import <AVFoundation/AVFoundation.h>
-
 #include "ofApp.h"
 
 //  IMPORTANT!!! if your sound doesn't work in the simulator

--- a/examples/ios/audioOutputExample/src/main.mm
+++ b/examples/ios/audioOutputExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/audioOutputExample/src/ofApp.h
+++ b/examples/ios/audioOutputExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/dirListExample/src/main.mm
+++ b/examples/ios/dirListExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/dirListExample/src/ofApp.h
+++ b/examples/ios/dirListExample/src/ofApp.h
@@ -1,9 +1,6 @@
-#ifndef _TEST_APP
-#define _TEST_APP
+#pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp {
 
@@ -34,6 +31,3 @@ class ofApp : public ofxiOSApp {
         int currentImage;
 
 };
-
-#endif
-

--- a/examples/ios/emptyExample/src/main.mm
+++ b/examples/ios/emptyExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/emptyExample/src/ofApp.h
+++ b/examples/ios/emptyExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/eventsExample/src/main.mm
+++ b/examples/ios/eventsExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/eventsExample/src/ofApp.h
+++ b/examples/ios/eventsExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/fontShapesExample/src/main.mm
+++ b/examples/ios/fontShapesExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/fontShapesExample/src/ofApp.h
+++ b/examples/ios/fontShapesExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/fontsExample/src/main.mm
+++ b/examples/ios/fontsExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/fontsExample/src/ofApp.h
+++ b/examples/ios/fontsExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/graphicsExample/src/main.mm
+++ b/examples/ios/graphicsExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/graphicsExample/src/ofApp.h
+++ b/examples/ios/graphicsExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/iPhoneGuiExample/src/main.mm
+++ b/examples/ios/iPhoneGuiExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/iPhoneGuiExample/src/ofApp.h
+++ b/examples/ios/iPhoneGuiExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 //  Note:
 //      If the app is not compiling, try removing the MyGuiView.xib reference

--- a/examples/ios/imageLoaderExample/src/main.mm
+++ b/examples/ios/imageLoaderExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/imageLoaderExample/src/ofApp.h
+++ b/examples/ios/imageLoaderExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/iosCustomSizeExample/src/main.mm
+++ b/examples/ios/iosCustomSizeExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main(){

--- a/examples/ios/iosCustomSizeExample/src/ofApp.h
+++ b/examples/ios/iosCustomSizeExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/iosES2ShaderExample/src/main.mm
+++ b/examples/ios/iosES2ShaderExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/iosES2ShaderExample/src/ofApp.h
+++ b/examples/ios/iosES2ShaderExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/iosExternalDisplayExample/src/main.mm
+++ b/examples/ios/iosExternalDisplayExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/iosExternalDisplayExample/src/ofApp.h
+++ b/examples/ios/iosExternalDisplayExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #include "ofxiOSExternalDisplay.h"
 
 class ofApp : public ofxiOSApp, public ofxiOSExternalDisplay {

--- a/examples/ios/iosNativeARCExample/src/Apps/CircleApp.h
+++ b/examples/ios/iosNativeARCExample/src/Apps/CircleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class CircleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeARCExample/src/Apps/ImageApp.h
+++ b/examples/ios/iosNativeARCExample/src/Apps/ImageApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ImageApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeARCExample/src/Apps/SquareApp.h
+++ b/examples/ios/iosNativeARCExample/src/Apps/SquareApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class SquareApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeARCExample/src/Apps/TriangleApp.h
+++ b/examples/ios/iosNativeARCExample/src/Apps/TriangleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class TriangleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeExample/src/AppViewControllers/CircleAppViewController.mm
+++ b/examples/ios/iosNativeExample/src/AppViewControllers/CircleAppViewController.mm
@@ -4,7 +4,8 @@
 //
 
 #import "CircleAppViewController.h"
-#import "ofxiOSExtras.h"
+#include "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
 
 @implementation CircleAppViewController
 

--- a/examples/ios/iosNativeExample/src/AppViewControllers/ImageAppViewController.mm
+++ b/examples/ios/iosNativeExample/src/AppViewControllers/ImageAppViewController.mm
@@ -4,7 +4,8 @@
 //
 
 #import "ImageAppViewController.h"
-#import "ofxiOSExtras.h"
+#include "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
 
 @implementation ImageAppViewController
 

--- a/examples/ios/iosNativeExample/src/AppViewControllers/SquareAppViewController.mm
+++ b/examples/ios/iosNativeExample/src/AppViewControllers/SquareAppViewController.mm
@@ -4,7 +4,8 @@
 //
 
 #import "SquareAppViewController.h"
-#import "ofxiOSExtras.h"
+#include "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
 
 @implementation SquareAppViewController
 

--- a/examples/ios/iosNativeExample/src/AppViewControllers/TriangleAppViewController.mm
+++ b/examples/ios/iosNativeExample/src/AppViewControllers/TriangleAppViewController.mm
@@ -4,7 +4,8 @@
 //
 
 #import "TriangleAppViewController.h"
-#import "ofxiOSExtras.h"
+#include "ofxiOSExtras.h"
+#include "ofAppiOSWindow.h"
 
 @implementation TriangleAppViewController
 

--- a/examples/ios/iosNativeExample/src/Apps/CircleApp.h
+++ b/examples/ios/iosNativeExample/src/Apps/CircleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class CircleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeExample/src/Apps/ImageApp.h
+++ b/examples/ios/iosNativeExample/src/Apps/ImageApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ImageApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeExample/src/Apps/SquareApp.h
+++ b/examples/ios/iosNativeExample/src/Apps/SquareApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class SquareApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeExample/src/Apps/TriangleApp.h
+++ b/examples/ios/iosNativeExample/src/Apps/TriangleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class TriangleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosNativeExample/src/main.mm
+++ b/examples/ios/iosNativeExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "SquareApp.h"
 
 int main(){

--- a/examples/ios/iosNativeExample/src/ofApp.h
+++ b/examples/ios/iosNativeExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/iosOrientationExample/src/main.mm
+++ b/examples/ios/iosOrientationExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/iosOrientationExample/src/ofApp.h
+++ b/examples/ios/iosOrientationExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
     

--- a/examples/ios/iosStoryboardExample/src/Apps/CircleApp.h
+++ b/examples/ios/iosStoryboardExample/src/Apps/CircleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class CircleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosStoryboardExample/src/Apps/ImageApp.h
+++ b/examples/ios/iosStoryboardExample/src/Apps/ImageApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ImageApp : public ofxiOSApp {
 	

--- a/examples/ios/iosStoryboardExample/src/Apps/SquareApp.h
+++ b/examples/ios/iosStoryboardExample/src/Apps/SquareApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class SquareApp : public ofxiOSApp {
 	

--- a/examples/ios/iosStoryboardExample/src/Apps/TriangleApp.h
+++ b/examples/ios/iosStoryboardExample/src/Apps/TriangleApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class TriangleApp : public ofxiOSApp {
 	

--- a/examples/ios/iosStoryboardExample/src/main.mm
+++ b/examples/ios/iosStoryboardExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "SquareApp.h"
 
 int main(){

--- a/examples/ios/iosStoryboardExample/src/ofApp.h
+++ b/examples/ios/iosStoryboardExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/moviePlayerExample/src/main.mm
+++ b/examples/ios/moviePlayerExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/moviePlayerExample/src/ofApp.h
+++ b/examples/ios/moviePlayerExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/ofxGuiExample/src/main.mm
+++ b/examples/ios/ofxGuiExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/ofxGuiExample/src/ofApp.h
+++ b/examples/ios/ofxGuiExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #include "ofxGui.h"
 
 class ofApp : public ofxiOSApp{

--- a/examples/ios/opencvExample/src/main.mm
+++ b/examples/ios/opencvExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/opencvExample/src/ofApp.h
+++ b/examples/ios/opencvExample/src/ofApp.h
@@ -1,12 +1,7 @@
 #pragma once
 
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-
-
-//ON IPHONE NOTE INCLUDE THIS BEFORE ANYTHING ELSE
 #include "ofxOpenCv.h"
 
 //warning video player doesn't currently work - use live video only

--- a/examples/ios/opencvFaceExample/src/main.mm
+++ b/examples/ios/opencvFaceExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/opencvFaceExample/src/ofApp.h
+++ b/examples/ios/opencvFaceExample/src/ofApp.h
@@ -1,13 +1,8 @@
 #pragma once
 
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-
-//ON IPHONE NOTE INCLUDE THIS BEFORE ANYTHING ELSE
 #include "ofxOpenCv.h"
-
 
 //UNCOMMENT TO USE CAMERA. CAMERA ONLY WORKS ON DEVICE NOT SIMULATOR
 //#define USE_CAMERA

--- a/examples/ios/oscReceiverExample/src/main.mm
+++ b/examples/ios/oscReceiverExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/oscReceiverExample/src/ofApp.h
+++ b/examples/ios/oscReceiverExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #include "ofxOsc.h"
 
 // listen on port 12345

--- a/examples/ios/oscSenderExample/src/main.mm
+++ b/examples/ios/oscSenderExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/oscSenderExample/src/ofApp.h
+++ b/examples/ios/oscSenderExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #include "ofxOsc.h"
 
 #define HOST "localhost"

--- a/examples/ios/polygonExample/src/main.mm
+++ b/examples/ios/polygonExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/polygonExample/src/ofApp.h
+++ b/examples/ios/polygonExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 typedef struct{
 

--- a/examples/ios/soundPlayerExample/src/main.mm
+++ b/examples/ios/soundPlayerExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/soundPlayerExample/src/ofApp.h
+++ b/examples/ios/soundPlayerExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 #import "AVSoundPlayer.h"
 
 class ofApp : public ofxiOSApp{

--- a/examples/ios/textureExample/src/main.mm
+++ b/examples/ios/textureExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/textureExample/src/ofApp.h
+++ b/examples/ios/textureExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/vboExample/src/main.mm
+++ b/examples/ios/vboExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/vboExample/src/ofApp.h
+++ b/examples/ios/vboExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 #define GRID_WIDTH  16
 #define GRID_HEIGHT 16

--- a/examples/ios/videoGrabberExample/src/main.mm
+++ b/examples/ios/videoGrabberExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/videoGrabberExample/src/ofApp.h
+++ b/examples/ios/videoGrabberExample/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp{
 	

--- a/examples/ios/xmlSettingsExample/src/main.mm
+++ b/examples/ios/xmlSettingsExample/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/examples/ios/xmlSettingsExample/src/ofApp.h
+++ b/examples/ios/xmlSettingsExample/src/ofApp.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
-#include "ofMain.h"
-
 #include "ofxXmlSettings.h"
 
 #define NUM_PTS 800

--- a/scripts/templates/ios/src/main.mm
+++ b/scripts/templates/ios/src/main.mm
@@ -1,5 +1,3 @@
-#include "ofMain.h"
-#include "ofAppiOSWindow.h"
 #include "ofApp.h"
 
 int main() {

--- a/scripts/templates/ios/src/ofApp.h
+++ b/scripts/templates/ios/src/ofApp.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include "ofMain.h"
 #include "ofxiOS.h"
-#include "ofxiOSExtras.h"
 
 class ofApp : public ofxiOSApp {
 	


### PR DESCRIPTION
ofxiOS has been plagued by messy and inconsistent header includes,
and creating a spider web of cross-referencing classes.
its been bugging me for ages!

this PR addresses this issue,
making sure that each ofxiOS class (and examples) only include classes that they need.

previously it was common to see `ofMain.h` being included everywhere,
now more specific core classes like `ofConstants.h` or `ofBaseTypes.h` are included when needed.

also added missing `pragma once` statements, for consistency.

have gone through and tested with all ios examples and all looking good...