### PR TITLE
optimise ofPixels::setImageType() on Windows VS

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -911,14 +911,16 @@ void ofPixels_<PixelType>::setImageType(ofImageType imageType){
 	dst.allocate(width,height,imageType);
 	PixelType * dstPtr = &dst[0];
 	PixelType * srcPtr = &pixels[0];
+	int dstNumChannels = dst.getNumChannels();
+	int srcNumChannels = getNumChannels();
 	int diffNumChannels = 0;
-	if(dst.getNumChannels()<getNumChannels()){
-		diffNumChannels = getNumChannels()-dst.getNumChannels();
+	if(dstNumChannels<srcNumChannels){
+		diffNumChannels = srcNumChannels-dstNumChannels;
 	}
 	for(int i=0;i<width*height;i++){
 		const PixelType & gray = *srcPtr;
-		for(int j=0;j<dst.getNumChannels();j++){
-			if(j<getNumChannels()){
+		for(int j=0;j<dstNumChannels;j++){
+			if(j<srcNumChannels){
 				*dstPtr++ =  *srcPtr++;
 			}else if(j<3){
 				*dstPtr++ = gray;


### PR DESCRIPTION
Using Visual Studio, calling getNumChannels() inside the for each pixel
loop has a huge effect on performance. By simply caching this result we
can get a 20x speed up. 180 -> 9ms on an 1920x1080 RGB to grayscale.

The difference with Xcode is minimal.