### PR TITLE
add $RPI_ROOT/usr/include/arm-linux-gnueabihf include path when cross compiling for Raspberry PI

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.shared.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.shared.mk
@@ -366,4 +366,7 @@ ifdef MAKEFILE_DEBUG
     $(foreach v, $(PLATFORM_CORE_EXCLUSIONS),$(info $(v)))
 endif
 
+ifdef RPI_ROOT
+	OF_CORE_INCLUDES_CFLAGS += $(addprefix -I,$(RPI_ROOT)/usr/include/arm-linux-gnueabihf)
+endif
 


### PR DESCRIPTION
TL;DR my cross compiles failed because they couldn't find the sys/cdefs.h header file. This patch adds the $(RPI_ROOT)/usr/include/arm-linux-gnueabihf path to the include paths, which fixed it.

I was following the [Cross compiler for OF 0.9.0/Jessie/arm6/RPi1 guide](https://forum.openframeworks.cc/t/cross-compiler-for-of-0-9-0-jessie-arm6-rpi1/21336/47) on the forum

Used a different mirror to get the debian image for my virtual machine:
[http://ftp.acc.umu.se/mirror/cdimage/release/8.4.0-live/amd64/iso-hybrid/debian-live-8.4.0-amd64-standard.iso](http://ftp.acc.umu.se/mirror/cdimage/release/8.4.0-live/amd64/iso-hybrid/debian-live-8.4.0-amd64-standard.iso)

Didn't manage to build the raspberry cross compiler from source, so used the updated compiler for the [raspberry pi tools repo](https://github.com/raspberrypi/tools) 

# tail .profile
export GST_VERSION=1.0
export RPI_ROOT=/home/pi/RPI_ROOT
export TOOLCHAIN_ROOT=/home/pi/tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin
export PLATFORM_OS=Linux
export PLATFORM_ARCH=armv6l
export PKG_CONFIG_PATH=$RPI_ROOT/usr/lib/arm-linux-gnueabihf/pkgconfig:$RPI_ROOT/usr/share/pkgconfig:$RPI_ROOT/usr/lib/pkgconfig
export PATH=$TOOLCHAIN_ROOT:$PATH

Not too familiar with Makefile either, so I hope this patch makes sense.

