### PR TITLE
iPad Pro Pencil and generic 3D touch inputs

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -10,6 +10,7 @@
 #include "ofAppiOSWindow.h"
 #include "ofGLRenderer.h"
 #include "ofGLProgrammableRenderer.h"
+#include "ofxiOS3dTouch.h"
 
 static ofxiOSEAGLView * _instanceRef = nil;
 
@@ -267,6 +268,15 @@ static ofxiOSEAGLView * _instanceRef = nil;
 			ofNotifyEvent(window->events().touchDoubleTap,touchArgs);	// send doubletap
         }
 		touchArgs.type = ofTouchEventArgs::down;
+
+		//add stylus specific data if available
+		//can be extended as new types become available
+		if(touch.type == UITouchTypeStylus){
+			static ofxiOS3dTouch stylusTouch;
+			stylusTouch.data = touch;
+			touchArgs.nativeTouchData = &stylusTouch;
+		}
+        
 		ofNotifyEvent(window->events().touchDown,touchArgs);	// but also send tap (upto app programmer to ignore this if doubletap came that frame)
 	}	
 }
@@ -299,6 +309,15 @@ static ofxiOSEAGLView * _instanceRef = nil;
 		touchArgs.y = touchPoint.y;
 		touchArgs.id = touchIndex;
 		touchArgs.type = ofTouchEventArgs::move;
+        
+		//add stylus specific data if available
+		//can be extended as new types become available
+		if(touch.type == UITouchTypeStylus){
+			static ofxiOS3dTouch stylusTouch;
+			stylusTouch.data = touch;
+			touchArgs.nativeTouchData = &stylusTouch;
+		}
+        
 		ofNotifyEvent(window->events().touchMoved, touchArgs);
 	}
 }
@@ -334,6 +353,15 @@ static ofxiOSEAGLView * _instanceRef = nil;
 		touchArgs.y = touchPoint.y;
 		touchArgs.id = touchIndex;
 		touchArgs.type = ofTouchEventArgs::up;
+        
+        //add stylus specific data if available
+		//can be extended as new types become available
+		if(touch.type == UITouchTypeStylus){
+			static ofxiOS3dTouch stylusTouch;
+			stylusTouch.data = touch;
+			touchArgs.nativeTouchData = &stylusTouch;
+		}
+        
 		ofNotifyEvent(window->events().touchUp, touchArgs);
 	}
 }

--- a/addons/ofxiOS/src/events/ofxiOS3dTouch.h
+++ b/addons/ofxiOS/src/events/ofxiOS3dTouch.h
@@ -1,0 +1,24 @@
+/*
+ *  ofxiOS3dTouch.h
+ *  iOS+OFLib
+ *
+ *  Created by Andreas Borg on 2/9/16
+ *  Copyright 2016 Local Projects LLC. All rights reserved.
+ *
+ */
+
+#ifndef _ofxiOS3dTouch
+#define _ofxiOS3dTouch
+
+#include "ofMain.h"
+#import <UIKit/UIKit.h>
+
+class ofxiOS3dTouch:public ofNativeTouchData {
+	
+  public:
+	
+	ofxiOS3dTouch(){};
+	UITouch * data;
+};
+
+#endif

--- a/addons/ofxiOS/src/ofxiOS.h
+++ b/addons/ofxiOS/src/ofxiOS.h
@@ -46,3 +46,4 @@
 #include "ofxiOSApp.h"
 #include "ofxiOSExtras.h"
 #include "ofxAccelerometer.h"
+#include "ofxiOS3dTouch.h"

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -115,6 +115,13 @@ class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
 	float scrollY;
 };
 
+//extend this to be able to pass native device specific data such as iOS Pencil azimuth
+class ofNativeTouchData{
+	public:
+	ofNativeTouchData(){};
+	~ofNativeTouchData(){};
+};
+
 class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
   public:
 	enum Type{
@@ -140,6 +147,7 @@ class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
 	,yspeed(0)
 	,xaccel(0)
 	,yaccel(0)
+	,nativeTouchData(0)
 	{
 
 	}
@@ -159,7 +167,8 @@ class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
 	,xspeed(0)
 	,yspeed(0)
 	,xaccel(0)
-	,yaccel(0){}
+	,yaccel(0)
+	,nativeTouchData(0){}
 
 	Type type;
 	int id;
@@ -171,6 +180,7 @@ class ofTouchEventArgs : public ofEventArgs, public ofVec2f {
 	float pressure;
 	float xspeed, yspeed;
 	float xaccel, yaccel;
+	ofNativeTouchData *nativeTouchData;
 };
 
 class ofResizeEventArgs : public ofEventArgs {


### PR DESCRIPTION
Here is one possible implementation of adding support for device specific touch input devices without having to create a separate event system.

The Apple Pencil can still be used as a normal finger touch input device, and the normal touch methods called in ofApp. However if the app needs access to the additional Pencil specific properties such as pen azimuth and force the native UITouch can be accessible through the nativeTouchData property.

https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITouch_Class/#//apple_ref/c/tdef/UITouchType

eg.
```
void ofApp::touchMoved(ofTouchEventArgs &touch){
    if(touch.nativeTouchData){
        UITouch * pencil = (UITouch *)((ofxiOS3dTouch*)touch.nativeTouchData)->data;
        CGFloat azimuth = [pencil azimuthAngleInView:ofxiOSGetGLView()];
       
    //A value of 0 radians indicates that the stylus is parallel to the surface; when the stylus is perpendicular to the surface, altitudeAngle is Pi/2.
    CGFloat altitudeAngle = pencil.altitudeAngle;
    }
}
```

Since new devices keep coming out this would be a flexible way of passing on native data to devices that can handle it without upsetting other. In this case the ofxiOSEAGLView added support for new iOS features, but other platforms could do the same. It is using the same paradigm used for passing custom data in bullet physics. The shortcoming is that it does not include strongly typed properties in the normal oF way, and in this case it is passing an ObjC pointer.

Unless someone wants the job to map all properties on all devices moving forward this is one way of handling it. This was put together quickly and works, but hasn't been road tested. Would welcome other design ideas for this.