### PR TITLE
overflow in 32bits systems with bigger images

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -56,7 +56,7 @@ static int pixelBitsFromPixelFormat(ofPixelFormat format){
 
 template<typename PixelType>
 static int bytesFromPixelFormat(int w, int h, ofPixelFormat format){
-	return w*h*pixelBitsFromPixelFormat<PixelType>(format)/8;
+	return w*h*(pixelBitsFromPixelFormat<PixelType>(format)/8);
 }
 
 static int channelsFromPixelFormat(ofPixelFormat format){


### PR DESCRIPTION
in bytesFromPixelFormat function, the calculation can overflow in 32bits systems with bigger images.