### PR TITLE
Revert to mutable mutex in ofThread.

### DIFF
--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -322,7 +322,7 @@ protected:
     ///
     ///     std::unique_lock<std::mutex> lock(mutex);
     ///
-    std::mutex mutex;
+    mutable std::mutex mutex;
 
 private:
     ///< \brief Implements Poco::Runnable::run().


### PR DESCRIPTION
This seems to have regressed here 22e1b1de2ea4775761093c3a8bf39948cf1b4849.

Herb Sutter et al seem to think a mutable mutex is just fine.

http://herbsutter.com/2013/01/01/video-you-dont-know-const-and-mutable/