### PR TITLE
bugfix PR now correctly shows when a video is loaded for AVF based players. 

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -94,6 +94,7 @@ protected:
 	
     bool loadPlayer(string name, bool bAsync);
 	void disposePlayer();
+    bool isReady() const;
 
 #ifdef __OBJC__
     ofAVFoundationVideoPlayer * videoPlayer;

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -221,7 +221,7 @@ void ofAVFoundationPlayer::update() {
     
     bFrameNew = false; // default.
     
-    if(!isLoaded()) {
+    if(!isLoaded() || !isReady()) {
         return;
     }
     
@@ -254,8 +254,14 @@ void ofAVFoundationPlayer::draw(const ofRectangle & rect) {
 }
 
 void ofAVFoundationPlayer::draw(float x, float y, float w, float h) {
-    if(isLoaded()) {
-        getTexturePtr()->draw(x, y, w, h);
+    if(isLoaded() && isReady()) {
+	
+		ofTexture * texturePtr = getTexturePtr();
+		if( texturePtr != NULL ){
+			if( texturePtr->isAllocated() ){
+				texturePtr->draw(x, y, w, h);
+			}
+		}
     }
 }
 
@@ -292,7 +298,7 @@ const ofPixels & ofAVFoundationPlayer::getPixels() const {
 }
 
 ofPixels & ofAVFoundationPlayer::getPixels() {
-    if(isLoaded() == false) {
+    if(isLoaded() == false || isReady() == false) {
         ofLogError("ofAVFoundationPlayer") << "getPixels(): Returning pixels that may be unallocated. Make sure to initialize the video player before calling getPixels.";
         return pixels;
     }
@@ -377,7 +383,7 @@ ofTexture * ofAVFoundationPlayer::getTexturePtr() {
 		return NULL;
 	}
 	
-    if(isLoaded() == false) {		
+    if(isLoaded() == false || isReady() == false) {
         return &videoTexture;
     }
     
@@ -567,6 +573,15 @@ bool ofAVFoundationPlayer::isPaused() const {
 
 //--------------------------------------------------------------
 bool ofAVFoundationPlayer::isLoaded() const {
+    if(videoPlayer == nullptr) {
+        return false;
+    }
+    
+    return [videoPlayer isLoaded];
+}
+
+//--------------------------------------------------------------
+bool ofAVFoundationPlayer::isReady() const {
     if(videoPlayer == nullptr) {
         return false;
     }

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -138,6 +138,10 @@ bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
         }
     }
 	
+	if( bAsync == false ){
+		pixels.allocate(getWidth(), getHeight(), getPixelFormat());
+	}
+	
     return bLoaded;
 }
 
@@ -298,7 +302,7 @@ const ofPixels & ofAVFoundationPlayer::getPixels() const {
 }
 
 ofPixels & ofAVFoundationPlayer::getPixels() {
-    if(isLoaded() == false || isReady() == false) {
+    if(isLoaded() == false || pixels.size() == 0) {
         ofLogError("ofAVFoundationPlayer") << "getPixels(): Returning pixels that may be unallocated. Make sure to initialize the video player before calling getPixels.";
         return pixels;
     }

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -121,6 +121,7 @@ typedef enum _playerLoopType{
 - (void)seekToTime:(CMTime)time withTolerance:(CMTime)tolerance;
 
 - (BOOL)isReady;
+- (BOOL)isLoaded;
 - (BOOL)isPlaying;
 - (BOOL)isNewFrame;
 - (BOOL)isFinished;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1213,6 +1213,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	return bReady;
 }
 
+- (BOOL)isLoaded {
+	return bLoaded;
+}
+
 - (BOOL)isPlaying {
 	return bPlaying;
 }

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -403,7 +403,9 @@ void ofVideoPlayer::resetAnchor(){
 
 //------------------------------------
 void ofVideoPlayer::draw(float _x, float _y, float _w, float _h) const{
-	ofGetCurrentRenderer()->draw(*this,_x,_y,_w,_h);
+	if( isUsingTexture() && getTexture().isAllocated() ){
+		ofGetCurrentRenderer()->draw(*this,_x,_y,_w,_h);
+	}
 }
 
 //------------------------------------

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -403,9 +403,7 @@ void ofVideoPlayer::resetAnchor(){
 
 //------------------------------------
 void ofVideoPlayer::draw(float _x, float _y, float _w, float _h) const{
-	if( isUsingTexture() && getTexture().isAllocated() ){
-		ofGetCurrentRenderer()->draw(*this,_x,_y,_w,_h);
-	}
+	ofGetCurrentRenderer()->draw(*this,_x,_y,_w,_h);
 }
 
 //------------------------------------


### PR DESCRIPTION
 - Also adds a couple of extra safety checks for null ptr textures. 
 - Removes unneeded error messages when texture hasn't yet been loaded. 
closes #4629

The main change here is that ofAVFoundationPlayer.mm now uses the Objective C **bLoaded** state for ofAVFoundationPlayer::isLoaded instead of the **bReady** flag. bReady isn't true immediately but only when the first frame can be delivered and that can take a few mills to happen and it doesn't seem possible or practical to block until thats true as well. 

This means in synchronous loading mode after the load function is called isLoaded will now return true. 
The player still takes time to have frames ready, but as long as you wait for the is FrameNew() you will have good pixels ( which is what you should wait for anyway ). 

For anything internally needing the pixels, we still use isReady() so we don't return an empty ofPixels or try and draw a texture with no data loaded. 

This should be a good fix to #4629 
