### PR TITLE
Add SO_REUSEADDR option to ofxTCPManager and ofxTCPServer.

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -144,7 +144,7 @@ bool ofxTCPManager::Listen(int iMaxConnections)
 	return ret;
 }
 
-bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse = false)
+bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse)
 {
 	struct sockaddr_in local;
 	memset(&local, 0, sizeof(sockaddr_in));

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -144,7 +144,7 @@ bool ofxTCPManager::Listen(int iMaxConnections)
 	return ret;
 }
 
-bool ofxTCPManager::Bind(unsigned short usPort)
+bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse = false)
 {
 	struct sockaddr_in local;
 	memset(&local, 0, sizeof(sockaddr_in));
@@ -153,6 +153,14 @@ bool ofxTCPManager::Bind(unsigned short usPort)
 	local.sin_addr.s_addr = INADDR_ANY;
 	//Port MUST be in Network Byte Order
 	local.sin_port = htons(usPort);
+
+	if (bReuse) {
+		int enable = 1;
+		if (setsockopt(m_hSocket,SOL_SOCKET,SO_REUSEADDR,&enable,sizeof(int)) < 0){
+			ofxNetworkCheckError();
+			return false;
+		}
+	}
 
 	if (::bind(m_hSocket,(struct sockaddr*)&local,sizeof(local))){
 		ofxNetworkCheckError();

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -144,7 +144,7 @@ bool ofxTCPManager::Listen(int iMaxConnections)
 	return ret;
 }
 
-bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse = false)
+bool ofxTCPManager::Bind(unsigned short usPort)
 {
 	struct sockaddr_in local;
 	memset(&local, 0, sizeof(sockaddr_in));
@@ -153,14 +153,6 @@ bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse = false)
 	local.sin_addr.s_addr = INADDR_ANY;
 	//Port MUST be in Network Byte Order
 	local.sin_port = htons(usPort);
-
-	if (bReuse) {
-		int enable = 1;
-		if (setsockopt(m_hSocket,SOL_SOCKET,SO_REUSEADDR,&enable,sizeof(int)) < 0){
-			ofxNetworkCheckError();
-			return false;
-		}
-	}
 
 	if (::bind(m_hSocket,(struct sockaddr*)&local,sizeof(local))){
 		ofxNetworkCheckError();

--- a/addons/ofxNetwork/src/ofxTCPManager.h
+++ b/addons/ofxNetwork/src/ofxTCPManager.h
@@ -176,7 +176,7 @@ public:
 	bool Create();
 	bool Listen(int iMaxConnections);
 	bool Connect(const char *pAddrStr, unsigned short usPort);
-	bool Bind(unsigned short usPort);
+	bool Bind(unsigned short usPort, bool bReuse);
 	bool Accept(ofxTCPManager& sock);
 	//sends the data, but it is not guaranteed that really all data will be sent
 	int  Send(const char* pBuff, const int iSize);

--- a/addons/ofxNetwork/src/ofxTCPManager.h
+++ b/addons/ofxNetwork/src/ofxTCPManager.h
@@ -176,7 +176,7 @@ public:
 	bool Create();
 	bool Listen(int iMaxConnections);
 	bool Connect(const char *pAddrStr, unsigned short usPort);
-	bool Bind(unsigned short usPort, bool bReuse);
+	bool Bind(unsigned short usPort, bool bReuse = false);
 	bool Accept(ofxTCPManager& sock);
 	//sends the data, but it is not guaranteed that really all data will be sent
 	int  Send(const char* pBuff, const int iSize);

--- a/addons/ofxNetwork/src/ofxTCPManager.h
+++ b/addons/ofxNetwork/src/ofxTCPManager.h
@@ -176,7 +176,7 @@ public:
 	bool Create();
 	bool Listen(int iMaxConnections);
 	bool Connect(const char *pAddrStr, unsigned short usPort);
-	bool Bind(unsigned short usPort, bool bReuse);
+	bool Bind(unsigned short usPort);
 	bool Accept(ofxTCPManager& sock);
 	//sends the data, but it is not guaranteed that really all data will be sent
 	int  Send(const char* pBuff, const int iSize);

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -38,7 +38,7 @@ bool ofxTCPServer::setup(const ofxTCPSettings &settings){
 		ofLogError("ofxTCPServer") << "setup(): couldn't create server";
 		return false;
 	}
-	if( !TCPServer.Bind(settings.port) ){
+	if( !TCPServer.Bind(settings.port, settings.reuse) ){
 		ofLogError("ofxTCPServer") << "setup(): couldn't bind to port " << settings.port;
 		return false;
 	}

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -23,12 +23,12 @@ void ofxTCPServer::setVerbose(bool _verbose){
 }
 
 //--------------------------
-bool ofxTCPServer::setup(int _port, bool blocking){
+bool ofxTCPServer::setup(int _port, bool blocking, bool reuse){
 	if( !TCPServer.Create() ){
 		ofLogError("ofxTCPServer") << "setup(): couldn't create server";
 		return false;
 	}
-	if( !TCPServer.Bind(_port) ){
+	if( !TCPServer.Bind(_port, reuse) ){
 		ofLogError("ofxTCPServer") << "setup(): couldn't bind to port " << _port;
 		return false;
 	}

--- a/addons/ofxNetwork/src/ofxTCPServer.cpp
+++ b/addons/ofxNetwork/src/ofxTCPServer.cpp
@@ -23,12 +23,12 @@ void ofxTCPServer::setVerbose(bool _verbose){
 }
 
 //--------------------------
-bool ofxTCPServer::setup(int _port, bool blocking, bool reuse){
+bool ofxTCPServer::setup(int _port, bool blocking){
 	if( !TCPServer.Create() ){
 		ofLogError("ofxTCPServer") << "setup(): couldn't create server";
 		return false;
 	}
-	if( !TCPServer.Bind(_port, reuse) ){
+	if( !TCPServer.Bind(_port) ){
 		ofLogError("ofxTCPServer") << "setup(): couldn't bind to port " << _port;
 		return false;
 	}

--- a/addons/ofxNetwork/src/ofxTCPServer.h
+++ b/addons/ofxNetwork/src/ofxTCPServer.h
@@ -23,7 +23,7 @@ class ofxTCPServer : public ofThread{
 		ofxTCPServer & operator=(const ofxTCPServer & mom) = delete;
 
 		void setVerbose(bool _verbose);
-		bool setup(int _port, bool blocking = false);
+		bool setup(int _port, bool blocking = false, bool reuse = false);
 		void setMessageDelimiter(std::string delim);
 	
 		bool close();

--- a/addons/ofxNetwork/src/ofxTCPServer.h
+++ b/addons/ofxNetwork/src/ofxTCPServer.h
@@ -23,7 +23,7 @@ class ofxTCPServer : public ofThread{
 		ofxTCPServer & operator=(const ofxTCPServer & mom) = delete;
 
 		void setVerbose(bool _verbose);
-		bool setup(int _port, bool blocking = false, bool reuse = false);
+		bool setup(int _port, bool blocking = false);
 		void setMessageDelimiter(std::string delim);
 	
 		bool close();

--- a/addons/ofxNetwork/src/ofxTCPSettings.h
+++ b/addons/ofxNetwork/src/ofxTCPSettings.h
@@ -13,6 +13,7 @@ public:
 	std::string address;
 	int port;
 	bool blocking = false;
+	bool reuse = false;
 
 	std::string messageDelimiter = "[/TCP]";
 

--- a/examples/communication/networkTcpServerExample/src/ofApp.cpp
+++ b/examples/communication/networkTcpServerExample/src/ofApp.cpp
@@ -11,6 +11,7 @@ void ofApp::setup(){
 
 	// set other options
 	//settings.blocking = false;
+	//settings.reuse = true;
 	//settings.messageDelimiter = "\n";
 
 	TCP.setup(settings);


### PR DESCRIPTION
When you don't close your socket cleanly (e.g. your program crashes), it can linger on your OS for quite some time before you're allowed to reuse the same port.

In this state, calls to `bind` will return `EADDRINUSE` error.

Most software deals with this by setting the `SO_REUSEADDR` socket option before calling `bind`. However, this functionality is missing from ofxTCPManager.

It looks like it confuses some people too:
https://forum.openframeworks.cc/t/tcp-server-socket-not-closing-already-in-use/22793

I'm setting it to `false` by default, to maintain old behaviour, but openFrameworks should seriously consider enabling it by default (that is, if this patch is accepted, of course).

NOTE: not tested on Windows, but should work there AFAIK.
