### PR TITLE
fix ofNode destructor when parented

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -18,11 +18,16 @@ ofNode::ofNode()
 
 //----------------------------------------
 ofNode::~ofNode(){
-	if(parent){
+	if(parent != nullptr){
 		parent->removeListener(*this);
 	}
-	for(auto child: children){
-		child->clearParent();
+
+	// clearParent() will remove children of this element as a side-effect.
+	// This changes the "children", and so we can't use a normal foreach
+	// loop, but must use the following construction to deal with newly
+	// invalidated iterators:
+	while (!children.empty()){
+		(*children.begin())->clearParent();
 	}
 }
 
@@ -119,20 +124,26 @@ void ofNode::removeListener(ofNode & node){
 }
 
 //----------------------------------------
-void ofNode::setParent(ofNode& parent, bool bMaintainGlobalTransform) {
-    if(bMaintainGlobalTransform) {
-		ofMatrix4x4 postParentGlobalTransform = getGlobalTransformMatrix() * parent.getGlobalTransformMatrix().getInverse();
-		parent.addListener(*this);
+void ofNode::setParent(ofNode& parent_, bool bMaintainGlobalTransform) {
+	if (parent != nullptr)
+	{
+		// we need to make sure to clear before
+		// re-assigning parenthood.
+		clearParent(bMaintainGlobalTransform);
+	}
+	if(bMaintainGlobalTransform) {
+		ofMatrix4x4 postParentGlobalTransform = getGlobalTransformMatrix() * parent_.getGlobalTransformMatrix().getInverse();
+		parent_.addListener(*this);
 		setTransformMatrix(postParentGlobalTransform);
 	} else {
-		parent.addListener(*this);
+		parent_.addListener(*this);
 	}
-	this->parent = &parent;
+	parent = &parent_;
 }
 
 //----------------------------------------
 void ofNode::clearParent(bool bMaintainGlobalTransform) {
-	if(parent){
+	if(parent != nullptr){
 		parent->removeListener(*this);
 	}
     if(bMaintainGlobalTransform) {

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -346,7 +346,7 @@ protected:
 	/// \brief classes extending ofNode can override this methods to get notified when the scale changed.
 	virtual void onScaleChanged() {}
 
-	ofNode * parent;
+	ofNode * parent = nullptr;
 
 private:
 	void onParentPositionChanged(ofVec3f & position) {onPositionChanged();}


### PR DESCRIPTION
+ safer destruction of ofNode

ofNodes with parents/children would not properly destroy,
since the destructor in ofNode would stumble over an
invalidated iterator since the children's list of a node
would get altered when deleting a child's parent's
children list, which points back, don't ask a genealogist,
to the object itself.

+ clear parent in setParent if parenthood is re-assigned

when re-assigning parenthood to an object that already had
a parent, listeners assigned by the previous parenthood were
not cleared. This should be fixed  now.

+ clear up parameter ambiguity in ofNode::setParent

To increase readability, the parameter in the member
function referring to the parent to be set is renamed.