### PR TITLE
Fix assimp anim load

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
@@ -11,7 +11,7 @@
 #include <assimp/postprocess.h>
 #include "ofxAssimpTexture.h"
 
-class aiMesh;
+struct aiMesh;
 
 class ofxAssimpMeshHelper {
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -280,6 +280,12 @@ void ofxAssimpModelLoader::loadGLResources(){
         meshHelper.validCache = true;
         meshHelper.hasChanged = false;
 
+		int numOfAnimations = scene->mNumAnimations;
+		for (int i = 0; i<numOfAnimations; i++) {
+			aiAnimation * animation = scene->mAnimations[i];
+			animations.push_back(ofxAssimpAnimation(scene, animation));
+		}
+
         if(hasAnimations()){
 			meshHelper.animatedPos.resize(mesh->mNumVertices);
 			if(mesh->HasNormals()){
@@ -328,11 +334,7 @@ void ofxAssimpModelLoader::loadGLResources(){
         //modelMeshes.push_back(meshHelper);
     }
     
-    int numOfAnimations = scene->mNumAnimations;
-    for(int i=0; i<numOfAnimations; i++) {
-        aiAnimation * animation = scene->mAnimations[i];
-        animations.push_back(ofxAssimpAnimation(scene, animation));
-    }
+
 
     ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): finished";
 }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -26,8 +26,11 @@ bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
     ofLogVerbose("ofxAssimpModelLoader") << "loadModel(): loading \"" << file.getFileName()
 		<< "\" from \"" << file.getEnclosingDirectory() << "\"";
     
-    if(scene != NULL){
+    if(scene.get() != nullptr){
         clear();
+		// we reset the shared_ptr explicitly here, to force the old 
+		// aiScene to be deleted **before** a new aiScene is created.
+		scene.reset();
     }
     
     // sets various properties & flags to a default preference
@@ -45,8 +48,11 @@ bool ofxAssimpModelLoader::loadModel(ofBuffer & buffer, bool optimize, const cha
     
     ofLogVerbose("ofxAssimpModelLoader") << "loadModel(): loading from memory buffer \"." << extension << "\"";
     
-    if(scene != NULL){
+    if(scene.get() != nullptr){
         clear();
+		// we reset the shared_ptr explicitly here, to force the old 
+		// aiScene to be deleted **before** a new aiScene is created.
+		scene.reset();
     }
     
     // sets various properties & flags to a default preference

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -19,8 +19,8 @@
 #include "ofxAssimpAnimation.h"
 #include "ofxAssimpTexture.h"
 
-class aiScene;
-class aiNode;
+struct aiScene;
+struct aiNode;
 
 class ofxAssimpModelLoader{
 


### PR DESCRIPTION
Addresses a few minor issues with the assimp loader. 

* Mainly fixes an crashing issue with animations not being counted properly
* Brings forward declarations in line with assimp library objects
* More explicit deletion of scene object, to secure assimp has freed the old scene when new scene is loaded.

More details in individual commits. 

Closes #4337 