### PR TITLE
fix for #4842 removing pixelScreenCoordScale multiplier from window resize callback

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1146,10 +1146,9 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int keycode, int scancod
 //------------------------------------------------------------
 void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_,int w, int h) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
-	instance->windowW = w * instance->pixelScreenCoordScale;
-	instance->windowH = h * instance->pixelScreenCoordScale;
+	instance->windowW = w;
+	instance->windowH = h;
 	instance->events().notifyWindowResized(w*instance->pixelScreenCoordScale, h*instance->pixelScreenCoordScale);
-
 	instance->nFramesSinceWindowResized = 0;
 }
 


### PR DESCRIPTION
Fix for #4842, #4746 & [datgui#39](https://github.com/braitsch/ofxDatGui/issues/39) where the window instance's dimensions were being multiplied by the pixelScreenCoordScale within the internal resize callback. The problem this created is that the dimensions are also multiplied by pixelScreenCoordScale within any query against the window e.g. getWidth, getHeight, getWindowSize etc so the multiplication was happening twice resulting in those calls returning a 4x value instead of a 2x value when pixelScreenCoordScale is greater than 1.