### PR TITLE
Added a method to copy a fbo to a pbo using glReadPixels.

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -1008,6 +1008,18 @@ void ofFbo::readToPixels(ofFloatPixels & pixels, int attachmentPoint) const{
 #endif
 }
 
+#ifndef TARGET_OPENGLES
+//----------------------------------------------------------
+void ofFbo::copyTo(ofBufferObject & buffer) const{
+	if(!bIsAllocated) return;
+	bind();
+	buffer.bind(GL_PIXEL_PACK_BUFFER);
+	glReadPixels(0, 0, settings.width, settings.height, ofGetGLFormatFromInternal(settings.internalformat), ofGetGlTypeFromInternal(settings.internalformat), NULL);
+	buffer.unbind(GL_PIXEL_PACK_BUFFER);
+	unbind();
+}
+#endif
+
 //----------------------------------------------------------
 void ofFbo::updateTexture(int attachmentPoint) {
 	if(!bIsAllocated) return;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -63,6 +63,12 @@ public:
 	void readToPixels(ofShortPixels & pixels, int attachmentPoint = 0) const;
 	void readToPixels(ofFloatPixels & pixels, int attachmentPoint = 0) const;
 
+#ifndef TARGET_OPENGLES
+	/// \brief Copy the fbo to an ofBufferObject.
+	/// \param buffer the target buffer to copy to.
+	void copyTo(ofBufferObject & buffer) const;
+#endif
+	
 	float getWidth() const;
 	float getHeight() const;
 


### PR DESCRIPTION
In order to get better performances when copying a FBO to a PBO, I have implemented the following method:

```
void ofFbo::copyTo(ofBufferObject & buffer) const{
	if(!bIsAllocated) return;
	bind();
	buffer.bind(GL_PIXEL_PACK_BUFFER);
	glReadPixels(0, 0, settings.width, settings.height, ofGetGLFormatFromInternal(settings.internalformat), ofGetGlTypeFromInternal(settings.internalformat), NULL);
	buffer.unbind(GL_PIXEL_PACK_BUFFER);
	unbind();
}
```
When copying big FBOs, using ```glReadPixels()``` instead of ```glGetTexImage()``` (via the ofTexture of the ofFbo) improves the performances quite substantially. (~20ms instead of ~80ms on a Mac Book Pro w/ a NVIDIA GeForce GT 650M 1024 MB)

Here a simple test app to see the differences in performance:
[https://gist.github.com/smallfly/75761a9178a917d13bc5](https://gist.github.com/smallfly/75761a9178a917d13bc5)