### PR TITLE
fix issue with 64 bit visual studio recompiles

### DIFF
--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
@@ -104,7 +104,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <BrowseInformation>true</BrowseInformation>
+      <BrowseInformation>false</BrowseInformation>
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
   </ItemDefinitionGroup>


### PR DESCRIPTION
+ previous openframeworks project settings for 64 bit visual studio
  compiles would cause "Browse Information" to be generated.

  These *.BCR files are deprecated, and would emit error messages during
  first compile. The next compile would fail since Visual Studio
  couldn't read the file, meaning you would have to do a full rebuild
  everytime you wanted to compile a 64bit app.

  In 32 bit, we rightly had these BCR Files not generated. This PR
  proposes to bring 64 bit in line with 32 bit, and to not create these
  files and with that the compile problem in the first place.