### PR TITLE
VBO fixes for custom attributes on fixed pipeline.

### DIFF
--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -382,42 +382,36 @@ void ofVbo::setIndexData(const ofIndexType * indices, int total, int usage){
 //--------------------------------------------------------------
 ofVbo::VertexAttribute & ofVbo::getOrCreateAttr(int location){
 	VertexAttribute * attr = nullptr;
-	if (ofIsGLProgrammableRenderer()) {
-		switch (location){
-			case ofShader::POSITION_ATTRIBUTE:
-				attr = &positionAttribute;
-				break;
-			case ofShader::COLOR_ATTRIBUTE:
-				attr = &colorAttribute;
-				break;
-			case ofShader::NORMAL_ATTRIBUTE:
-				attr = &normalAttribute;
-				break;
-			case ofShader::TEXCOORD_ATTRIBUTE:
-				attr = &texCoordAttribute;
-				break;
-			default:
-				customAttributes[location].location = location;
-				attr = &customAttributes[location];
-				vaoChanged = true;
-				break;
-		}
-	}else{
-		customAttributes[location].location = location;
-		attr = &customAttributes[location];
-		vaoChanged = true;
+	switch (location){
+		case ofShader::POSITION_ATTRIBUTE:
+			attr = &positionAttribute;
+			break;
+		case ofShader::COLOR_ATTRIBUTE:
+			attr = &colorAttribute;
+			break;
+		case ofShader::NORMAL_ATTRIBUTE:
+			attr = &normalAttribute;
+			break;
+		case ofShader::TEXCOORD_ATTRIBUTE:
+			attr = &texCoordAttribute;
+			break;
+		default:
+			customAttributes[location].location = location;
+			attr = &customAttributes[location];
+			vaoChanged = true;
+			break;
 	}
 	return *attr;
 }
 
 //--------------------------------------------------------------
 void ofVbo::setAttributeData(int location, const float * attrib0x, int numCoords, int total, int usage, int stride){
-	if(ofIsGLProgrammableRenderer() && location==ofShader::POSITION_ATTRIBUTE){
+	if(location==ofShader::POSITION_ATTRIBUTE){
 		totalVerts = total;
 	}
 
 	bool normalize = false;
-	if(ofIsGLProgrammableRenderer() && !hasAttribute(location)){
+	if(!hasAttribute(location)){
 		vaoChanged = true;
 		bUsingVerts |= (location == ofShader::POSITION_ATTRIBUTE);
 		bUsingColors |= (location == ofShader::COLOR_ATTRIBUTE);


### PR DESCRIPTION
Hello, I'm bringing this up again because I noticed that the current ofVbo still doesn't behave as expected. The main issue is that `setAttributeData` is going through a different code path with the fixed pipeline, and not using the existing `VertexAttribute` objects for vertices, normals, colours, tex coords, etc.

With this change, something like the following will work the same under both fixed and programmable pipeline.
```
volVbo.setVertexData(volVerts, 24, GL_STATIC_DRAW);
volVbo.setNormalData(volNormals, 24, GL_STATIC_DRAW);
volVbo.setAttributeData(ofShader::COLOR_ATTRIBUTE, (float *)volVerts, 3, 24, GL_STATIC_DRAW);
volVbo.setAttributeData(ofShader::TEXCOORD_ATTRIBUTE, (float *)volVerts, 3, 24, GL_STATIC_DRAW);
volVbo.setIndexData(volIndices, 36, GL_STATIC_DRAW);
```

Sorry for not using the previous PR, but it seems to have completely vanished, probably because I got rid of the branch associated with it. For reference, this all started because I'm trying to use 3D textures with ofVbo.

cc @arturoc @tgfrerer 