### PR TITLE
Don't include glx.h globally on linux

### DIFF
--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -4,12 +4,17 @@
 #include "ofTypes.h"
 #include "ofEvents.h"
 #include "ofWindowSettings.h"
-#if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
-#include <X11/Xlib.h>
-#endif
 
 class ofBaseApp;
 class ofBaseRenderer;
+
+#if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI)
+struct __GLXcontextRec;
+typedef __GLXcontextRec * GLXContext;
+typedef unsigned long Window;
+struct _XDisplay;
+typedef struct _XDisplay Display;
+#endif
 
 class ofAppBaseWindow{
 

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -24,6 +24,7 @@
 	#include "ofImage.h"
 	#include <X11/Xatom.h>
 	#include <GL/freeglut_ext.h>
+	#include <GL/glx.h>
 #endif
 
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -209,7 +209,6 @@ enum ofTargetPlatform{
 		#include <GL/glew.h>
 		#include <GL/gl.h>
 		#include <GL/glext.h>
-		#include <GL/glx.h>
 	#endif
 
 	// for some reason, this isn't defined at compile time,
@@ -384,7 +383,7 @@ typedef TESSindex ofIndexType;
 // clang has a bug where it won't support tls on some versions even
 // on c++11, this is a workaround that bug
 #ifndef HAS_TLS
-	#if __clang__
+	#if defined(__clang__) && __clang__
 		#if __has_feature(cxx_thread_local) && !defined(__MINGW64__) && !defined(__MINGW32__) && !defined(__ANDROID__)
 			#define HAS_TLS 1
 		#endif


### PR DESCRIPTION
glx includes several X headers which defined several macros with very
common names so it's really common to have clashes with those names.

this moves that header include into the cpps that need it and uses
forward declarations in the headers that needs them