### PR TITLE
ofNode: better default for up vector on lookAt. Closes #4594

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -231,6 +231,14 @@ void ofNode::rotateAround(float degrees, const ofVec3f& axis, const ofVec3f& poi
 }
 
 //----------------------------------------
+void ofNode::lookAt(const ofVec3f& lookAtPosition){
+    ofQuaternion q;
+    q.makeRotate({0.f,0.f,1.f}, getPosition() - lookAtPosition);
+    auto up = q * ofVec3f(0.f,1.f,0.f);
+    lookAt(lookAtPosition, up);
+}
+
+//----------------------------------------
 void ofNode::lookAt(const ofVec3f& lookAtPosition, ofVec3f upVector) {
 	if(parent) upVector = upVector * ofMatrix4x4::getInverseOf(parent->getGlobalTransformMatrix());	
 	ofVec3f zaxis = (getGlobalPosition() - lookAtPosition).getNormalized();
@@ -245,6 +253,14 @@ void ofNode::lookAt(const ofVec3f& lookAtPosition, ofVec3f upVector) {
 		
 		setGlobalOrientation(m.getRotate());
 	}
+}
+
+//----------------------------------------
+void ofNode::lookAt(const ofNode& lookAtNode){
+    ofQuaternion q;
+    q.makeRotate({0.f,0.f,1.f}, getPosition() - lookAtNode.getGlobalPosition());
+    auto up = q * ofVec3f(0.f,1.f,0.f);
+    lookAt(lookAtNode, up);
 }
 
 //----------------------------------------
@@ -351,7 +367,7 @@ void ofNode::orbit(float longitude, float latitude, float radius, ofNode& center
 void ofNode::resetTransform() {
 	setPosition(ofVec3f());
 	setOrientation(ofVec3f());
-    setScale({1.f,1.f,1.f});
+    	setScale({1.f,1.f,1.f});
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -232,10 +232,15 @@ void ofNode::rotateAround(float degrees, const ofVec3f& axis, const ofVec3f& poi
 
 //----------------------------------------
 void ofNode::lookAt(const ofVec3f& lookAtPosition){
-    ofQuaternion q;
-    q.makeRotate({0.f,0.f,1.f}, getPosition() - lookAtPosition);
-    auto up = q * ofVec3f(0.f,1.f,0.f);
-    lookAt(lookAtPosition, up);
+    auto relPosition = (getGlobalPosition() - lookAtPosition);
+    auto radius = relPosition.length();
+    if(radius>0){
+        auto latitude = ofRadToDeg(acos(relPosition.y / radius)) - 90;
+        auto longitude = ofRadToDeg(atan2(relPosition.x , relPosition.z));
+        ofQuaternion q(latitude, ofVec3f(1,0,0), longitude, ofVec3f(0,1,0), 0, ofVec3f(0,0,1));
+        setGlobalOrientation(q);
+    }
+
 }
 
 //----------------------------------------
@@ -257,10 +262,7 @@ void ofNode::lookAt(const ofVec3f& lookAtPosition, ofVec3f upVector) {
 
 //----------------------------------------
 void ofNode::lookAt(const ofNode& lookAtNode){
-    ofQuaternion q;
-    q.makeRotate({0.f,0.f,1.f}, getPosition() - lookAtNode.getGlobalPosition());
-    auto up = q * ofVec3f(0.f,1.f,0.f);
-    lookAt(lookAtNode, up);
+    lookAt(lookAtNode.getGlobalPosition());
 }
 
 //----------------------------------------
@@ -349,7 +351,6 @@ ofVec3f ofNode::getGlobalScale() const {
 
 //----------------------------------------
 void ofNode::orbit(float longitude, float latitude, float radius, const ofVec3f& centerPoint) {
-	
 	ofQuaternion q(latitude, ofVec3f(1,0,0), longitude, ofVec3f(0,1,0), 0, ofVec3f(0,0,1));
 	setPosition((ofVec3f(0,0,radius)-centerPoint)*q +centerPoint);
 	setOrientation(q);
@@ -367,7 +368,7 @@ void ofNode::orbit(float longitude, float latitude, float radius, ofNode& center
 void ofNode::resetTransform() {
 	setPosition(ofVec3f());
 	setOrientation(ofVec3f());
-    	setScale({1.f,1.f,1.f});
+    setScale({1.f,1.f,1.f});
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -114,7 +114,7 @@ public:
 	ofQuaternion getGlobalOrientation() const;
 	ofVec3f getGlobalScale() const;
 
-	/// \}	
+	/// \}	
 	/// \name Setters
 	/// \{
 
@@ -142,7 +142,7 @@ public:
 	void setScale(const ofVec3f& s);
 	
 	/// \}
-	/// \name Modifiers
+	/// \name Modifiers
 	/// \{
 
 	/// \brief Move by arbitrary amount
@@ -182,13 +182,25 @@ public:
 	void rotateAround(const ofQuaternion& q, const ofVec3f& point);
 	
 	/// \brief Rotate around arbitrary axis by angle around point
-	void rotateAround(float degrees, const ofVec3f& axis, const ofVec3f& point);	
+    void rotateAround(float degrees, const ofVec3f& axis, const ofVec3f& point);
+
+    /// \brief Orient node to look at position (-z axis pointing to position)
+    ///
+    /// This version calculates the up vector by rotating {0,1,0} by the same
+    /// angle that will rotate {0,0,1} to the current position - lookAtPosition
+    void lookAt(const ofVec3f& lookAtPosition);
 
 	/// \brief Orient node to look at position (-z axis pointing to position)
-	void lookAt(const ofVec3f& lookAtPosition, ofVec3f upVector = ofVec3f(0, 1, 0));
+    void lookAt(const ofVec3f& lookAtPosition, ofVec3f upVector);
+
+    /// \brief Orient node to look at node (-z axis pointing to node)
+    ///
+    /// This version calculates the up vector by rotating {0,1,0} by the same
+    /// angle that will rotate {0,0,1} to the current position - lookAtPosition
+    void lookAt(const ofNode& lookAtNode);
 	
 	/// \brief Orient node to look at node (-z axis pointing to node)
-	void lookAt(const ofNode& lookAtNode, const ofVec3f& upVector = ofVec3f(0, 1, 0));
+    void lookAt(const ofNode& lookAtNode, const ofVec3f& upVector);
 	
 	/// \brief Orbit object around target at radius
 	void orbit(float longitude, float latitude, float radius, const ofVec3f& centerPoint = ofVec3f(0, 0, 0));


### PR DESCRIPTION
Instead of using {0,1,0} get's the vector of the camera position to
the lookAt point. then figures out the rotation that transforms {0,0,1}
into that vector and rotates {0,1,0} by that rotation to get the up vector.