### PR TITLE
Custom input area for mouse events in ofEasyCam

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -64,11 +64,18 @@ void ofEasyCam::update(ofEventArgs & args){
 }
 
 //----------------------------------------
-void ofEasyCam::begin(ofRectangle _viewport){
-	if(!bEventsSet){
+void ofEasyCam::begin(ofRectangle _viewport) {
+	// By default, input area for mouse events is set same as camera's viewport
+	ofEasyCam::begin(_viewport, _viewport);
+}
+
+//----------------------------------------
+void ofEasyCam::begin(ofRectangle _viewport, ofRectangle _inputArea) {
+	if (!bEventsSet) {
 		setEvents(ofEvents());
 	}
 	viewport = getViewport(_viewport);
+	inputArea = getViewport(_inputArea);
 	ofCamera::begin(viewport);
 }
 
@@ -287,7 +294,7 @@ void ofEasyCam::updateRotation(){
 }
 
 void ofEasyCam::mousePressed(ofMouseEventArgs & mouse){
-	ofRectangle viewport = getViewport(this->viewport);
+	ofRectangle viewport = getViewport(this->inputArea);
 	if(viewport.inside(mouse.x, mouse.y)){
 		lastMouse = mouse;
 		prevMouse = mouse;
@@ -315,7 +322,7 @@ void ofEasyCam::mousePressed(ofMouseEventArgs & mouse){
 
 void ofEasyCam::mouseReleased(ofMouseEventArgs & mouse){
 	unsigned long curTap = ofGetElapsedTimeMillis();
-	ofRectangle viewport = getViewport(this->viewport);
+	ofRectangle viewport = getViewport(this->inputArea);
 	if(lastTap != 0 && curTap - lastTap < doubleclickTime){
 		reset();
 		return;
@@ -342,7 +349,7 @@ void ofEasyCam::mouseDragged(ofMouseEventArgs & mouse){
 }
 
 void ofEasyCam::mouseScrolled(ofMouseEventArgs & mouse){
-	ofRectangle viewport = getViewport(this->viewport);
+	ofRectangle viewport = getViewport(this->inputArea);
 	prevPosition = ofCamera::getGlobalPosition();
 	prevAxisZ = getZAxis();
 	moveZ = mouse.scrollY * 30 * sensitivityZ * (getDistance() + FLT_EPSILON)/ viewport.height;
@@ -350,7 +357,7 @@ void ofEasyCam::mouseScrolled(ofMouseEventArgs & mouse){
 }
 
 void ofEasyCam::updateMouse(const ofMouseEventArgs & mouse){
-	ofRectangle viewport = getViewport(this->viewport);
+	ofRectangle viewport = getViewport(this->inputArea);
 	int vFlip;
 	if(isVFlipped()){
 		vFlip = -1;

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -21,6 +21,8 @@ public:
 	/// \{
 
 	virtual void begin(ofRectangle viewport = ofRectangle());
+    
+    virtual void begin(ofRectangle viewport = ofRectangle(), ofRectangle inputArea = ofRectangle());
 
     /// \brief Reset the camera position and orientation.
 	void reset();
@@ -202,7 +204,10 @@ private:
 
     /// \brief The previous camera orientation.
 	ofQuaternion prevOrientation;
-
+    
+    /// \brief Area listening mouse inputs to control camera.
+    ofRectangle inputArea;
+    /// \brief Camera rendering viewport.
 	ofRectangle viewport;
 
 	ofCoreEvents * events;


### PR DESCRIPTION
This proposal refers to #4846 : it allows user to set a custom area to control an ofEasyCam. 

It is especially useful when you want to render an ofEasyCam in an ofFbo : if you draw the fbo's texture scaled or translated on the screen (so texture drawn doesn't match camera's viewport), mouse inputs becomes inaccurate. This feature allows user to allocate a specific part of screen to camera's control, and in my example, you can set the input area so controls match where fbo is drawn.

To do that, I added an ofRectangle representing the area where mouse events are tested, and in mousePressed etc functions, I check if mouse is inside this area instead of the whole camera's viewport.
This area can be set optionally in begin() function (as viewport), and is set to viewport by default. 