### PR TITLE
OFAndroid - try to load x86 lib before arm to resolve houdini crashes

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -1019,29 +1019,33 @@ public class OFAndroid {
     public static native boolean hasNeon();
 	 
     static {
-    	try{
-    	    String arch = System.getProperty("os.arch");
-    	    if(arch.contains("arm")){
-        		Log.i("OF","static init");
-        		System.loadLibrary("neondetection"); 
-	        	if(hasNeon()){
-	        		Log.i("OF","loading neon optimized library");
-	        		System.loadLibrary("OFAndroidApp_neon");
-	        	}else{
-	        		Log.i("OF","loading not-neon optimized library");
-	        		System.loadLibrary("OFAndroidApp");
-	        	}
-	        }else{
-	        	System.loadLibrary("OFAndroidApp");
-	        }
-    	}catch(Throwable e){
-    		Log.i("OF","failed neon detection, loading not-neon library",e);
-    		System.loadLibrary("OFAndroidApp");
-    	}
-    	Log.i("OF","initializing app");
+        
+        Log.i("OF","static init");
+        
+        try {
+            Log.i("OF","loading x86 library");
+            System.loadLibrary("OFAndroidApp_x86");
+        }
+        catch(Throwable ex)	{
+            Log.i("OF","failed x86 loading, trying neon detection",e);
+            
+            try{
+                System.loadLibrary("neondetection");
+                if(hasNeon()){
+                    Log.i("OF","loading neon optimized library");
+                    System.loadLibrary("OFAndroidApp_neon");
+                }
+                else{
+                    Log.i("OF","loading not-neon optimized library");
+                    System.loadLibrary("OFAndroidApp");
+                }
+            }catch(Throwable e){
+                Log.i("OF","failed neon detection, loading not-neon library",e);
+                System.loadLibrary("OFAndroidApp");
+            }
+        }
+        Log.i("OF","initializing app");
     }
-
-
 
 	public static SurfaceView getGLContentView() {
         return mGLView;

--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -131,8 +131,8 @@ endif
 
 ifeq ($(ABI),x86)
 	ABI_PATH = x86
-	PLATFORM_PROJECT_RELEASE_TARGET = libs/$(ABI_PATH)/libOFAndroidApp.so
-	PLATFORM_PROJECT_DEBUG_TARGET = libs/$(ABI_PATH)/libOFAndroidApp.so
+    PLATFORM_PROJECT_RELEASE_TARGET = libs/$(ABI_PATH)/libOFAndroidApp_x86.so
+    PLATFORM_PROJECT_DEBUG_TARGET = libs/$(ABI_PATH)/libOFAndroidApp_x86.so
 endif
 
 PLATFORM_CORELIB_RELEASE_TARGET = $(OF_CORE_LIB_PATH)/$(ABI)/libopenFrameworks.a


### PR DESCRIPTION
1. Build x86 native lib to libOFAndroidApp_x86.so (instead of libOFAndroidApp.so)
2. try to load x86, and if failed, load the arm. This resolves crashes on arm emulated asus devices that report arm instead of x86.

See discussion here: http://forum.openframeworks.cc/t/ofandroid-doesnt-work-on-x86-devices/21164/25
