### PR TITLE
Android camera refactor

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -41,7 +41,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
         }
 	}
 
-    public int getNumCameras() {
+    public int getNumCameras(){
         return Camera.getNumberOfCameras();
     }
 
@@ -215,10 +215,14 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
         return cameraOrientation;
     }
 
-    public boolean getIsCameraFacingFront(){
-        return cameraFacing == Camera.CameraInfo.CAMERA_FACING_FRONT;
+    public int getFacingOfCamera(int _deviceID){
+        if(_deviceID == -1) _deviceID = deviceID;
+
+        Camera.CameraInfo info = new Camera.CameraInfo();
+        Camera.getCameraInfo(_deviceID, info);
+        return info.facing;
     }
-	
+
 	public boolean setAutoFocus(boolean autofocus){
 		
 		if(initialized){

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -35,74 +35,74 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		}
 
 		try {
-            // Create surface texture instance
+			// Create surface texture instance
 			surfaceTexture = new SurfaceTexture(texID);
 
 			// set texture as preview surface for camera
-            camera.setPreviewTexture(surfaceTexture);
-        } catch (Exception e1) {
-            Log.e("OF","Error initializing gl surface",e1);
-        }
+			camera.setPreviewTexture(surfaceTexture);
+		} catch (Exception e1) {
+			Log.e("OF","Error initializing gl surface",e1);
+		}
 	}
 
-    public int getNumCameras(){
+	public int getNumCameras(){
 		if (Build.VERSION.SDK_INT < 9) {
 			return 1;
 		}
 
 		return Camera.getNumberOfCameras();
-    }
+	}
 
-    public int getCameraFacing(int facing){
+	public int getCameraFacing(int facing){
 		if (Build.VERSION.SDK_INT < 9) {
 			return 0;
 		}
 
 		int numCameras = Camera.getNumberOfCameras();
-        Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
-        for(int i=0;i<numCameras;i++){
-            Camera.getCameraInfo(i, cameraInfo);
-            int _facing = cameraInfo.facing;
-            if(_facing == facing){
-                return i;
-            }
-        }
-        return -1;
-    }
+		Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
+		for(int i=0;i<numCameras;i++){
+			Camera.getCameraInfo(i, cameraInfo);
+			int _facing = cameraInfo.facing;
+			if(_facing == facing){
+				return i;
+			}
+		}
+		return -1;
+	}
 
-    public void setDeviceID(int _deviceId){
-        deviceID = _deviceId;
+	public void setDeviceID(int _deviceId){
+		deviceID = _deviceId;
 
-        if(initialized){
-            stopGrabber();
+		if(initialized){
+			stopGrabber();
 
-            initGrabber(width, height, targetFps, texID);
-        }
-    }
+			initGrabber(width, height, targetFps, texID);
+		}
+	}
 
 	public void initGrabber(int w, int h, int _targetFps, int _texID){
-        if(camera != null){
-            camera.release();
-        }
+		if(camera != null){
+			camera.release();
+		}
 
 		if(deviceID==-1)
-            deviceID = getCameraFacing(0);
+			deviceID = getCameraFacing(0);
 
-        try {
+		try {
 			if (Build.VERSION.SDK_INT >= 9) {
 				camera = Camera.open(deviceID);
 			} else {
 				camera = Camera.open();
 			}
 		} catch (Exception e) {
-            Log.e("OF","Error trying to open specific camera, trying default",e);
-            camera = Camera.open();
-        }
+			Log.e("OF","Error trying to open specific camera, trying default",e);
+			camera = Camera.open();
+		}
 
-        if(_texID != -1) {
-            texID = _texID;
-            setTexture(texID);
-        }
+		if(_texID != -1) {
+			texID = _texID;
+			setTexture(texID);
+		}
 
 		Camera.Parameters config = camera.getParameters();
 		
@@ -126,12 +126,12 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		config.setPictureSize(w, h);
 		config.setPreviewSize(w, h);
 		config.setPreviewFormat(ImageFormat.NV21);
-        try{
+		try{
 			Method setRecordingHint = config.getClass().getMethod("setRecordingHint",boolean.class);
 			setRecordingHint.invoke(config, true);
-        }catch(Exception e){
-        	Log.i("OF","couldn't set recording hint");
-        }
+		}catch(Exception e){
+			Log.i("OF","couldn't set recording hint");
+		}
 		try{
 			camera.setParameters(config);
 		}catch(Exception e){
@@ -143,37 +143,37 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		height = config.getPreviewSize().height;
 		if(width!=w || height!=h)  Log.w("OF","camera size different than asked for, resizing (this can slow the app)");
 		
-        targetFps = _targetFps;
+		targetFps = _targetFps;
 
-        // If target fps is not defined, then take the maximum fps
-        if(targetFps == -1) {
-            for(Integer i : config.getSupportedPreviewFrameRates()){
-                if(targetFps < i) {
-                    targetFps = i;
-                }
-            }
-        }
+		// If target fps is not defined, then take the maximum fps
+		if(targetFps == -1) {
+			for(Integer i : config.getSupportedPreviewFrameRates()){
+				if(targetFps < i) {
+					targetFps = i;
+				}
+			}
+		}
 
-        Log.i("OF", "Grabber fps: " + targetFps);
-        config = camera.getParameters();
-        config.setPreviewFrameRate(targetFps);
-        try{
-            camera.setParameters(config);
-        } catch(Exception e){
-            Log.e("OF","couldn init camera", e);
-        }
+		Log.i("OF", "Grabber fps: " + targetFps);
+		config = camera.getParameters();
+		config.setPreviewFrameRate(targetFps);
+		try{
+			camera.setParameters(config);
+		} catch(Exception e){
+			Log.e("OF","couldn init camera", e);
+		}
 
 		Log.i("OF", "camera settings: " + width + "x" + height);
 
-        int bufferSize = width * height;
-        if(buffer == null || buffer.length != bufferSize) {
-            // it actually needs (width*height) * 3/2
-            bufferSize = bufferSize * ImageFormat.getBitsPerPixel(config.getPreviewFormat()) / 8;
-            buffer[0] = new byte[bufferSize];
-            buffer[1] = new byte[bufferSize];
-        }
+		int bufferSize = width * height;
+		if(buffer == null || buffer.length != bufferSize) {
+			// it actually needs (width*height) * 3/2
+			bufferSize = bufferSize * ImageFormat.getBitsPerPixel(config.getPreviewFormat()) / 8;
+			buffer[0] = new byte[bufferSize];
+			buffer[1] = new byte[bufferSize];
+		}
 
-        //orientationListener = new OrientationListener(OFAndroid.getContext());
+		//orientationListener = new OrientationListener(OFAndroid.getContext());
 		//orientationListener.enable();
 		
 		thread = new Thread(this);
@@ -181,38 +181,38 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		initialized = true;
 	}
 
-    public void stopGrabber(){
-        if(initialized){
-            Log.i("OF", "stopping camera");
-            camera.stopPreview();
-            previewStarted = false;
-            try {
-                thread.join();
-            } catch (InterruptedException e) {
-                Log.e("OF", "problem trying to close camera thread", e);
-            }
-            camera.setPreviewCallback(null);
-            try {
+	public void stopGrabber(){
+		if(initialized){
+			Log.i("OF", "stopping camera");
+			camera.stopPreview();
+			previewStarted = false;
+			try {
+				thread.join();
+			} catch (InterruptedException e) {
+				Log.e("OF", "problem trying to close camera thread", e);
+			}
+			camera.setPreviewCallback(null);
+			try {
 				if (Build.VERSION.SDK_INT >= 11) {
 					camera.setPreviewTexture(surfaceTexture);
 				}
 			} catch (Exception e) {
-            }
-            camera.release();
-            //orientationListener.disable();
-            initialized = false;
-        }
-    }
+			}
+			camera.release();
+			//orientationListener.disable();
+			initialized = false;
+		}
+	}
 	
 	public void update(){
-        try {
+		try {
 			if (Build.VERSION.SDK_INT >= 11) {
 				surfaceTexture.updateTexImage();
 			}
 		} catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
 
 		try {
 			// Add the other buffer to the callback queue to indicate we are ready for new frame
@@ -248,7 +248,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		}
 	}
 
-    public int getCameraOrientation(int _deviceID){
+	public int getCameraOrientation(int _deviceID){
 		if (android.os.Build.VERSION.SDK_INT < 9) {
 			return 0;
 		}
@@ -259,19 +259,19 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		info = new Camera.CameraInfo();
 		Camera.getCameraInfo(_deviceID, info);
 		return info.orientation;
-    }
+	}
 
-    public int getFacingOfCamera(int _deviceID){
+	public int getFacingOfCamera(int _deviceID){
 		if (android.os.Build.VERSION.SDK_INT < 9) {
 			return 0;
 		}
 
-        if(_deviceID == -1) _deviceID = deviceID;
+		if(_deviceID == -1) _deviceID = deviceID;
 
-        Camera.CameraInfo info = new Camera.CameraInfo();
-        Camera.getCameraInfo(_deviceID, info);
-        return info.facing;
-    }
+		Camera.CameraInfo info = new Camera.CameraInfo();
+		Camera.getCameraInfo(_deviceID, info);
+		return info.facing;
+	}
 
 	public boolean setAutoFocus(boolean autofocus){
 		
@@ -341,9 +341,9 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	public void run() {
 		thread.setPriority(Thread.MAX_PRIORITY);
 		try {
-            // Add the first callback buffer to the queue
+			// Add the first callback buffer to the queue
 			camera.addCallbackBuffer(buffer[0]);
-            camera.setPreviewCallbackWithBuffer(this);
+			camera.setPreviewCallbackWithBuffer(this);
 
 			Log.i("OF","setting camera callback with buffer");
 		} catch (SecurityException e) {
@@ -360,8 +360,8 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		}
 	}
 
-    // Currently not used
-    private class OrientationListener extends OrientationEventListener{
+	// Currently not used
+	private class OrientationListener extends OrientationEventListener{
 		private int rotation = -1;
 
 		public OrientationListener(Context context) {
@@ -395,7 +395,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	private Camera camera;
 	private int deviceID = -1;
 	private byte[][] buffer = {null, null};
-    private boolean bufferFlipFlip = false;
+	private boolean bufferFlipFlip = false;
 	private int width, height, targetFps;
 	private int texID;
 	private Thread thread;

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -29,34 +29,20 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		return instanceId;
 	}
 	
-	public static boolean supportsTextureRendering(){
-		try {
-			Class.forName("android.graphics.SurfaceTexture");
-			return true;
-		} catch (ClassNotFoundException e) {
-			return false;
-		}
-	}
-	
 	public void initGrabber(int w, int h, int _targetFps){
 		initGrabber(w,h,_targetFps,0);
 	}
 	
 	public void setTexture(int texID){
-		if(supportsTextureRendering()){
-			try {
-				// get SurfaceTexture class and create an instance
-				Class<?> surfaceTextureClass = Class.forName("android.graphics.SurfaceTexture");
-				Constructor<?> constructor = surfaceTextureClass.getConstructor(int.class);
-				surfaceTexture = constructor.newInstance(texID);
-				
-				// set texture as preview surface for camera
-				Method setPreviewTexture = camera.getClass().getMethod("setPreviewTexture", surfaceTextureClass);
-				setPreviewTexture.invoke(camera, surfaceTexture);
-			} catch (Exception e1) {
-				Log.e("OF","Error initializing gl surface",e1);
-			} 
-		}
+        try {
+            // Create surface texture instance
+            surfaceTexture = new SurfaceTexture(texID);
+
+            // set texture as preview surface for camera
+            camera.setPreviewTexture(surfaceTexture);
+        } catch (Exception e1) {
+            Log.e("OF","Error initializing gl surface",e1);
+        }
 	}
 	
 	public void initGrabber(int w, int h, int _targetFps, int texID){
@@ -164,27 +150,17 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	}
 	
 	public void update(){
-		if(supportsTextureRendering()){
-			Class<?> surfaceTextureClass;
-			try {
-				surfaceTextureClass = Class.forName("android.graphics.SurfaceTexture");
-				Method updateTexImage = surfaceTextureClass.getMethod("updateTexImage");
-				if(surfaceTexture != null) updateTexImage.invoke(surfaceTexture);
-			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			//SurfaceTexture surface = (SurfaceTexture)surfaceTexture;
-			//surface.updateTexImage();
-		}
+        try {
+            surfaceTexture.updateTexImage();
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
 	}
 
 	public void getTextureMatrix(float[] mtx) {
-		Class<?> surfaceTextureClass;
 		try {
-			surfaceTextureClass = Class.forName("android.graphics.SurfaceTexture");
-			Method getTransformMatrix = surfaceTextureClass.getMethod("getTransformMatrix",float[].class);
-			if(surfaceTexture != null) getTransformMatrix.invoke(surfaceTexture,mtx);
+			if(surfaceTexture != null) surfaceTexture.getTransformMatrix(mtx);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -237,15 +213,11 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 				Log.e("OF", "problem trying to close camera thread", e);
 			}
 			camera.setPreviewCallback(null);
-			if(supportsTextureRendering()){
-				try {
-					Class<?> surfaceTextureClass = Class.forName("android.graphics.SurfaceTexture");
-					Method setPreviewTexture = camera.getClass().getMethod("setPreviewTexture", surfaceTextureClass);
-					setPreviewTexture.invoke(camera, (Object)null);
-				} catch (Exception e) {
-				}
-			}
-			camera.release();
+            try {
+                camera.setPreviewTexture(surfaceTexture);
+            } catch (Exception e) {
+            }
+            camera.release();
 			orientationListener.disable();
 		}
 	}
@@ -287,13 +259,13 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 			Camera.class.getMethod("setPreviewCallbackWithBuffer", Camera.PreviewCallback.class).invoke(camera, this);
 			Log.i("OF","setting camera callback with buffer");
 		} catch (SecurityException e) {
-			Log.e("OF","security exception, check permissions in your AndroidManifest to acces to the camera",e);
+			Log.e("OF","security exception, check permissions in your AndroidManifest to access to the camera",e);
 		} catch (NoSuchMethodException e) {
 			try {
 				Camera.class.getMethod("setPreviewCallback", Camera.PreviewCallback.class).invoke(camera, this);
 				Log.i("OF","setting camera callback without buffer");
 			} catch (SecurityException e1) {
-				Log.e("OF","security exception, check permissions in your AndroidManifest to acces to the camera",e1);
+				Log.e("OF","security exception, check permissions in your AndroidManifest to access to the camera",e1);
 			} catch (Exception e1) {
 				Log.e("OF","cannot create callback, the camera can only be used from api v7",e1);
 			} 
@@ -356,7 +328,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	private boolean previewStarted = false;
 	private Method addBufferMethod;
 	private OrientationListener orientationListener;
-	Object surfaceTexture;
+	SurfaceTexture surfaceTexture;
 	
 
 }

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -39,7 +39,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 
 		try {
             // Create surface texture instance
-				surfaceTexture = new SurfaceTexture(texID);
+			surfaceTexture = new SurfaceTexture(texID);
 
 			// set texture as preview surface for camera
             camera.setPreviewTexture(surfaceTexture);
@@ -216,14 +216,6 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-
-       try {
-            // Add the other buffer to the callback queue to indicate we are ready for new frame
-            camera.addCallbackBuffer(buffer[bufferFlipFlip?0:1]);
-            bufferFlipFlip = !bufferFlipFlip;
-        } catch (Exception e) {
-            Log.e("OF", "error adding buffer", e);
-        }
 	}
 
 	// Getting the current frame data as byte array
@@ -334,18 +326,15 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		//Log.i("OF","video buffer length: " + data.length);
 		//Log.i("OF", "size: " + camera.getParameters().getPreviewSize().width + "x" + camera.getParameters().getPreviewSize().height);
 		//Log.i("OF", "format " + camera.getParameters().getPreviewFormat());
-		threadLock.lock();
 
 		// Tell the of app that a new frame has arrived
-		newFrame(width, height, instanceId);
+		newFrame(data, width, height, instanceId);
 
-		/*try {
+		try {
             camera.addCallbackBuffer(buffer[0]);
         } catch (Exception e) {
             Log.e("OF","error adding buffer",e);
-        }*/
-
-		threadLock.unlock();
+        }
 	}
 
 	public void run() {
@@ -400,7 +389,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		
 	}
 	
-	public static native int newFrame(int width, int height, int cameraId);
+	public static native int newFrame(byte[] data, int width, int height, int cameraId);
 	
 	
 

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -1,13 +1,9 @@
 package cc.openframeworks;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
-
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -163,7 +159,6 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
         Camera.CameraInfo info = new Camera.CameraInfo();
         Camera.getCameraInfo(deviceID, info);
 
-        cameraFacing = info.facing;
         cameraOrientation = info.orientation;
 
 		//orientationListener = new OrientationListener(OFAndroid.getContext());
@@ -233,8 +228,12 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		}
 	}
 
-    public int getCameraOrientation(){
-        return cameraOrientation;
+    public int getCameraOrientation(int _deviceID){
+		if(_deviceID == -1) _deviceID = deviceID;
+
+		Camera.CameraInfo info = new Camera.CameraInfo();
+		Camera.getCameraInfo(_deviceID, info);
+		return info.orientation;
     }
 
     public int getFacingOfCamera(int _deviceID){
@@ -380,17 +379,14 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 	private int width, height, targetFps;
 	private int texID;
     private int cameraOrientation;
-    private int cameraFacing;
 	private Thread thread;
 	private ReentrantLock threadLock;
 	private int instanceId;
 	private static int nextId=0;
 	public static Map<Integer,OFAndroidVideoGrabber> camera_instances = new HashMap<Integer,OFAndroidVideoGrabber>();
-	//private static OFCameraSurface cameraSurface = null;
-	//private static ViewGroup rootViewGroup = null;
 	private boolean initialized = false;
 	private boolean previewStarted = false;
-	private OrientationListener orientationListener;
+	//private OrientationListener orientationListener;
 	SurfaceTexture surfaceTexture;
 	
 

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -106,7 +106,7 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		for(Integer i : config.getSupportedPreviewFrameRates()){
 			Log.i("OF",i.toString());
 		}
-		
+
 		Log.i("OF", "Grabber default format: " + config.getPreviewFormat());
 		Log.i("OF", "Grabber default preview size: " + config.getPreviewSize().width + "," + config.getPreviewSize().height);
 		config.setPictureSize(w, h);
@@ -129,18 +129,25 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		height = config.getPreviewSize().height;
 		if(width!=w || height!=h)  Log.w("OF","camera size different than asked for, resizing (this can slow the app)");
 		
-		
-		if(_targetFps!=-1){
-			config = camera.getParameters();
-			config.setPreviewFrameRate(_targetFps);
-			try{
-				camera.setParameters(config);
-			}catch(Exception e){
-				Log.e("OF","couldn init camera", e);
-			}
-		}
-		
-		targetFps = _targetFps;
+        targetFps = _targetFps;
+
+        // If target fps is not defined, then take the maximum fps
+        if(targetFps == -1) {
+            for(Integer i : config.getSupportedPreviewFrameRates()){
+                if(targetFps < i) {
+                    targetFps = i;
+                }
+            }
+        }
+
+        config = camera.getParameters();
+        config.setPreviewFrameRate(targetFps);
+        try{
+            camera.setParameters(config);
+        } catch(Exception e){
+            Log.e("OF","couldn init camera", e);
+        }
+
 		Log.i("OF","camera settings: " + width + "x" + height);
 		
 		// it actually needs (width*height) * 3/2

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -205,24 +205,24 @@ void ofxAndroidVideoGrabber::update(){
 		// Call update in the java code
 		// This will tell the camera api that we are ready for a new frame
 		jmethodID update = ofGetJNIEnv()->GetMethodID(getJavaClass(), "update", "()V");
-        ofGetJNIEnv()->CallVoidMethod(data->javaVideoGrabber, update);
+		ofGetJNIEnv()->CallVoidMethod(data->javaVideoGrabber, update);
 
 		// Get the texture matrix
-        jmethodID javaGetTextureMatrix = ofGetJNIEnv()->GetMethodID(getJavaClass(),"getTextureMatrix","([F)V");
-        if(!javaGetTextureMatrix){
-            ofLogError("ofxAndroidVideoPlayer") << "update(): couldn't get java javaGetTextureMatrix for VideoPlayer";
-            return;
-        }
-        ofGetJNIEnv()->CallVoidMethod(data->javaVideoGrabber,javaGetTextureMatrix,data->matrixJava);
-        jfloat * m = ofGetJNIEnv()->GetFloatArrayElements(data->matrixJava,0);
+		jmethodID javaGetTextureMatrix = ofGetJNIEnv()->GetMethodID(getJavaClass(),"getTextureMatrix","([F)V");
+		if(!javaGetTextureMatrix){
+			ofLogError("ofxAndroidVideoPlayer") << "update(): couldn't get java javaGetTextureMatrix for VideoPlayer";
+			return;
+		}
+		ofGetJNIEnv()->CallVoidMethod(data->javaVideoGrabber,javaGetTextureMatrix,data->matrixJava);
+		jfloat * m = ofGetJNIEnv()->GetFloatArrayElements(data->matrixJava,0);
 
-        ofMatrix4x4 vFlipTextureMatrix;
-        vFlipTextureMatrix.scale(1,-1,1);
-        vFlipTextureMatrix.translate(0,1,0);
-        ofMatrix4x4 textureMatrix(m);
-        data->texture.setTextureMatrix(vFlipTextureMatrix * textureMatrix );
+		ofMatrix4x4 vFlipTextureMatrix;
+		vFlipTextureMatrix.scale(1,-1,1);
+		vFlipTextureMatrix.translate(0,1,0);
+		ofMatrix4x4 textureMatrix(m);
+		data->texture.setTextureMatrix(vFlipTextureMatrix * textureMatrix );
 
-        ofGetJNIEnv()->ReleaseFloatArrayElements(data->matrixJava,m,0);
+		ofGetJNIEnv()->ReleaseFloatArrayElements(data->matrixJava,m,0);
 	} else {
 		data->bIsFrameNew = false;
 	}
@@ -438,11 +438,11 @@ void ofxAndroidVideoGrabber::setDesiredFrameRate(int framerate){
 }
 
 float ofxAndroidVideoGrabber::getHeight() const{
-    return data->height;
+	return data->height;
 }
 
 float ofxAndroidVideoGrabber::getWidth() const{
-    return data->width;
+	return data->width;
 }
 
 bool ofxAndroidVideoGrabber::setPixelFormat(ofPixelFormat pixelFormat){
@@ -470,85 +470,85 @@ ofPixelFormat ofxAndroidVideoGrabber::getPixelFormat() const{
  {
 	static bool inited = false;
 	if(inited) return;
-    long int crv,cbu,cgu,cgv;
-    int i,ind;
+	long int crv,cbu,cgu,cgv;
+	int i,ind;
 
-    crv = 104597; cbu = 132201;  /* fra matrise i global.h */
-    cgu = 25675;  cgv = 53279;
+	crv = 104597; cbu = 132201;  /* fra matrise i global.h */
+	cgu = 25675;  cgv = 53279;
 
-    for (i = 0; i < 256; i++) {
-       crv_tab[i] = (i-128) * crv;
-       cbu_tab[i] = (i-128) * cbu;
-       cgu_tab[i] = (i-128) * cgu;
-       cgv_tab[i] = (i-128) * cgv;
-       tab_76309[i] = 76309*(i-16);
-    }
+	for (i = 0; i < 256; i++) {
+	   crv_tab[i] = (i-128) * crv;
+	   cbu_tab[i] = (i-128) * cbu;
+	   cgu_tab[i] = (i-128) * cgu;
+	   cgv_tab[i] = (i-128) * cgv;
+	   tab_76309[i] = 76309*(i-16);
+	}
 
-    for (i=0; i<384; i++)
-       clp[i] =0;
-    ind=384;
-    for (i=0;i<256; i++)
-        clp[ind++]=i;
-    ind=640;
-    for (i=0;i<384;i++)
-        clp[ind++]=255;
+	for (i=0; i<384; i++)
+	   clp[i] =0;
+	ind=384;
+	for (i=0;i<256; i++)
+		clp[ind++]=i;
+	ind=640;
+	for (i=0;i<384;i++)
+		clp[ind++]=255;
 
-    inited = true;
+	inited = true;
  }
 
  void ConvertYUV2RGB(unsigned char *src0,unsigned char *src1,unsigned char *dst_ori,
-                                  int width,int height)
+								  int width,int height)
  {
-     register int y1,y2,u,v;
-     register unsigned char *py1,*py2;
-     register int i,j, c1, c2, c3, c4;
-     register unsigned char *d1, *d2;
+	 register int y1,y2,u,v;
+	 register unsigned char *py1,*py2;
+	 register int i,j, c1, c2, c3, c4;
+	 register unsigned char *d1, *d2;
 
-     int width3 = 3*width;
-     py1=src0;
-     py2=py1+width;
-     d1=dst_ori;
-     d2=d1+width3;
-     for (j = 0; j < height; j += 2) {
-         for (i = 0; i < width; i += 2) {
+	 int width3 = 3*width;
+	 py1=src0;
+	 py2=py1+width;
+	 d1=dst_ori;
+	 d2=d1+width3;
+	 for (j = 0; j < height; j += 2) {
+		 for (i = 0; i < width; i += 2) {
 
-             v = *src1++;
-             u = *src1++;
+			 v = *src1++;
+			 u = *src1++;
 
-             c1 = crv_tab[v];
-             c2 = cgu_tab[u];
-             c3 = cgv_tab[v];
-             c4 = cbu_tab[u];
+			 c1 = crv_tab[v];
+			 c2 = cgu_tab[u];
+			 c3 = cgv_tab[v];
+			 c4 = cbu_tab[u];
 
-             //up-left
-             y1 = tab_76309[*py1++];
-             *d1++ = clp[384+((y1 + c1)>>16)];
-             *d1++ = clp[384+((y1 - c2 - c3)>>16)];
-             *d1++ = clp[384+((y1 + c4)>>16)];
+			 //up-left
+			 y1 = tab_76309[*py1++];
+			 *d1++ = clp[384+((y1 + c1)>>16)];
+			 *d1++ = clp[384+((y1 - c2 - c3)>>16)];
+			 *d1++ = clp[384+((y1 + c4)>>16)];
 
-             //down-left
-             y2 = tab_76309[*py2++];
-             *d2++ = clp[384+((y2 + c1)>>16)];
-             *d2++ = clp[384+((y2 - c2 - c3)>>16)];
-             *d2++ = clp[384+((y2 + c4)>>16)];
+			 //down-left
+			 y2 = tab_76309[*py2++];
+			 *d2++ = clp[384+((y2 + c1)>>16)];
+			 *d2++ = clp[384+((y2 - c2 - c3)>>16)];
+			 *d2++ = clp[384+((y2 + c4)>>16)];
 
-             //up-right
-             y1 = tab_76309[*py1++];
-             *d1++ = clp[384+((y1 + c1)>>16)];
-             *d1++ = clp[384+((y1 - c2 - c3)>>16)];
-             *d1++ = clp[384+((y1 + c4)>>16)];
+			 //up-right
+			 y1 = tab_76309[*py1++];
+			 *d1++ = clp[384+((y1 + c1)>>16)];
+			 *d1++ = clp[384+((y1 - c2 - c3)>>16)];
+			 *d1++ = clp[384+((y1 + c4)>>16)];
 
-             //down-right
-             y2 = tab_76309[*py2++];
-             *d2++ = clp[384+((y2 + c1)>>16)];
-             *d2++ = clp[384+((y2 - c2 - c3)>>16)];
-             *d2++ = clp[384+((y2 + c4)>>16)];
-         }
-         d1 += width3;
-         d2 += width3;
-         py1+=   width;
-         py2+=   width;
-     }
+			 //down-right
+			 y2 = tab_76309[*py2++];
+			 *d2++ = clp[384+((y2 + c1)>>16)];
+			 *d2++ = clp[384+((y2 - c2 - c3)>>16)];
+			 *d2++ = clp[384+((y2 + c4)>>16)];
+		 }
+		 d1 += width3;
+		 d2 += width3;
+		 py1+=   width;
+		 py2+=   width;
+	 }
 
 
 }
@@ -565,122 +565,122 @@ ofPixelFormat ofxAndroidVideoGrabber::getPixelFormat() const{
 
 //we tackle the conversion two pixels at a time for greater speed
 void ConvertYUV2toRGB565(unsigned char* yuvs, unsigned char* rgbs, int width, int height) {
-    //the end of the luminance data
-    int lumEnd = width * height;
-    //points to the next luminance value pair
-    int lumPtr = 0;
-    //points to the next chromiance value pair
-    int chrPtr = lumEnd;
-    //points to the next byte output pair of RGB565 value
-    int outPtr = 0;
-    //the end of the current luminance scanline
-    int lineEnd = width;
-    register int R, G, B;
-    register int Y1;
-    register int Y2;
-    register int Cr;
-    register int Cb;
+	//the end of the luminance data
+	int lumEnd = width * height;
+	//points to the next luminance value pair
+	int lumPtr = 0;
+	//points to the next chromiance value pair
+	int chrPtr = lumEnd;
+	//points to the next byte output pair of RGB565 value
+	int outPtr = 0;
+	//the end of the current luminance scanline
+	int lineEnd = width;
+	register int R, G, B;
+	register int Y1;
+	register int Y2;
+	register int Cr;
+	register int Cb;
 
-    while (true) {
+	while (true) {
 
-        //skip back to the start of the chromiance values when necessary
-        if (lumPtr == lineEnd) {
-            if (lumPtr == lumEnd) break; //we've reached the end
-            //division here is a bit expensive, but's only done once per scanline
-            chrPtr = lumEnd + ((lumPtr  >> 1) / width) * width;
-            lineEnd += width;
-        }
+		//skip back to the start of the chromiance values when necessary
+		if (lumPtr == lineEnd) {
+			if (lumPtr == lumEnd) break; //we've reached the end
+			//division here is a bit expensive, but's only done once per scanline
+			chrPtr = lumEnd + ((lumPtr  >> 1) / width) * width;
+			lineEnd += width;
+		}
 
-        //read the luminance and chromiance values
-        Y1 = yuvs[lumPtr++] & 0xff;
-        Y2 = yuvs[lumPtr++] & 0xff;
-        Cr = (yuvs[chrPtr++] & 0xff) - 128;
-        Cb = (yuvs[chrPtr++] & 0xff) - 128;
+		//read the luminance and chromiance values
+		Y1 = yuvs[lumPtr++] & 0xff;
+		Y2 = yuvs[lumPtr++] & 0xff;
+		Cr = (yuvs[chrPtr++] & 0xff) - 128;
+		Cb = (yuvs[chrPtr++] & 0xff) - 128;
 
-        //generate first RGB components
-        B = Y1 + ((454 * Cb) >> 8);
-        if(B < 0) B = 0; else if(B > 255) B = 255;
-        G = Y1 - ((88 * Cb + 183 * Cr) >> 8);
-        if(G < 0) G = 0; else if(G > 255) G = 255;
-        R = Y1 + ((359 * Cr) >> 8);
-        if(R < 0) R = 0; else if(R > 255) R = 255;
-        //NOTE: this assume little-endian encoding
-        rgbs[outPtr++]  = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-        rgbs[outPtr++]  = (unsigned char) ((R & 0xf8) | (G >> 5));
+		//generate first RGB components
+		B = Y1 + ((454 * Cb) >> 8);
+		if(B < 0) B = 0; else if(B > 255) B = 255;
+		G = Y1 - ((88 * Cb + 183 * Cr) >> 8);
+		if(G < 0) G = 0; else if(G > 255) G = 255;
+		R = Y1 + ((359 * Cr) >> 8);
+		if(R < 0) R = 0; else if(R > 255) R = 255;
+		//NOTE: this assume little-endian encoding
+		rgbs[outPtr++]  = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+		rgbs[outPtr++]  = (unsigned char) ((R & 0xf8) | (G >> 5));
 
-        //generate second RGB components
-        B = Y2 + ((454 * Cb) >> 8);
-        if(B < 0) B = 0; else if(B > 255) B = 255;
-        G = Y2 - ((88 * Cb + 183 * Cr) >> 8);
-        if(G < 0) G = 0; else if(G > 255) G = 255;
-        R = Y2 + ((359 * Cr) >> 8);
-        if(R < 0) R = 0; else if(R > 255) R = 255;
-        //NOTE: this assume little-endian encoding
-        rgbs[outPtr++]  = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-        rgbs[outPtr++]  = (unsigned char) ((R & 0xf8) | (G >> 5));
-    }
+		//generate second RGB components
+		B = Y2 + ((454 * Cb) >> 8);
+		if(B < 0) B = 0; else if(B > 255) B = 255;
+		G = Y2 - ((88 * Cb + 183 * Cr) >> 8);
+		if(G < 0) G = 0; else if(G > 255) G = 255;
+		R = Y2 + ((359 * Cr) >> 8);
+		if(R < 0) R = 0; else if(R > 255) R = 255;
+		//NOTE: this assume little-endian encoding
+		rgbs[outPtr++]  = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+		rgbs[outPtr++]  = (unsigned char) ((R & 0xf8) | (G >> 5));
+	}
 }
 void ConvertYUV2toRGB565_2(unsigned char *src0,unsigned char *src1,unsigned char *dst_ori,
-                                 int width,int height)
+								 int width,int height)
 {
-    register int y1,y2,u,v;
-    register unsigned char *py1,*py2;
-    register int i,j, c1, c2, c3, c4;
-    register unsigned char *d1, *d2;
-    register int R,G,B;
-    int width2 = 2*width;
-    py1=src0;
-    py2=py1+width;
-    d1=dst_ori;
-    d2=d1+width2;
-    for (j = 0; j < height; j += 2) {
-        for (i = 0; i < width; i += 2) {
+	register int y1,y2,u,v;
+	register unsigned char *py1,*py2;
+	register int i,j, c1, c2, c3, c4;
+	register unsigned char *d1, *d2;
+	register int R,G,B;
+	int width2 = 2*width;
+	py1=src0;
+	py2=py1+width;
+	d1=dst_ori;
+	d2=d1+width2;
+	for (j = 0; j < height; j += 2) {
+		for (i = 0; i < width; i += 2) {
 
-            v = *src1++;
-            u = *src1++;
+			v = *src1++;
+			u = *src1++;
 
-            c1 = crv_tab[v];
-            c2 = cgu_tab[u];
-            c3 = cgv_tab[v];
-            c4 = cbu_tab[u];
+			c1 = crv_tab[v];
+			c2 = cgu_tab[u];
+			c3 = cgv_tab[v];
+			c4 = cbu_tab[u];
 
-            //up-left
-            y1 = tab_76309[*py1++];
-            R = clp[384+((y1 + c1)>>16)];
-            G = clp[384+((y1 - c2 - c3)>>16)];
-            B = clp[384+((y1 + c4)>>16)];
-            *d1++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-            *d1++ = (unsigned char) ((R & 0xf8) | (G >> 5));
+			//up-left
+			y1 = tab_76309[*py1++];
+			R = clp[384+((y1 + c1)>>16)];
+			G = clp[384+((y1 - c2 - c3)>>16)];
+			B = clp[384+((y1 + c4)>>16)];
+			*d1++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+			*d1++ = (unsigned char) ((R & 0xf8) | (G >> 5));
 
-            //down-left
-            y2 = tab_76309[*py2++];
-            B = clp[384+((y2 + c1)>>16)];
-            G = clp[384+((y2 - c2 - c3)>>16)];
-            R = clp[384+((y2 + c4)>>16)];
-            *d2++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-            *d2++ = (unsigned char) ((R & 0xf8) | (G >> 5));
+			//down-left
+			y2 = tab_76309[*py2++];
+			B = clp[384+((y2 + c1)>>16)];
+			G = clp[384+((y2 - c2 - c3)>>16)];
+			R = clp[384+((y2 + c4)>>16)];
+			*d2++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+			*d2++ = (unsigned char) ((R & 0xf8) | (G >> 5));
 
-            //up-right
-            y1 = tab_76309[*py1++];
-            R = clp[384+((y1 + c1)>>16)];
-            G = clp[384+((y1 - c2 - c3)>>16)];
-            B = clp[384+((y1 + c4)>>16)];
-            *d1++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-            *d1++ = (unsigned char) ((R & 0xf8) | (G >> 5));
+			//up-right
+			y1 = tab_76309[*py1++];
+			R = clp[384+((y1 + c1)>>16)];
+			G = clp[384+((y1 - c2 - c3)>>16)];
+			B = clp[384+((y1 + c4)>>16)];
+			*d1++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+			*d1++ = (unsigned char) ((R & 0xf8) | (G >> 5));
 
-            //down-right
-            y2 = tab_76309[*py2++];
-            B = clp[384+((y2 + c1)>>16)];
-            G = clp[384+((y2 - c2 - c3)>>16)];
-            R = clp[384+((y2 + c4)>>16)];
-            *d2++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
-            *d2++ = (unsigned char) ((R & 0xf8) | (G >> 5));
-        }
-        d1 += width2;
-        d2 += width2;
-        py1+=   width;
-        py2+=   width;
-    }
+			//down-right
+			y2 = tab_76309[*py2++];
+			B = clp[384+((y2 + c1)>>16)];
+			G = clp[384+((y2 - c2 - c3)>>16)];
+			R = clp[384+((y2 + c4)>>16)];
+			*d2++ = (unsigned char) (((G & 0x3c) << 3) | (B >> 3));
+			*d2++ = (unsigned char) ((R & 0xf8) | (G >> 5));
+		}
+		d1 += width2;
+		d2 += width2;
+		py1+=   width;
+		py2+=   width;
+	}
 
 
 }
@@ -725,7 +725,7 @@ Java_cc_openframeworks_OFAndroidVideoGrabber_newFrame(JNIEnv*  env, jobject  thi
 		data->bNewBackFrame=true;
 	}
 
-    data->newPixels = true;
+	data->newPixels = true;
 
 	return 0;
 }

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -400,15 +400,15 @@ int ofxAndroidVideoGrabber::getNumCameras() const{
 	}
 }
 
-int ofxAndroidVideoGrabber::getCameraOrientation()const{
+int ofxAndroidVideoGrabber::getCameraOrientation(int device)const{
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return 0;
 
 	jclass javaClass = getJavaClass();
 
-	jmethodID javagetCameraOrientation= env->GetMethodID(javaClass,"getCameraOrientation","()I");
+	jmethodID javagetCameraOrientation= env->GetMethodID(javaClass,"getCameraOrientation","(I)I");
 	if(data->javaVideoGrabber && javagetCameraOrientation){
-		return env->CallIntMethod(data->javaVideoGrabber,javagetCameraOrientation);
+		return env->CallIntMethod(data->javaVideoGrabber,javagetCameraOrientation, device);
 	} else {
 		ofLogError("ofxAndroidVideoGrabber") << "getCameraOrientation(): couldn't get OFAndroidVideoGrabber getCameraOrientation method";
 		return 0;

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -31,6 +31,8 @@ struct ofxAndroidVideoGrabber::Data{
 	void onAppResume();
 	void loadTexture();
 	void reloadTexture();
+    int width;
+    int height;
 };
 
 map<int,weak_ptr<ofxAndroidVideoGrabber::Data>> & instances(){
@@ -339,11 +341,11 @@ void ofxAndroidVideoGrabber::setDesiredFrameRate(int framerate){
 }
 
 float ofxAndroidVideoGrabber::getHeight() const{
-	return data->frontPixels.getHeight();
+    return data->height;
 }
 
 float ofxAndroidVideoGrabber::getWidth() const{
-	return data->frontPixels.getWidth();
+    return data->width;
 }
 
 bool ofxAndroidVideoGrabber::setPixelFormat(ofPixelFormat pixelFormat){
@@ -596,6 +598,9 @@ jint
 Java_cc_openframeworks_OFAndroidVideoGrabber_newFrame(JNIEnv*  env, jobject  thiz, jbyteArray array, jint width, jint height, jint cameraId){
 	auto data = instances()[cameraId].lock();
 	if(!data) return 1;
+
+    data->width = width;
+    data->height = height;
 
 	auto currentFrame = (unsigned char*)env->GetPrimitiveArrayCritical(array, NULL);
 	if(!currentFrame) return 1;

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -174,7 +174,20 @@ void ofxAndroidVideoGrabber::Data::onAppResume(){
 	appPaused = false;
 }
 vector<ofVideoDevice> ofxAndroidVideoGrabber::listDevices() const{
-	return vector<ofVideoDevice>();
+
+	vector<ofVideoDevice> devices;
+
+	int numDevices = getNumCameras();
+	for(int i = 0; i < numDevices; i++){
+		int facing = getFacingOfCamera(i);
+		ofVideoDevice vd;
+		vd.deviceName = facing == 0? "Back" : "Front";
+		vd.id = i;
+		vd.bAvailable = true;
+		devices.push_back(vd);
+	}
+
+	return devices;
 }
 
 bool ofxAndroidVideoGrabber::isFrameNew() const{
@@ -298,7 +311,7 @@ void ofxAndroidVideoGrabber::setVerbose(bool bTalkToMe){
 
 }
 
-int ofxAndroidVideoGrabber::getCameraFacing(int facing){
+int ofxAndroidVideoGrabber::getCameraFacing(int facing)const{
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return -1;
 
@@ -313,15 +326,15 @@ int ofxAndroidVideoGrabber::getCameraFacing(int facing){
 	}
 }
 
-int ofxAndroidVideoGrabber::getBackCamera(){
+int ofxAndroidVideoGrabber::getBackCamera()const{
 	return getCameraFacing(0);
 }
 
-int ofxAndroidVideoGrabber::getFrontCamera(){
+int ofxAndroidVideoGrabber::getFrontCamera()const{
 	return getCameraFacing(1);
 }
 
-int ofxAndroidVideoGrabber::getNumCameras(){
+int ofxAndroidVideoGrabber::getNumCameras() const{
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return 0;
 
@@ -336,7 +349,7 @@ int ofxAndroidVideoGrabber::getNumCameras(){
 	}
 }
 
-int ofxAndroidVideoGrabber::getCameraOrientation(){
+int ofxAndroidVideoGrabber::getCameraOrientation()const{
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return 0;
 
@@ -351,17 +364,17 @@ int ofxAndroidVideoGrabber::getCameraOrientation(){
 	}
 }
 
-int ofxAndroidVideoGrabber::getIsCameraFacingFront(){
+int ofxAndroidVideoGrabber::getFacingOfCamera(int device)const{
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return 0;
 
 	jclass javaClass = getJavaClass();
 
-	jmethodID javagetIsCameraFacingFront= env->GetMethodID(javaClass,"getIsCameraFacingFront","()Z");
-	if(data->javaVideoGrabber && javagetIsCameraFacingFront){
-		return env->CallBooleanMethod(data->javaVideoGrabber,javagetIsCameraFacingFront);
+	jmethodID javagetFacingOfCamera= env->GetMethodID(javaClass,"getFacingOfCamera","(I)I");
+	if(data->javaVideoGrabber && javagetFacingOfCamera){
+		return env->CallIntMethod(data->javaVideoGrabber,javagetFacingOfCamera, device);
 	} else {
-		ofLogError("ofxAndroidVideoGrabber") << "getIsCameraFacingFront(): couldn't get OFAndroidVideoGrabber getIsCameraFacingFront method";
+		ofLogError("ofxAndroidVideoGrabber") << "getFacingOfCamera(): couldn't get OFAndroidVideoGrabber getFacingOfCamera method";
 		return 0;
 	}
 }

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -241,7 +241,25 @@ void ofxAndroidVideoGrabber::close(){
 
 
 ofTexture *	ofxAndroidVideoGrabber::getTexturePtr(){
-	return &data->texture;
+	if(supportsTextureRendering()) return &data->texture;
+	else return nullptr;
+}
+
+bool ofxAndroidVideoGrabber::supportsTextureRendering(){
+	static bool supportsTexture = false;
+	static bool supportChecked = false;
+	if(!supportChecked){
+		JNIEnv *env = ofGetJNIEnv();
+		if(!env){
+			ofLogError("ofxAndroidVideoGrabber") << "init grabber failed :  couldn't get environment using GetEnv()";
+			return false;
+		}
+
+		jmethodID supportsTextureMethod = env->GetStaticMethodID(getJavaClass(),"supportsTextureRendering","()Z");
+		supportsTexture = env->CallStaticBooleanMethod(getJavaClass(),supportsTextureMethod);
+		supportChecked = true;
+	}
+	return supportsTexture;
 }
 
 bool ofxAndroidVideoGrabber::setup(int w, int h){

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -327,15 +327,13 @@ ofPixels& ofxAndroidVideoGrabber::getPixels(){
 		}
 
 
-
-		//time_one_frame = ofGetSystemTime();
 		if(data->internalPixelFormat==OF_PIXELS_RGB){
 			ConvertYUV2RGB(currentFrame, 					// y component
 						   currentFrame+(data->width*data->height),			// uv components
 						   pixels.getData(),data->width,data->height);
-		}else if(data->internalPixelFormat==OF_PIXELS_RGB565){
+		} else if(data->internalPixelFormat==OF_PIXELS_RGB565){
 			ConvertYUV2toRGB565(currentFrame,pixels.getData(),data->width,data->height);
-		}else if(data->internalPixelFormat==OF_PIXELS_MONO){
+		} else if(data->internalPixelFormat==OF_PIXELS_MONO){
 			pixels.setFromPixels(currentFrame,data->width,data->height,OF_IMAGE_GRAYSCALE);
 		}
 

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -226,20 +226,8 @@ ofTexture *	ofxAndroidVideoGrabber::getTexturePtr(){
 }
 
 bool ofxAndroidVideoGrabber::supportsTextureRendering(){
-	static bool supportsTexture = false;
-	static bool supportChecked = false;
-	if(!supportChecked){
-		JNIEnv *env = ofGetJNIEnv();
-		if(!env){
-			ofLogError("ofxAndroidVideoGrabber") << "init grabber failed :  couldn't get environment using GetEnv()";
-			return false;
-		}
-
-		jmethodID supportsTextureMethod = env->GetStaticMethodID(getJavaClass(),"supportsTextureRendering","()Z");
-		supportsTexture = env->CallStaticBooleanMethod(getJavaClass(),supportsTextureMethod);
-		supportChecked = true;
-	}
-	return supportsTexture;
+    // TODO: Remove function
+    return true;
 }
 
 bool ofxAndroidVideoGrabber::setup(int w, int h){

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -20,19 +20,21 @@ public:
 	~ofxAndroidVideoGrabber();
 
 	vector<ofVideoDevice>	listDevices() const;
-	bool	setup(int w, int h);
-	bool	isInitialized() const;
+	bool setup(int w, int h);
+	bool isInitialized() const;
 
-	bool	isFrameNew() const;
-	void	update();
+	bool isFrameNew() const;
+	void update();
 
 	ofPixels& getPixels();
 	const ofPixels&	getPixels() const;
 
-	void	close();
+	void setUsePixels(bool usePixels);
 
-	float	getHeight() const;
-	float	getWidth() const;
+	void close();
+
+	float getHeight() const;
+	float getWidth() const;
 
 	//should implement!
 	void setVerbose(bool bTalkToMe);
@@ -83,7 +85,6 @@ private:
 
 	/// Get number of cameras available
 	int getNumCameras()const;
-
 
 	bool initCamera();
 

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -37,13 +37,41 @@ public:
 
 	//should implement!
 	void setVerbose(bool bTalkToMe);
-	void setDeviceID(int _deviceID);
+
+
+	/// Set desired frame rate of the camera.
+	/// By default will the camera pick the highest frame rate available
 	void setDesiredFrameRate(int framerate);
+
+	/// Set specific camera device id.
+	/// Must be a value between 0 and numCameras.
+	/// Default is first back facing camera
+	void setDeviceID(int _deviceID);
+
 	void videoSettings();
 	bool setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat getPixelFormat() const;
 
 	// specifics android
+
+	/// Get number of cameras available
+	int getNumCameras();
+
+	/// Get device id of back facing camera.
+	/// Returns -1 if no match is found
+	int getBackCamera();
+
+	/// Get device id of front facing (selfie) camera.
+	/// Returns -1 if no match is found
+	int getFrontCamera();
+
+	/// Get the physical orientation of the camera. Typically on a phone the camera mounted in
+	/// landscape mode, this returns
+	int getCameraOrientation();
+
+	/// Returns true if the camera is frontal facing. Use getFrontCamera() or getBackCamera()
+	/// to specify the camera during initialization
+	int getIsCameraFacingFront();
 
 	bool setAutoFocus(bool autofocus);
 
@@ -53,7 +81,8 @@ public:
 
 	struct Data;
 private:
-	bool supportsTextureRendering();
+	int getCameraFacing(int facing);
+	bool initCamera();
 
 	// only to be used internally to resize;
 	ofPixelsRef getAuxBuffer();

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -19,7 +19,6 @@ public:
 	ofxAndroidVideoGrabber();
 	~ofxAndroidVideoGrabber();
 
-	//needs implementing
 	vector<ofVideoDevice>	listDevices() const;
 	bool	setup(int w, int h);
 	bool	isInitialized() const;
@@ -54,34 +53,36 @@ public:
 
 	// specifics android
 
-	/// Get number of cameras available
-	int getNumCameras();
-
 	/// Get device id of back facing camera.
 	/// Returns -1 if no match is found
-	int getBackCamera();
+	int getBackCamera()const;
 
 	/// Get device id of front facing (selfie) camera.
 	/// Returns -1 if no match is found
-	int getFrontCamera();
+	int getFrontCamera()const;
 
 	/// Get the physical orientation of the camera. Typically on a phone the camera mounted in
-	/// landscape mode, this returns
-	int getCameraOrientation();
+	/// landscape mode, this returns 90
+	int getCameraOrientation()const;
 
-	/// Returns true if the camera is frontal facing. Use getFrontCamera() or getBackCamera()
-	/// to specify the camera during initialization
-	int getIsCameraFacingFront();
+	/// Get facing of camera.
+	/// Leave device = -1 to get selected cameras facing
+	///
+	/// Returns 0 on backfacing camera, and 1 on frontal facing camera.
+	int getFacingOfCamera(int device=-1)const;
 
 	bool setAutoFocus(bool autofocus);
 
 	ofTexture *	getTexturePtr();
 
-	ofEvent<ofPixels> newFrameE;
-
 	struct Data;
 private:
-	int getCameraFacing(int facing);
+	int getCameraFacing(int facing)const;
+
+	/// Get number of cameras available
+	int getNumCameras()const;
+
+
 	bool initCamera();
 
 	// only to be used internally to resize;

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -75,6 +75,8 @@ public:
 
 	ofTexture *	getTexturePtr();
 
+	bool supportsTextureRendering();
+
 	struct Data;
 private:
 	int getCameraFacing(int facing)const;

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -63,7 +63,7 @@ public:
 
 	/// Get the physical orientation of the camera. Typically on a phone the camera mounted in
 	/// landscape mode, this returns 90
-	int getCameraOrientation()const;
+	int getCameraOrientation(int device=-1)const;
 
 	/// Get facing of camera.
 	/// Leave device = -1 to get selected cameras facing

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -4,21 +4,25 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofBackground(0,0,0);
-	ofSetLogLevel(OF_LOG_NOTICE);
+	//ofSetLogLevel(OF_LOG_NOTICE);
 	//ofSetOrientation(OF_ORIENTATION_90_LEFT);
 
 	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
-	androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
 
+	// Select specific facing camera
+	//androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
 
-	grabber.setup(1280,960);
+	grabber.setPixelFormat(OF_PIXELS_RGB);
+	grabber.setup(640,480);
+
+	grabberImage.allocate(grabber.getWidth(), grabber.getHeight(), OF_IMAGE_COLOR);
 
 	one_second_time = ofGetElapsedTimeMillis();
 	camera_fps = 0;
 	frames_one_sec = 0;
 
 	orientation = androidGrabber->getCameraOrientation();
-	frontalFacing = androidGrabber->getIsCameraFacingFront();
+	facing = androidGrabber->getFacingOfCamera();
 }
 
 //--------------------------------------------------------------
@@ -31,6 +35,8 @@ void ofApp::update(){
 			frames_one_sec = 0;
 			one_second_time = ofGetElapsedTimeMillis();
 		}
+		//grabber.getPixels();
+		//grabberImage.setFromPixels(grabber.getPixels());
 	}
 }
 
@@ -40,26 +46,36 @@ void ofApp::draw(){
     float grabberAspectRatio = grabber.getWidth() / grabber.getHeight();
 
     // Draw camera image centered in the window
+	ofPushMatrix();
     ofSetHexColor(0xFFFFFF);
 	ofSetRectMode(OF_RECTMODE_CENTER);
 
+	ofTranslate(ofGetWidth() / 2, ofGetHeight() / 2);
+
+	int wOrientation = ofOrientationToDegrees(ofGetOrientation());
+	ofLogNotice()<<"Orientation: "<<ofGetOrientation()<<endl;
+
 	if(ofGetWidth() > ofGetHeight()) {
-		grabber.draw(ofGetWidth() / 2, ofGetHeight() / 2, ofGetHeight() * grabberAspectRatio,
+		grabber.draw(0,0, ofGetHeight() * grabberAspectRatio,
 					 ofGetHeight());
 	} else {
-		grabber.draw(ofGetWidth() / 2, ofGetHeight() / 2, ofGetWidth(),
+		grabber.draw(0,0, ofGetWidth(),
 					 ofGetWidth()  * 1.0/grabberAspectRatio);
 
 	}
+	ofPopMatrix();
+	ofSetRectMode(OF_RECTMODE_CORNER);
+
+	// Draw the image through raw pixels
+	grabberImage.draw(0,110, 300, 300*grabberAspectRatio);
 
 	// Draw text gui
-	ofSetRectMode(OF_RECTMODE_CORNER);
 	ofDrawRectangle(0, 0, 300, 100);
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("fps: " + ofToString(ofGetFrameRate()),20,20);
 	ofDrawBitmapString("camera fps: " + ofToString(camera_fps),20,40);
 
-	if(frontalFacing) {
+	if(facing == 1) {
 		ofDrawBitmapString("facing: front", 20, 60);
 	}  else {
 		ofDrawBitmapString("facing: back", 20, 60);
@@ -86,13 +102,14 @@ void ofApp::windowResized(int w, int h){
 void ofApp::touchDown(int x, int y, int id){
 	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
 
-	if(frontalFacing) {
+	if(facing == 1) {
 		androidGrabber->setDeviceID(androidGrabber->getBackCamera());
 	} else {
 		androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
 	}
+
 	orientation = androidGrabber->getCameraOrientation();
-	frontalFacing = androidGrabber->getIsCameraFacingFront();
+	facing = androidGrabber->getFacingOfCamera();
 }
 
 //--------------------------------------------------------------

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -5,12 +5,20 @@
 void ofApp::setup(){
 	ofBackground(0,0,0);
 	ofSetLogLevel(OF_LOG_NOTICE);
-	ofSetOrientation(OF_ORIENTATION_90_LEFT);
-	grabber.setup(320,240);
+	//ofSetOrientation(OF_ORIENTATION_90_LEFT);
+
+	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
+	androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
+
+
+	grabber.setup(1280,960);
 
 	one_second_time = ofGetElapsedTimeMillis();
 	camera_fps = 0;
 	frames_one_sec = 0;
+
+	orientation = androidGrabber->getCameraOrientation();
+	frontalFacing = androidGrabber->getIsCameraFacingFront();
 }
 
 //--------------------------------------------------------------
@@ -34,14 +42,29 @@ void ofApp::draw(){
     // Draw camera image centered in the window
     ofSetHexColor(0xFFFFFF);
 	ofSetRectMode(OF_RECTMODE_CENTER);
-	grabber.draw(ofGetWidth()/2, ofGetHeight()/2, ofGetHeight()*grabberAspectRatio , ofGetHeight());
+
+	if(ofGetWidth() > ofGetHeight()) {
+		grabber.draw(ofGetWidth() / 2, ofGetHeight() / 2, ofGetHeight() * grabberAspectRatio,
+					 ofGetHeight());
+	} else {
+		grabber.draw(ofGetWidth() / 2, ofGetHeight() / 2, ofGetWidth(),
+					 ofGetWidth()  * 1.0/grabberAspectRatio);
+
+	}
 
 	// Draw text gui
 	ofSetRectMode(OF_RECTMODE_CORNER);
-	ofDrawRectangle(0, 0, 300, 50);
+	ofDrawRectangle(0, 0, 300, 100);
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("fps: " + ofToString(ofGetFrameRate()),20,20);
 	ofDrawBitmapString("camera fps: " + ofToString(camera_fps),20,40);
+
+	if(frontalFacing) {
+		ofDrawBitmapString("facing: front", 20, 60);
+	}  else {
+		ofDrawBitmapString("facing: back", 20, 60);
+	}
+	ofDrawBitmapString("orientation: " + ofToString(orientation) ,20,80);
 }
 
 //--------------------------------------------------------------
@@ -61,7 +84,15 @@ void ofApp::windowResized(int w, int h){
 
 //--------------------------------------------------------------
 void ofApp::touchDown(int x, int y, int id){
+	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
 
+	if(frontalFacing) {
+		androidGrabber->setDeviceID(androidGrabber->getBackCamera());
+	} else {
+		androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
+	}
+	orientation = androidGrabber->getCameraOrientation();
+	frontalFacing = androidGrabber->getIsCameraFacingFront();
 }
 
 //--------------------------------------------------------------

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -16,15 +16,15 @@ void ofApp::setup(){
 	// (other image formats will include heavy pixel conversion)
 	grabber.setPixelFormat(OF_PIXELS_MONO);
 
-	// Start the grabber
-	grabber.setup(1280,960);
+	// Hint the grabber if you don't need pixel data for better performance
+	//((ofxAndroidVideoGrabber*)grabber.getGrabber().get())->setUsePixels(false);
 
-	// Get the native android grabber referene for android specific functions
-	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
+	// Start the grabber
+	grabber.setup(1920,1080);
 
 	// Get the orientation and facing of the current camera
-	orientation = androidGrabber->getCameraOrientation();
-	facing = androidGrabber->getFacingOfCamera();
+	orientation = ((ofxAndroidVideoGrabber*)grabber.getGrabber().get())->getCameraOrientation();
+	facing = ((ofxAndroidVideoGrabber*)grabber.getGrabber().get())->getFacingOfCamera();
 
 	one_second_time = ofGetElapsedTimeMillis();
 	camera_fps = 0;
@@ -109,7 +109,7 @@ void ofApp::touchDown(int x, int y, int id){
 	// Swap between back and front camera
 
 	// Get the native android video grabber
-	std::shared_ptr<ofxAndroidVideoGrabber> androidGrabber = grabber.getGrabber<ofxAndroidVideoGrabber>();
+	ofxAndroidVideoGrabber* androidGrabber = (ofxAndroidVideoGrabber*)grabber.getGrabber().get();
 
 	// If the current camera is frontal, then choose the back camera
 	if(facing == 1) {

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -20,7 +20,7 @@ void ofApp::setup(){
 	//((ofxAndroidVideoGrabber*)grabber.getGrabber().get())->setUsePixels(false);
 
 	// Start the grabber
-	grabber.setup(1920,1080);
+	grabber.setup(1280,960);
 
 	// Get the orientation and facing of the current camera
 	orientation = ((ofxAndroidVideoGrabber*)grabber.getGrabber().get())->getCameraOrientation();

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -48,12 +48,12 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){    
-    // Calculate aspect ratio of grabber image
-    float grabberAspectRatio = grabber.getWidth() / grabber.getHeight();
+	// Calculate aspect ratio of grabber image
+	float grabberAspectRatio = grabber.getWidth() / grabber.getHeight();
 
-    // Draw camera image centered in the window
+	// Draw camera image centered in the window
 	ofPushMatrix();
-    ofSetHexColor(0xFFFFFF);
+	ofSetHexColor(0xFFFFFF);
 	ofSetRectMode(OF_RECTMODE_CENTER);
 
 	ofTranslate(ofGetWidth() / 2, ofGetHeight() / 2);

--- a/examples/android/androidCameraExample/src/ofApp.h
+++ b/examples/android/androidCameraExample/src/ofApp.h
@@ -37,4 +37,7 @@ class ofApp : public ofxAndroidApp{
 		int camera_fps;
 		int frames_one_sec;
 
+		bool frontalFacing;
+		int orientation;
+
 };

--- a/examples/android/androidCameraExample/src/ofApp.h
+++ b/examples/android/androidCameraExample/src/ofApp.h
@@ -31,13 +31,16 @@ class ofApp : public ofxAndroidApp{
 		void okPressed();
 		void cancelPressed();
 
-
 		ofVideoGrabber grabber;
+
+		// Image storing a clone of the grabber image
+		ofImage grabberImage;
+
 		int one_second_time;
 		int camera_fps;
 		int frames_one_sec;
 
-		bool frontalFacing;
+		bool facing;
 		int orientation;
 
 };

--- a/scripts/ci/android/install.sh
+++ b/scripts/ci/android/install.sh
@@ -12,7 +12,7 @@ else
     echo "Downloading NDK"
     # curl -Lk http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin -o ndk.bin
     # get slimmed and recompressed NDK from our server instead
-    curl -Lk http://192.237.185.151/android-ndk-r10e.tar.bz2 -o ndk.bin
+    curl -Lk http://ci.openframeworks.cc/android-ndk-r10e.tar.bz2 -o ndk.bin
     chmod a+x ndk.bin
     # "Normal" way:
     # ./ndk.bin -y | grep -v Extracting


### PR DESCRIPTION
This PR tries to improve the android camera. 

- By default it will now select the best frame rate available instead of first (that on nexus 6 is 15fps). Fixes #4502 
- ```getPixels()``` now works, and the pixel conversion and copying only happens if needed (drastically improves performance). Fixes #3752
- Running without calling ```getPixels()```allows the code to run 30fps in full HD on a Nexus 6
- Now the deviceID can be changed while the camera is running, so its now possbile to swap camera easily
- ```listDevices()``` is now implemented 
- Functions for getting the facing and orientation of cameras
- Removed legacy code regarding supporting very old API 8 that didn't support surface textures
- Updated android grabber sample to show more functionality 

There are some outstanding issues: 
- ~~This PR requires the API level to be raised to 11  from 8 #4505~~
- ```getPixels()``` and the texture are sometimes not flipped the same way on some devices. Need to look at the matrix transformation
- In the sample, the orientation of the image is not correct. Depends on #4508 

The code is tested on following devices: 
- Nexus 6 (Running Android 5.1) 
- Nexus 9 (Running Android 5.1) 
- Fairphone 1 (Running Android 4.4) 