### PR TITLE
fix an issue with arrow heads not drawing centered

### DIFF
--- a/libs/openFrameworks/graphics/of3dGraphics.cpp
+++ b/libs/openFrameworks/graphics/of3dGraphics.cpp
@@ -505,7 +505,7 @@ void of3dGraphics::drawArrow(const ofVec3f& start, const ofVec3f& end, float hea
 	//draw cone
 	ofMatrix4x4 mat;
 	mat.makeRotationMatrix( ofVec3f(0,1,0), start - end );
-	mat.translate(end + ofVec3f(0,headSize*0.5,0));
+	mat.translate(end);
 	renderer->pushMatrix();
 	renderer->multMatrix(mat.getPtr());
     drawCone(headSize, headSize*2.);


### PR DESCRIPTION
The cones used to draw arrow heads were drawing at the wrong position, offset slightly (0.5 * headSize) from where they should be. This was especially apparent when arrowheads were larger.

This commit fixes this.

Before (was): 
![testarrows_debug 2015-12-02 15-28-02-912](https://cloud.githubusercontent.com/assets/423509/11535066/0f346e78-990a-11e5-9baf-3928b314fe4f.png)

After this fix:
![testarrows_debug 2015-12-02 15-28-23-213](https://cloud.githubusercontent.com/assets/423509/11535073/19c396b6-990a-11e5-8177-3a992e7655a9.png)

