### PR TITLE
Fix for iOS OpenCV missing AssetsFramework

### DIFF
--- a/addons/ofxOpenCv/addon_config.mk
+++ b/addons/ofxOpenCv/addon_config.mk
@@ -128,3 +128,7 @@ android/armeabi-v7a:
 	ADDON_LIBS += libs/opencv/lib/android/armeabi-v7a/libopencv_core.a 
 	ADDON_LIBS += libs/opencv/lib/android/armeabi-v7a/libopencv_flann.a
 	ADDON_LIBS += libs/opencv/lib/android/armeabi-v7a/libopencv_contrib.a
+
+ios:
+	# osx/iOS only, any framework that should be included in the project
+	ADDON_FRAMEWORKS = AssetsFramework


### PR DESCRIPTION
Fix for AssetsFramework work not being built into the project generator builds for iOS OpenCV examples

