### PR TITLE
update to close Android video player properly

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
@@ -178,7 +178,24 @@ bool ofxAndroidVideoPlayer::loadMovie(string fileName){
 
 //---------------------------------------------------------------------------
 void ofxAndroidVideoPlayer::close(){
+	if(!javaVideoPlayer){
+		ofLogError("ofxAndroidVideoPlayer") << "unloadMovie(): java VideoPlayer not loaded";
+		return;
+	}
+	JNIEnv *env = ofGetJNIEnv();
+	if (!env) {
+		ofLogError("ofxAndroidVideoPlayer") << "unloadMovie(): couldn't get environment using GetEnv()";
+		return;
+	}
 
+	jmethodID javaUnloadMethod = env->GetMethodID(javaClass,"unloadMovie","()V");
+	if(!javaUnloadMethod){
+		ofLogError("ofxAndroidVideoPlayer") << "unloadMovie(): couldn't get java unloadMovie for VideoPlayer";
+		return;
+	}
+
+	unloadTexture();
+	env->CallVoidMethod(javaVideoPlayer,javaUnloadMethod);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
The ofxAndroidVideoPlayer doesn't close properly.

I Play a video file, I stop it, I pause-resume the app and the video restarts again himself without calling him. Another issue, not closed mediaplayer causes ioConfigChanged() error on some devices when trying to start a soundplayer after the app resume.

I see that the inside of the close() method is empty. I added the necessary code lines inside this method.