### PR TITLE
[proposal] make ofxOsc strong

### DIFF
--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -59,7 +59,7 @@ ofxOscReceiver & ofxOscReceiver::operator=(const ofxOscReceiver & mom){
 	return *this;
 }
 
-void ofxOscReceiver::setup( int listen_port )
+bool ofxOscReceiver::setup( int listen_port )
 {
     if( osc::UdpSocket::GetUdpBufferSize() == 0 ){
     	osc::UdpSocket::SetUdpBufferSize(65535);
@@ -71,14 +71,24 @@ void ofxOscReceiver::setup( int listen_port )
 	}
 	
 	// create socket
-	auto socket = new osc::UdpListeningReceiveSocket( osc::IpEndpointName( osc::IpEndpointName::ANY_ADDRESS, listen_port ), this, allowReuse );
-	auto deleter = [](osc::UdpListeningReceiveSocket*socket){
-		// tell the socket to shutdown
-		socket->Break();
-		delete socket;
-	};
-	auto new_ptr = std::unique_ptr<osc::UdpListeningReceiveSocket, decltype(deleter)>(socket, deleter);
-	listen_socket = std::move(new_ptr);
+    osc::UdpListeningReceiveSocket *socket = nullptr;
+    try {
+        socket = new osc::UdpListeningReceiveSocket( osc::IpEndpointName( osc::IpEndpointName::ANY_ADDRESS, listen_port ), this, allowReuse );
+        auto deleter = [](osc::UdpListeningReceiveSocket*socket){
+            // tell the socket to shutdown
+            socket->Break();
+            delete socket;
+        };
+        auto new_ptr = std::unique_ptr<osc::UdpListeningReceiveSocket, decltype(deleter)>(socket, deleter);
+        listen_socket = std::move(new_ptr);
+    } catch (std::exception &e) {
+        ofLogError("ofxOscReceiver") << "listen_port: " << listen_port << " " << e.what();
+        if(socket != nullptr) {
+            delete socket;
+            socket = nullptr;
+        }
+        return false;
+    }
 
 	listen_thread = std::thread([this]{
         while(listen_socket) {
@@ -96,6 +106,8 @@ void ofxOscReceiver::setup( int listen_port )
 	listen_thread.detach();
 
 	this->listen_port = listen_port;
+    
+    return true;
 }
 
 void ofxOscReceiver::shutdown()

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -81,7 +81,13 @@ void ofxOscReceiver::setup( int listen_port )
 	listen_socket = std::move(new_ptr);
 
 	listen_thread = std::thread([this]{
-		listen_socket->Run();
+        while(listen_socket) {
+            try {
+                listen_socket->Run();
+            } catch(std::exception &e) {
+                ofLogWarning() << e.what();
+            }
+        }
 	});
 
 	// detach thread so we don't have to wait on it before creating a new socket

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -55,7 +55,7 @@ public:
 	ofxOscReceiver & operator=(const ofxOscReceiver & mom);
 
 	/// listen_port is the port to listen for messages on
-	void setup( int listen_port );
+	bool setup( int listen_port );
 
 	/// returns true if there are any messages waiting for collection
 	bool hasWaitingMessages();


### PR DESCRIPTION
for example, we wrote like this:

```cpp
    ofxOscReceiver receiver;
    void setup() { receiver.setup(9005); }
```

and we do in terminal.app (or similar)

```
$ nc -4u localhost 9005
> a
```

maybe your app got crush.
so, this process is too extreme.
but, recently, some app got bad packet and crushed 10 machines at same time. (maybe bad packet is broadcasted)
i think this is very critical.

and, more critical point is "we cannot catch this exception from the outside now."

now, this PR is first aid.
(but, i hope to be accepted this PR as soon as possible.)

i think good solution is:
doing propagate exception with `std::promise`, `std::future`, or `std::async`.
or, simply, replace ofLog (is implemented now) with send error message with `ofThreadChannel` when catch exception. and notify error.
or, is this OK?

i don't know policy of exception handling in oF.
and i want to discuss for bright future we can use osc in peace.

best regards. 