### PR TITLE
Fix for iOS Backgrounding Crash #4544

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -169,6 +169,11 @@
     [ofxiOSGetGLView() stopAnimation];
 	
 	ofxiOSAlerts.lostFocus();
+	glFinish();
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+	glFinish();
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {


### PR DESCRIPTION
Fixes: iOS #4544 "Background Apps May Not Execute Commands on the Graphics Hardware"