### PR TITLE
Android: use fixed data zip file name

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -218,12 +218,9 @@ public class OFAndroid {
 	    		}
 	    		
 	    		
-	    		String app_name="";
 				try {
 					int app_name_id = Class.forName(packageName+".R$string").getField("app_name").getInt(null);
-					app_name = ofActivity.getResources().getText(app_name_id).toString().toLowerCase(Locale.US);
-					Log.i("OF","app name: " + app_name);
-					
+
 					if(copydata){
 						StatFs stat = new StatFs(dataPath);
 						double sdAvailSize = (double)stat.getAvailableBlocks()
@@ -238,8 +235,7 @@ public class OFAndroid {
 		    					fileId = files[i].getInt(null);
 		    					String resName = ofActivity.getResources().getText(fileId).toString();
 		    					fileName = resName.substring(resName.lastIndexOf("/"));
-		    					Log.i("OF","checking " + fileName);
-		    					if(fileName.equals("/" + app_name + "resources.zip")){
+		    					if(fileName.equals("/ofdataresources.zip")){
 		    						
 			    					from = ofActivity.getResources().openRawResource(fileId);
 									try{

--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -108,7 +108,7 @@ endif
 TOOLCHAIN_PATH=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/
 
 DATA_FILES = $(shell find bin/data -type f 2>/dev/null)
-RESNAME=$(shell echo $(APPNAME)Resources | tr '[A-Z]' '[a-z]')
+RESNAME=ofdataresources
 RESFILE=$(RESNAME).zip
 
 ifeq ($(ABI),armv7)


### PR DESCRIPTION
I had an issue having an android app with a app name including a space. The bin/data folder got saved into a .zip file using the name of the folder the app is in. When unzipped, it used the app name (so the label of the app), these where not the same in my case since i wanted a space in my app name. 

This PR is making a fixed name (`ofdataresources`) instead for the data zip folder. I cant think of issues having a fixed name instead of a dynamic names based on app name. 