### PR TITLE
save window position on OS X before going fullscreen

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -153,10 +153,10 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, settings.glesVersion);
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 		glfwWindowHint(GLFW_CLIENT_API,GLFW_OPENGL_ES_API);
-		if(settings.glesVersion>=1){
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer);
+		if(settings.glesVersion>=2){
+			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
 		}else{
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer);
+			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 		}
 	#else
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -153,10 +153,10 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, settings.glesVersion);
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 		glfwWindowHint(GLFW_CLIENT_API,GLFW_OPENGL_ES_API);
-        if(settings.glesVersion>=2){
-            currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+		if(settings.glesVersion>=1){
+			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer);
 		}else{
-            currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer);
 		}
 	#else
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
@@ -693,6 +693,13 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 		ofVec3f screenSize = getScreenSize();
  
 		ofRectangle allScreensSpace;
+		
+		// save window shape before going fullscreen
+		ofPoint pos = getWindowPosition();
+		windowRect.x = pos.x;
+		windowRect.y = pos.y;
+		windowRect.width = windowW;
+		windowRect.height = windowH;
  
         if( settings.multiMonitorFullScreen && monitorCount > 1 ){
  
@@ -730,16 +737,22 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
             setWindowShape(screenSize.x, screenSize.y);
 			setWindowPosition(0,0);
 		}
+		
+		// make sure to save current pos if not specified in settings
+		if( settings.isPositionSet() ) {
+			ofVec3f pos = getWindowPosition();
+			settings.setPosition(ofVec2f(pos.x, pos.y));
+		}
  
         //make sure the window is getting the mouse/key events
         [cocoaWindow makeFirstResponder:cocoaWindow.contentView];
  
 	}else if( windowMode == OF_WINDOW ){
-        int nonFullScreenX = getWindowPosition().x;
-        int nonFullScreenY = getWindowPosition().y;
+        int nonFullScreenX = windowRect.x;
+        int nonFullScreenY = windowRect.y;
         
-        int nonFullScreenW = getWindowSize().x;
-        int nonFullScreenH = getWindowSize().y;
+        int nonFullScreenW = windowRect.width;
+        int nonFullScreenH = windowRect.height;
  
         
 		[NSApp setPresentationOptions:NSApplicationPresentationDefault];
@@ -752,7 +765,7 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 		// if we have recorded the screen posion, put it there
 		// if not, better to let the system do it (and put it where it wants)
 		if (ofGetFrameNum() > 0){
-			setWindowPosition(nonFullScreenX,nonFullScreenY);
+			setWindowPosition(nonFullScreenX, nonFullScreenY);
 		}
  
 		//----------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -748,24 +748,26 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
         [cocoaWindow makeFirstResponder:cocoaWindow.contentView];
  
 	}else if( windowMode == OF_WINDOW ){
-        int nonFullScreenX = windowRect.x;
-        int nonFullScreenY = windowRect.y;
-        
-        int nonFullScreenW = windowRect.width;
-        int nonFullScreenH = windowRect.height;
- 
+	
+		// set window shape if started in fullscreen
+		if(windowRect.width == 0 && windowRect.height == 0) {
+			windowRect.x = getWindowPosition().x;
+			windowRect.y = getWindowPosition().y;
+			windowRect.width = getWindowSize().x;
+			windowRect.height = getWindowSize().y;
+		}
         
 		[NSApp setPresentationOptions:NSApplicationPresentationDefault];
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windowP);
 		[cocoaWindow setStyleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask];
  
-		setWindowShape(nonFullScreenW, nonFullScreenH);
+		setWindowShape(windowRect.width, windowRect.height);
  
 		//----------------------------------------------------
 		// if we have recorded the screen posion, put it there
 		// if not, better to let the system do it (and put it where it wants)
 		if (ofGetFrameNum() > 0){
-			setWindowPosition(nonFullScreenX, nonFullScreenY);
+			setWindowPosition(windowRect.x, windowRect.y);
 		}
  
 		//----------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -8,8 +8,8 @@
 #include "ofAppBaseWindow.h"
 #include "ofEvents.h"
 #include "ofPixels.h"
+#include "ofRectangle.h"
 
-//class ofVec3f;
 class ofBaseApp;
 
 #ifdef TARGET_OPENGLES
@@ -189,6 +189,11 @@ private:
 
 	bool			bEnableSetupScreen;
 	int				windowW, windowH;
+
+#ifdef TARGET_OSX
+	/// saved window shape before fullscreen
+	ofRectangle windowRect;
+#endif
 
 	int				buttonInUse;
 	bool			buttonPressed;


### PR DESCRIPTION
This is a small fix for #4639 using an ofRectangle.

For some reason, there was an update to ofAppGLFWWindow.cpp line 156 that wasn't merged when I fetched for upstream, so that is reflected in the small whitespace change there.