### PR TITLE
Bugfix glfw fullscreen multi - fix for setting monitor and fullscreen in glfw settings on OSX

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -207,6 +207,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 					settings.width = mode->width;
 					settings.height = mode->height;
 					setWindowShape(settings.width, settings.height);
+					setWindowPosition(settings.getPosition().x,settings.getPosition().y);
 				}
 			}else{
 				setWindowPosition(settings.getPosition().x,settings.getPosition().y);

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -206,6 +206,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 					auto mode = glfwGetVideoMode(monitors[settings.monitor]);
 					settings.width = mode->width;
 					settings.height = mode->height;
+					//for OS X we need to set this first as the window size affects the window positon
 					setWindowShape(settings.width, settings.height);
 					setWindowPosition(settings.getPosition().x,settings.getPosition().y);
 				}


### PR DESCRIPTION
`settings.monitor = 1;
settings.windowMode = OF_FULLSCREEN;`
will now work on OSX, as long as the position is not set in the settings.
Must set the window shape and then the position, as previously commented here
https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/app/ofAppGLFWWindow.cpp#L707