### PR TITLE
fix warning in ofTrueTypeFont

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1261,7 +1261,7 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
 				}else if(settings.direction == ofTtfSettings::RightToLeft){
 					x += glyphs.back().props.width;
 				}
-				glyphPositions.emplace_back(x,y);
+				glyphPositions.emplace_back(static_cast<float>(x), static_cast<float>(y));
 				x += glyphs.back().props.advance * letterSpacing;
 				height = max(height, glyphs.back().props.ymax + y + long(getLineHeight()));
 			}


### PR DESCRIPTION
since glyphPositions are `emplaced` back, visual studio (and possibly
other compilers) warn bitterly about implicit type conversion.

this pr makes the conversion explicit to end the whining.

Since we're storing the glyph position in an ofVec2f and we don't have
an integer vector type there's no way not to have a type conversion at
some point.