### PR TITLE
iOS Revert AVSoundPlayer Change to Fix AudioInput example

### DIFF
--- a/addons/ofxiOS/src/sound/AVSoundPlayer.m
+++ b/addons/ofxiOS/src/sound/AVSoundPlayer.m
@@ -25,18 +25,6 @@
     return self;
 }
 
-- (void) setupSharedSession {
-	static BOOL audioSessionSetup = NO;
-	if(audioSessionSetup) {
-		return;
-	}
-	[[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback error: nil];
-	UInt32 doSetProperty = 1;
-	AudioSessionSetProperty (kAudioSessionProperty_OverrideCategoryMixWithOthers, sizeof(doSetProperty), &doSetProperty);
-	[[AVAudioSession sharedInstance] setActive: YES error: nil];
-	audioSessionSetup = YES;
-}
-
 - (void)dealloc {
     [self unloadSound];
     [super dealloc];
@@ -57,7 +45,7 @@
 
 - (BOOL)loadWithURL:(NSURL*)url {
     [self unloadSound];
-	[self setupSharedSession];
+    
     NSError * error = nil;
     self.player = [[[AVAudioPlayer alloc] initWithContentsOfURL:url
                                                           error:&error] autorelease];

--- a/addons/ofxiOS/src/sound/AVSoundPlayer.m
+++ b/addons/ofxiOS/src/sound/AVSoundPlayer.m
@@ -25,8 +25,6 @@
     return self;
 }
 
-// setupSharedSession is to prevent other iOS Classes closing the audio feed, such as AVAssetReader, when reading from disk
-// It is set once on first launch of a AVAudioPlayer and remains as a set property from then on
 - (void) setupSharedSession {
 	static BOOL audioSessionSetup = NO;
 	if(audioSessionSetup) {


### PR DESCRIPTION
Fixes https://github.com/openframeworks/openFrameworks/issues/4551

-- 

Reverts AVSoundPlayer changes to fix an strange occurring sound bug, however causes a more serious no audio input bug.

