### PR TITLE
ofFileUtils: fix several problems in windows:

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1034,3 +1034,23 @@ ofTargetPlatform ofGetTargetPlatform(){
     return OF_TARGET_EMSCRIPTEN;
 #endif
 }
+
+std::string ofGetEnv(const std::string & var){
+#ifdef TARGET_WIN32
+	const size_t BUFSIZE = 4096;
+	std::vector<char> pszOldVal(BUFSIZE, 0);
+	auto size = GetEnvironmentVariableA(var.c_str(), pszOldVal.data(), BUFSIZE);
+	if(size>0){
+		return std::string(pszOldVal.begin(), pszOldVal.begin()+size);
+	}else{
+		return "";
+	}
+#else
+	auto value = getenv(var.c_str());
+	if(value){
+		return value;
+	}else{
+		return "";
+	}
+#endif
+}

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -905,6 +905,8 @@ string ofSystem(const string& command);
 ofTargetPlatform ofGetTargetPlatform();
 
 
+std::string ofGetEnv(const std::string & var);
+
 /// Allows to iterate over a string's utf8 codepoints.
 /// The easiest way to use it is with a c++11 range style
 /// for loop like:


### PR DESCRIPTION
- moveTo was trying to move with the stream opened which failed on windows
- create was loosing the binary mode when changing the mode
- getHomeFolder wash using getenv which might fail
- adds ofGetEnv for multiplatform getenv