### PR TITLE
iOS Example fix for iOSNativeARCExample

### DIFF
--- a/examples/ios/iosNativeARCExample/src/AppViewControllers/CircleAppViewController.mm
+++ b/examples/ios/iosNativeARCExample/src/AppViewControllers/CircleAppViewController.mm
@@ -5,6 +5,7 @@
 
 #import "CircleAppViewController.h"
 #import "ofxiOSExtras.h"
+#import "ofAppiOSWindow.h"
 
 @implementation CircleAppViewController
 

--- a/examples/ios/iosNativeARCExample/src/AppViewControllers/ImageAppViewController.mm
+++ b/examples/ios/iosNativeARCExample/src/AppViewControllers/ImageAppViewController.mm
@@ -5,6 +5,7 @@
 
 #import "ImageAppViewController.h"
 #import "ofxiOSExtras.h"
+#import "ofAppiOSWindow.h"
 
 @implementation ImageAppViewController
 

--- a/examples/ios/iosNativeARCExample/src/AppViewControllers/SquareAppViewController.mm
+++ b/examples/ios/iosNativeARCExample/src/AppViewControllers/SquareAppViewController.mm
@@ -5,6 +5,7 @@
 
 #import "SquareAppViewController.h"
 #import "ofxiOSExtras.h"
+#import "ofAppiOSWindow.h"
 
 @implementation SquareAppViewController
 

--- a/examples/ios/iosNativeARCExample/src/AppViewControllers/TriangleAppViewController.mm
+++ b/examples/ios/iosNativeARCExample/src/AppViewControllers/TriangleAppViewController.mm
@@ -5,6 +5,7 @@
 
 #import "TriangleAppViewController.h"
 #import "ofxiOSExtras.h"
+#import "ofAppiOSWindow.h"
 
 @implementation TriangleAppViewController
 


### PR DESCRIPTION
- Fixes missing ofAppiOSWindow import

As reported here: http://forum.openframeworks.cc/t/member-access-into-incomplete-type-ofappioswindow/21462