### PR TITLE
Fix for Cannot find protocol declaration iOS UIViewControllerTransitionCoordinator

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSViewController.mm
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.mm
@@ -304,6 +304,7 @@
 //http://stackoverflow.com/questions/25935006/ios8-interface-rotation-methods-not-called
 
 //borg
+#ifdef __IPHONE_8_0
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
 
 	CGPoint center;
@@ -326,6 +327,7 @@
 		self.glView.frame = CGRectMake(0, 0, size.width,size.height);
 	}
 }
+#endif
 
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {


### PR DESCRIPTION
Fix for Cannot find protocol declaration for 'UIViewControllerTransitionCoordinator' iOS <8 SDK

Fixes #4627

It was ```NS_AVAILABLE_IOS(8_0);```.