### PR TITLE
FreeImage fix for OS X and Windows

### DIFF
--- a/libs/FreeImage/include/FreeImage.h
+++ b/libs/FreeImage/include/FreeImage.h
@@ -150,22 +150,22 @@ FI_STRUCT (FIMULTIBITMAP) { void *data; };
 #ifndef _MSC_VER
 // define portable types for 32-bit / 64-bit OS
 #include <inttypes.h>
-typedef int32_t BOOL;
-typedef uint8_t BYTE;
-typedef uint16_t WORD;
-typedef uint32_t DWORD;
-typedef int32_t LONG;
-typedef int64_t INT64;
-typedef uint64_t UINT64;
+#define BOOL int32_t
+#define BYTE uint8_t
+#define WORD uint16_t
+#define DWORD uint32_t
+#define LONG int32_t
+#define INT64 int64_t
+#define UINT64 uint64_t
 #else
 // MS is not C99 ISO compliant
-typedef long BOOL;
-typedef unsigned char BYTE;
-typedef unsigned short WORD;
-typedef unsigned long DWORD;
-typedef long LONG;
-typedef signed __int64 INT64;
-typedef unsigned __int64 UINT64;
+#define BOOL long
+#define BYTE unsigned char
+#define WORD unsigned short
+#define DWORD unsigned long
+#define LONG long
+#define INT64 signed __int64
+#define UINT64 unsigned __int64
 #endif // _MSC_VER
 
 #if (defined(_WIN32) || defined(__WIN32__))
@@ -1149,5 +1149,13 @@ DLL_API FIBITMAP *DLL_CALLCONV FreeImage_MultigridPoissonSolver(FIBITMAP *Laplac
 #ifdef __cplusplus
 }
 #endif
+
+#undef BOOL
+#undef BYTE
+#undef WORD
+#undef DWORD
+#undef LONG
+#undef INT64
+#undef UINT64
 
 #endif // FREEIMAGE_H


### PR DESCRIPTION
Fixes issues with OS X and BOOL issues on some compilers.

Only seems to be an issue for older compilers / systems.

Older issues that solved this: 
(2009) #76
(2013) #1889

This has cropped up again in 2015 due to updating to 3.17.0 and this no longer being an issue on Modern OS X Xcode compilers.

Previous PR:
#4833

# This is the final PR!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!