### PR TITLE
ofxGui: fix possible crash during construction

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -66,7 +66,7 @@ ofBitmapFont ofxBaseGui::bitmapFont;
 
 ofxBaseGui::ofxBaseGui(){
 	parent = nullptr;
-	currentFrame = ofGetFrameNum();
+	currentFrame = 0;
 #ifndef TARGET_EMSCRIPTEN
     serializer = std::make_shared<ofXml>();
 #endif


### PR DESCRIPTION
fix for #4769 

Calling ofGetFrameNum() in the constructor can cause the application to crash if ofMainLoop is not up and running. 

Setting the current frame to zero should actually be sufficient. isGuiDrawing() will still return false until you are drawing it the first time and after that the value set during construction doesn't matter anymore.