### PR TITLE
[AVFoundationPlayer] Fix crashes when unloading a video

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -31,7 +31,7 @@ typedef enum _playerLoopType{
 
 
 //---------------------------------------------------------- video player.
-@interface ofAVFoundationVideoPlayer : NSObject <AVPlayerItemOutputPullDelegate> {
+@interface ofAVFoundationVideoPlayer : NSObject {
 	
     AVPlayer * _player;
 	AVAsset * _asset;
@@ -44,7 +44,6 @@ typedef enum _playerLoopType{
 	
 #if USE_VIDEO_OUTPUT
 	CMVideoFormatDescriptionRef _videoInfo;
-	dispatch_queue_t _myVideoOutputQueue;
 	AVPlayerItemVideoOutput * _videoOutput;
 #endif
 	

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -501,6 +501,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 				
 #if USE_VIDEO_OUTPUT
 				// remove output
+				[currentVideoOutput setDelegate:nil queue:nil];
 				[currentItem removeOutput:currentVideoOutput];
 				
 				// release videouOutput

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -44,9 +44,6 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		deallocCond = nil;
 		
 #if USE_VIDEO_OUTPUT
-		// create videooutput queue
-		_myVideoOutputQueue = dispatch_queue_create(NULL, NULL);
-		
 		// create videooutput
 		_videoOutput = nil;
 		_videoInfo = nil;
@@ -107,7 +104,6 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	}
 	
 	self.videoOutput.suppressesPlayerRendering = YES;
-	[self.videoOutput setDelegate:self queue:_myVideoOutputQueue];
 }
 #endif
 
@@ -120,10 +116,6 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	}
 	
 	[asyncLock lock];
-	
-#if USE_VIDEO_OUTPUT
-	dispatch_release(_myVideoOutputQueue);
-#endif
 	
 	[asyncLock unlock];
 	
@@ -501,7 +493,6 @@ static const void *PlayerRateContext = &ItemStatusContext;
 				
 #if USE_VIDEO_OUTPUT
 				// remove output
-				[currentVideoOutput setDelegate:nil queue:nil];
 				[currentItem removeOutput:currentVideoOutput];
 				
 				// release videouOutput
@@ -581,14 +572,6 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	[asyncLock lock];
 	[self unloadVideoAsync];
 	[asyncLock unlock];
-}
-
-
-#pragma mark - AVPlayerItemOutputPullDelegate
-
-- (void)outputMediaDataWillChange:(AVPlayerItemOutput *)sender
-{
-	NSLog(@"outputMediaDataWillChange");
 }
 
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -115,7 +115,9 @@ static const void *PlayerRateContext = &ItemStatusContext;
 //---------------------------------------------------------- cleanup / dispose.
 - (void)dealloc
 {
-	[self unloadVideo];
+	if (_player != nil){
+		[self unloadVideo];
+	}
 	
 	[asyncLock lock];
 	

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -460,6 +460,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 			if (currentReader != nil) {
 				[currentReader cancelReading];
 				[currentReader autorelease];
+				currentReader = nil;
 				
 				if (currentVideoTrack != nil) {
 					[currentVideoTrack autorelease];

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -527,7 +527,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 				if (currentTimeObserver != nil) {
 					[currentPlayer removeTimeObserver:currentTimeObserver];
-					[currentTimeObserver release];
+					[currentTimeObserver autorelease];
 					currentTimeObserver = nil;
 				}
 				


### PR DESCRIPTION
Updated: Ok, now I think I finally fixed a real issue by https://github.com/openframeworks/openFrameworks/commit/fdea3689050d39b133ade2dac2293d2a975ce981. The reason of crashes is that AVPlayerItemVideoOutput delegate wasn't released property. See http://stackoverflow.com/questions/29103254/copy-helper-block-crash-in-avfoundation for explanation.

Also, I added a few cleanup that I noticed while debugging. 


### Previous description (please ignore below. just keep this old description for someone read discussion on the thread)

There are two commits in this PR:

- [ofAVFoundationPlayer] Internal AVFoundationVideoPlayer will be dealloced synchronously instead of asynchronously. This ensures that dealloc runs before the ofAVFoundationPlayer's destructor finished.
- [AVFoundationVideoPlayer] Avoid unloading a video twice. This should prevent unexpected future or current bugs.

Let me illustrate the timings of the dealloc of AVFoundationVideoPlayer and destructor of ofAVFoundationVideoPlayer runs w/o this patch.

Before:
```
[notice ] start: Destructor of ofAVFoundationPlayer
[notice ] videoPlayer is not nullptr! needs dealloc property
2016-01-18 19:47:38.246 AVFoundationPlayerCrashDebug[53601:2963124] start: unloadVideoAsync
2016-01-18 19:47:38.247 AVFoundationPlayerCrashDebug[53601:2963124] pass: unloadVideoAsync
[notice ] end: Destructor of ofAVFoundationPlayer
2016-01-18 19:47:38.263 AVFoundationPlayerCrashDebug[53601:2963123] dealloc cond signal!
2016-01-18 19:47:38.264 AVFoundationPlayerCrashDebug[53601:2963124] dealocCond waited. must have finished unloadVideoAsync
2016-01-18 19:47:38.264 AVFoundationPlayerCrashDebug[53601:2963124] AVFoundationVideoPlayer.m: start dealloc
2016-01-18 19:47:38.265 AVFoundationPlayerCrashDebug[53601:2963124] start: unloadVideoAsync
2016-01-18 19:47:38.265 AVFoundationPlayerCrashDebug[53601:2963124] pass: unloadVideoAsync
2016-01-18 19:47:38.266 AVFoundationPlayerCrashDebug[53601:2963222] dealloc cond signal!
2016-01-18 19:47:38.266 AVFoundationPlayerCrashDebug[53601:2963124] dealocCond waited. must have finished unloadVideoAsync
2016-01-18 19:47:38.267 AVFoundationPlayerCrashDebug[53601:2963124] AVFoundationVideoPlayer.m: end dealloc
```

After:
```
[notice ] start: Destructor of ofAVFoundationPlayer
[notice ] videoPlayer is not nullptr! needs dealloc property
2016-01-18 19:46:04.691 AVFoundationPlayerCrashDebug[47725:2666285] start: unloadVideoAsync
2016-01-18 19:46:04.691 AVFoundationPlayerCrashDebug[47725:2666285] pass: unloadVideoAsync
2016-01-18 19:46:04.705 AVFoundationPlayerCrashDebug[47725:2947859] dealloc cond signal!
2016-01-18 19:46:05.252 AVFoundationPlayerCrashDebug[47725:2666285] dealocCond waited. must have finished unloadVideoAsync
2016-01-18 19:46:05.252 AVFoundationPlayerCrashDebug[47725:2947859] AVFoundationVideoPlayer.m: start dealloc
2016-01-18 19:46:05.252 AVFoundationPlayerCrashDebug[47725:2947859] _player is nil: already unloaded.
2016-01-18 19:46:05.253 AVFoundationPlayerCrashDebug[47725:2947859] AVFoundationVideoPlayer.m: end dealloc
[notice ] end: Destructor of ofAVFoundationPlayer
```

 
With these changes, I'm not having any crash so far using the code as I noted in #4738. I'm running a sample app over 30 mins and getting no crash.

fixes #4738 

~~My commits include debug logging that would be helpful for someone who can test this branch. I will remove it and rebase this branch if this PR is acceptable.~~ done