### PR TITLE
ofAVFoundationPlayer close-open fix

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -170,6 +170,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	BOOL _bPlayStateBeforeLoad = bPlayStateBeforeLoad;
 	
 	// set internal state
+	bIsUnloaded = NO;
 	bReady = NO;
 	bLoaded = NO;
 	bPlayStateBeforeLoad = NO;


### PR DESCRIPTION
need to set internal state on load otherwise first load after close has no effect.