### PR TITLE
fix ofEasyCam scroll behaviour

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -329,7 +329,7 @@ void ofEasyCam::mouseScrolled(ofMouseEventArgs & mouse){
 	ofRectangle viewport = getViewport(this->viewport);
 	prevPosition = ofCamera::getGlobalPosition();
 	prevAxisZ = getZAxis();
-	moveZ = mouse.y * 30 * sensitivityZ * (getDistance() + FLT_EPSILON)/ viewport.height;
+	moveZ = mouse.scrollY * 30 * sensitivityZ * (getDistance() + FLT_EPSILON)/ viewport.height;
 	bDoScrollZoom = true;
 }
 


### PR DESCRIPTION
Unfortunately #4524 introduced an issue with ofEasyCam, which was tracking the mouse argument's `.y` instead of the new `.scrollY`.

This PR fixes this.