### PR TITLE
ofBuffer reserve without memcpy

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -21,28 +21,24 @@
 
 //--------------------------------------------------
 ofBuffer::ofBuffer()
-:currentLine(end(),end())
-,position(0){
+:currentLine(end(),end()){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(const char * _buffer, std::size_t size)
 :buffer(_buffer,_buffer+size)
-,currentLine(end(),end())
-,position(size){
+,currentLine(end(),end()){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(const string & text)
 :buffer(text.begin(),text.end())
-,currentLine(end(),end())
-,position(text.size()){
+,currentLine(end(),end()){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(istream & stream, size_t ioBlockSize)
-:currentLine(end(),end())
-,position(0){
+:currentLine(end(),end()){
 	set(stream, ioBlockSize);
 }
 
@@ -53,7 +49,6 @@ bool ofBuffer::set(istream & stream, size_t ioBlockSize){
 		return false;
 	}else{
 		buffer.clear();
-		position = 0;
 	}
 
 	vector<char> aux_buffer(ioBlockSize);
@@ -66,7 +61,7 @@ bool ofBuffer::set(istream & stream, size_t ioBlockSize){
 
 //--------------------------------------------------
 void ofBuffer::setall(char mem){
-	buffer.assign(position, mem);
+	buffer.assign(buffer.size(), mem);
 }
 
 //--------------------------------------------------
@@ -81,7 +76,6 @@ bool ofBuffer::writeTo(ostream & stream) const {
 //--------------------------------------------------
 void ofBuffer::set(const char * _buffer, std::size_t _size){
 	buffer.assign(_buffer, _buffer+_size);
-	position = _size;
 }
 
 //--------------------------------------------------
@@ -96,22 +90,17 @@ void ofBuffer::append(const string& _buffer){
 
 //--------------------------------------------------
 void ofBuffer::append(const char * _buffer, std::size_t _size){
-	auto newPosition = position + _size;
-	if (newPosition > buffer.size()) {
-		buffer.resize(newPosition);
-	}
-	memcpy(buffer.data() + position, _buffer, _size);
-	position = newPosition;
+	buffer.insert(buffer.end(), _buffer, _buffer + _size);
 }
 
 //--------------------------------------------------
 void ofBuffer::reserve(size_t size){
-	buffer.resize(size);
+	buffer.reserve(size);
 }
 
 //--------------------------------------------------
 void ofBuffer::clear(){
-	position = 0;
+	buffer.clear();
 }
 
 //--------------------------------------------------
@@ -122,23 +111,16 @@ void ofBuffer::allocate(std::size_t _size){
 //--------------------------------------------------
 void ofBuffer::resize(std::size_t _size){
 	buffer.resize(_size);
-	position = _size;
 }
 
 
 //--------------------------------------------------
 char * ofBuffer::getData(){
-	if(position == 0){
-		return nullptr;
-	}
 	return buffer.data();
 }
 
 //--------------------------------------------------
 const char * ofBuffer::getData() const{
-	if(position == 0){
-		return nullptr;
-	}
 	return buffer.data();
 }
 
@@ -157,7 +139,7 @@ string ofBuffer::getText() const {
 	if(buffer.empty()){
 		return "";
 	}
-	return std::string(buffer.begin(), buffer.begin()+position);
+	return std::string(buffer.begin(), buffer.end());
 }
 
 //--------------------------------------------------
@@ -173,7 +155,7 @@ ofBuffer & ofBuffer::operator=(const string & text){
 
 //--------------------------------------------------
 std::size_t ofBuffer::size() const {
-	return position;
+	return buffer.size();
 }
 
 //--------------------------------------------------
@@ -209,7 +191,7 @@ vector<char>::iterator ofBuffer::begin(){
 
 //--------------------------------------------------
 vector<char>::iterator ofBuffer::end(){
-	return buffer.begin() + position;
+	return buffer.end();
 }
 
 //--------------------------------------------------
@@ -219,12 +201,12 @@ vector<char>::const_iterator ofBuffer::begin() const{
 
 //--------------------------------------------------
 vector<char>::const_iterator ofBuffer::end() const{
-	return buffer.begin() + position;
+	return buffer.end();
 }
 
 //--------------------------------------------------
 vector<char>::reverse_iterator ofBuffer::rbegin(){
-	return buffer.rend() - position;
+	return buffer.rbegin();
 }
 
 //--------------------------------------------------
@@ -234,7 +216,7 @@ vector<char>::reverse_iterator ofBuffer::rend(){
 
 //--------------------------------------------------
 vector<char>::const_reverse_iterator ofBuffer::rbegin() const{
-	return buffer.rend() - position;
+	return buffer.rbegin();
 }
 
 //--------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -21,27 +21,28 @@
 
 //--------------------------------------------------
 ofBuffer::ofBuffer()
-:currentLine(end(),end()){
-	buffer.resize(1);
+:currentLine(end(),end())
+,position(0){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(const char * _buffer, std::size_t size)
 :buffer(_buffer,_buffer+size)
-,currentLine(end(),end()){
-	buffer.resize(buffer.size()+1,0);
+,currentLine(end(),end())
+,position(size){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(const string & text)
 :buffer(text.begin(),text.end())
-,currentLine(end(),end()){
-	buffer.resize(buffer.size()+1,0);
+,currentLine(end(),end())
+,position(text.size()){
 }
 
 //--------------------------------------------------
 ofBuffer::ofBuffer(istream & stream, size_t ioBlockSize)
-:currentLine(end(),end()){
+:currentLine(end(),end())
+,position(0){
 	set(stream, ioBlockSize);
 }
 
@@ -52,15 +53,20 @@ bool ofBuffer::set(istream & stream, size_t ioBlockSize){
 		return false;
 	}else{
 		buffer.clear();
+		position = 0;
 	}
 
 	vector<char> aux_buffer(ioBlockSize);
 	while(stream.good()){
 		stream.read(&aux_buffer[0], ioBlockSize);
-		buffer.insert(buffer.end(),aux_buffer.begin(),aux_buffer.begin()+stream.gcount());
+		append(aux_buffer.data(), stream.gcount());
 	}
-	buffer.push_back(0);
 	return true;
+}
+
+//--------------------------------------------------
+void ofBuffer::setall(char mem){
+	buffer.assign(position, mem);
 }
 
 //--------------------------------------------------
@@ -68,19 +74,19 @@ bool ofBuffer::writeTo(ostream & stream) const {
 	if(stream.bad()){
 		return false;
 	}
-	stream.write(&(buffer[0]), buffer.size() - 1);
+	stream.write(buffer.data(), buffer.size());
 	return stream.good();
 }
 
 //--------------------------------------------------
 void ofBuffer::set(const char * _buffer, std::size_t _size){
-	buffer.assign(_buffer,_buffer+_size);
-	buffer.resize(buffer.size()+1,0);
+	buffer.assign(_buffer, _buffer+_size);
+	position = _size;
 }
 
 //--------------------------------------------------
 void ofBuffer::set(const string & text){
-	set(text.c_str(),text.size());
+	set(text.c_str(), text.size());
 }
 
 //--------------------------------------------------
@@ -90,45 +96,59 @@ void ofBuffer::append(const string& _buffer){
 
 //--------------------------------------------------
 void ofBuffer::append(const char * _buffer, std::size_t _size){
-	buffer.insert(buffer.end()-1,_buffer,_buffer+_size);
-	buffer.back() = 0;
+	auto newPosition = position + _size;
+	if (newPosition > buffer.size()) {
+		buffer.resize(newPosition);
+	}
+	memcpy(buffer.data() + position, _buffer, _size);
+	position = newPosition;
+}
+
+//--------------------------------------------------
+void ofBuffer::reserve(size_t size){
+	buffer.resize(size);
 }
 
 //--------------------------------------------------
 void ofBuffer::clear(){
-	buffer.resize(1,0);
+	position = 0;
 }
 
 //--------------------------------------------------
 void ofBuffer::allocate(std::size_t _size){
-	clear();
-	//we always add a 0 at the end to avoid problems with strings
-	buffer.resize(_size + 1, 0);
+	resize(_size);
 }
 
 //--------------------------------------------------
+void ofBuffer::resize(std::size_t _size){
+	buffer.resize(_size);
+	position = _size;
+}
+
+
+//--------------------------------------------------
 char * ofBuffer::getData(){
-	if(buffer.empty()){
+	if(position == 0){
 		return nullptr;
 	}
-	return &buffer[0];
+	return buffer.data();
 }
 
 //--------------------------------------------------
 const char * ofBuffer::getData() const{
-	if(buffer.empty()){
+	if(position == 0){
 		return nullptr;
 	}
-	return &buffer[0];
+	return buffer.data();
 }
 
 //--------------------------------------------------
-char *ofBuffer::getBinaryBuffer(){
+char * ofBuffer::getBinaryBuffer(){
 	return getData();
 }
 
 //--------------------------------------------------
-const char *ofBuffer::getBinaryBuffer() const {
+const char * ofBuffer::getBinaryBuffer() const {
 	return getData();
 }
 
@@ -137,7 +157,7 @@ string ofBuffer::getText() const {
 	if(buffer.empty()){
 		return "";
 	}
-	return &buffer[0];
+	return std::string(buffer.begin(), buffer.begin()+position);
 }
 
 //--------------------------------------------------
@@ -152,12 +172,8 @@ ofBuffer & ofBuffer::operator=(const string & text){
 }
 
 //--------------------------------------------------
-long ofBuffer::size() const {
-	if(buffer.empty()){
-		return 0;
-	}
-	//we always add a 0 at the end to avoid problems with strings
-	return buffer.size() - 1;
+std::size_t ofBuffer::size() const {
+	return position;
 }
 
 //--------------------------------------------------
@@ -193,7 +209,7 @@ vector<char>::iterator ofBuffer::begin(){
 
 //--------------------------------------------------
 vector<char>::iterator ofBuffer::end(){
-	return buffer.end();
+	return buffer.begin() + position;
 }
 
 //--------------------------------------------------
@@ -203,12 +219,12 @@ vector<char>::const_iterator ofBuffer::begin() const{
 
 //--------------------------------------------------
 vector<char>::const_iterator ofBuffer::end() const{
-	return buffer.end();
+	return buffer.begin() + position;
 }
 
 //--------------------------------------------------
 vector<char>::reverse_iterator ofBuffer::rbegin(){
-	return buffer.rbegin();
+	return buffer.rend() - position;
 }
 
 //--------------------------------------------------
@@ -218,7 +234,7 @@ vector<char>::reverse_iterator ofBuffer::rend(){
 
 //--------------------------------------------------
 vector<char>::const_reverse_iterator ofBuffer::rbegin() const{
-	return buffer.rbegin();
+	return buffer.rend() - position;
 }
 
 //--------------------------------------------------
@@ -300,9 +316,9 @@ bool ofBuffer::Line::empty() const{
 }
 
 //--------------------------------------------------
-ofBuffer::Lines::Lines(vector<char> & buffer)
-:_begin(buffer.begin())
-,_end(buffer.end()){}
+ofBuffer::Lines::Lines(vector<char>::iterator begin, vector<char>::iterator end)
+:_begin(begin)
+,_end(end){}
 
 //--------------------------------------------------
 ofBuffer::Line ofBuffer::Lines::begin(){
@@ -316,7 +332,7 @@ ofBuffer::Line ofBuffer::Lines::end(){
 
 //--------------------------------------------------
 ofBuffer::Lines ofBuffer::getLines(){
-	return ofBuffer::Lines(buffer);
+	return ofBuffer::Lines(begin(), end());
 }
 
 //--------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -95,7 +95,6 @@ public:
 private:
 	vector<char> 	buffer;
 	Line			currentLine;
-	size_t			position;
 };
 
 //--------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -23,16 +23,19 @@ public:
 	ofBuffer(istream & stream, size_t ioBlockSize = 1024);
 
 	void set(const char * _buffer, std::size_t _size);
-	void set(const string & text);
+    void set(const string & text);
 	bool set(istream & stream, size_t ioBlockSize = 1024);
+    void setall(char mem);
 	void append(const string& _buffer);
 	void append(const char * _buffer, std::size_t _size);
+	void reserve(size_t size);
 
 	bool writeTo(ostream & stream) const;
 
 	void clear();
 
 	void allocate(std::size_t _size);
+    void resize(std::size_t _size);
 
 	char * getData();
 	const char * getData() const;
@@ -43,7 +46,7 @@ public:
 	operator string() const;  // cast to string, to use a buffer as a string
 	ofBuffer & operator=(const string & text);
 
-	long size() const;
+	std::size_t size() const;
 
 	OF_DEPRECATED_MSG("use a lines iterator instead",string getNextLine());
 	OF_DEPRECATED_MSG("use a lines iterator instead",string getFirstLine());
@@ -79,7 +82,7 @@ public:
 	};
 
 	struct Lines{
-		Lines(vector<char> & buffer);
+		Lines(vector<char>::iterator begin, vector<char>::iterator end);
         Line begin();
         Line end();
 
@@ -92,6 +95,7 @@ public:
 private:
 	vector<char> 	buffer;
 	Line			currentLine;
+	size_t			position;
 };
 
 //--------------------------------------------------

--- a/tests/utils/buffer/addons.make
+++ b/tests/utils/buffer/addons.make
@@ -1,0 +1,1 @@
+ofxUnitTests

--- a/tests/utils/buffer/buffer.sln
+++ b/tests/utils/buffer/buffer.sln
@@ -1,0 +1,35 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "buffer", "buffer.vcxproj", "{7FD42DF7-442E-479A-BA76-D0022F99702A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openframeworksLib", "..\..\..\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj", "{5837595D-ACA9-485C-8E76-729040CE4B0B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|Win32.Build.0 = Debug|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|x64.ActiveCfg = Debug|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|x64.Build.0 = Debug|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|Win32.ActiveCfg = Release|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|Win32.Build.0 = Release|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|x64.ActiveCfg = Release|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|x64.Build.0 = Release|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|Win32.Build.0 = Debug|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|x64.ActiveCfg = Debug|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|x64.Build.0 = Debug|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|Win32.ActiveCfg = Release|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|Win32.Build.0 = Release|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|x64.ActiveCfg = Release|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/utils/buffer/buffer.vcxproj
+++ b/tests/utils/buffer/buffer.vcxproj
@@ -172,10 +172,8 @@
 	</ItemDefinitionGroup>
 	<ItemGroup>
 		<ClCompile Include="src\main.cpp" />
-		<ClCompile Include="src\ofApp.cpp" />
 	</ItemGroup>
 	<ItemGroup>
-		<ClInclude Include="src\ofApp.h" />
 		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h" />
 	</ItemGroup>
 	<ItemGroup>

--- a/tests/utils/buffer/buffer.vcxproj
+++ b/tests/utils/buffer/buffer.vcxproj
@@ -1,0 +1,199 @@
+<?xml version="1.0"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|Win32">
+			<Configuration>Debug</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|Win32">
+			<Configuration>Release</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<ProjectGuid>{7FD42DF7-442E-479A-BA76-D0022F99702A}</ProjectGuid>
+		<Keyword>Win32Proj</Keyword>
+		<RootNamespace>buffer</RootNamespace>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<TargetName>$(ProjectName)_debug</TargetName>
+		<LinkIncremental>true</LinkIncremental>
+		<GenerateManifest>true</GenerateManifest>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<TargetName>$(ProjectName)_debug</TargetName>
+		<LinkIncremental>true</LinkIncremental>
+		<GenerateManifest>true</GenerateManifest>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<LinkIncremental>false</LinkIncremental>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<LinkIncremental>false</LinkIncremental>
+	</PropertyGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<ClCompile>
+			<Optimization>Disabled</Optimization>
+			<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+		</ClCompile>
+		<Link>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<ClCompile>
+			<Optimization>Disabled</Optimization>
+			<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+			<MultiProcessorCompilation>true</MultiProcessorCompilation>
+		</ClCompile>
+		<Link>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<ClCompile>
+			<WholeProgramOptimization>false</WholeProgramOptimization>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+			<MultiProcessorCompilation>true</MultiProcessorCompilation>
+		</ClCompile>
+		<Link>
+			<IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+			<GenerateDebugInformation>false</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<OptimizeReferences>true</OptimizeReferences>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<ClCompile>
+			<WholeProgramOptimization>false</WholeProgramOptimization>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+		</ClCompile>
+		<Link>
+			<IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+			<GenerateDebugInformation>false</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<OptimizeReferences>true</OptimizeReferences>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClCompile Include="src\main.cpp" />
+		<ClCompile Include="src\ofApp.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="src\ofApp.h" />
+		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="$(OF_ROOT)\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">
+			<Project>{5837595d-aca9-485c-8e76-729040ce4b0b}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ResourceCompile Include="icon.rc">
+			<AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/D_DEBUG %(AdditionalOptions)</AdditionalOptions>
+			<AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/D_DEBUG %(AdditionalOptions)</AdditionalOptions>
+			<AdditionalIncludeDirectories>$(OF_ROOT)\libs\openFrameworksCompiled\project\vs</AdditionalIncludeDirectories>
+		</ResourceCompile>
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties RESOURCE_FILE="icon.rc" />
+		</VisualStudio>
+	</ProjectExtensions>
+</Project>

--- a/tests/utils/buffer/buffer.vcxproj.filters
+++ b/tests/utils/buffer/buffer.vcxproj.filters
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<ClCompile Include="src\ofApp.cpp">
+			<Filter>src</Filter>
+		</ClCompile>
+		<ClCompile Include="src\main.cpp">
+			<Filter>src</Filter>
+		</ClCompile>
+	</ItemGroup>
+	<ItemGroup>
+		<Filter Include="src">
+			<UniqueIdentifier>{d8376475-7454-4a24-b08a-aac121d3ad6f}</UniqueIdentifier>
+		</Filter>
+		<Filter Include="addons">
+			<UniqueIdentifier>{71834F65-F3A9-211E-73B8-DC85}</UniqueIdentifier>
+		</Filter>
+		<Filter Include="addons\ofxUnitTests">
+			<UniqueIdentifier>{99AF7102-9423-91D4-8CD7-6602}</UniqueIdentifier>
+		</Filter>
+		<Filter Include="addons\ofxUnitTests\src">
+			<UniqueIdentifier>{6DB6A1EA-29BB-7859-928B-898A}</UniqueIdentifier>
+		</Filter>
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="src\ofApp.h">
+			<Filter>src</Filter>
+		</ClInclude>
+		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h">
+			<Filter>addons\ofxUnitTests\src</Filter>
+		</ClInclude>
+	</ItemGroup>
+	<ItemGroup>
+		<ResourceCompile Include="icon.rc" />
+	</ItemGroup>
+</Project>

--- a/tests/utils/buffer/buffer.vcxproj.filters
+++ b/tests/utils/buffer/buffer.vcxproj.filters
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<ItemGroup>
-		<ClCompile Include="src\ofApp.cpp">
-			<Filter>src</Filter>
-		</ClCompile>
 		<ClCompile Include="src\main.cpp">
 			<Filter>src</Filter>
 		</ClCompile>
@@ -23,9 +20,6 @@
 		</Filter>
 	</ItemGroup>
 	<ItemGroup>
-		<ClInclude Include="src\ofApp.h">
-			<Filter>src</Filter>
-		</ClInclude>
 		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h">
 			<Filter>addons\ofxUnitTests\src</Filter>
 		</ClInclude>

--- a/tests/utils/buffer/buffer.vcxproj.user
+++ b/tests/utils/buffer/buffer.vcxproj.user
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/tests/utils/buffer/icon.rc
+++ b/tests/utils/buffer/icon.rc
@@ -1,0 +1,8 @@
+// Icon Resource Definition
+#define MAIN_ICON                       102
+
+#if defined(_DEBUG)
+MAIN_ICON               ICON                    "icon_debug.ico"
+#else
+MAIN_ICON               ICON                    "icon.ico"
+#endif

--- a/tests/utils/buffer/src/main.cpp
+++ b/tests/utils/buffer/src/main.cpp
@@ -1,0 +1,189 @@
+#include "ofFileUtils.h"
+#include "ofUtils.h"
+#include "ofxUnitTests.h"
+
+class ofApp: public ofxUnitTestsApp{
+	void run(){
+		std::vector<char> src(2048);
+		for(auto & c: src){
+			c = ofRandom(255);
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "constructor allocator";
+			ofBuffer buffer(src.data(), src.size());
+			test_eq(buffer.size(), src.size(), "constructor does correct allocation");
+			test(buffer.end() == buffer.begin() + src.size(), "correct boundaries");
+			bool bufferEqual = true;
+			auto srcIt = src.begin();
+			for(auto & c: buffer){
+				bufferEqual &= c == *srcIt++;
+			}
+			test(bufferEqual, "data is correct");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "text constructor allocator";
+			std::string text("This is a text test");
+			ofBuffer buffer(text);
+			test_eq(buffer.size(), text.size(), "constructor does correct allocation");
+			test(buffer.end() == buffer.begin() + text.size(), "correct boundaries");
+			bool bufferEqual = true;
+			auto srcIt = text.begin();
+			for(auto & c: buffer){
+				bufferEqual &= c == *srcIt++;
+			}
+			test(bufferEqual, "data is correct");
+			test_eq(text, buffer.getText(), "getText");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "set allocator";
+			ofBuffer buffer;
+			buffer.set(src.data(), src.size());
+			test_eq(buffer.size(), src.size(), "set does correct allocation");
+			test(buffer.end() == buffer.begin() + src.size(), "correct boundaries");
+			bool bufferEqual = true;
+			auto srcIt = src.begin();
+			for(auto & c: buffer){
+				bufferEqual &= c == *srcIt++;
+			}
+			test(bufferEqual, "data is correct");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "text set allocator";
+			std::string text("This is a text test");
+			ofBuffer buffer;
+			buffer.set(text);
+			test_eq(buffer.size(), text.size(), "text set does correct allocation");
+			test(buffer.end() == buffer.begin() + text.size(), "correct boundaries");
+			bool bufferEqual = true;
+			auto srcIt = text.begin();
+			for(auto & c: buffer){
+				bufferEqual &= c == *srcIt++;
+			}
+			test(bufferEqual, "data is correct");
+			test_eq(text, buffer.getText(), "getText");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "allocate & setall";
+			ofBuffer buffer;
+			auto bufferSize = 2048;
+			buffer.allocate(bufferSize);
+			test_eq(buffer.size(), bufferSize, "allocate does correct allocation");
+			test(buffer.end() == buffer.begin() + bufferSize, "correct boundaries");
+			bool bufferEqual = true;
+			buffer.setall(5);
+			for(auto & c: buffer){
+				bufferEqual &= c == 5;
+			}
+			test(bufferEqual, "data is correct");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "append text";
+			std::string text("This is a text test");
+			ofBuffer buffer;
+			for(int i=0;i<5;i++){
+				buffer.append(text);
+			}
+			test_eq(buffer.size(), text.size() * 5, "text append does correct allocation");
+			test(buffer.end() == buffer.begin() + text.size() * 5, "correct boundaries");
+			bool bufferEqual = true;
+			auto bufferIt = buffer.begin();
+			for(int i=0;i<5;i++){
+				for(auto & c: text){
+					bufferEqual &= c == *bufferIt++;
+				}
+			}
+			test(bufferEqual, "data is correct");
+			test_eq(text+text+text+text+text, buffer.getText(), "getText");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "append raw data";
+			ofBuffer buffer;
+			for(int i=0;i<5;i++){
+				buffer.append(src.data(), src.size());
+			}
+			test_eq(buffer.size(), src.size() * 5, "text append does correct allocation");
+			test(buffer.end() == buffer.begin() + src.size() * 5, "correct boundaries");
+			bool bufferEqual = true;
+			auto bufferIt = buffer.begin();
+			for(int i=0;i<5;i++){
+				for(auto & c: src){
+					bufferEqual &= c == *bufferIt++;
+				}
+			}
+			test(bufferEqual, "data is correct");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "append raw data";
+			ofBuffer buffer;
+			test_eq((uint64_t)buffer.getData(),(uint64_t)nullptr,"unallocated buffer getData");
+			test(buffer.begin() == buffer.end(),"unallocated buffer begin");
+			buffer.set(src.data(), src.size());
+			test(buffer.getData() == &*buffer.begin(),"getData == begin");
+		}
+
+		{
+			ofLogNotice() << "-------------------";
+			ofLogNotice() << "lines iterator";
+			std::vector<std::string> lines;
+			lines.push_back("Lorem ipsum dolor sit amet,");
+			lines.push_back("consectetur adipiscing elit.");
+			lines.push_back("Vivamus viverra tortor ut condimentum");
+			lines.push_back("condimentum. Vestibulum id luctus lectus.");
+			lines.push_back("Duis porttitor turpis orci, eget pellentesque");
+			lines.push_back("enim varius eu. Integer lectus urna,");
+			lines.push_back("auctor in tincidunt nec, porta vitae tellus.");
+			lines.push_back("Integer ac blandit felis, ullamcorper iaculis felis.");
+			lines.push_back("Fusce eget sollicitudin purus, sed porttitor ante.");
+			lines.push_back("Integer mattis tortor at lectus venenatis laoreet.");
+			lines.push_back("Phasellus nibh massa, pellentesque non consequat vitae,");
+			lines.push_back("volutpat ac quam. Cras ac mauris in justo");
+			lines.push_back("hendrerit tincidunt eget a magna. Nullam volutpat,");
+			lines.push_back("erat sit amet facilisis tempor,");
+			lines.push_back("tellus urna volutpat dolor,");
+			lines.push_back("a ornare nisl libero quis orci.");
+			lines.push_back("Fusce in nunc id orci lobortis semper.");
+			ofBuffer buffer;
+			for(auto & line: lines){
+				buffer.append(line + "\n"); // This should append one more line but the result should be correct
+			}
+
+			auto numLines = 0;
+			auto linesIt = lines.begin();
+			auto allLinesEqual = true;
+			for(auto line: buffer.getLines()){
+				allLinesEqual &= line == *linesIt++;
+				++numLines;
+			}
+			test(allLinesEqual, "all lines are correct");
+			test_eq(numLines,lines.size(),"lines iterator correct numLines");
+		}
+	}
+};
+
+
+#include "ofAppNoWindow.h"
+#include "ofAppRunner.h"
+//========================================================================
+int main( ){
+	ofInit();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
+	ofRunApp(window, app);
+	return ofRunMainLoop();
+}


### PR DESCRIPTION
after doing some better benchmarkings it seems as fast as using memcpy once removed the extra insert for the null terminator. @elliotwoods can you test both PR's with your application? i'd prefer to merge this one by now since it's implementation is much safer by not depending on tracking the size manually