### PR TITLE
Add slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://ofslack.herokuapp.com)
-
 [openFrameworks](http://openframeworks.cc/)
 ================
 
 openFrameworks is a C++ toolkit for creative coding.  If you are new to OF, welcome!
+
+[![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://ofslack.herokuapp.com)
 
 ##Build status
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://yourdomain.com)
+
 [openFrameworks](http://openframeworks.cc/)
 ================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://yourdomain.com)
+[![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://ofslack.herokuapp.com)
 
 [openFrameworks](http://openframeworks.cc/)
 ================


### PR DESCRIPTION
I've added slackin to our slack on an heroku instance, so people can get invites without asking @ofZach personally. This adds a small badge in the readme 