### PR TITLE
qt-creator removed prefix for addon frameworks

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -347,7 +347,7 @@ Module{
         for(var addon in ADDONS){
             var addonPath = ADDONS[addon];
             var addonFrameworks = [];
-            addonFrameworks = Helpers.parseAddonConfig(addonPath, "ADDON_FRAMEWORKS", addonFrameworks, platform, addonPath+"/");
+            addonFrameworks = Helpers.parseAddonConfig(addonPath, "ADDON_FRAMEWORKS", addonFrameworks, platform);
             frameworks = frameworks.concat(addonFrameworks);
         }
         return frameworks;


### PR DESCRIPTION
qbs prefixed addon frameworks with the addon path.
This led to errors like: `:-1: error: framework not found /Users/thomasgeissl/programming/of/ofTG/addons/ofxMidi/CoreMIDI`
