### PR TITLE
fix scrolling behaviour for ofxSlider

### DIFF
--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -122,9 +122,9 @@ getRange(Type min, Type max, float width){
 template<typename Type>
 bool ofxSlider<Type>::mouseScrolled(ofMouseEventArgs & args){
 	if(mouseInside){
-		if(args.y>0 || args.y<0){
+		if(args.scrollY>0 || args.scrollY<0){
 			double range = getRange(value.getMin(),value.getMax(),b.width);
-			Type newValue = value + ofMap(args.y,-1,1,-range, range);
+			Type newValue = value + ofMap(args.scrollY,-1,1,-range, range);
 			newValue = ofClamp(newValue,value.getMin(),value.getMax());
 			value = newValue;
 		}


### PR DESCRIPTION
This updates `ofxSlider` to use the `.scrollY` property of `ofMouseEventArgs` instead of `.y`.

I went through all core ofAddons searching for mentions of mouse scrolls, ofxSlider was the only element that appears to need updating.

Incidentally, I found that #4524 might have fixed an issue with `ofxGuiGroup::mouseScrolled`:

Before, the following method would have returned unpredictable results, since `args.x` and `args.y` would have been referring to scroll coordinates, not mouse coordinates.

```
bool ofxGuiGroup::mouseScrolled(ofMouseEventArgs & args){
	ofMouseEventArgs a = args;
	for(std::size_t i = 0; i < collection.size(); i++){
		if(collection[i]->mouseScrolled(a)){
			return true;
		}
	}
	if(isGuiDrawing() && b.inside(ofPoint(args.x, args.y))){
		return true;
	}else{
		return false;
	}
}
```

With `.scrollY` and `.y` now being separate, the gui element hit test should work as expected.
