### PR TITLE
std::function listeners for ofEvent + unregister token. Replaces #4392

### DIFF
--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -382,7 +382,7 @@ protected:
 		}, make_function_id((ofEvent<T>*)nullptr,function));
 	}
 
-#if _MSC_VER
+#ifdef _MSC_VER
 	FunctionPtr make_function(check_function<bool(T&)> f, int priority){
 		return std::make_shared<Function>(priority, [f](const void*,T&t){return f(t);}, of::priv::make_function_id());
 	}
@@ -565,7 +565,7 @@ protected:
 		}, make_function_id((ofEvent<void>*)nullptr,function));
 	}
 
-#if _MSC_VER
+#ifdef _MSC_VER
 	FunctionPtr make_function(check_function<bool()> f, int priority){
 		return std::make_shared<Function>(priority, [f](const void*){return f();}, of::priv::make_function_id());
 	}

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -414,6 +414,10 @@ protected:
 	FunctionPtr make_function(std::function<void(const void*, T&)> f, int priority) {
 		return std::make_shared<Function>(priority, [f](const void*s, T&t) {f(s, t); return false; }, of::priv::make_function_id());
 	}
+
+	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::removeFunction;
+	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addFunction;
+	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addNoToken;
 #endif
 
 public:
@@ -593,7 +597,12 @@ protected:
 	FunctionPtr make_function(std::function<void(const void*)> f, int priority) {
 		return std::make_shared<Function>(priority, [f](const void*s) {f(s); return false; }, of::priv::make_function_id());
 	}
+
+	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::removeFunction;
+	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addFunction;
+	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addNoToken;
 #endif
+
 public:
 	template<class TObj, typename TMethod>
 	void add(TObj * listener, TMethod method, int priority){

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -6,102 +6,10 @@
 #include <thread>
 #include <memory>
 #include <iterator>
+#include <atomic>
 
 class ofEventAttendedException: public std::exception{};
 
-
-template<typename Function, typename Mutex=std::recursive_mutex>
-class ofBaseEvent{
-public:
-	/// \brief Basic constructor enabling an ofBaseEvent.
-	///
-	/// \see ofBaseEvent::ofBaseEvent(const ofBaseEvent & mom)
-	/// \see ofBaseEvent::enable()
-	/// \see ofBaseEvent::disable()
-	/// \see ofBaseEvent::isEnabled()
-	ofBaseEvent()
-	:enabled(true){
-	}
-
-	/// \brief Copy-constructor for ofBaseEvent.
-	///
-	/// \see ofBaseEvent::ofBaseEvent()
-	ofBaseEvent(const ofBaseEvent & mom)
-	:enabled(mom.enabled){
-		std::unique_lock<Mutex> lck(const_cast<ofBaseEvent&>(mom).mtx);
-		functions = mom.functions;
-	}
-
-	/// \brief Overloading the assignment operator.
-	ofBaseEvent & operator=(const ofBaseEvent & mom){
-		if(&mom==this){
-			return *this;
-		}
-		std::unique_lock<Mutex> lck(const_cast<ofBaseEvent&>(mom).mtx);
-		std::unique_lock<Mutex> lck2(mtx);
-		functions = mom.functions;
-		enabled = mom.enabled;
-		return *this;
-	}
-
-	/// \brief Enable an event.
-	///
-	/// \see ofBaseEvent::disable()
-	/// \see ofBaseEvent::isEnabled()
-	void enable() {
-		enabled = true;
-	}
-
-	/// \brief Disable an event.
-	///
-	/// \see ofBaseEvent::enable()
-	/// \see ofBaseEvent::isEnabled()
-	void disable() {
-		enabled = false;
-	}
-
-	/// \brief Check whether an event is enabled or not.
-	///
-	/// \returns true if enables
-	/// \see ofBaseEvent::enable()
-	/// \see ofBaseEvent::disable()
-	bool isEnabled() const {
-		return enabled;
-	}
-
-	std::size_t size() const {
-		return functions.size();
-	}
-
-protected:
-	template<typename TFunction>
-	void add(TFunction && f){
-		std::unique_lock<Mutex> lck(mtx);
-		auto it = functions.begin();
-		for(; it!=functions.end(); ++it){
-			if((*it)->priority>f->priority) break;
-		}
-		functions.emplace(it, f);
-	}
-
-	template<typename TFunction>
-	void remove(const TFunction & function){
-		std::unique_lock<Mutex> lck(mtx);
-		auto it = functions.begin();
-		for(; it!=functions.end(); ++it){
-			auto f = *it;
-			if(*f == *function){
-				f->disable();
-				functions.erase(it);
-				break;
-			}
-		}
-	}
-
-	Mutex mtx;
-	std::vector<std::shared_ptr<Function>> functions;
-	bool enabled;
-};
 
 /*! \cond PRIVATE */
 namespace of{
@@ -112,11 +20,48 @@ namespace priv{
 		void unlock(){}
 	};
 
+	class AbstractEventToken{
+		public:
+			virtual ~AbstractEventToken();
+	};
+
 	class BaseFunctionId{
 	public:
-		virtual ~BaseFunctionId(){};
+		BaseFunctionId(){}
+		BaseFunctionId(const BaseFunctionId &) = delete;
+		BaseFunctionId & operator=(const BaseFunctionId &) = delete;
+		virtual ~BaseFunctionId();
 		virtual bool operator==(const BaseFunctionId &) const = 0;
+		virtual BaseFunctionId * clone() const = 0;
 	};
+
+	class StdFunctionId: public BaseFunctionId{
+		static std::atomic<uint_fast64_t> nextId;
+		uint64_t id;
+
+		StdFunctionId(uint64_t id)
+		:id(id){}
+	public:
+		StdFunctionId(){
+			id = nextId++;
+		}
+
+		virtual ~StdFunctionId();
+
+		bool operator==(const BaseFunctionId & otherid) const{
+			const auto * other = dynamic_cast<const StdFunctionId*>(&otherid);
+			return other && id == other->id;
+		}
+
+		BaseFunctionId * clone() const{
+			return new StdFunctionId(id);
+		}
+	};
+
+
+	inline std::unique_ptr<StdFunctionId> make_function_id(){
+		return std::unique_ptr<StdFunctionId>(new StdFunctionId());
+	}
 
 	template<typename T, class Mutex>
 	class Function{
@@ -184,12 +129,161 @@ namespace priv{
 		std::function<bool(const void*)> function;
 		Mutex mtx;
 	};
+
+
+	template<typename Function, typename Mutex=std::recursive_mutex>
+	class BaseEvent{
+	public:
+		BaseEvent(){}
+
+		BaseEvent(const BaseEvent & mom){
+			std::unique_lock<Mutex> lck(const_cast<BaseEvent&>(mom).self->mtx);
+			self->functions = mom.self->functions;
+		}
+
+		BaseEvent & operator=(const BaseEvent & mom){
+			if(&mom==this){
+				return *this;
+			}
+			std::unique_lock<Mutex> lck(const_cast<BaseEvent&>(mom).self->mtx);
+			std::unique_lock<Mutex> lck2(self->mtx);
+			self->functions = mom.self->functions;
+			self->enabled = mom.self->enabled;
+			return *this;
+		}
+
+		BaseEvent(BaseEvent && mom){
+			std::unique_lock<Mutex> lck(const_cast<BaseEvent&>(mom).self->mtx);
+			self->functions = std::move(mom.self->functions);
+			self->enabled = std::move(mom.self->enabled);
+		}
+
+		BaseEvent & operator=(BaseEvent && mom){
+			if(&mom==this){
+				return *this;
+			}
+			std::unique_lock<Mutex> lck(const_cast<BaseEvent&>(mom).self->mtx);
+			std::unique_lock<Mutex> lck2(self->mtx);
+			self->functions = mom.self->functions;
+			self->enabled = mom.self->enabled;
+			return *this;
+		}
+
+		void enable() {
+			self->enabled = true;
+		}
+
+		void disable() {
+			self->enabled = false;
+		}
+
+		bool isEnabled() const {
+			return self->enabled;
+		}
+
+		std::size_t size() const {
+			return self->functions.size();
+		}
+
+	protected:
+
+		struct Data{
+			Mutex mtx;
+			std::vector<std::shared_ptr<Function>> functions;
+			bool enabled = true;
+
+			void remove(const BaseFunctionId & id){
+				std::unique_lock<Mutex> lck(mtx);
+				auto it = functions.begin();
+				for(; it!=functions.end(); ++it){
+					auto f = *it;
+					if(*f->id == id){
+						f->disable();
+						functions.erase(it);
+						break;
+					}
+				}
+			}
+		};
+		std::shared_ptr<Data> self{new Data};
+
+		class EventToken: public AbstractEventToken{
+			public:
+				EventToken();
+				template<typename Id>
+				EventToken(std::shared_ptr<BaseEvent<Function,Mutex>::Data> & event, const Id & id)
+				:event(event)
+				,id(id.clone()){
+
+				}
+
+				~EventToken(){
+					auto event = this->event.lock();
+					if(event){
+						event->remove(*id);
+					}
+				}
+
+			private:
+				std::weak_ptr<BaseEvent::Data> event;
+				std::unique_ptr<BaseFunctionId> id;
+		};
+
+		std::unique_ptr<EventToken> make_token(const Function & f){
+			return std::unique_ptr<EventToken>(new EventToken(self,*f.id));
+		}
+
+		template<typename TFunction>
+		void addNoToken(TFunction && f){
+			std::unique_lock<Mutex> lck(self->mtx);
+			auto it = self->functions.begin();
+			for(; it!=self->functions.end(); ++it){
+				if((*it)->priority>f->priority) break;
+			}
+			self->functions.emplace(it, f);
+		}
+
+		template<typename TFunction>
+		std::unique_ptr<EventToken> add(TFunction && f){
+			std::unique_lock<Mutex> lck(self->mtx);
+			auto it = self->functions.begin();
+			for(; it!=self->functions.end(); ++it){
+				if((*it)->priority>f->priority) break;
+			}
+			self->functions.emplace(it, f);
+			return make_token(*f);
+		}
+
+		template<typename TFunction>
+		void remove(const TFunction & function){
+			self->remove(*function->id);
+		}
+	};
 }
 }
 /*! \endcond */
 
+enum ofEventOrder{
+	OF_EVENT_ORDER_BEFORE_APP=0,
+	OF_EVENT_ORDER_APP=100,
+	OF_EVENT_ORDER_AFTER_APP=200
+};
+
+class ofEventListener{
+public:
+	ofEventListener(){}
+	ofEventListener(std::unique_ptr<of::priv::AbstractEventToken> && token)
+	:token(std::move(token)){}
+	void unsubscribe(){
+		token.reset();
+	}
+private:
+	std::unique_ptr<of::priv::AbstractEventToken> token;
+};
+
+
 template<typename T, typename Mutex=std::recursive_mutex>
-class ofEvent: public ofBaseEvent<of::priv::Function<T,Mutex>,Mutex>{
+class ofEvent: public of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>{
 protected:
 	typedef of::priv::Function<T,Mutex> Function;
 	typedef std::shared_ptr<Function> FunctionPtr;
@@ -273,31 +367,58 @@ protected:
 			return false;
 		}, make_function_id((ofEvent<T>*)nullptr,function));
 	}
+
+	FunctionPtr make_function(std::function<bool(T&)> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*,T&t){return f(t);}, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<bool(const void*,T&)> f, int priority){
+		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<void(T&)> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*,T&t){f(t);return false;}, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<void(const void*,T&)> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*s,T&t){f(s,t); return false;}, of::priv::make_function_id());
+	}
+
 public:
 	template<class TObj, typename TMethod>
+	ofEventListener newListener(TObj * listener, TMethod method, int priority = OF_EVENT_ORDER_AFTER_APP){
+		return ofEventListener(of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::add(make_function(listener,method,priority)));
+	}
+
+	template<class TObj, typename TMethod>
 	void add(TObj * listener, TMethod method, int priority){
-		ofBaseEvent<of::priv::Function<T,Mutex>,Mutex>::add(make_function(listener,method,priority));
+		of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addNoToken(make_function(listener,method,priority));
 	}
 
 	template<class TObj, typename TMethod>
 	void remove(TObj * listener, TMethod method, int priority){
-		ofBaseEvent<of::priv::Function<T,Mutex>,Mutex>::remove(make_function(listener,method,priority));
+		of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::remove(make_function(listener,method,priority));
+	}
+
+	template<typename TFunction>
+	ofEventListener newListener(TFunction function, int priority = OF_EVENT_ORDER_AFTER_APP){
+		return ofEventListener(of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::add(make_function(function,priority)));
 	}
 
 	template<typename TFunction>
 	void add(TFunction function, int priority){
-		ofBaseEvent<of::priv::Function<T,Mutex>,Mutex>::add(make_function(function,priority));
+		of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addNoToken(make_function(function,priority));
 	}
 
 	template<typename TFunction>
 	void remove(TFunction function, int priority){
-		ofBaseEvent<of::priv::Function<T,Mutex>,Mutex>::remove(make_function(function,priority));
+		of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::remove(make_function(function,priority));
 	}
 
 	inline void notify(const void* sender, T & param){
-		if(ofEvent<T,Mutex>::enabled && !ofEvent<T,Mutex>::functions.empty()){
-			std::unique_lock<Mutex> lck(ofEvent<T,Mutex>::mtx);
-			std::vector<std::shared_ptr<of::priv::Function<T,Mutex>>> functions_copy(ofEvent<T,Mutex>::functions);
+		if(ofEvent<T,Mutex>::self->enabled && !ofEvent<T,Mutex>::self->functions.empty()){
+			std::unique_lock<Mutex> lck(ofEvent<T,Mutex>::self->mtx);
+			std::vector<std::shared_ptr<of::priv::Function<T,Mutex>>> functions_copy(ofEvent<T,Mutex>::self->functions);
 			lck.unlock();
 			for(auto & f: functions_copy){
                 if(f->notify(sender,param)){
@@ -306,10 +427,23 @@ public:
 			}
 		}
 	}
+
+	inline void notify(T & param){
+		if(ofEvent<T,Mutex>::self->enabled && !ofEvent<T,Mutex>::self->functions.empty()){
+			std::unique_lock<Mutex> lck(ofEvent<T,Mutex>::self->mtx);
+			std::vector<std::shared_ptr<of::priv::Function<T,Mutex>>> functions_copy(ofEvent<T,Mutex>::self->functions);
+			lck.unlock();
+			for(auto & f: functions_copy){
+				if(f->notify(nullptr,param)){
+					throw ofEventAttendedException();
+				}
+			}
+		}
+	}
 };
 
 template<typename Mutex>
-class ofEvent<void,Mutex>: public ofBaseEvent<of::priv::Function<void,Mutex>,Mutex>{
+class ofEvent<void,Mutex>: public of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>{
 protected:
 	typedef of::priv::Function<void,Mutex> Function;
 	typedef std::shared_ptr<Function> FunctionPtr;
@@ -394,34 +528,73 @@ protected:
 			return false;
 		}, make_function_id((ofEvent<void>*)nullptr,function));
 	}
+
+	FunctionPtr make_function(std::function<bool()> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*){return f();}, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<bool(const void*)> f, int priority){
+		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<void()> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*){f(); return false;}, of::priv::make_function_id());
+	}
+
+	FunctionPtr make_function(std::function<void(const void*)> f, int priority){
+		return std::make_shared<Function>(priority, [f](const void*s){f(s); return false;}, of::priv::make_function_id());
+	}
 public:
 	template<class TObj, typename TMethod>
 	void add(TObj * listener, TMethod method, int priority){
-		ofBaseEvent<of::priv::Function<void,Mutex>,Mutex>::add(make_function(listener,method,priority));
+		of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addNoToken(make_function(listener,method,priority));
+	}
+
+	template<class TObj, typename TMethod>
+	ofEventListener newListener(TObj * listener, TMethod method, int priority = OF_EVENT_ORDER_AFTER_APP){
+		return ofEventListener(of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::add(make_function(listener,method,priority)));
 	}
 
 	template<class TObj, typename TMethod>
 	void remove(TObj * listener, TMethod method, int priority){
-		ofBaseEvent<of::priv::Function<void,Mutex>,Mutex>::remove(make_function(listener,method,priority));
+		of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::remove(make_function(listener,method,priority));
 	}
 
 	template<typename TFunction>
 	void add(TFunction function, int priority){
-		ofBaseEvent<of::priv::Function<void,Mutex>,Mutex>::add(make_function(function,priority));
+		of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addNoToken(make_function(function,priority));
+	}
+
+	template<typename TFunction>
+	ofEventListener newListener(TFunction function, int priority = OF_EVENT_ORDER_AFTER_APP){
+		return ofEventListener(of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::add(make_function(function,priority)));
 	}
 
 	template<typename TFunction>
 	void remove(TFunction function, int priority){
-		ofBaseEvent<of::priv::Function<void,Mutex>,Mutex>::remove(make_function(function,priority));
+		of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::remove(make_function(function,priority));
 	}
 
 	void notify(const void* sender){
-		if(ofEvent<void,Mutex>::enabled && !ofEvent<void,Mutex>::functions.empty()){
-			std::unique_lock<Mutex> lck(ofEvent<void,Mutex>::mtx);
-			std::vector<std::shared_ptr<of::priv::Function<void,Mutex>>> functions_copy(ofEvent<void,Mutex>::functions);
+		if(ofEvent<void,Mutex>::self->enabled && !ofEvent<void,Mutex>::self->functions.empty()){
+			std::unique_lock<Mutex> lck(ofEvent<void,Mutex>::self->mtx);
+			std::vector<std::shared_ptr<of::priv::Function<void,Mutex>>> functions_copy(ofEvent<void,Mutex>::self->functions);
 			lck.unlock();
 			for(auto & f: functions_copy){
 				if(f->notify(sender)){
+					throw ofEventAttendedException();
+				}
+			}
+		}
+	}
+
+	void notify(){
+		if(ofEvent<void,Mutex>::self->enabled && !ofEvent<void,Mutex>::self->functions.empty()){
+			std::unique_lock<Mutex> lck(ofEvent<void,Mutex>::self->mtx);
+			std::vector<std::shared_ptr<of::priv::Function<void,Mutex>>> functions_copy(ofEvent<void,Mutex>::self->functions);
+			lck.unlock();
+			for(auto & f: functions_copy){
+				if(f->notify(nullptr)){
 					throw ofEventAttendedException();
 				}
 			}

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -211,7 +211,7 @@ namespace priv{
 			public:
 				EventToken();
 				template<typename Id>
-				EventToken(std::shared_ptr<BaseEvent<Function,Mutex>::Data> & event, const Id & id)
+				EventToken(std::shared_ptr<Data> & event, const Id & id)
 				:event(event)
 				,id(id.clone()){
 

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -225,7 +225,7 @@ namespace priv{
 				}
 
 			private:
-				std::weak_ptr<BaseEvent::Data> event;
+				std::weak_ptr<Data> event;
 				std::unique_ptr<BaseFunctionId> id;
 		};
 

--- a/libs/openFrameworks/events/ofEventUtils.h
+++ b/libs/openFrameworks/events/ofEventUtils.h
@@ -6,14 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
-
-enum ofEventOrder{
-	OF_EVENT_ORDER_BEFORE_APP=0,
-	OF_EVENT_ORDER_APP=100,
-	OF_EVENT_ORDER_AFTER_APP=200
-};
-
 //----------------------------------------------------
 // register any method of any class to an event.
 // the method must provide one of the following
@@ -219,7 +211,7 @@ inline void ofNotifyEvent(EventType & event, ArgumentsType & args, SenderType * 
 template <class EventType,typename ArgumentsType>
 inline void ofNotifyEvent(EventType & event, ArgumentsType & args){
 	try{
-		event.notify(nullptr,args);
+		event.notify(args);
 	}catch(ofEventAttendedException &){
 
 	}
@@ -237,7 +229,7 @@ inline void ofNotifyEvent(EventType & event, const ArgumentsType & args, SenderT
 template <class EventType,typename ArgumentsType>
 inline void ofNotifyEvent(EventType & event, const ArgumentsType & args){
 	try{
-		event.notify(nullptr,args);
+		event.notify(args);
 	}catch(ofEventAttendedException &){
 
 	}
@@ -254,7 +246,7 @@ inline void ofNotifyEvent(ofEvent<void> & event, SenderType * sender){
 
 inline void ofNotifyEvent(ofEvent<void> & event){
 	try{
-		event.notify(nullptr);
+		event.notify();
 	}catch(ofEventAttendedException &){
 
 	}

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -443,3 +443,16 @@ void ofSendMessage(string messageString){
 	ofMessage msg(messageString);
 	ofSendMessage(msg);
 }
+
+//------------------------------------------
+namespace of{
+	namespace priv{
+		std::atomic<uint_fast64_t> StdFunctionId::nextId;
+
+		AbstractEventToken::~AbstractEventToken(){}
+
+		BaseFunctionId::~BaseFunctionId(){}
+
+		StdFunctionId::~StdFunctionId(){}
+	}
+}

--- a/tests/events/events/addons.make
+++ b/tests/events/events/addons.make
@@ -1,0 +1,1 @@
+ofxUnitTests

--- a/tests/events/events/events.sln
+++ b/tests/events/events/events.sln
@@ -1,0 +1,35 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "events", "events.vcxproj", "{7FD42DF7-442E-479A-BA76-D0022F99702A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openframeworksLib", "..\..\..\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj", "{5837595D-ACA9-485C-8E76-729040CE4B0B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|Win32.Build.0 = Debug|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|x64.ActiveCfg = Debug|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Debug|x64.Build.0 = Debug|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|Win32.ActiveCfg = Release|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|Win32.Build.0 = Release|Win32
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|x64.ActiveCfg = Release|x64
+		{7FD42DF7-442E-479A-BA76-D0022F99702A}.Release|x64.Build.0 = Release|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|Win32.ActiveCfg = Debug|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|Win32.Build.0 = Debug|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|x64.ActiveCfg = Debug|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Debug|x64.Build.0 = Debug|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|Win32.ActiveCfg = Release|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|Win32.Build.0 = Release|Win32
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|x64.ActiveCfg = Release|x64
+		{5837595D-ACA9-485C-8E76-729040CE4B0B}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/events/events/events.vcxproj
+++ b/tests/events/events/events.vcxproj
@@ -172,10 +172,6 @@
 	</ItemDefinitionGroup>
 	<ItemGroup>
 		<ClCompile Include="src\main.cpp" />
-		<ClCompile Include="src\ofApp.cpp" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="src\ofApp.h" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="$(OF_ROOT)\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">

--- a/tests/events/events/events.vcxproj
+++ b/tests/events/events/events.vcxproj
@@ -95,7 +95,7 @@
 			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
 			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
 			<WarningLevel>Level3</WarningLevel>
-			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
 			<CompileAs>CompileAsCpp</CompileAs>
 		</ClCompile>
 		<Link>
@@ -114,7 +114,7 @@
 			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
 			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
 			<WarningLevel>Level3</WarningLevel>
-			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
 			<CompileAs>CompileAsCpp</CompileAs>
 			<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		</ClCompile>
@@ -133,7 +133,7 @@
 			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
 			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
 			<WarningLevel>Level3</WarningLevel>
-			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
 			<CompileAs>CompileAsCpp</CompileAs>
 			<MultiProcessorCompilation>true</MultiProcessorCompilation>
 		</ClCompile>
@@ -155,7 +155,7 @@
 			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
 			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
 			<WarningLevel>Level3</WarningLevel>
-			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\..\addons\ofxUnitTests\src</AdditionalIncludeDirectories>
 			<CompileAs>CompileAsCpp</CompileAs>
 		</ClCompile>
 		<Link>
@@ -172,6 +172,9 @@
 	</ItemDefinitionGroup>
 	<ItemGroup>
 		<ClCompile Include="src\main.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="$(OF_ROOT)\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">

--- a/tests/events/events/events.vcxproj
+++ b/tests/events/events/events.vcxproj
@@ -1,0 +1,198 @@
+<?xml version="1.0"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|Win32">
+			<Configuration>Debug</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|Win32">
+			<Configuration>Release</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<ProjectGuid>{7FD42DF7-442E-479A-BA76-D0022F99702A}</ProjectGuid>
+		<Keyword>Win32Proj</Keyword>
+		<RootNamespace>events</RootNamespace>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<CharacterSet>Unicode</CharacterSet>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug.props" />
+	</ImportGroup>
+	<ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+		<Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug.props" />
+	</ImportGroup>
+	<PropertyGroup Label="UserMacros" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<TargetName>$(ProjectName)_debug</TargetName>
+		<LinkIncremental>true</LinkIncremental>
+		<GenerateManifest>true</GenerateManifest>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<TargetName>$(ProjectName)_debug</TargetName>
+		<LinkIncremental>true</LinkIncremental>
+		<GenerateManifest>true</GenerateManifest>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<LinkIncremental>false</LinkIncremental>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<OutDir>bin\</OutDir>
+		<IntDir>obj\$(Configuration)\</IntDir>
+		<LinkIncremental>false</LinkIncremental>
+	</PropertyGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+		<ClCompile>
+			<Optimization>Disabled</Optimization>
+			<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+		</ClCompile>
+		<Link>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+		<ClCompile>
+			<Optimization>Disabled</Optimization>
+			<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+			<MultiProcessorCompilation>true</MultiProcessorCompilation>
+		</ClCompile>
+		<Link>
+			<GenerateDebugInformation>true</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+		<ClCompile>
+			<WholeProgramOptimization>false</WholeProgramOptimization>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+			<MultiProcessorCompilation>true</MultiProcessorCompilation>
+		</ClCompile>
+		<Link>
+			<IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+			<GenerateDebugInformation>false</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<OptimizeReferences>true</OptimizeReferences>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+		<ClCompile>
+			<WholeProgramOptimization>false</WholeProgramOptimization>
+			<PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+			<WarningLevel>Level3</WarningLevel>
+			<AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src</AdditionalIncludeDirectories>
+			<CompileAs>CompileAsCpp</CompileAs>
+		</ClCompile>
+		<Link>
+			<IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+			<GenerateDebugInformation>false</GenerateDebugInformation>
+			<SubSystem>Console</SubSystem>
+			<OptimizeReferences>true</OptimizeReferences>
+			<EnableCOMDATFolding>true</EnableCOMDATFolding>
+			<RandomizedBaseAddress>false</RandomizedBaseAddress>
+			<AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+			<AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+		</Link>
+		<PostBuildEvent />
+	</ItemDefinitionGroup>
+	<ItemGroup>
+		<ClCompile Include="src\main.cpp" />
+		<ClCompile Include="src\ofApp.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="src\ofApp.h" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="$(OF_ROOT)\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">
+			<Project>{5837595d-aca9-485c-8e76-729040ce4b0b}</Project>
+		</ProjectReference>
+	</ItemGroup>
+	<ItemGroup>
+		<ResourceCompile Include="icon.rc">
+			<AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/D_DEBUG %(AdditionalOptions)</AdditionalOptions>
+			<AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/D_DEBUG %(AdditionalOptions)</AdditionalOptions>
+			<AdditionalIncludeDirectories>$(OF_ROOT)\libs\openFrameworksCompiled\project\vs</AdditionalIncludeDirectories>
+		</ResourceCompile>
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties RESOURCE_FILE="icon.rc" />
+		</VisualStudio>
+	</ProjectExtensions>
+</Project>

--- a/tests/events/events/events.vcxproj.filters
+++ b/tests/events/events/events.vcxproj.filters
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<ClCompile Include="src\ofApp.cpp">
+			<Filter>src</Filter>
+		</ClCompile>
+		<ClCompile Include="src\main.cpp">
+			<Filter>src</Filter>
+		</ClCompile>
+	</ItemGroup>
+	<ItemGroup>
+		<Filter Include="src">
+			<UniqueIdentifier>{d8376475-7454-4a24-b08a-aac121d3ad6f}</UniqueIdentifier>
+		</Filter>
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="src\ofApp.h">
+			<Filter>src</Filter>
+		</ClInclude>
+	</ItemGroup>
+	<ItemGroup>
+		<ResourceCompile Include="icon.rc" />
+	</ItemGroup>
+</Project>

--- a/tests/events/events/events.vcxproj.filters
+++ b/tests/events/events/events.vcxproj.filters
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<ItemGroup>
-		<ClCompile Include="src\ofApp.cpp">
-			<Filter>src</Filter>
-		</ClCompile>
 		<ClCompile Include="src\main.cpp">
 			<Filter>src</Filter>
 		</ClCompile>
@@ -12,11 +9,6 @@
 		<Filter Include="src">
 			<UniqueIdentifier>{d8376475-7454-4a24-b08a-aac121d3ad6f}</UniqueIdentifier>
 		</Filter>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="src\ofApp.h">
-			<Filter>src</Filter>
-		</ClInclude>
 	</ItemGroup>
 	<ItemGroup>
 		<ResourceCompile Include="icon.rc" />

--- a/tests/events/events/events.vcxproj.filters
+++ b/tests/events/events/events.vcxproj.filters
@@ -9,6 +9,20 @@
 		<Filter Include="src">
 			<UniqueIdentifier>{d8376475-7454-4a24-b08a-aac121d3ad6f}</UniqueIdentifier>
 		</Filter>
+		<Filter Include="addons">
+			<UniqueIdentifier>{71834F65-F3A9-211E-73B8-DC85}</UniqueIdentifier>
+		</Filter>
+		<Filter Include="addons\ofxUnitTests">
+			<UniqueIdentifier>{99AF7102-9423-91D4-8CD7-6602}</UniqueIdentifier>
+		</Filter>
+		<Filter Include="addons\ofxUnitTests\src">
+			<UniqueIdentifier>{6DB6A1EA-29BB-7859-928B-898A}</UniqueIdentifier>
+		</Filter>
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="..\..\..\addons\ofxUnitTests\src\ofxUnitTests.h">
+			<Filter>addons\ofxUnitTests\src</Filter>
+		</ClInclude>
 	</ItemGroup>
 	<ItemGroup>
 		<ResourceCompile Include="icon.rc" />

--- a/tests/events/events/events.vcxproj.user
+++ b/tests/events/events/events.vcxproj.user
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)/bin</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>

--- a/tests/events/events/icon.rc
+++ b/tests/events/events/icon.rc
@@ -1,0 +1,8 @@
+// Icon Resource Definition
+#define MAIN_ICON                       102
+
+#if defined(_DEBUG)
+MAIN_ICON               ICON                    "icon_debug.ico"
+#else
+MAIN_ICON               ICON                    "icon.ico"
+#endif

--- a/tests/events/events/src/main.cpp
+++ b/tests/events/events/src/main.cpp
@@ -1,0 +1,173 @@
+#include "ofMain.h"
+#include "ofAppNoWindow.h"
+#include "ofxUnitTests.h"
+
+namespace {
+	int lastIntFromCFunc = 0;
+	int lastIntFromCFuncWithToken = 0;
+	int selfUnregisterValue = 0;
+	bool toggleVoidFunc = false;
+	ofEvent<const int> selfUnregisterEvent;
+
+	void intFunctListener(const int & i){
+		lastIntFromCFunc = i;
+	}
+
+	void intFunctListenerWithToken(const int & i){
+		lastIntFromCFuncWithToken = i;
+	}
+
+	void selfUnregister(const int & i){
+		selfUnregisterValue = i;
+		ofRemoveListener(selfUnregisterEvent, selfUnregister);
+	}
+
+	void voidFunc(){
+		toggleVoidFunc = !toggleVoidFunc;
+	}
+}
+
+class ofApp: public ofxUnitTestsApp{
+	int lastInt = 0;
+	int lastIntFromLambda = 0;
+	int lastIntWithToken = 0;
+	bool toggleForVoidListener = false;
+	bool toggleForVoidLambdaListener = false;
+	bool toggleForVoidListenerWithToken = false;
+
+	void intListener(const int & i){
+		lastInt = i;
+	}
+
+	void intListenerWithToken(const int & i){
+		lastIntWithToken = i;
+	}
+
+	void voidListener(){
+		toggleForVoidListener = !toggleForVoidListener;
+	}
+
+	void voidListenerWithToken(){
+		toggleForVoidListenerWithToken = !toggleForVoidListenerWithToken;
+	}
+
+	void run(){
+		{
+			ofEvent<const int> intEvent;
+			ofAddListener(intEvent, this, &ofApp::intListener);
+			ofAddListener(intEvent, intFunctListener);
+			auto listenerLambda = intEvent.newListener([&](const int & i){
+				lastIntFromLambda = i;
+			}, 0);
+			auto listenerMember = intEvent.newListener(this, &ofApp::intListenerWithToken);
+			auto listenerFunc = intEvent.newListener(intFunctListenerWithToken);
+
+			ofNotifyEvent(intEvent, 5);
+			test_eq(lastInt, 5, "Testing int event to member function");
+			test_eq(lastIntWithToken, 5, "Testing int event to member function with release token");
+			test_eq(lastIntFromLambda, 5, "Testing int event to lambda function");
+			test_eq(lastIntFromCFunc, 5, "Testing int event to c function");
+			test_eq(lastIntFromCFuncWithToken, 5, "Testing int event to c function with release token");
+
+			intEvent.disable();
+			ofNotifyEvent(intEvent, 6);
+			test_eq(lastInt, 5, "Testing disabled int event to member function");
+			test_eq(lastIntWithToken, 5, "Testing disabled int event to member function with release token");
+			test_eq(lastIntFromLambda, 5, "Testing disabled int event to lambda function");
+			test_eq(lastIntFromCFunc, 5, "Testing disabled int event to c function");
+			test_eq(lastIntFromCFuncWithToken, 5, "Testing disabled int event to c function with release token");
+
+			intEvent.enable();
+			ofNotifyEvent(intEvent, 6);
+			test_eq(lastInt, 6, "Testing re-enabled int event to member function");
+			test_eq(lastIntWithToken, 6, "Testing re-enabled int event to member function with release token");
+			test_eq(lastIntFromLambda, 6, "Testing re-enabled int event to lambda function");
+			test_eq(lastIntFromCFunc, 6, "Testing re-enabled int event to c function");
+			test_eq(lastIntFromCFuncWithToken, 6, "Testing re-enabled int event to c function with release token");
+
+			ofRemoveListener(intEvent, this, &ofApp::intListener);
+			ofRemoveListener(intEvent, &intFunctListener);
+			listenerLambda.unsubscribe();
+			listenerMember.unsubscribe();
+			listenerFunc.unsubscribe();
+			ofNotifyEvent(intEvent, 5);
+			test_eq(lastInt, 6, "Testing remove listener on int event to member function");
+			test_eq(lastIntWithToken, 6, "Testing remove listener on int event to member function with release token");
+			test_eq(lastIntFromLambda, 6, "Testing remove listener on int event to lambda function");
+			test_eq(lastIntFromCFunc, 6, "Testing remove listener on int event to c function");
+			test_eq(lastIntFromCFuncWithToken, 6, "Testing remove listener on int event to c function with release token");
+		}
+
+		{
+			ofEventListener listener;
+			{
+				ofEvent<const int> intEvent;
+				listener = intEvent.newListener([&](const int & i){
+					lastIntFromLambda = i;
+				}, 0);
+			}
+			listener.unsubscribe();
+		}
+
+		{
+			lastIntFromCFunc = 0;
+			auto listener = selfUnregisterEvent.newListener(selfUnregister);
+			selfUnregisterEvent.notify(5);
+			test_eq(selfUnregisterValue, 5, "Testing remove listener on event callback, first call");
+			selfUnregisterEvent.notify(6);
+			test_eq(selfUnregisterValue, 5, "Testing remove listener on event callback, second call");
+		}
+
+		{
+			ofEvent<void> voidEvent;
+			ofAddListener(voidEvent, this, &ofApp::voidListener);
+			auto listenerVoidLambda = voidEvent.newListener([&]{
+				toggleForVoidLambdaListener = !toggleForVoidLambdaListener;
+			});
+			auto listenerVoidMember = voidEvent.newListener(this, &ofApp::voidListenerWithToken);
+			auto listenerVoidFunc = voidEvent.newListener(voidFunc);
+
+			voidEvent.notify();
+			test_eq(toggleForVoidListener, true, "Void event with member function");
+			test_eq(toggleForVoidLambdaListener, true, "Void event with lambda function");
+			test_eq(toggleForVoidListenerWithToken, true, "Void event with member function with release token");
+			test_eq(toggleVoidFunc, true, "Void event with c function");
+
+			voidEvent.disable();
+			voidEvent.notify();
+			test_eq(toggleForVoidListener, true, "Disabled void event with member function");
+			test_eq(toggleForVoidLambdaListener, true, "Disabled void event with lambda function");
+			test_eq(toggleForVoidListenerWithToken, true, "Disabled void event with member function with release token");
+			test_eq(toggleVoidFunc, true, "Disabled void event with c function");
+
+			voidEvent.enable();
+			voidEvent.notify();
+			test_eq(toggleForVoidListener, false, "Re-enabled void event with member function");
+			test_eq(toggleForVoidLambdaListener, false, "Re-enabled void event with lambda function");
+			test_eq(toggleForVoidListenerWithToken, false, "Re-enabled void event with member function with release token");
+			test_eq(toggleVoidFunc, false, "Re-enabled void event with c function");
+
+			ofRemoveListener(voidEvent, this, &ofApp::voidListener);
+			listenerVoidLambda.unsubscribe();
+			listenerVoidMember.unsubscribe();
+			listenerVoidFunc.unsubscribe();
+			test_eq(toggleForVoidListener, false, "Unregistered void event with member function");
+			test_eq(toggleForVoidLambdaListener, false, "Unregistered void event with lambda function");
+			test_eq(toggleForVoidListenerWithToken, false, "Unregistered void event with member function with release token");
+			test_eq(toggleVoidFunc, false, "Unregistered void event with c function");
+		}
+	}
+};
+
+//========================================================================
+int main( ){
+    ofInit();
+    auto window = make_shared<ofAppNoWindow>();
+    auto app = make_shared<ofApp>();
+    // this kicks off the running of my app
+    // can be OF_WINDOW or OF_FULLSCREEN
+    // pass in width and height too:
+    ofRunApp(window, app);
+    return ofRunMainLoop();
+
+}


### PR DESCRIPTION
ofEvent now supports adding std::function as a listener, that allows among other things:

- pass a lambda function as a listener
- pass a function with a different signature as a listener.

For example to pass a lambda as a listener now you can do:

```cpp
ofEvents().mouseMoved.newListener([](ofMouseEventArgs & mouse){
	cout << mouse << endl;
});
```

Since std::function doesn't have an equality operator, there's no way to
unregister an event the old way calling `ofRemoveListener(function)` since
that required to compare the passed function with every other registered in
the event and remove it if it was the same.

`ofRemoveListener`also has some other problems, for example, the typical pattern:

```cpp
class MyClass{
public:
    MyClass(){
         ofAddListener(ofEvents().mouseMoved,this,&MyClass::mouseMoved);
    }

    ~MyClass(){
         ofRemoveListener(ofEvents().mouseMoved,this,&MyClass::mouseMoved);
    }

    void mouseMoved(ofMouseMoved & mouse){
    ....
    }
}
```

Has a problem with copy construction:

```
MyClass obj;
vector<MyClass> objs;
objs.push_back(obj);
```

Won't be registered as listener and there won't be any compiler error.
Because of the [rule of three](https://en.wikipedia.org/wiki/Rule_of_three_%28C%2B%2B_programming%29)
Any class that adds a listener in it's constructor and unregisters
in it's destructor. Needs also a copy constructor, operator=, and in
c++11 to be completely correct also a move constructor and an operator=
with move parameter.

With the new way of registering listeners one does:

```cpp
class MyClass{
    ofEventListener mouseMovedListener;
public:
    MyClass(){
         mouseMovedListener = ofEvents().mouseMoved.newListener(this,&MyClass::mouseMoved);
    }

    void mouseMoved(ofMouseMoved & mouse){
    ....
    }
}
```

The ofEventListener class unregisters the event automatically when it goes out
of scope avoiding the need for a destructor and because of that avoiding the
need for copy constructor...

Also since the class is not copyable if someone tries to copy an instance
of a class that contains an ofEventListener the compiler will give an error.

In any case the old method still works.