### PR TITLE
ofEasyCam: Add setters for mouse release inertia

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -31,6 +31,7 @@ ofEasyCam::ofEasyCam(){
 	bDoScrollZoom = false;
 	bInsideArcball = true;
 	bEnableMouseMiddleButton = true;
+	bMouseReleaseInertiaEnabled = true;
 	bAutoDistance = true;
 	doTranslationKey = 'm';
 	bEventsSet = false;
@@ -196,6 +197,16 @@ void ofEasyCam::disableMouseInput(){
 }
 
 //----------------------------------------
+void ofEasyCam::enableMouseReleaseInertia(){
+  bMouseReleaseInertiaEnabled = true;
+}
+
+//----------------------------------------
+void ofEasyCam::disableMouseReleaseInertia(){
+  bMouseReleaseInertiaEnabled = false;
+}
+
+//----------------------------------------
 void ofEasyCam::setEvents(ofCoreEvents & _events){
 	// If en/disableMouseInput were called within ofApp::setup(),
 	// bMouseInputEnabled will tell us about whether the camera
@@ -321,18 +332,21 @@ void ofEasyCam::mouseReleased(ofMouseEventArgs & mouse){
 		return;
 	}
 	lastTap = curTap;
-	bApplyInertia = true;
-	mouseVel = mouse  - prevMouse;
 
-	updateMouse(mouse);
-	ofVec2f center(viewport.width/2, viewport.height/2);
-	int vFlip;
-	if(isVFlipped()){
-		vFlip = -1;
-	}else{
-		vFlip =  1;
-	}
-	zRot = -vFlip * ofVec2f(mouse.x - viewport.x - center.x, mouse.y - viewport.y - center.y).angle(prevMouse - ofVec2f(viewport.x, viewport.y) - center);
+	if (bMouseReleaseInertiaEnabled){
+		bApplyInertia = true;
+		mouseVel = mouse  - prevMouse;
+
+		updateMouse(mouse);
+		ofVec2f center(viewport.width/2, viewport.height/2);
+		int vFlip;
+		if(isVFlipped()){
+			vFlip = -1;
+		}else{
+			vFlip =  1;
+		}
+		zRot = -vFlip * ofVec2f(mouse.x - viewport.x - center.x, mouse.y - viewport.y - center.y).angle(prevMouse - ofVec2f(viewport.x, viewport.y) - center);
+  }
 }
 
 void ofEasyCam::mouseDragged(ofMouseEventArgs & mouse){

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -113,6 +113,12 @@ public:
     /// \brief Disable mouse camera control.
 	void disableMouseInput();
 
+    /// \brief Enable inertia on releasing the mouse.
+	void enableMouseReleaseInertia();
+  
+    /// \brief Disable inertia on releasing the mouse
+	void disableMouseReleaseInertia();
+
     /// \brief Determine if mouse camera control is enabled.
     /// \todo Rename to isMouseInputEnabled().
     /// \returns true iff mouse camera control is enabled.
@@ -145,6 +151,7 @@ private:
 	bool bDoScrollZoom;
 	bool bInsideArcball;
 	bool bMouseInputEnabled;
+	bool bMouseReleaseInertiaEnabled;
 	bool bDistanceSet;
     bool bAutoDistance;
     bool bEventsSet;


### PR DESCRIPTION
Add setters to disable/enable mouse release inertia.
This can avoid unintended camera spinning on touch sensitive
input devices like iOS where the delta between different touch
points will cause the camera to spin rapidly.

See https://github.com/openframeworks/openFrameworks/issues/5019