### PR TITLE
ofxCvImage pts array array delete fix

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvImage.cpp
@@ -391,7 +391,7 @@ void  ofxCvImage::drawBlobIntoMe( ofxCvBlob& blob, int color ) {
 	   int nPts = blob.nPts;
 	   cvFillPoly( cvImage, &pts, &nPts, 1,
 				   CV_RGB(color,color,color) );
-	   delete [] pts;
+	   delete[] pts;
 	}
 }
 

--- a/addons/ofxOpenCv/src/ofxCvImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvImage.cpp
@@ -391,7 +391,7 @@ void  ofxCvImage::drawBlobIntoMe( ofxCvBlob& blob, int color ) {
 	   int nPts = blob.nPts;
 	   cvFillPoly( cvImage, &pts, &nPts, 1,
 				   CV_RGB(color,color,color) );
-	   delete pts[];
+	   delete [] pts;
 	}
 }
 

--- a/addons/ofxOpenCv/src/ofxCvImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvImage.cpp
@@ -391,7 +391,7 @@ void  ofxCvImage::drawBlobIntoMe( ofxCvBlob& blob, int color ) {
 	   int nPts = blob.nPts;
 	   cvFillPoly( cvImage, &pts, &nPts, 1,
 				   CV_RGB(color,color,color) );
-	   delete pts;
+	   delete pts[];
 	}
 }
 


### PR DESCRIPTION
Fix for the following clang warning:

~~~
openFrameworks/addons/ofxOpenCv/src/ofxCvImage.cpp:394:5:
'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'?
~~~