### PR TITLE
Fix for ply mesh data loader with uchar color type

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -792,6 +792,8 @@ void ofMesh::load(string path){
 	ofIndexType currentVertex = 0;
 	ofIndexType currentFace = 0;
 
+	bool colorTypeIsUChar = false; /// flag to distinguish between uchar (more common) and float (less common) color format in ply file
+	
 	enum State{
 		Header,
 		VertexDef,
@@ -865,6 +867,7 @@ void ofMesh::load(string path){
 		}
 
 		if(state==VertexDef && (lineStr.find("property uchar red")==0 || lineStr.find("property uchar green")==0 || lineStr.find("property uchar blue")==0 || lineStr.find("property uchar alpha")==0)){
+			colorTypeIsUChar = true;
 			colorCompsFound++;
 			meshDefinition.push_back(Color);
 			data.getColors().resize(data.getVertices().size());
@@ -933,7 +936,13 @@ void ofMesh::load(string path){
 						sline >> *(&data.getVertices()[currentVertex].x + (vAttr++)%vertexCoordsFound);
 						break;
 					case Color:
-						sline >> *(&data.getColors()[currentVertex].r + (cAttr++)%colorCompsFound);
+						if (colorTypeIsUChar){
+							int c = 0;
+							sline >> c;
+							*(&data.getColors()[currentVertex].r + (cAttr++)%colorCompsFound) = c/255.f;
+						} else {
+							sline >> *(&data.getColors()[currentVertex].r + (cAttr++)%colorCompsFound);
+						}
 						break;
 					case Normal:
 						sline >> *(&data.getNormals()[currentVertex].x + (nAttr++)%normalsCoordsFound);


### PR DESCRIPTION
When loading meshes from .ply files, color vertex attributes may be specified as `uchar`, not just float. 

The existing implementation was not allowing for this, and `uchars` were righteously (though not rightfully) interpreted as `float`s.

This PR suggests adding a flag for the vertex color type derived whilst reading the file's manifest section.

It then makes interpretation of color data type dependent on this flag, and scales `uchar` color data to normalised float range, so that both types, either `uchar` or `float` may be used to the same effect.

Fixes #4935