### PR TITLE
ofEvents/App: when trying to access events check that events are already initialized

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -54,7 +54,6 @@ int ofRunMainLoop();
 
 
 ofBaseApp * ofGetAppPtr();
-void ofSetAppPtr(shared_ptr<ofBaseApp> appPtr);
 
 void		ofExit(int status=0);
 

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -226,10 +226,6 @@ shared_ptr<ofBaseApp> ofMainLoop::getCurrentApp(){
 	return windowsApps[currentWindow.lock()];
 }
 
-ofCoreEvents & ofMainLoop::events(){
-	return currentWindow.lock()->events();
-}
-
 void ofMainLoop::shouldClose(int _status){
 	for(auto i: windowsApps){
 		i.first->setWindowShouldClose();

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -34,7 +34,6 @@ public:
 	void loopOnce();
 	void pollEvents();
 	void exit();
-	ofCoreEvents & events();
 	void shouldClose(int status);
 	std::shared_ptr<ofAppBaseWindow> getCurrentWindow();
 	void setCurrentWindow(std::shared_ptr<ofAppBaseWindow> window);

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -1,4 +1,5 @@
 #include "ofEvents.h"
+#include "ofAppRunner.h"
 
 
 static ofEventArgs voidEventArgs;
@@ -6,57 +7,112 @@ static ofEventArgs voidEventArgs;
 
 //--------------------------------------
 void ofSetFrameRate(int targetRate){
-	ofEvents().setFrameRate(targetRate);
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().setFrameRate(targetRate);
+	}else{
+		ofLogWarning("ofEvents") << "Trying to set framerate before mainloop is ready";
+	}
 }
 
 //--------------------------------------
 float ofGetFrameRate(){
-	return ofEvents().getFrameRate();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getFrameRate();
+	}else{
+		return 0.f;
+	}
 }
 
 //--------------------------------------
 float ofGetTargetFrameRate(){
-	return ofEvents().getTargetFrameRate();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getTargetFrameRate();
+	}else{
+		return 0.f;
+	}
 }
 
 //--------------------------------------
 double ofGetLastFrameTime(){
-	return ofEvents().getLastFrameTime();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getLastFrameTime();
+	}else{
+		return 0.f;
+	}
 }
 
 //--------------------------------------
 uint64_t ofGetFrameNum(){
-	return ofEvents().getFrameNum();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getFrameNum();
+	}else{
+		return 0;
+	}
 }
 
 //--------------------------------------
 bool ofGetMousePressed(int button){ //by default any button
-	return ofEvents().getMousePressed(button);
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getMousePressed(button);
+	}else{
+		return false;
+	}
 }
 
 //--------------------------------------
 bool ofGetKeyPressed(int key){
-	return ofEvents().getKeyPressed(key);
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getKeyPressed(key);
+	}else{
+		return false;
+	}
 }
 
 //--------------------------------------
 int ofGetMouseX(){
-	return ofEvents().getMouseX();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getMouseX();
+	}else{
+		return 0;
+	}
 }
 
 //--------------------------------------
 int ofGetMouseY(){
-	return ofEvents().getMouseY();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getMouseY();
+	}else{
+		return 0;
+	}
 }
 
 //--------------------------------------
 int ofGetPreviousMouseX(){
-	return ofEvents().getPreviousMouseX();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getPreviousMouseX();
+	}else{
+		return 0;
+	}
 }
 
 //--------------------------------------
 int ofGetPreviousMouseY(){
-	return ofEvents().getPreviousMouseY();
+	auto window = ofGetMainLoop()->getCurrentWindow();
+	if(window){
+		window->events().getPreviousMouseY();
+	}else{
+		return 0;
+	}
 }
 
 ofCoreEvents::ofCoreEvents()


### PR DESCRIPTION
Fixes #4769 problems when trying to access events before the window is setup and #5028 problems when trying to remove events after the window is gone.