### PR TITLE
add any folder with name prefix apps to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,5 +126,5 @@ Desktop.ini
 #########################
 
 .mailmap
-/apps*
-!/docs/apps/*
+/apps*/
+

--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,4 @@ Desktop.ini
 
 .mailmap
 /apps*
-!/docs/apps*
+!/docs/apps/*

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,4 @@ Desktop.ini
 #########################
 
 .mailmap
-/apps*
+/apps**

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ Desktop.ini
 #########################
 
 .mailmap
+/apps*

--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,4 @@ Desktop.ini
 #########################
 
 .mailmap
-/apps**
+/apps*

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ Desktop.ini
 
 .mailmap
 /apps*
+!/docs/apps*


### PR DESCRIPTION
From forum post https://forum.openframeworks.cc/t/branches-and-my-of-folder/22277, to allow for folders named apps* in the of directory.