### PR TITLE
ignore addons.make in examples folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ examples/**/[Dd]ebug*/
 examples/**/[Rr]elease*/
 examples/**/gcc-debug/
 examples/**/gcc-release/
+examples/**/addons.make
 tests/**/[Dd]ebug*/
 tests/**/[Rr]elease*/
 tests/**/gcc-debug/
@@ -127,4 +128,3 @@ Desktop.ini
 
 .mailmap
 /apps*/
-


### PR DESCRIPTION
Ignoring addons.make in examples folders, so that project generator doesn't create a great deal of new untracked files to the local git projects.