### PR TITLE
better fix for drawing wireframes on non GLES addresses #4553

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -722,7 +722,9 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
     ofPushMatrix();
     ofMultMatrix(modelMatrix);
     
-    int curRenderType = -1;
+#ifndef TARGET_OPENGLES
+        glPolygonMode(GL_FRONT_AND_BACK, ofGetGLPolyMode(renderType));
+#endif
     
     for(unsigned int i=0; i<modelMeshes.size(); i++) {
         ofxAssimpMeshHelper & mesh = modelMeshes[i];
@@ -748,14 +750,8 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
         }
         
         ofEnableBlendMode(mesh.blendMode);
+        
 #ifndef TARGET_OPENGLES
-        
-        //avoid setting it over and over again for the same type.
-        if( curRenderType != renderType ){
-            glPolygonMode(GL_FRONT_AND_BACK, ofGetGLPolyMode(renderType));
-            curRenderType = renderType;
-        }
-        
         mesh.vbo.drawElements(GL_TRIANGLES,mesh.indices.size());
 #else
         switch(renderType){
@@ -763,6 +759,8 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
 		    	mesh.vbo.drawElements(GL_TRIANGLES,mesh.indices.size());
 		    	break;
 		    case OF_MESH_WIREFRAME:
+                //note this won't look the same as on non ES renderers.
+                //there is no easy way to convert GL_TRIANGLES to outlines for each triangle
 		    	mesh.vbo.drawElements(GL_LINES,mesh.indices.size());
 		    	break;
 		    case OF_MESH_POINTS:
@@ -785,7 +783,8 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
     }
     
     #ifndef TARGET_OPENGLES
-        if( curRenderType != OF_MESH_FILL ){
+        //set the drawing mode back to FILL if its drawn the model with a different mode.
+        if( renderType != OF_MESH_FILL ){
             glPolygonMode(GL_FRONT_AND_BACK, ofGetGLPolyMode(OF_MESH_FILL));
         }
     #endif


### PR DESCRIPTION
fixes regressions in 0.9.0 
doesn't solve the ability to do proper wireframe outlines on ES - but that was the case for 0.8.4 as well. 