### PR TITLE
This at least gets basic TCP networking working again by fixing three…

### DIFF
--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -19,9 +19,9 @@
 #endif
 
 
-#define ofxNetworkCheckError() ofxNetworkCheckErrno(__FILE__,ofToString(__LINE__))
+#define ofxNetworkCheckError() ofxNetworkCheckErrno(__FILE__, __LINE__)
 
-inline int ofxNetworkCheckErrno(const string & file, const string & line){
+inline int ofxNetworkCheckErrno(const char* file, int line) {
 	#ifdef TARGET_WIN32
 		int	err	= WSAGetLastError();
 	#else
@@ -119,6 +119,9 @@ inline int ofxNetworkCheckErrno(const string & file, const string & line){
 		//ofLogError("ofxNetwork") << file << ": " << line << " EAGAIN: try again";
 		break;
 #endif
+	case OFXNETWORK_ERROR(WOULDBLOCK):
+		// Not an error worth reporting, this is normal if the socket is non-blocking
+		break;
 	default:
 		ofLogError("ofxNetwork") << file << ": " << line << " unknown error: " << err << " see errno.h for description of the error";
 		break;

--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -115,9 +115,12 @@ inline int ofxNetworkCheckErrno(const char* file, int line) {
 		ofLogError("ofxNetwork") << file << ": " << line << " EINVAL: invalid argument";
 		break;
 #if !defined(TARGET_WIN32)
-	case OFXNETWORK_ERROR(AGAIN):
+#if defined(EAGAIN) && defined(EWOULDBLOCK) && EAGAIN != EWOULDBLOCK
+	case EAGAIN:
+		// Not an error worth reporting, this is normal if the socket is non-blocking
 		//ofLogError("ofxNetwork") << file << ": " << line << " EAGAIN: try again";
 		break;
+#endif
 #endif
 	case OFXNETWORK_ERROR(WOULDBLOCK):
 		// Not an error worth reporting, this is normal if the socket is non-blocking

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -182,7 +182,6 @@ bool ofxTCPManager::Connect(char *pAddrStr, unsigned short usPort)
         FD_ZERO(&fd);
         FD_SET(m_hSocket, &fd);
         timeval	tv=	{(time_t)m_dwTimeoutConnect, 0};
-        fd_set fdset;
         if(select(m_hSocket+1,NULL,&fd,NULL,&tv)== 1) {
             int so_error;
             socklen_t len = sizeof so_error;
@@ -340,7 +339,15 @@ int ofxTCPManager::Receive(char* pBuff, const int iSize)
   		}
   	}
   	int ret = recv(m_hSocket, pBuff, iSize, 0);
-  	if(ret==-1)  ofxNetworkCheckError();
+	if (SOCKET_ERROR == ret)
+	{
+		int err = ofxNetworkCheckError();
+		if (OFXNETWORK_ERROR(WOULDBLOCK) == err)
+		{
+			// Non-blocking socket, no data to receive
+			ret = 0;
+		}
+	}
 	return ret;
 }
 


### PR DESCRIPTION
… issues:

Addressing issue #4556

The macro ofxNetworkCheckError() and the function it calls ofxNetworkCheckErrno() make no attempt to convert parameters to strings avoiding calling any function that might reset the errno or (WSA)GetLastError() value.
ofxNetworkCheckErrno() will not generate a log entry if (WSA)EWOULDBLOCK is the error.
ofxTCPManager::Receive() checks the error returned from ofxNetworkCheckError() and sets the return value to 0 (instead of -1) if (WSA)EWOULDBLOCK is returned, indicating no data available and not an error.