### PR TITLE
bugfix for OS X. stops window moving on ofSetWindowShape closes #4753

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -540,7 +540,15 @@ void ofAppGLFWWindow::setWindowPosition(int x, int y){
 
 //------------------------------------------------------------
 void ofAppGLFWWindow::setWindowShape(int w, int h){
-	glfwSetWindowSize(windowP,w/pixelScreenCoordScale,h/pixelScreenCoordScale);
+	#ifdef TARGET_OSX
+		ofPoint pos = getWindowPosition();
+		glfwSetWindowSize(windowP,w/pixelScreenCoordScale,h/pixelScreenCoordScale);
+		if( pos != getWindowPosition() ){
+			setWindowPosition(pos.x, pos.y);
+		}
+	#else
+		glfwSetWindowSize(windowP,w/pixelScreenCoordScale,h/pixelScreenCoordScale);
+	#endif
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
Its not ideal that we have to do this, but I think this is due to OS X having lower left as the origin for cocoa windows. ( http://stackoverflow.com/questions/12408334/cocoa-nsview-origin-x-at-the-bottom ) 

If we want a quick fix that works this should cover it, but it might be a good idea to file an issue with GLFW and get it fixed there. 

