### PR TITLE
fix shader assignment constructor

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -130,7 +130,7 @@ ofShader & ofShader::operator=(const ofShader & mom){
 		retainProgram(program);
 		for(auto it: shaders){
 			auto shader = it.second;
-			retainShader(shader.type);
+			retainShader(shader.id);
 		}
 #ifdef TARGET_ANDROID
 		ofAddListener(ofxAndroidEvents().unloadGL,this,&ofShader::unloadGL);


### PR DESCRIPTION
ofShader's assignment constructor was retaining shader type
instead of id.

In case you ever wondered about an error message a la:

    "something's wrong here, releasing unknown shader id xxx"

when quitting your app, this is because when copy-assigning
shaders, the wrong id would have been stored, thus upon
destruction of the ofShader object the mismatch appears.