### PR TITLE
add keyboard hot plug support

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -269,7 +269,7 @@ protected:
 	void destroyNativeKeyboard();
 
 	void readNativeMouseEvents();
-	void readNativeKeyboardEvents();
+	void readNativeKeyboardEvents(int kb_fd);
 	void readNativeUDevEvents();
 
 	static void handleX11Event(const XEvent& event);


### PR DESCRIPTION
I used Arduino as Keyboard on RPi with magsafe connection.
So I added multiple keyboard support and hotplug support. Based on V0.9.2

Basically I changed keyboard_fd to an array. And another array keeps path of each device.
setupNativeKeyboard() will first check if any device disappears, and then add new device.
readNativeUDevEvents() will call setupNativeKeyboard to config new keyboard settings.


