### PR TITLE
fix area lights for programmable renderer

### DIFF
--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -308,13 +308,9 @@ static const string fragmentShader = R"(
 
 		ambient += light.ambient.rgb * attenuation;
 		diffuse += light.diffuse.rgb * nDotVP * attenuation;
-)"
 #ifndef TARGET_OPENGLES
-	R"(
 #define SPECULAR_REFLECTION
-	)"
 #endif
-R"(
 #ifndef SPECULAR_REFLECTION
 		// ha! no branching :)
 		pf = mix(0.0, pow(nDotHV, mat_shininess), step(0.0000001, nDotVP));

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -197,9 +197,7 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 	}
 }
 
-#define STRINGIFY(x) #x
-
-static const string vertexShader = STRINGIFY(
+static const string vertexShader = R"(
 	OUT vec2 outtexcoord; // pass the texCoord if needed
 	OUT vec3 transformedNormal;
 	OUT vec3 eyePosition3;
@@ -226,10 +224,10 @@ static const string vertexShader = STRINGIFY(
 		outtexcoord = (textureMatrix*vec4(texcoord.x,texcoord.y,0,1)).xy;
 		gl_Position = modelViewProjectionMatrix * position;
 	}
-);
+)";
 
 
-static const string fragmentShader = STRINGIFY(
+static const string fragmentShader = R"(
 	IN vec2 outtexcoord; // pass the texCoord if needed
 	IN vec3 transformedNormal;
 	// Eye-coordinate position of vertex
@@ -310,9 +308,13 @@ static const string fragmentShader = STRINGIFY(
 
 		ambient += light.ambient.rgb * attenuation;
 		diffuse += light.diffuse.rgb * nDotVP * attenuation;
+)"
 #ifndef TARGET_OPENGLES
+	R"(
 #define SPECULAR_REFLECTION
+	)"
 #endif
+R"(
 #ifndef SPECULAR_REFLECTION
 		// ha! no branching :)
 		pf = mix(0.0, pow(nDotHV, mat_shininess), step(0.0000001, nDotVP));
@@ -459,15 +461,15 @@ static const string fragmentShader = STRINGIFY(
 
 		////////////////////////////////////////////////////////////
 		// now add the material info
-		\n#ifdef HAS_TEXTURE\n
+		#ifdef HAS_TEXTURE
 			vec4 tex = TEXTURE(tex0, outtexcoord);
 			vec4 localColor = vec4(ambient,1.0) * mat_ambient + vec4(diffuse,1.0) * tex + vec4(specular,1.0) * mat_specular + mat_emissive;
-		\n#else\n
+		#else
 			vec4 localColor = vec4(ambient,1.0) * mat_ambient + vec4(diffuse,1.0) * mat_diffuse + vec4(specular,1.0) * mat_specular + mat_emissive;
-		\n#endif\n
+		#endif
 		FRAG_COLOR = clamp( localColor, 0.0, 1.0 );
 	}
-);
+)";
 
 
 static string shaderHeader(string header, int maxLights, bool hasTexture){


### PR DESCRIPTION
Because the old implementation of `ofMaterial.cpp` mixed the `STRINGIFY`preprocessor macro with GLSL preprocessor directives, the behaviour of the c preprocessor for this file was undefined.

This lead to strange GLSL code in VS2015 builds, and `ofMaterial` may have been considered broken on this platform(s).

To close #4495, this PR suggests & implements the following:

* Using **Raw String Literals** for inline GLSL code instead of `STRINGIFY`. This allows us to
  concat different cpp constants based on the cpp build environment. Raw String Literals are a C++11 feature. See: http://en.cppreference.com/w/cpp/language/string_literal

* Anything within Raw String Literals is not interpreted by the preprocessor, also escapes are not scanned. It is literally a literal.

Tested on XCode 7.1 / clang 7.0.0 and VS2015; Raw string literals are advertised as supported by GCC from 4.5 onwards. https://gcc.gnu.org/projects/cxx0x.html