### PR TITLE
bugfix for AVF video player not drawing if ARB textures are enabled Closes #4722

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -105,6 +105,7 @@ protected:
     bool bResetPixels;
     bool bUpdatePixels;
     bool bUpdateTexture;
+	bool bUseTextureCache;
 	
     ofPixels pixels;
 	ofPixelFormat pixelFormat;


### PR DESCRIPTION
I had to add back in the bool used to check if the player should use the cached texture. 
This should be a good fix for #4722

I tested with a 1080p video and the average fps difference between the ARB approach with texture caching and the nonARB with no caching was 150 fps vs 148 fps. 