### PR TITLE
Improve variable quoting in cleanAllExamples.sh and buildAllExamples.…

### DIFF
--- a/scripts/linux/buildAllExamples.sh
+++ b/scripts/linux/buildAllExamples.sh
@@ -5,34 +5,34 @@ export LC_ALL=C
 for category in $( find ../../examples/ -maxdepth 1 -type d )
 do
     if [ "$category" = "../../examples/android" -o "$category" = "../../examples/ios" -o "$category" = "../../examples/" ]; then
-            continue
+        continue
     fi
-    
+
     echo category $category
-    for example in $( find $category -maxdepth 1 -type d | grep -v osx )
-    do        
-	if [ "$example" = "$category" ]; then
-                continue
+    for example in $( find "$category" -maxdepth 1 -type d | grep -v osx )
+    do
+        if [ "$example" = "$category" ]; then
+            continue
         fi
 
-        echo "-----------------------------------------------------------------"
-        echo "building " + $example
-        
-	    #projectGenerator .
-        make Debug -j2 -C $example
+        echo -----------------------------------------------------------------
+        echo building  $example
+
+        #projectGenerator .
+        make Debug -j2 -C "$example"
         ret=$?
         if [ $ret -ne 0 ]; then
-          echo error compiling $example
-          exit
+            echo error compiling $example
+            exit
         fi
-        make Release -j2 -C $example
+        make Release -j2 -C "$example"
         ret=$?
         if [ $ret -ne 0 ]; then
-          echo error compiling $example
-          exit
+            echo error compiling $example
+            exit
         fi
-        
-        echo "-----------------------------------------------------------------"
-        echo ""
+
+        echo -----------------------------------------------------------------
+        echo
     done
 done

--- a/scripts/linux/cleanAllExamples.sh
+++ b/scripts/linux/cleanAllExamples.sh
@@ -3,25 +3,25 @@
 for category in $( find ../../examples/ -maxdepth 1 -type d )
 do
     if [ "$category" = "../../examples/android" -o "$category" = "../../examples/ios" -o "$category" = "../../examples/" ]; then
-            continue
+        continue
     fi
-    
-    for example in $( find $category -maxdepth 1 -type d | grep -v osx )
+
+    for example in $( find "$category" -maxdepth 1 -type d | grep -v osx )
     do
-	    if [ "$example" = "$category" ]; then
-		    continue
-	    fi
-        echo "-----------------------------------------------------------------"
-        echo "cleaning " + $example
-        
-	    make clean -C $example
-        rm -rf $example/obj 2> /dev/null
-        rm -rf $example/*.layout 2> /dev/null
-        rm -rf $example/*.backup 2> /dev/null
-        rm -rf $example/*.depend 2> /dev/null
-        rm $example/*~ 2> /dev/null
-        
-        echo "-----------------------------------------------------------------"
-        echo ""
+        if [ "$example" = "$category" ]; then
+            continue
+        fi
+        echo -----------------------------------------------------------------
+        echo cleaning "$example"
+
+        make clean -C "$example"
+        rm -rf "${example:?}/obj" 2> /dev/null
+        rm -rf "${example:?}/"*.layout 2> /dev/null
+        rm -rf "${example:?}/"*.backup 2> /dev/null
+        rm -rf "${example:?}/"*.depend 2> /dev/null
+        rm "${example:?}/"*~ 2> /dev/null
+
+        echo -----------------------------------------------------------------
+        echo
     done
 done


### PR DESCRIPTION
…sh linux scripts and fix minor formatting/whitespace issues.

Most important contribution is the use is of quotes in the variables in the lines containing "rm -rf" in cleanAllExamples.sh as a undefined, empty or variable containing spaces could cause unrelated files to be deleted. I used the "${VAR:?}" idiom that terminates the script immediately if the variable is empty (whitespace only) or unset.
I could have put it in only one appearence of the variables, but it makes sense to put it  in every statement so that if more code is inserted in between them, an eventual accident is avoided.
Considering the context in which the variables are used, it's unlikely that we will ever have a problem, but in a script that is meant to be run as root, it's better to be safe when running 'rm -rf'

Added quotes to variables where necessary in other less critical places (where spaces could generate issues) and fixed formatting/whitespace/style issues on the way.