### PR TITLE
fix ofMouseEventArgs for scroll event

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -963,7 +963,7 @@ void ofAppGLFWWindow::entry_cb(GLFWwindow *windowP_, int entered) {
 void ofAppGLFWWindow::scroll_cb(GLFWwindow* windowP_, double x, double y) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
 	rotateMouseXY(instance->orientation, instance->getWidth(), instance->getHeight(), x, y);
-	instance->events().notifyMouseScrolled(x, y);
+	instance->events().notifyMouseScrolled(instance->events().getMouseX(), instance->events().getMouseY(), x, y);
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofBaseApp.h
+++ b/libs/openFrameworks/app/ofBaseApp.h
@@ -38,7 +38,7 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 		virtual void mouseReleased(int x, int y, int button ){}
 
 		/// \brief Called on the active window when the mouse wheel is scrolled
-		virtual void mouseScrolled( float x, float y ){}
+		virtual void mouseScrolled(int x, int y, float scrollX, float scrollY ){}
 
 		/// \brief Called on the active window when the mouse cursor enters the
 		/// window area
@@ -104,7 +104,7 @@ class ofBaseApp : public ofBaseSoundInput, public ofBaseSoundOutput{
 			mouseReleased(mouse.x,mouse.y,mouse.button);
 		}
 		virtual void mouseScrolled( ofMouseEventArgs & mouse ){
-			mouseScrolled(mouse.x,mouse.y);
+			mouseScrolled(mouse.x, mouse.y, mouse.scrollX, mouse.scrollY);
 		}
 		virtual void mouseEntered( ofMouseEventArgs & mouse ){
 			mouseEntered(mouse.x,mouse.y);

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -311,7 +311,7 @@ void ofCoreEvents::notifyMouseEvent(const ofMouseEventArgs & mouseEvent){
 			notifyMouseReleased(mouseEvent.x,mouseEvent.y,mouseEvent.button);
 			break;
 		case ofMouseEventArgs::Scrolled:
-			notifyMouseScrolled(mouseEvent.x,mouseEvent.y);
+			notifyMouseScrolled(mouseEvent.x,mouseEvent.y,mouseEvent.scrollX,mouseEvent.scrollY);
 			break;
 		case ofMouseEventArgs::Entered:
 			notifyMouseEntered(mouseEvent.x,mouseEvent.y);
@@ -398,12 +398,10 @@ void ofCoreEvents::notifyMouseMoved(int x, int y){
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseScrolled(float x, float y){
+void ofCoreEvents::notifyMouseScrolled(int x, int y, float scrollX, float scrollY){
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Scrolled,x,y);
-
-	mouseEventArgs.x = x;
-	mouseEventArgs.y = y;
-	mouseEventArgs.type = ofMouseEventArgs::Scrolled;
+	mouseEventArgs.scrollX = scrollX;
+	mouseEventArgs.scrollY = scrollY;
 	ofNotifyEvent( mouseScrolled, mouseEventArgs );
 }
 

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -88,20 +88,31 @@ class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
 
 	ofMouseEventArgs()
 	:type(Pressed)
-	,button(OF_MOUSE_BUTTON_LEFT){}
+	,button(OF_MOUSE_BUTTON_LEFT)
+	,scrollX(0.f)
+	,scrollY(0.f)
+	{}
 
 	ofMouseEventArgs(Type type, float x, float y, int button)
 	:ofVec2f(x,y)
 	,type(type)
-	,button(button){}
+	,button(button)
+	,scrollX(0.f)
+	,scrollY(0.f)
+	{}
 
 	ofMouseEventArgs(Type type, float x, float y)
 	:ofVec2f(x,y)
 	,type(type)
-	,button(0){}
+	,button(0)
+	,scrollX(0.f)
+	,scrollY(0.f)
+	{}
 
 	Type type;
 	int button;
+	float scrollX;
+	float scrollY;
 };
 
 class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
@@ -244,7 +255,7 @@ class ofCoreEvents {
 	void notifyMouseReleased(int x, int y, int button);
 	void notifyMouseDragged(int x, int y, int button);
 	void notifyMouseMoved(int x, int y);
-	void notifyMouseScrolled(float x, float y);
+	void notifyMouseScrolled(int x, int y, float scrollX, float scrollY);
 	void notifyMouseEntered(int x, int y);
 	void notifyMouseExited(int x, int y);
 	void notifyMouseEvent(const ofMouseEventArgs & mouseEvent);


### PR DESCRIPTION
When scrolling, `ofMouseEventArgs` would report the scroll
offset in the same place where it usually would report the
current mouse coordinates: `ofMouseEventArgs.[xy]`

This meant that to find out where on screen a scroll event
occured, you had to call `ofGetMouse[XY]` when responding to a
scroll event.

All other mouse events, e.g. Press/Release pass on the
current mouse position as `ofMouseEventArgs.[xy]`.

This brings the scroll event into line, by:

+ adding `scrollX` and `scrollY` to `ofMouseEventArgs`
+ passing the current mouse position in `.x` and `.y`,
  in line with other mouse event responders

I've double-checked our legacy GLUT window, and
ofAppEGLWindow if they needed updating too, but these window
classes appear not to capture scrolling events anyway.

Closes #4523