### PR TITLE
Updated OF_TARGET_WINGCC changed to OF_TARGET_MINGW 

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -18,6 +18,7 @@ enum ofLoopType{
 enum ofTargetPlatform{
 	OF_TARGET_OSX,
     OF_TARGET_MINGW,
+    OF_TARGET_WINGCC,
 	OF_TARGET_WINVS,
 	OF_TARGET_IOS,
 	OF_TARGET_ANDROID,

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -18,7 +18,6 @@ enum ofLoopType{
 enum ofTargetPlatform{
 	OF_TARGET_OSX,
     OF_TARGET_MINGW,
-    OF_TARGET_WINGCC,
 	OF_TARGET_WINVS,
 	OF_TARGET_IOS,
 	OF_TARGET_ANDROID,

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1013,7 +1013,7 @@ ofTargetPlatform ofGetTargetPlatform(){
     #if (_MSC_VER)
         return OF_TARGET_WINVS;
     #else
-        return OF_TARGET_WINGCC;
+        return OF_TARGET_MINGW;
     #endif
 #elif defined(TARGET_ANDROID)
     return OF_TARGET_ANDROID;


### PR DESCRIPTION
Fix for #4559 adding OF_TARGET_WINGCC to the ofTargetPlatform enum in ofConstants.h. This fixes build issues on Windows 10 when using GCC with Msys2.