### PR TITLE
Fix android camera example

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -413,6 +413,7 @@ int ofxAndroidVideoGrabber::getFacingOfCamera(int device)const{
 }
 
 void ofxAndroidVideoGrabber::setDeviceID(int _deviceID){
+	if(isInitialized()) ofLogNotice("ofxAndroidVideoGrabber") << "setDeviceID(): call close before changing device id";
 
 	JNIEnv *env = ofGetJNIEnv();
 	if(!env) return;

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -106,10 +106,13 @@ void ofApp::windowResized(int w, int h){
 
 //--------------------------------------------------------------
 void ofApp::touchDown(int x, int y, int id){
-	// Swap between back and front camera
+    // Swap between back and front camera
 
 	// Get the native android video grabber
-	ofxAndroidVideoGrabber* androidGrabber = (ofxAndroidVideoGrabber*)grabber.getGrabber().get();
+    ofxAndroidVideoGrabber* androidGrabber = (ofxAndroidVideoGrabber*)grabber.getGrabber().get();
+
+	// First close the camera
+	grabber.close();
 
 	// If the current camera is frontal, then choose the back camera
 	if(facing == 1) {
@@ -117,6 +120,9 @@ void ofApp::touchDown(int x, int y, int id){
 	} else {
 		androidGrabber->setDeviceID(androidGrabber->getFrontCamera());
 	}
+
+	// Open the camera
+	grabber.setup(grabber.getWidth(), grabber.getHeight());
 
 	// Read current orientation and facing out again
 	orientation = androidGrabber->getCameraOrientation();


### PR DESCRIPTION
Adds in close an setup in swapping of camera. I dont like that you have to close and open it this way, but thats the only way to do it with the current api
