### PR TITLE
Android: Raise min sdk version to 11 (Android 3.0)

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/AndroidManifest.xml
+++ b/addons/ofxAndroid/ofAndroidLib/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="cc.openframeworks.cc">
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="11"
         android:targetSdkVersion="20" />
 </manifest>

--- a/addons/ofxAndroid/ofAndroidLib/build.gradle
+++ b/addons/ofxAndroid/ofAndroidLib/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 11
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/examples/android/androidCameraExample/AndroidManifest.xml
+++ b/examples/android/androidCameraExample/AndroidManifest.xml
@@ -6,8 +6,8 @@
     android:installLocation="preferExternal">
 
     <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="17" />
+        android:minSdkVersion="11"
+        android:targetSdkVersion="22" />
 
     <uses-permission android:name="android.permission.CAMERA"></uses-permission>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>

--- a/examples/android/androidCameraExample/build.gradle
+++ b/examples/android/androidCameraExample/build.gradle
@@ -20,10 +20,10 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 11
         targetSdkVersion 22
     }
 


### PR DESCRIPTION
See more here: #4505
Android 3.0 is so old that i think its a very fair requirement, and simplifies code in the camera class. 