### PR TITLE
Bug fix: wrap hue value in ofColor::setHsb

### DIFF
--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -445,6 +445,8 @@ void ofColor_<PixelType>::setBrightness(float brightness) {
 
 template<typename PixelType>
 void ofColor_<PixelType>::setHsb(float hue, float saturation, float brightness, float alpha) {
+	// hue needs to be limited! otherwise none of the switch statements are executed and the function won't have any affect
+	hue = ofWrap(hue, 0, limit()); // wrapping makes more sense then clipping since hue is circular.
 	saturation = ofClamp(saturation, 0, limit());
 	brightness = ofClamp(brightness, 0, limit());
 	if(brightness == 0) { // black


### PR DESCRIPTION
In ofColor::setHsb(), the hue argument needs to be limited in some way because otherwise none of the switch statements are executed and the function won't have any affect. This is not what a user would expect, since saturation and brightness can go out of range without any problems as they both get clamped. 
For hue I'd suggest to use ofWrap to make it behave circular.
