### PR TITLE
added note about sharing context between windows

### DIFF
--- a/examples/events/multiWindowOneAppExample/src/main.cpp
+++ b/examples/events/multiWindowOneAppExample/src/main.cpp
@@ -15,6 +15,8 @@ int main( ){
 	settings.height = 300;
 	settings.setPosition(ofVec2f(0,0));
 	settings.resizable = false;
+	// uncomment next line to share main's assets with gui
+	//settings.shareContextWith = mainWindow;	
 	shared_ptr<ofAppBaseWindow> guiWindow = ofCreateWindow(settings);
 	guiWindow->setVerticalSync(false);
 

--- a/examples/events/multiWindowOneAppExample/src/main.cpp
+++ b/examples/events/multiWindowOneAppExample/src/main.cpp
@@ -15,7 +15,7 @@ int main( ){
 	settings.height = 300;
 	settings.setPosition(ofVec2f(0,0));
 	settings.resizable = false;
-	// uncomment next line to share main's assets with gui
+	// uncomment next line to share main's OpenGL resources with gui
 	//settings.shareContextWith = mainWindow;	
 	shared_ptr<ofAppBaseWindow> guiWindow = ofCreateWindow(settings);
 	guiWindow->setVerticalSync(false);


### PR DESCRIPTION
added a commented line about sharing window contexts, which is necessary to share pixels between windows. this might be helpful to include in the example if it's not clear from the docs.