### PR TITLE
ofxNetwork - settings "cache" is broken

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -130,6 +130,8 @@ bool ofxTCPManager::Create()
 
 	if(!ret) ofxNetworkCheckError();
 
+	nonBlocking = false;
+
 	return ret;
 }
 


### PR DESCRIPTION
`ofxTCPManager` stores various socket options to avoid doing extra work and to return them without querying the socket interface.

For example,

```
//----------------------------------------------------------------------------$
bool ofxTCPManager::SetNonBlocking(bool useNonBlocking)
{
        if(useNonBlocking==nonBlocking){
                return true;
        }
        ....
```

This avoids calling all the setsockopt/ioctl code.

However, the socket underneath might be destroyed and re-created via, for example, `Connect` and `Close`. After that, those "cached" values do not represent the actual state and are actually in the way.

Consider:

```
ofxTCPManager tcp;
tcp.Create();
tcp.SetNonBlocking(true);
tcp.Close();
tcp.Create(); // now blocking again, yet the "nonBlocking" bool is TRUE
tcp.SetNonBlocking(true); // does nothing !!!
```

I do not know the full extent of this problem, if the server is affected similarly, if the UDP code has similar issues, etc. But likely answers are: extent is wide, other options are affected too, server is broken too, UDP is broken too :)
