### PR TITLE
Fix for copying of ofTrueTypeFonts

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -304,7 +304,7 @@ private:
 	friend void ofUnloadAllFontTextures();
 	friend void ofReloadAllFontTextures();
 #endif
-	FT_Face		face;
+	shared_ptr<FT_Face>		face;
 	void		unloadTextures();
 	void		reloadTextures();
 	static bool	initLibraries();


### PR DESCRIPTION
Changed the face variable to be a shared_ptr that only gets deleted when the use count is 1 or less.
Currently the face variable is not getting copied over and will crash on copy.
To replicate the issue that this fixes:
`ofTrueTypeFont tfont;
tfont.load("verdana.ttf", 14, true, true);

verdana14 = tfont;
verdana14.drawString("Font Example - use keyboard to type", 30, 35);`