### PR TITLE
ofThread: fix thread join

### DIFF
--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -101,13 +101,17 @@ void ofThread::waitForThread(bool callStopThread, long milliseconds){
 			return; // waitForThread should only be called outside thread
 		}
 
-        if (INFINITE_JOIN_TIMEOUT == milliseconds){
-            thread.join();
-        }else{
-            // Wait for "joinWaitMillis" milliseconds for thread to finish
-            if(!thread.tryJoin(milliseconds)){
-				// unable to completely wait for thread
+        try{
+            if (INFINITE_JOIN_TIMEOUT == milliseconds){
+                thread.join();
+            }else{
+                // Wait for "joinWaitMillis" milliseconds for thread to finish
+                if(!thread.tryJoin(milliseconds)){
+                    // unable to completely wait for thread
+                }
             }
+        }catch(...){
+            
         }
     }
 }


### PR DESCRIPTION
Sometimes when trying to join a thread that has already been detached
poco throws an exception. This catches it so the app doesn't crash