### PR TITLE
fix some issues with HIDPI (Retina)

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -455,11 +455,6 @@ ofPoint ofAppGLFWWindow::getWindowSize(){
 			return ofPoint(currentW*pixelScreenCoordScale,currentH*pixelScreenCoordScale);
 		}
 	}else{
-		/*glfwGetWindowSize(windowP, &currentW, &currentH);
-		if(windowMode != OF_FULLSCREEN){
-			windowW = currentW;
-			windowH = currentH;
-		}*/
 		return ofPoint(currentW*pixelScreenCoordScale,currentH*pixelScreenCoordScale);
 	}
 }
@@ -561,16 +556,17 @@ void ofAppGLFWWindow::setWindowShape(int w, int h){
 		windowW = w;
 		windowH = h;
 	}
-	currentW = w;
-	currentH = h;
+	currentW = w/pixelScreenCoordScale;
+	currentH = h/pixelScreenCoordScale;
+	
 	#ifdef TARGET_OSX
 		ofPoint pos = getWindowPosition();
-		glfwSetWindowSize(windowP,w/pixelScreenCoordScale,h/pixelScreenCoordScale);
+		glfwSetWindowSize(windowP,currentW,currentH);
 		if( pos != getWindowPosition() ){
 			setWindowPosition(pos.x, pos.y);
 		}
 	#else
-		glfwSetWindowSize(windowP,w/pixelScreenCoordScale,h/pixelScreenCoordScale);
+		glfwSetWindowSize(windowP,currentW,currentH);
 	#endif
 }
 
@@ -1178,8 +1174,8 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int keycode, int scancod
 void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_,int w, int h) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
 	if(instance->windowMode == OF_WINDOW){
-		instance->windowW = w;
-		instance->windowH = h;
+		instance->windowW = w * instance->pixelScreenCoordScale;
+		instance->windowH = h * instance->pixelScreenCoordScale;
 	}
 	instance->currentW = w;
 	instance->currentH = h;

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -193,8 +193,8 @@ private:
 	ofWindowMode	windowMode;
 
 	bool			bEnableSetupScreen;
-	int				windowW, windowH;
-	int				currentW, currentH;
+	int				windowW, windowH;		// physical pixels width
+	int				currentW, currentH;		// scaled pixels width
 
 	ofRectangle windowRect;
 


### PR DESCRIPTION
* fixes a bug where HiDPi projects would not get the correct
  ofGetWidth() and ofGetHeight() values. This bug may have
  been introduced recently with some essential linux fixes.

* adds a comment to clarify meaning of currentW and windowW,
  one being the current virtual (possibly scaled pixel) and
  the other the physical 1:1 monitor pixel.

* tested on os x with both retina and non-retina screens,
  fullscreen + fullscreen restore.

* does not query glfwWindowSize but uses cached values to
  remain true to the earlier linux fix.

* Uses callback return value to retrieve new window size
  when window resized.