### PR TITLE
use templates for ofCreateWindow and mainLoop::createWindow

### DIFF
--- a/addons/ofxAndroid/src/ofAppAndroidWindow.h
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.h
@@ -24,7 +24,6 @@ public:
 	static void pollEvents(){}
 	static bool allowsMultiWindow(){ return false; }
 
-    using ofAppBaseWindow::setup;
 	void setup(const ofGLESWindowSettings & settings);
 	void update();
 	void draw();

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -142,9 +142,7 @@ public:
     static bool allowsMultiWindow(){ return false; }
     static bool needsPolling(){ return false; }
     static void pollEvents(){ }
-    
-    void setup(const ofWindowSettings & _settings);
-    void setup(const ofGLESWindowSettings & _settings);
+
     void setup(const ofiOSWindowSettings & _settings);
 	void setup();
     

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -66,24 +66,6 @@ void ofAppiOSWindow::close() {
     }
 }
 
-void ofAppiOSWindow::setup(const ofWindowSettings & _settings) {
-    const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&_settings);
-    if(iosSettings){
-        setup(*iosSettings);
-    } else{
-        setup(ofiOSWindowSettings(_settings));
-    }
-}
-
-void ofAppiOSWindow::setup(const ofGLESWindowSettings & _settings) {
-    const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&_settings);
-    if(iosSettings){
-        setup(*iosSettings);
-    } else{
-        setup(ofiOSWindowSettings(_settings));
-    }
-}
-
 void ofAppiOSWindow::setup(const ofiOSWindowSettings & _settings) {
     settings = _settings;
 	setup();

--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -18,7 +18,6 @@ public:
 	ofAppBaseWindow(){};
 	virtual ~ofAppBaseWindow(){};
 
-	virtual void setup(const ofWindowSettings & settings)=0;
 	virtual void update()=0;
 	virtual void draw()=0;
 	virtual bool getWindowShouldClose(){
@@ -94,32 +93,4 @@ public:
 	virtual HGLRC getWGLContext(){return 0;}
 	virtual HWND getWin32Window(){return 0;}
 #endif
-};
-
-class ofAppBaseGLWindow: public ofAppBaseWindow{
-public:
-	virtual ~ofAppBaseGLWindow(){}
-	virtual void setup(const ofGLWindowSettings & settings)=0;
-	void setup(const ofWindowSettings & settings){
-		const ofGLWindowSettings * glSettings = dynamic_cast<const ofGLWindowSettings*>(&settings);
-		if(glSettings){
-			setup(*glSettings);
-		}else{
-			setup(ofGLWindowSettings(settings));
-		}
-	}
-};
-
-class ofAppBaseGLESWindow: public ofAppBaseWindow{
-public:
-	virtual ~ofAppBaseGLESWindow(){}
-	virtual void setup(const ofGLESWindowSettings & settings)=0;
-	void setup(const ofWindowSettings & settings){
-		const ofGLESWindowSettings * glSettings = dynamic_cast<const ofGLESWindowSettings*>(&settings);
-		if(glSettings){
-			setup(*glSettings);
-		}else{
-			setup(ofGLESWindowSettings(settings));
-		}
-	}
 };

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -379,16 +379,6 @@ EGLNativeDisplayType ofAppEGLWindow::getNativeDisplay() {
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setup(const ofGLESWindowSettings & settings){
-	const Settings * glSettings = dynamic_cast<const Settings*>(&settings);
-	if(glSettings){
-		setup(*glSettings);
-	}else{
-		setup(Settings(settings));
-	}
-}
-
-//------------------------------------------------------------
 void ofAppEGLWindow::setup(const Settings & _settings) {
 	settings = _settings;
 	windowMode = OF_WINDOW;

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -87,7 +87,6 @@ public:
 	static void pollEvents();
 
 	void setup(const Settings & settings);
-	void setup(const ofGLESWindowSettings & settings);
 	void update();
 	void draw();
 	void close();

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -105,19 +105,6 @@ void ofAppGLFWWindow::setStencilBits(int stencil){
 }
 
 //------------------------------------------------------------
-#ifdef TARGET_OPENGLES
-void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings){
-#else
-void ofAppGLFWWindow::setup(const ofGLWindowSettings & settings){
-#endif
-	const ofGLFWWindowSettings * glSettings = dynamic_cast<const ofGLFWWindowSettings*>(&settings);
-	if(glSettings){
-		setup(*glSettings);
-	}else{
-		setup(ofGLFWWindowSettings(settings));
-	}
-}
-
 void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 	if(windowP){
 		ofLogError() << "window already setup, probably you are mixing old and new style setup";

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -46,12 +46,7 @@ public:
 	shared_ptr<ofAppBaseWindow> shareContextWith;
 };
 
-#ifdef TARGET_OPENGLES
-class ofAppGLFWWindow : public ofAppBaseGLESWindow{
-#else
-class ofAppGLFWWindow : public ofAppBaseGLWindow {
-#endif
-
+class ofAppGLFWWindow : public ofAppBaseWindow {
 public:
 
 	ofAppGLFWWindow();
@@ -68,13 +63,7 @@ public:
 	static void pollEvents(){ glfwPollEvents(); }
 
 
-    // this functions are only meant to be called from inside OF don't call them from your code
-    using ofAppBaseWindow::setup;
-#ifdef TARGET_OPENGLES
-	void setup(const ofGLESWindowSettings & settings);
-#else
-	void setup(const ofGLWindowSettings & settings);
-#endif
+	// this functions are only meant to be called from inside OF don't call them from your code
 	void setup(const ofGLFWWindowSettings & settings);
 	void update();
 	void draw();

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -10,7 +10,7 @@
 class ofBaseApp;
 class ofBaseRenderer;
 
-class ofAppGlutWindow : public ofAppBaseGLWindow {
+class ofAppGlutWindow : public ofAppBaseWindow {
 
 public:
 
@@ -23,7 +23,6 @@ public:
 	static bool needsPolling(){ return false; }
 	static void pollEvents(){  }
 
-	using ofAppBaseWindow::setup;
 	void setup(const ofGLWindowSettings & settings);
 	void update();
 	void draw();

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -191,11 +191,6 @@ void ofSetupOpenGL(int w, int h, ofWindowMode screenMode){
 	ofCreateWindow(settings);
 }
 
-shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings){
-	ofInit();
-	return mainLoop()->createWindow(settings);
-}
-
 //-----------------------	gets called when the app exits
 //							currently looking at who to turn off
 //							at the end of the application

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -18,9 +18,15 @@ class ofCoreEvents;
 
 void ofInit();
 void ofSetupOpenGL(int w, int h, ofWindowMode screenMode);	// sets up the opengl context!
-shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings);	// sets up the opengl context!
 shared_ptr<ofMainLoop> ofGetMainLoop();
 void ofSetMainLoop(shared_ptr<ofMainLoop> mainLoop);
+
+
+template<typename Settings>
+shared_ptr<ofAppBaseWindow> ofCreateWindow(const Settings & settings){
+	ofInit();
+	return ofGetMainLoop()->createWindow(settings);
+}
 
 template<typename Window>
 void ofSetupOpenGL(shared_ptr<Window> windowPtr, int w, int h, ofWindowMode screenMode){

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -9,24 +9,10 @@
 #include "ofWindowSettings.h"
 #include "ofConstants.h"
 
-//========================================================================
-// default windowing
-#ifdef TARGET_NODISPLAY
-	#include "ofAppNoWindow.h"
-#elif defined(TARGET_OF_IOS)
-	#include "ofAppiOSWindow.h"
-#elif defined(TARGET_ANDROID)
-	#include "ofAppAndroidWindow.h"
-	#include "ofxAndroidUtils.h"
-	#include "ofxAndroidApp.h"
-#elif defined(TARGET_RASPBERRY_PI)
-	#include "ofAppEGLWindow.h"
-#elif defined(TARGET_EMSCRIPTEN)
-	#include "ofxAppEmscriptenWindow.h"
-#else
-	#include "ofAppGLFWWindow.h"
+#if defined(TARGET_ANDROID)
+#include "ofxAndroidUtils.h"
+#include "ofxAndroidApp.h"
 #endif
-
 
 ofMainLoop::ofMainLoop()
 :bShouldClose(false)
@@ -38,29 +24,6 @@ ofMainLoop::ofMainLoop()
 
 ofMainLoop::~ofMainLoop() {
 	exit();
-}
-
-shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & settings){
-#ifdef TARGET_NODISPLAY
-	shared_ptr<ofAppNoWindow> window = shared_ptr<ofAppNoWindow>(new ofAppNoWindow());
-#else
-	#if defined(TARGET_OF_IOS)
-	shared_ptr<ofAppiOSWindow> window = shared_ptr<ofAppiOSWindow>(new ofAppiOSWindow());
-	#elif defined(TARGET_ANDROID)
-	shared_ptr<ofAppAndroidWindow> window = shared_ptr<ofAppAndroidWindow>(new ofAppAndroidWindow());
-	#elif defined(TARGET_RASPBERRY_PI)
-	shared_ptr<ofAppEGLWindow> window = shared_ptr<ofAppEGLWindow>(new ofAppEGLWindow());
-	#elif defined(TARGET_EMSCRIPTEN)
-	shared_ptr<ofxAppEmscriptenWindow> window = shared_ptr<ofxAppEmscriptenWindow>(new ofxAppEmscriptenWindow);
-	#elif defined(TARGET_OPENGLES)
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
-	#else
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
-	#endif
-#endif
-	addWindow(window);
-	window->setup(settings);
-	return window;
 }
 
 void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> app){

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -5,12 +5,47 @@
 #include "ofBaseApp.h"
 #include "ofEvents.h"
 
+#ifdef TARGET_NODISPLAY
+	#include "ofAppNoWindow.h"
+#elif defined(TARGET_OF_IOS)
+	#include "ofAppiOSWindow.h"
+#elif defined(TARGET_ANDROID)
+	#include "ofAppAndroidWindow.h"
+#elif defined(TARGET_RASPBERRY_PI)
+	#include "ofAppEGLWindow.h"
+#elif defined(TARGET_EMSCRIPTEN)
+	#include "ofxAppEmscriptenWindow.h"
+#else
+	#include "ofAppGLFWWindow.h"
+#endif
+
 class ofMainLoop {
 public:
 	ofMainLoop();
 	virtual ~ofMainLoop();
 
-	shared_ptr<ofAppBaseWindow> createWindow(const ofWindowSettings & settings);
+	template<typename Settings>
+	shared_ptr<ofAppBaseWindow> createWindow(const Settings & settings){
+		#if defined(TARGET_NODISPLAY)
+		shared_ptr<ofAppNoWindow> window = shared_ptr<ofAppNoWindow>(new ofAppNoWindow());
+		#elif defined(TARGET_OF_IOS)
+		shared_ptr<ofAppiOSWindow> window = shared_ptr<ofAppiOSWindow>(new ofAppiOSWindow());
+		#elif defined(TARGET_ANDROID)
+		shared_ptr<ofAppAndroidWindow> window = shared_ptr<ofAppAndroidWindow>(new ofAppAndroidWindow());
+		#elif defined(TARGET_RASPBERRY_PI)
+		shared_ptr<ofAppEGLWindow> window = shared_ptr<ofAppEGLWindow>(new ofAppEGLWindow());
+		#elif defined(TARGET_EMSCRIPTEN)
+		shared_ptr<ofxAppEmscriptenWindow> window = shared_ptr<ofxAppEmscriptenWindow>(new ofxAppEmscriptenWindow);
+		#elif defined(TARGET_OPENGLES)
+		shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+		#else
+		shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+		#endif
+		addWindow(window);
+		window->setup(settings);
+		return window;
+	}
+
 	template<typename Window>
 	void addWindow(shared_ptr<Window> window){
 		allowMultiWindow = Window::allowsMultiWindow();


### PR DESCRIPTION
otherwise the implementation for the windows needs to dynamic_cast to
get the correct type for the settings object

Fixes #4755