### PR TITLE
Add support for OF_PIXELS_NV21 in android video grabber

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -726,7 +726,9 @@ Java_cc_openframeworks_OFAndroidVideoGrabber_newFrame(JNIEnv*  env, jobject  thi
 			ConvertYUV2toRGB565(currentFrame, pixels.getData(), width, height);
 		} else if (data->internalPixelFormat == OF_PIXELS_MONO) {
 			pixels.setFromPixels(currentFrame, width, height, OF_IMAGE_GRAYSCALE);
-		}
+		} else if (data->internalPixelFormat == OF_PIXELS_NV21) {
+            		pixels.setFromPixels(currentFrame, width, height, OF_PIXELS_NV21);
+        	}
 
 		if (needsResize) {
 			pixels.resize(data->width, data->height, OF_INTERPOLATE_NEAREST_NEIGHBOR);


### PR DESCRIPTION
This adds support for the native pixel format NV21 of the android video grabber in the returned ofPixels. 

ofPixels does not support OF_PIXELS_NV21 very well, but it's useful for advanced pixel processing in openframeworks where you need the native pixels for better performance just using ofPixels for passing the data on. 