### PR TITLE
Bugfix correctly load non square pixels for AVF player. Closes #4937

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -52,10 +52,13 @@ public:
 	
     float getWidth() const;
     float getHeight() const;
-	
+    float getDisplayWidth() const;
+    float getDisplayHeight() const;
+
     bool isPaused() const;
     bool isLoaded() const;
     bool isPlaying() const;
+	bool isAnamorphic() const;
 	
     float getPosition() const;
     float getSpeed() const;

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -567,6 +567,24 @@ float ofAVFoundationPlayer::getHeight() const {
 }
 
 //--------------------------------------------------------------
+float ofAVFoundationPlayer::getDisplayWidth() const {
+    if(videoPlayer == nullptr) {
+        return 0;
+    }
+    
+    return [videoPlayer getDisplayWidth];
+}
+
+//--------------------------------------------------------------
+float ofAVFoundationPlayer::getDisplayHeight() const {
+    if(videoPlayer == nullptr) {
+        return 0;
+    }
+    
+    return [videoPlayer getDisplayHeight];
+}
+
+//--------------------------------------------------------------
 bool ofAVFoundationPlayer::isPaused() const {
     if(videoPlayer == nullptr) {
         return false;
@@ -600,6 +618,15 @@ bool ofAVFoundationPlayer::isPlaying() const {
     }
     
     return [videoPlayer isPlaying];
+}
+
+//--------------------------------------------------------------
+bool ofAVFoundationPlayer::isAnamorphic() const {
+    if(videoPlayer == nullptr) {
+        return false;
+    }
+    
+    return [videoPlayer isAnamorphic];
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -127,6 +127,7 @@ typedef enum _playerLoopType{
 - (BOOL)isPlaying;
 - (BOOL)isNewFrame;
 - (BOOL)isFinished;
+- (BOOL)isAnamorphic;
 
 - (void)setEnableVideoSampling:(BOOL)value;
 - (void)setEnableAudioSampling:(BOOL)value;
@@ -143,6 +144,9 @@ typedef enum _playerLoopType{
 
 - (NSInteger)getWidth;
 - (NSInteger)getHeight;
+- (NSInteger)getDisplayWidth;
+- (NSInteger)getDisplayHeight;
+
 - (CMTime)getCurrentTime;
 - (double)getCurrentTimeInSec;
 - (CMTime)getDuration;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -64,6 +64,9 @@ typedef enum _playerLoopType{
     
     NSInteger videoWidth;
     NSInteger videoHeight;
+
+    NSInteger displayWidth;
+    NSInteger displayHeight;
 	
     playerLoopType loop;
 	

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -305,7 +305,11 @@ static const void *PlayerRateContext = &ItemStatusContext;
 				}
 			}
 			
-			NSLog(@"video loaded at %li x %li @ %f fps", (long)videoWidth, (long)videoHeight, frameRate);
+			if( [self isAnamorphic] ){
+				NSLog(@"anamorphic video loaded at %li x %li - display width is %li x %li @ %f fps", (long)videoWidth, (long)videoHeight, (long)displayWidth, (long)displayHeight, frameRate);
+			}else{
+				NSLog(@"video loaded at %li x %li @ %f fps", (long)videoWidth, (long)videoHeight, frameRate);
+			}
 			
 //			currentTime = CMTimeMakeWithSeconds((1.0/frameRate), NSEC_PER_SEC);//kCMTimeZero;
 			currentTime = CMTimeMakeWithSeconds(0.0, NSEC_PER_SEC);//kCMTimeZero;
@@ -1242,6 +1246,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	return bFinished;
 }
 
+- (BOOL)isAnamorphic {
+	return ( displayWidth != videoWidth || displayHeight != videoHeight );
+}
+
 //---------------------------------------------------------- sampling getters / setters.
 - (void)setEnableVideoSampling:(BOOL)value {
 	bSampleVideo = value;
@@ -1293,6 +1301,14 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (NSInteger)getHeight {
 	return videoHeight;
+}
+
+- (NSInteger)getDisplayWidth {
+	return displayWidth;
+}
+
+- (NSInteger)getDisplayHeight {
+	return displayHeight;
 }
 
 - (CMTime)getCurrentTime {


### PR DESCRIPTION
Before the AVF player was loading a non square video as ( for example ) 1920x1080 but both the pixel data and the texture coming from AVFoundation were actually 1440x1080. 

This caused a crash when accessing pixels and resulted in the texture being drawn in a strange way. 
see : https://forum.openframeworks.cc/t/issues-with-pixel-ratios-in-ofvideoplayer/22120/10?u=theo

This PR loads the video at the size that represent the real pixel data and adds the ability to query what the intended stretched display size is meant to be. 

For now the new calls to getDisplayWidth() / getDisplayHeight are isolated to the ofAVFoundationPlayer class - if this is something we might want to support across platforms on linux and windows we could add it to the ofVideoPlayer and potentially even make the draw calls aware of the scaling needed. 

For now this seems like a conservative fix which leaves the display scaling up to the user, but provides them with the information they need to account for the non square pixels. 

An example of how you would do that is:

```
ofAVFoundationPlayer player;

//--------------------------------------------------------------
void ofApp::setup(){
    player.load("HDV_test.mov");
    player.play();
    ofSetWindowPosition(0, 0);
}

//--------------------------------------------------------------
void ofApp::update(){
    player.update();
}

//--------------------------------------------------------------
void ofApp::draw(){
    if( player.isAnamorphic() ){
        player.draw(0, 0, player.getDisplayWidth(), player.getDisplayHeight());
    }else{
        player.draw(0, 0);
    }
}
```


 