### PR TITLE
Doxygen sections ofRectangle & ofVec2f

### DIFF
--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -65,9 +65,8 @@ class ofVec4f;
 /// \sa ofVec4f for 4D vectors
 class ofVec2f {
 public:
-	/// \cond INTERNAL
+	/// \internal
 	static const int DIM = 2;
-	//// \endcond
 	
 	/// \brief Stores the `x` component of the vector.
 	float x;
@@ -75,10 +74,7 @@ public:
 	/// \brief Stores the `y` component of the vector.
 	float y;
     
-    //---------------------
-	/// \name Construct a 2D vector
-	/// \{
-    
+	/// \section Construct a 2D vector
 	/// \brief Construct a 2D vector.
 	/// 
 	/// ~~~~{.cpp}
@@ -124,13 +120,7 @@ public:
 	/// 
     ofVec2f( const ofVec4f& vec );
 	
-    /// \}
-
-	//---------------------
-	/// \name Access components
-	/// \{
-
-
+	/// \section Access components
 	/// \brief Returns a pointer to the memory position of the first element of the vector (x);
 	/// the second element (y) immediately follows it in memory.
 	/// 
@@ -193,13 +183,7 @@ public:
 	
 	void set( float scalar );
 
-    /// \}
-
-    //---------------------
-	/// \name Comparison 
-	/// \{
-
-	
+	/// \section Comparison
 	/// \brief Check for equality between two ofVec2f
 	/// 
 	/// ~~~~{.cpp}
@@ -282,13 +266,7 @@ public:
     /// \sa align()
     bool alignRad( const ofVec2f& vec, float tolerance = 0.0001f ) const;
 	
-	/// \}
-
-	//---------------------
-	/// \name Operators
-	/// \{
-
-    
+	/// \section Operators
 	/// \brief Super easy vector addition. Returns a new vector (x+vec.x,y+vec.y).
 	/// 
 	/// ~~~~{.cpp}
@@ -445,17 +423,12 @@ public:
     ofVec2f& operator/=( const float f );
 
 	
-	/// \cond INTERNAL
+	/// \internal
 	friend ostream& operator<<(ostream& os, const ofVec2f& vec);
+	/// \internal
 	friend istream& operator>>(istream& is, const ofVec2f& vec);
-	/// \endcond
 	
-	/// \}
-	
-	//---------------------
-	/// \name Simple manipulations
-	/// \{
-
+	/// \section Simple manipulations
 	/// Return a new ofVec2f that is the result of scaling this vector up or down so
 	/// that it has the requested length.
 	/// 
@@ -567,14 +540,8 @@ public:
 				 const ofVec2f& vx, const ofVec2f& vy );
 
 
-    /// \}
-	
-	
-	//---------------------
-	/// \name Distance
-	/// \{
-
-    /// \brief Distance between two points.
+    /// \section Distance
+	/// \brief Distance between two points.
     ///
     /// Treats both this vector and pnt as points in 2D space, and calculates and
     /// returns the distance between them.
@@ -619,12 +586,7 @@ public:
 	/// \sa distance()
     float squareDistance( const ofVec2f& pnt ) const;
 	
-	/// \}
-
-	//---------------------
-	/// \name Interpolation
-	/// \{
-
+	/// \section Interpolation
     /// \brief Linear interpolation
     /// 
 	/// Perform a linear interpolation of this vector's position towards pnt
@@ -716,13 +678,8 @@ public:
 	/// \returns Vector that is the avarage of the points in the array
     ofVec2f&  average( const ofVec2f* points, std::size_t num );
     
-    /// \}
-
-    //---------------------
-	/// \name Limit
-	/// \{
-
-	/// \brief Returns a normalized copy of this vector. 
+	/// \section Limit
+	/// \brief Returns a normalized copy of this vector.
 	/// 	
 	/// *Normalization* means to scale the vector so that its length
 	/// (magnitude) is exactly 1, at which stage all that is left is the
@@ -788,13 +745,7 @@ public:
     ofVec2f& limit(float max);
 
 	
-	/// \}
-
-	//---------------------
-	/// \name Measurement
-	/// \{
-
-	
+	/// \section Measurement
 	/// \brief Return the length (magnitude) of this vector.
 	/// 
 	/// ~~~~{.cpp}
@@ -851,12 +802,7 @@ public:
 	/// \returns The angle in radians (-PI...PI)
     float angleRad( const ofVec2f& vec ) const;
 	
-	/// \}
-
-	//---------------------
-	/// \name Perpendicular
-	/// \{
-
+	/// \section Perpendicular
 	/// \brief Return the *normalized* ofVec2f that is perpendicular to this vector
 	/// (ie rotated 90 degrees and normalized).
 	/// 
@@ -915,13 +861,9 @@ public:
     float dot( const ofVec2f& vec ) const;
 	
 	
-	/// \}
-
-
 
     //---------------------------------------------------
     // this methods are deprecated in 006 please dont use:
-	/// \cond INTERNAL
 
     // getScaled
     OF_DEPRECATED_MSG("Use member method getScaled() instead.", ofVec2f rescaled( const float length ) const);
@@ -961,13 +903,8 @@ public:
 
     // return all one vector
     static ofVec2f one() { return ofVec2f(1, 1); }
-
-    /// \endcond
 };
 
-
-
-/// \cond INTERNAL
 
 // Non-Member operators
 //
@@ -977,15 +914,12 @@ ofVec2f operator*( float f, const ofVec2f& vec );
 ofVec2f operator/( float f, const ofVec2f& vec );
 
 
-/// \endcond
-
 
 
 
 /////////////////
 // Implementation
 /////////////////
-/// \cond INTERNAL
 
 
 inline ofVec2f::ofVec2f(): x(0), y(0) {}
@@ -1504,6 +1438,3 @@ inline ofVec2f operator*( float f, const ofVec2f& vec ) {
 inline ofVec2f operator/( float f, const ofVec2f& vec ) {
     return ofVec2f( f/vec.x, f/vec.y);
 }
-
-
-/// \endcond

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -17,9 +17,7 @@
 class ofRectangle{
 public:
 
-    /// \name Constructor
-    /// \{
-
+    /// \section Constructor
     /// \brief Construct a rectangle with zero width and zero height at 0, 0.
     ofRectangle();
 
@@ -61,11 +59,7 @@ public:
     /// \brief Destroy the rectangle.
     virtual ~ofRectangle();
 
-    /// \}
-
-    /// \name Setters
-    /// \{
-
+    /// \section Setters
     /// \brief Set the position and size of the rectangle.
     ///
     /// To produce consistent results, users are encouraged to initialize
@@ -155,11 +149,7 @@ public:
     /// \param h The height of the rectangle.
     void setFromCenter(const ofPoint& p, float w, float h);
 
-    /// \}
-
-    /// \name Transformation
-    /// \{
-
+    /// \section Transformation
     /// \brief Translate the rectangle's position by an x and y amount.
     /// \param dx The amount to translate in the x direction.
     /// \param dy The amount to translate in the y direction.
@@ -293,12 +283,7 @@ public:
                  ofAlignHorz subjectHorzAnchor,
                  ofAlignVert subjectVertAnchor);
 
-    /// \}
-
-    /// \name Alignment
-    /// \{
-
-
+    /// \section Alignment
     /// \brief Horizontally align a rectangle using a position and anchor edge.
     ///
     /// Aligns the horizontal position of the ofRectangle to the given x-
@@ -435,11 +420,7 @@ public:
                  ofAlignHorz thisHorzAnchor,
                  ofAlignVert thisVertAnchor);
 
-    /// \}
-
-    /// \name Intersection
-    /// \{
-
+    /// \section Intersection
     /// \brief Determines if the coordinates (x, y) are within the ofRectangle.
     ///
     /// Note that coordinates on the edge of the ofRectangle are not
@@ -572,11 +553,7 @@ public:
     ///          this rectangle and the passed rectangle..
     ofRectangle getUnion(const ofRectangle& rect) const;
 
-    /// \}
-
-    /// \name Standardization
-    /// \{
-
+    /// \section Standardization
     /// \brief Standardize the rectangle
     ///
     /// "Standardized" rectangles are rectangles whose width and height are positive: width >= 0 and height
@@ -601,11 +578,7 @@ public:
     /// \returns true if both width >= 0 and height >= 0.
     bool isStandardized() const;
 
-    /// \}
-
-    /// \name Getters
-    /// \{
-
+    /// \section Getters
     /// \brief Get the area of the ofRectangle.
     ///
     /// This is the product of the width and height of the recatngle.
@@ -739,11 +712,7 @@ public:
     /// \returns The height of the rectangle.
     float getHeight() const;
 
-    /// \}
-
-    /// \name Operators
-    /// \{
-
+    /// \section Operators
     /// \brief Assignment operator.
     /// \param rect The rectangle to assign.
     /// \returns A reference to this rectangle.
@@ -775,13 +744,7 @@ public:
     
     bool isZero() const;
 
-
-    /// \}
-
-    /// \name Properties
-    /// \{
-
-
+    /// \section Properties
     /// \brief The (x,y) position of the ofRectangle as an ofPoint.
     ///
     /// \warning The z-component of this position is preserved and can be used
@@ -799,15 +762,15 @@ public:
 
     /// \brief The height of the ofRectangle.
     float height;
-
-    /// \}
 };
 
-/// \cond INTERNAL
+/// \internal
 /// \warning The internal z component of the ofPoint is preserved even though it
 /// is not used.
 ostream& operator<<(ostream& os, const ofRectangle& rect);
+
+/// \internal
 /// \warning The internal z component of the ofPoint is preserved even though it
 /// is not used.
 istream& operator>>(istream& is, ofRectangle& rect);
-/// \endcond
+

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -556,8 +556,8 @@ public:
     /// \section Standardization
     /// \brief Standardize the rectangle
     ///
-    /// "Standardized" rectangles are rectangles whose width and height are positive: width >= 0 and height
-    /// >= 0. This method can be used to ensure that the rectangle is
+    /// "Standardized" rectangles are rectangles whose width and height are positive: width >= 0
+	/// and height >= 0. This method can be used to ensure that the rectangle is
     /// "standardized". If the rectangle is non-standard, it will modify the x /
     /// width and y / height values into their respective standardized versions.
     void standardize();


### PR DESCRIPTION
Changed sections to  `\section` syntax and internal functions to `\internal` syntax

@bakercp 
