### PR TITLE
iOS - Fix for AirPlay Mirroring BlackScreen by Default - Post App Launch

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -230,7 +230,6 @@
  */
 
 - (void)handleScreenConnectNotification:(NSNotification*)aNotification {
-    [self createExternalWindowWithPreferredMode]; // create external window as soon as external screen is connected to prevent unwanted mirroring.
     ofxiOSExternalDisplay::alertExternalDisplayConnected(); // alert any OF apps listening for a new external device.
 }
 
@@ -240,7 +239,7 @@
 }
 
 - (void)handleScreenModeDidChangeNotification:(NSNotification*)aNotification {
-    //
+	ofxiOSExternalDisplay::alertExternalDisplayChanged();
 }
 
 //-------------------------------------------------------------------------------------------

--- a/examples/ios/iosExternalDisplayExample/src/ofApp.mm
+++ b/examples/ios/iosExternalDisplayExample/src/ofApp.mm
@@ -285,6 +285,7 @@ void ofApp::deviceOrientationChanged(int newOrientation){
 
 //--------------------------------------------------------------
 void ofApp::externalDisplayConnected(){
+    [ofxiOSGetAppDelegate() createExternalWindowWithPreferredMode]; // create external window as soon as external screen is connected to prevent unwanted mirroring.
     ofLogVerbose("external display connected.");
     presentExternalDisplayPopup();
 }


### PR DESCRIPTION
When using AirPlay with Mirroring on, All apps and views of the iOS device are mirrored on the external display.

Default action for an iOS Application after Mirroring is trigged is to display as normal, just also on the external screen. This still occurs with an oF iOS Application if the device starts AirPlay Mirroring and then proceeded to open an oF iOS App.

### Issue:
- If the user starts an iOS oF app first and then proceeds to turn on AirPlay mirror while the iOS oF application is active, the screen shows a black screen hiding the main view of the App.
This is defined by default the ofxiOSAppDelegate, which creates a Black screen to hide the iOS oF Application display in the case the user wants to hide the view (not default behaviour by iOS).

Lets lose that hide screen by default, and if someone wants to handle that case, they can do it in the alertExternalDisplayConnected event , as now set in the iOSExternalDisplayExample.

@julapy @openframeworks/ios 