### PR TITLE
add newListener() method to ofParameter

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -430,6 +430,11 @@ public:
 		ofRemoveListener(obj->changedE,listener,method,prio);
 	}
 
+	template<typename... Args>
+	ofEventListener newListener(Args...args) {
+		return obj->changedE.newListener(args...);
+	}
+
 	void enableEvents();
 	void disableEvents();
 	bool isSerializable() const;


### PR DESCRIPTION
If you want to use an `ofEventListener` to respond to an `ofEvent`, you best create one using a templated factory method which is part of `ofEvent<T>`.

Since ofParameter shields users from accessing its data directly by holding it inside a private data `obj`, there is no way to call the `newListener` factory method on a parameter changed event (`changedE`) which you want to observe.

This PR proposes to add a `newListener` method to `ofParameter`, which will, based on dark templating magick, forward any of its parameters to the `ofEvent` object held by the private `ofParameter::obj`.

I wish there was a simpler way, but this seems to me the best way to observe an ofParameter and responding to any changes using a lambda.

Minimal testcase:
<https://gist.github.com/tgfrerer/f9fc6e3b2ebe88633ab5>