### PR TITLE
Fix events

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -411,8 +411,8 @@ public class OFAndroid {
     public static native void onScaleEnd(ScaleGestureDetector detector);
     public static native boolean onScale(ScaleGestureDetector detector);
     
-    public static native void onKeyDown(int keyCode);
-    public static native void onKeyUp(int keyCode);
+    public static native boolean onKeyDown(int keyCode, int unicode);
+    public static native boolean onKeyUp(int keyCode, int unicode);
     public static native boolean onBackPressed();
     
     public static native boolean onMenuItemSelected(String menu_id);
@@ -850,22 +850,9 @@ public class OFAndroid {
            		return false;
            	}
         }
-		
-        if (KeyEvent.isModifierKey(keyCode)) {
-        	/* Android sends a shift keycode (for instance),
-        	   then the key that goes with the shift. We don't need the first
-        	   keycode, that info is in event.getMetaState() anyway */
-        	return false;
-        }
-        else
-        {
-        	int unicodeChar = event.getUnicodeChar();
-        	onKeyDown(unicodeChar);
 
-        	// return false to let Android handle certain keys
-    		// like the back and menu keys
-        	return false;
-        }
+		int unicodeChar = event.getUnicodeChar();
+		return onKeyDown(keyCode, unicodeChar);
 	}
 	
 	/**
@@ -875,21 +862,8 @@ public class OFAndroid {
 	 * @return true to say we handled this, false to tell Android to handle it
 	 */
 	public static boolean keyUp(int keyCode, KeyEvent event) {
-        if (KeyEvent.isModifierKey(keyCode)) {
-        	/* Android sends a shift keycode (for instance),
-        	   then the key that goes with the shift. We don't need the first
-        	   keycode, that info is in event.getMetaState() anyway */
-        	return false;
-        }
-        else
-        {
-    		int unicodeChar = event.getUnicodeChar();
-    		onKeyUp(unicodeChar);
-    		
-    		// return false to let Android handle certain keys
-    		// like the back and menu keys
-        	return false;
-        }
+		int unicodeChar = event.getUnicodeChar();
+		return onKeyUp(keyCode, unicodeChar);
 	}
 }
 

--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -524,53 +524,47 @@ Java_cc_openframeworks_OFAndroid_onSwipe(JNIEnv*  env, jclass  thiz, jint id, ji
 
 jboolean
 Java_cc_openframeworks_OFAndroid_onScale(JNIEnv*  env, jclass  thiz, jobject detector){
-	try{
-		ofxAndroidScaleEventArgs scale(detector);
-		ofxAndroidEvents().scale.notify(nullptr,scale);
-	}catch(...){
-		return true;
-	}
-	return false;
+	ofxAndroidScaleEventArgs scale(detector);
+	return ofxAndroidEvents().scale.notify(nullptr,scale);
 }
 
 jboolean
 Java_cc_openframeworks_OFAndroid_onScaleBegin(JNIEnv*  env, jclass  thiz, jobject detector){
-	try{
-		ofxAndroidScaleEventArgs scale(detector);
-		ofxAndroidEvents().scaleBegin.notify(nullptr,scale);
-	}catch(...){
-		return true;
-	}
-	return false;
+	ofxAndroidScaleEventArgs scale(detector);
+	return ofxAndroidEvents().scaleBegin.notify(nullptr,scale);
 }
 
 void
 Java_cc_openframeworks_OFAndroid_onScaleEnd(JNIEnv*  env, jclass  thiz, jobject detector){
-	try{
-		ofxAndroidScaleEventArgs scale(detector);
-		ofxAndroidEvents().scaleEnd.notify(nullptr,scale);
-	}catch(...){
-	}
+	ofxAndroidScaleEventArgs scale(detector);
+    ofxAndroidEvents().scaleEnd.notify(nullptr,scale);
 }
 
-void
-Java_cc_openframeworks_OFAndroid_onKeyDown(JNIEnv*  env, jobject  thiz, jint  keyCode){
-	window->events().notifyKeyPressed(keyCode);
+jboolean
+Java_cc_openframeworks_OFAndroid_onKeyDown(JNIEnv*  env, jobject  thiz, jint  keyCode, jint unicode){
+    ofKeyEventArgs key;
+	key.type = ofKeyEventArgs::Pressed;
+    key.key = unicode;
+    key.keycode = keyCode;
+    key.scancode = keyCode;
+    key.codepoint = unicode;
+    return window->events().notifyKeyEvent(key);
 }
 
-void
-Java_cc_openframeworks_OFAndroid_onKeyUp(JNIEnv*  env, jobject  thiz, jint  keyCode){
-	window->events().notifyKeyReleased(keyCode);
+jboolean
+Java_cc_openframeworks_OFAndroid_onKeyUp(JNIEnv*  env, jobject  thiz, jint  keyCode, jint unicode){
+    ofKeyEventArgs key;
+	key.type = ofKeyEventArgs::Released;
+    key.key = unicode;
+    key.keycode = keyCode;
+    key.scancode = keyCode;
+    key.codepoint = unicode;
+    return window->events().notifyKeyEvent(key);
 }
 
 jboolean
 Java_cc_openframeworks_OFAndroid_onBackPressed(){
-	try{
-		ofxAndroidEvents().backPressed.notify(nullptr);
-	}catch(...){
-		return true;
-	}
-	return false;
+	return ofxAndroidEvents().backPressed.notify(nullptr);
 }
 
 jboolean
@@ -578,13 +572,8 @@ Java_cc_openframeworks_OFAndroid_onMenuItemSelected( JNIEnv*  env, jobject  thiz
 	jboolean iscopy;
 	const char * menu_id_str = env->GetStringUTFChars(menu_id, &iscopy);
 	if(!menu_id_str) return false;
-	try{
-		string id_str(menu_id_str);
-		ofxAndroidEvents().menuItemSelected.notify(nullptr,id_str);
-	}catch(...){
-		return true;
-	}
-	return false;
+	string id_str(menu_id_str);
+	return ofxAndroidEvents().menuItemSelected.notify(nullptr,id_str);
 }
 
 jboolean
@@ -592,13 +581,8 @@ Java_cc_openframeworks_OFAndroid_onMenuItemChecked( JNIEnv*  env, jobject  thiz,
 	jboolean iscopy;
 	const char *menu_id_str = env->GetStringUTFChars(menu_id, &iscopy);
 	if(!menu_id_str) return false;
-	try{
-		string id_str(menu_id_str);
-		ofxAndroidEvents().menuItemChecked.notify(nullptr,id_str);
-	}catch(...){
-		return true;
-	}
-	return false;
+	string id_str(menu_id_str);
+	return ofxAndroidEvents().menuItemChecked.notify(nullptr,id_str);
 }
 
 void

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -7,24 +7,30 @@
 #include <memory>
 #include <iterator>
 #include <atomic>
-
-class ofEventAttendedException: public std::exception{};
+#include <stddef.h>
+#include <functional>
 
 
 /*! \cond PRIVATE */
 namespace of{
 namespace priv{
+	// Helper classes and methods, only for internal use of ofEvent
+
+	// -------------------------------------
 	class NoopMutex{
 	public:
 		void lock(){}
 		void unlock(){}
 	};
 
+	// -------------------------------------
 	class AbstractEventToken{
 		public:
 			virtual ~AbstractEventToken();
 	};
 
+
+	// -------------------------------------
 	class BaseFunctionId{
 	public:
 		BaseFunctionId(){}
@@ -35,6 +41,7 @@ namespace priv{
 		virtual BaseFunctionId * clone() const = 0;
 	};
 
+	// -------------------------------------
 	class StdFunctionId: public BaseFunctionId{
 		static std::atomic<uint_fast64_t> nextId;
 		uint64_t id;
@@ -59,10 +66,12 @@ namespace priv{
 	};
 
 
+	// -------------------------------------
 	inline std::unique_ptr<StdFunctionId> make_function_id(){
 		return std::unique_ptr<StdFunctionId>(new StdFunctionId());
 	}
 
+	// -------------------------------------
 	template<typename T, class Mutex>
 	class Function{
 	public:
@@ -97,6 +106,7 @@ namespace priv{
 		Mutex mtx;
 	};
 
+	// -------------------------------------
 	template<class Mutex>
 	class Function<void,Mutex>{
 	public:
@@ -131,6 +141,7 @@ namespace priv{
 	};
 
 
+	// -------------------------------------
 	template<typename Function, typename Mutex=std::recursive_mutex>
 	class BaseEvent{
 	public:
@@ -186,20 +197,6 @@ namespace priv{
 		}
 
 	protected:
-
-#if _MSC_VER
-		template<typename> struct check_function;
-		template<typename R, typename... Args>
-		struct check_function<R(Args...)> : public std::function<R(Args...)> {
-			template<typename T,
-			class = typename std::enable_if<
-				std::is_same<R, void>::value
-				|| std::is_convertible<
-				decltype(std::declval<T>()(std::declval<Args>()...)),
-				R>::value>::type>
-				check_function(T &&t) : std::function<R(Args...)>(std::forward<T>(t)) { }
-		};
-#endif
 
 		struct Data{
 			Mutex mtx;
@@ -267,22 +264,117 @@ namespace priv{
 			self->functions.emplace(it, f);
 			return make_token(*f);
 		}
+	};
 
-		template<typename TFunction>
-		void removeFunction(const TFunction & function){
-			self->remove(*function->id);
-		}
+
+
+
+	// -------------------------------------
+	// Helper functions to disambiguate parameters
+	// https://github.com/sth/callable.hpp
+	namespace detail {
+
+	/** Count the number of types given to the template */
+	template<typename... Types>
+	struct tva_count;
+
+	template<>
+	struct tva_count<> {
+		static const size_t value = 0;
+	};
+
+	template<typename Type, typename... Types>
+	struct tva_count<Type, Types...> {
+		static const size_t value = tva_count<Types...>::value + 1;
+	};
+
+
+	/** Get the nth type given to the template */
+	template<size_t n, typename... Types>
+	struct tva_n;
+
+	template<size_t N, typename Type, typename... Types>
+	struct tva_n<N, Type, Types...> : tva_n<N-1, Types...> {
+	};
+
+	template<typename Type, typename... Types>
+	struct tva_n<0, Type, Types...> {
+		typedef Type type;
+	};
+
+
+	/** Define traits for a function type */
+	template<typename Fun>
+	struct callable_traits_fn;
+
+	template<typename Ret, typename... Args>
+	struct callable_traits_fn<Ret (Args...)> {
+		typedef Ret (*function_ptr)(Args...);
+		typedef Ret function_type(Args...);
+		typedef Ret return_type;
+		static const size_t argc;
+
+		template<size_t N>
+		using argument_type = typename tva_n<N, Args...>::type;
+	};
+
+	template<typename Ret, typename... Args>
+	const size_t callable_traits_fn<Ret (Args...)>::argc = tva_count<Args...>::value;
+
+
+	/** Define traits for a operator() member function pointer type */
+	template<typename MemFun>
+	struct callable_traits_memfn;
+
+	template<typename Class, typename Ret, typename... Args>
+	struct callable_traits_memfn<Ret (Class::*)(Args...)> : callable_traits_fn<Ret (Args...)> {
+	};
+
+	template<typename Class, typename Ret, typename... Args>
+	struct callable_traits_memfn<Ret (Class::*)(Args...) const> : callable_traits_fn<Ret (Args...)> {
+	};
+
+
+	// classes with operator()
+	template<typename Callable>
+	struct callable_traits_d : detail::callable_traits_memfn<decltype(&Callable::operator())> {
+	};
+
+	// functions
+	template<typename Ret, typename... Args>
+	struct callable_traits_d<Ret (Args...)> : detail::callable_traits_fn<Ret (Args...)> {
+	};
+
+	// function pointers
+	template<typename Ret, typename... Args>
+	struct callable_traits_d<Ret (*)(Args...)> : detail::callable_traits_fn<Ret (Args...)> {
+	};
+
+	// std::function specializations
+	template<typename Ret, typename... Args>
+	struct callable_traits_d<std::function<Ret (Args...)>> : detail::callable_traits_fn<Ret (Args...)> {
+	};
+
+	} // namespace detail
+
+
+	// Main template
+
+	template<typename Callable>
+	struct callable_traits : detail::callable_traits_d<typename std::remove_reference<Callable>::type> {
 	};
 }
 }
 /*! \endcond */
 
+// -------------------------------------
 enum ofEventOrder{
 	OF_EVENT_ORDER_BEFORE_APP=0,
 	OF_EVENT_ORDER_APP=100,
 	OF_EVENT_ORDER_AFTER_APP=200
 };
 
+// -------------------------------------
 class ofEventListener{
 public:
 	ofEventListener(){}
@@ -296,6 +388,8 @@ private:
 };
 
 
+// -------------------------------------
+// ofEvent main implementation
 template<typename T, typename Mutex=std::recursive_mutex>
 class ofEvent: public of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>{
 protected:
@@ -360,65 +454,35 @@ protected:
 		}, make_function_id(listener,method));
 	}
 
-	FunctionPtr make_function(bool (*function)(T&), int priority){
-		return std::make_shared<Function>(priority, std::bind(function,std::placeholders::_2), make_function_id((ofEvent<T>*)nullptr,function));
+	template<typename F>
+	std::unique_ptr<of::priv::BaseFunctionId> make_std_function_id(const F & f){
+		auto function = f.template target<typename of::priv::callable_traits<F>::function_ptr>();
+		if(function){
+			return make_function_id((ofEvent<T>*)nullptr,*function);
+		}else{
+			return of::priv::make_function_id();
+		}
 	}
 
-	FunctionPtr make_function(void (*function)(T&), int priority){
-		return std::make_shared<Function>(priority, [function](const void*, T&t){
-			(function)(t);
-			return false;
-		}, make_function_id((ofEvent<T>*)nullptr,function));
-	}
-
-	FunctionPtr make_function(bool (*function)(const void*, T&), int priority){
-		return std::make_shared<Function>(priority, function, make_function_id((ofEvent<T>*)nullptr,function));
-	}
-
-	FunctionPtr make_function(void (*function)(const void*, T&), int priority){
-		return std::make_shared<Function>(priority, [function](const void*s, T&t){
-			function(s,t);
-			return false;
-		}, make_function_id((ofEvent<T>*)nullptr,function));
-	}
-
-#ifdef _MSC_VER
-	FunctionPtr make_function(check_function<bool(T&)> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*,T&t){return f(t);}, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<bool(const void*,T&)> f, int priority){
-		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<void(T&)> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*,T&t){f(t);return false;}, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<void(const void*,T&)> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*s,T&t){f(s,t); return false;}, of::priv::make_function_id());
-	}
-#else
 	FunctionPtr make_function(std::function<bool(T&)> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*, T&t) {return f(t); }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*, T&t) {return f(t); }, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<bool(const void*, T&)> f, int priority) {
-		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, f, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<void(T&)> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*, T&t) {f(t); return false; }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*, T&t) {f(t); return false; }, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<void(const void*, T&)> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*s, T&t) {f(s, t); return false; }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*s, T&t) {f(s, t); return false; }, make_std_function_id(f));
 	}
 
-	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::removeFunction;
+
 	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addFunction;
 	using of::priv::BaseEvent<of::priv::Function<T,Mutex>,Mutex>::addNoToken;
-#endif
 
 public:
 	template<class TObj, typename TMethod>
@@ -433,51 +497,57 @@ public:
 
 	template<class TObj, typename TMethod>
 	void remove(TObj * listener, TMethod method, int priority){
-		removeFunction(make_function(listener,method,priority));
+		 ofEvent<T,Mutex>::self->remove(*make_function_id(listener,method));
 	}
 
 	template<typename TFunction>
 	ofEventListener newListener(TFunction function, int priority = OF_EVENT_ORDER_AFTER_APP) {
-		return ofEventListener(addFunction(make_function(function, priority)));
+		return ofEventListener(addFunction(make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function), priority)));
 	}
 
 	template<typename TFunction>
 	void add(TFunction function, int priority){
-		addNoToken(make_function(function,priority));
+		addNoToken(make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function),priority));
 	}
 
 	template<typename TFunction>
 	void remove(TFunction function, int priority){
-		removeFunction(make_function(function,priority));
+		 ofEvent<T,Mutex>::self->remove(*make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function), priority)->id);
 	}
 
-	inline void notify(const void* sender, T & param){
+	inline bool notify(const void* sender, T & param){
 		if(ofEvent<T,Mutex>::self->enabled && !ofEvent<T,Mutex>::self->functions.empty()){
 			std::unique_lock<Mutex> lck(ofEvent<T,Mutex>::self->mtx);
-			std::vector<std::shared_ptr<of::priv::Function<T,Mutex>>> functions_copy(ofEvent<T,Mutex>::self->functions);
+			auto functions_copy = ofEvent<T,Mutex>::self->functions;
 			lck.unlock();
 			for(auto & f: functions_copy){
                 if(f->notify(sender,param)){
-                    throw ofEventAttendedException();
+					return true;
                 }
 			}
 		}
+		return false;
 	}
 
-	inline void notify(T & param){
+	inline bool notify(T & param){
 		if(ofEvent<T,Mutex>::self->enabled && !ofEvent<T,Mutex>::self->functions.empty()){
 			std::unique_lock<Mutex> lck(ofEvent<T,Mutex>::self->mtx);
-			std::vector<std::shared_ptr<of::priv::Function<T,Mutex>>> functions_copy(ofEvent<T,Mutex>::self->functions);
+			auto functions_copy = ofEvent<T,Mutex>::self->functions;
 			lck.unlock();
 			for(auto & f: functions_copy){
 				if(f->notify(nullptr,param)){
-					throw ofEventAttendedException();
+					return true;
 				}
 			}
 		}
+		return false;
 	}
 };
 
+
+
+// -------------------------------------
+// void event template specialization,
 template<typename Mutex>
 class ofEvent<void,Mutex>: public of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>{
 protected:
@@ -543,65 +613,34 @@ protected:
 		}, make_function_id(listener,method));
 	}
 
-	FunctionPtr make_function(bool (*function)(), int priority){
-		return std::make_shared<Function>(priority, std::bind(function), make_function_id((ofEvent<void>*)nullptr,function));
+	template<typename F>
+	std::unique_ptr<of::priv::BaseFunctionId> make_std_function_id(const F & f){
+		auto function = f.template target<typename of::priv::callable_traits<F>::function_ptr>();
+		if(function){
+			return make_function_id((ofEvent<void>*)nullptr,*function);
+		}else{
+			return of::priv::make_function_id();
+		}
 	}
 
-	FunctionPtr make_function(void (*function)(), int priority){
-		return std::make_shared<Function>(priority,[function](const void*){
-			function();
-			return false;
-		}, make_function_id((ofEvent<void>*)nullptr,function));
-	}
-
-	FunctionPtr make_function(bool (*function)(const void*), int priority){
-		return std::make_shared<Function>(priority, function, make_function_id((ofEvent<void>*)nullptr,function));
-	}
-
-	FunctionPtr make_function(void (*function)(const void*), int priority){
-		return std::make_shared<Function>(priority,[function](const void* sender){
-			function(sender);
-			return false;
-		}, make_function_id((ofEvent<void>*)nullptr,function));
-	}
-
-#ifdef _MSC_VER
-	FunctionPtr make_function(check_function<bool()> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*){return f();}, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<bool(const void*)> f, int priority){
-		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<void()> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*){f(); return false;}, of::priv::make_function_id());
-	}
-
-	FunctionPtr make_function(check_function<void(const void*)> f, int priority){
-		return std::make_shared<Function>(priority, [f](const void*s){f(s); return false;}, of::priv::make_function_id());
-	}
-#else
 	FunctionPtr make_function(std::function<bool()> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*) {return f(); }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*) {return f(); }, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<bool(const void*)> f, int priority) {
-		return std::make_shared<Function>(priority, f, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, f, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<void()> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*) {f(); return false; }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*) {f(); return false; }, make_std_function_id(f));
 	}
 
 	FunctionPtr make_function(std::function<void(const void*)> f, int priority) {
-		return std::make_shared<Function>(priority, [f](const void*s) {f(s); return false; }, of::priv::make_function_id());
+		return std::make_shared<Function>(priority, [f](const void*s) {f(s); return false; }, make_std_function_id(f));
 	}
 
-	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::removeFunction;
 	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addFunction;
 	using of::priv::BaseEvent<of::priv::Function<void,Mutex>,Mutex>::addNoToken;
-#endif
 
 public:
 	template<class TObj, typename TMethod>
@@ -616,63 +655,68 @@ public:
 
 	template<class TObj, typename TMethod>
 	void remove(TObj * listener, TMethod method, int priority){
-		removeFunction(make_function(listener,method,priority));
+		ofEvent<void,Mutex>::self->remove(*make_function_id(listener,method));
 	}
 
 	template<typename TFunction>
 	void add(TFunction function, int priority){
-		addNoToken(make_function(function,priority));
+		addNoToken(make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function),priority));
 	}
 
 	template<typename TFunction>
 	ofEventListener newListener(TFunction function, int priority = OF_EVENT_ORDER_AFTER_APP) {
-		return ofEventListener(addFunction(make_function(function, priority)));
+		return ofEventListener(addFunction(make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function), priority)));
 	}
 
 	template<typename TFunction>
 	void remove(TFunction function, int priority){
-		removeFunction(make_function(function,priority));
+		 ofEvent<void,Mutex>::self->remove(*make_function(std::function<typename of::priv::callable_traits<TFunction>::function_type>(function),priority)->id);
 	}
 
-	void notify(const void* sender){
+	bool notify(const void* sender){
 		if(ofEvent<void,Mutex>::self->enabled && !ofEvent<void,Mutex>::self->functions.empty()){
 			std::unique_lock<Mutex> lck(ofEvent<void,Mutex>::self->mtx);
-			std::vector<std::shared_ptr<of::priv::Function<void,Mutex>>> functions_copy(ofEvent<void,Mutex>::self->functions);
+			auto functions_copy = ofEvent<void,Mutex>::self->functions;
 			lck.unlock();
 			for(auto & f: functions_copy){
 				if(f->notify(sender)){
-					throw ofEventAttendedException();
+					return true;
 				}
 			}
 		}
+		return false;
 	}
 
-	void notify(){
+	bool notify(){
 		if(ofEvent<void,Mutex>::self->enabled && !ofEvent<void,Mutex>::self->functions.empty()){
 			std::unique_lock<Mutex> lck(ofEvent<void,Mutex>::self->mtx);
-			std::vector<std::shared_ptr<of::priv::Function<void,Mutex>>> functions_copy(ofEvent<void,Mutex>::self->functions);
+			auto functions_copy = ofEvent<void,Mutex>::self->functions;
 			lck.unlock();
 			for(auto & f: functions_copy){
 				if(f->notify(nullptr)){
-					throw ofEventAttendedException();
+					return true;
 				}
 			}
 		}
+		return false;
 	}
 };
 
+
+// -------------------------------------
 /// Non thread safe event that avoids locks and copies of the listeners
 /// making it faster than a plain ofEvent
 template<typename T>
 class ofFastEvent: public ofEvent<T,of::priv::NoopMutex>{
 public:
-	inline void notify(const void* sender, T & param){
+	inline bool notify(const void* sender, T & param){
 		if(ofFastEvent::enabled){
 			for(auto & f: ofFastEvent::functions){
                 if(f->notify(sender,param)){
-                    throw ofEventAttendedException();
+					return true;
                 }
 			}
 		}
+		return false;
 	}
 };

--- a/libs/openFrameworks/events/ofEventUtils.h
+++ b/libs/openFrameworks/events/ofEventUtils.h
@@ -7,13 +7,14 @@
 #include <stdlib.h>
 
 //----------------------------------------------------
-// register any method of any class to an event.
-// the method must provide one of the following
-// signatures:
-//     void method(ArgumentsType & args)
-//     void method(const void * sender, ArgumentsType &args)
-// ie:
-//     ofAddListener(addon.newIntEvent, this, &Class::method)
+/// register any method of any class to an event.
+///
+/// the method must provide one of the following
+/// signatures:
+///     void method(ArgumentsType & args)
+///     void method(const void * sender, ArgumentsType &args)
+/// ie:
+///     ofAddListener(addon.newIntEvent, this, &Class::method)
 
 template <class EventType,typename ArgumentsType, class ListenerClass>
 void ofAddListener(EventType & event, ListenerClass  * listener, void (ListenerClass::*listenerMethod)(const void*, ArgumentsType&), int prio=OF_EVENT_ORDER_AFTER_APP){
@@ -107,13 +108,14 @@ inline void ofAddListener(ofEvent<void> & event, bool (*listenerFunction)(), int
     event.add(listenerFunction, prio);
 }
 //----------------------------------------------------
-// unregister any method of any class to an event.
-// the method must provide one the following
-// signatures:
-//     void method(ArgumentsType & args)
-//     void method(const void * sender, ArgumentsType &args)
-// ie:
-//     ofAddListener(addon.newIntEvent, this, &Class::method)
+/// unregister any method of any class to an event.
+///
+/// the method must provide one the following
+/// signatures:
+///     void method(ArgumentsType & args)
+///     void method(const void * sender, ArgumentsType &args)
+/// ie:
+///     ofAddListener(addon.newIntEvent, this, &Class::method)
 
 template <class EventType,typename ArgumentsType, class ListenerClass>
 void ofRemoveListener(EventType & event, ListenerClass  * listener, void (ListenerClass::*listenerMethod)(const void*, ArgumentsType&), int prio=OF_EVENT_ORDER_AFTER_APP){
@@ -191,64 +193,43 @@ inline void ofRemoveListener(ofEvent<void> & event, bool (*listenerFunction)(), 
     event.remove(listenerFunction, prio);
 }
 //----------------------------------------------------
-// notifies an event so all the registered listeners
-// get called
-// ie:
-//	ofNotifyEvent(addon.newIntEvent, intArgument, this)
-//
-// or in case there's no sender:
-//	ofNotifyEvent(addon.newIntEvent, intArgument)
+/// notifies an event so all the registered listeners
+/// get called
+///
+/// ie:
+///	ofNotifyEvent(addon.newIntEvent, intArgument, this)
+///
+/// or in case there's no sender:
+///	ofNotifyEvent(addon.newIntEvent, intArgument)
+///
+/// @returns: true in case any listener attended the event
 
 template <class EventType,typename ArgumentsType, typename SenderType>
-inline void ofNotifyEvent(EventType & event, ArgumentsType & args, SenderType * sender){
-	try{
-		event.notify(sender,args);
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(EventType & event, ArgumentsType & args, SenderType * sender){
+	return event.notify(sender,args);
 }
 
 template <class EventType,typename ArgumentsType>
-inline void ofNotifyEvent(EventType & event, ArgumentsType & args){
-	try{
-		event.notify(args);
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(EventType & event, ArgumentsType & args){
+	return event.notify(args);
 }
 
 template <class EventType, typename ArgumentsType, typename SenderType>
-inline void ofNotifyEvent(EventType & event, const ArgumentsType & args, SenderType * sender){
-	try{
-		event.notify(sender,args);
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(EventType & event, const ArgumentsType & args, SenderType * sender){
+	return event.notify(sender,args);
 }
 
 template <class EventType,typename ArgumentsType>
-inline void ofNotifyEvent(EventType & event, const ArgumentsType & args){
-	try{
-		event.notify(args);
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(EventType & event, const ArgumentsType & args){
+	return event.notify(args);
 }
 
 template <typename SenderType>
-inline void ofNotifyEvent(ofEvent<void> & event, SenderType * sender){
-	try{
-		event.notify(sender);
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(ofEvent<void> & event, SenderType * sender){
+	return event.notify(sender);
 }
 
-inline void ofNotifyEvent(ofEvent<void> & event){
-	try{
-		event.notify();
-	}catch(ofEventAttendedException &){
-
-	}
+inline bool ofNotifyEvent(ofEvent<void> & event){
+	return event.notify();
 }
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -245,19 +245,19 @@ int ofCoreEvents::getPreviousMouseY() const{
 }
 
 //------------------------------------------
-void ofCoreEvents::notifySetup(){
-	ofNotifyEvent( setup, voidEventArgs );
+bool ofCoreEvents::notifySetup(){
+	return ofNotifyEvent( setup, voidEventArgs );
 }
 
 #include "ofGraphics.h"
 //------------------------------------------
-void ofCoreEvents::notifyUpdate(){
-	ofNotifyEvent( update, voidEventArgs );
+bool ofCoreEvents::notifyUpdate(){
+	return ofNotifyEvent( update, voidEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyDraw(){
-	ofNotifyEvent( draw, voidEventArgs );
+bool ofCoreEvents::notifyDraw(){
+	auto attended = ofNotifyEvent( draw, voidEventArgs );
 
 	if (bFrameRateSet){
 		timer.waitNext();
@@ -274,112 +274,114 @@ void ofCoreEvents::notifyDraw(){
 		}*/
 	}
 	fps.newFrame();
-	
+	return attended;
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyKeyPressed(int key, int keycode, int scancode, int codepoint){
+bool ofCoreEvents::notifyKeyPressed(int key, int keycode, int scancode, uint32_t codepoint){
 	// FIXME: modifiers are being reported twice, for generic and for left/right
 	// add operators to the arguments class so it can be checked for both
+	bool attended = false;
     if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
         pressedKeys.insert(OF_KEY_CONTROL);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_CONTROL);
-        ofNotifyEvent( keyPressed, keyEventArgs );
+		attended = ofNotifyEvent( keyPressed, keyEventArgs );
     }
     else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
         pressedKeys.insert(OF_KEY_SHIFT);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_SHIFT);
-        ofNotifyEvent( keyPressed, keyEventArgs );
+		attended = ofNotifyEvent( keyPressed, keyEventArgs );
     }
     else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
         pressedKeys.insert(OF_KEY_ALT);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_ALT);
-        ofNotifyEvent( keyPressed, keyEventArgs );
+		attended = ofNotifyEvent( keyPressed, keyEventArgs );
     }
     else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
         pressedKeys.insert(OF_KEY_SUPER);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_SUPER);
-        ofNotifyEvent( keyPressed, keyEventArgs );
+		attended = ofNotifyEvent( keyPressed, keyEventArgs );
     }
-            
+
 	pressedKeys.insert(key);
-    ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,key,keycode,scancode,codepoint);
-	ofNotifyEvent( keyPressed, keyEventArgs );
+	if(!attended){
+		ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,key,keycode,scancode,codepoint);
+		return ofNotifyEvent( keyPressed, keyEventArgs );
+	}else{
+		return attended;
+	}
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyKeyReleased(int key, int keycode, int scancode, int codepoint){
+bool ofCoreEvents::notifyKeyReleased(int key, int keycode, int scancode, uint32_t codepoint){
 	// FIXME: modifiers are being reported twice, for generic and for left/right
 	// add operators to the arguments class so it can be checked for both
+	bool attended = false;
     if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
         pressedKeys.erase(OF_KEY_CONTROL);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_CONTROL);
-    	ofNotifyEvent( keyReleased, keyEventArgs );
+		attended = ofNotifyEvent( keyReleased, keyEventArgs );
     }
     else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
         pressedKeys.erase(OF_KEY_SHIFT);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_SHIFT);
-    	ofNotifyEvent( keyReleased, keyEventArgs );
+		attended = ofNotifyEvent( keyReleased, keyEventArgs );
     }
     else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
         pressedKeys.erase(OF_KEY_ALT);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_ALT);
-    	ofNotifyEvent( keyReleased, keyEventArgs );
+		attended = ofNotifyEvent( keyReleased, keyEventArgs );
     }
     else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
         pressedKeys.erase(OF_KEY_SUPER);
         ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_SUPER);
-    	ofNotifyEvent( keyReleased, keyEventArgs );
+		attended = ofNotifyEvent( keyReleased, keyEventArgs );
     }
     
 	pressedKeys.erase(key);
-    ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,key,keycode,scancode,codepoint);
-	ofNotifyEvent( keyReleased, keyEventArgs );
+	if(!attended){
+		ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,key,keycode,scancode,codepoint);
+		return ofNotifyEvent( keyReleased, keyEventArgs );
+	}else{
+		return attended;
+	}
 }
 
 
 //------------------------------------------
-void ofCoreEvents::notifyKeyEvent(const ofKeyEventArgs & keyEvent){
+bool ofCoreEvents::notifyKeyEvent(const ofKeyEventArgs & keyEvent){
 	switch(keyEvent.type){
 		case ofKeyEventArgs::Pressed:
-			notifyKeyPressed(keyEvent.key);
-			break;
+			return notifyKeyPressed(keyEvent.key, keyEvent.keycode, keyEvent.scancode, keyEvent.codepoint);
 		case ofKeyEventArgs::Released:
-			notifyKeyReleased(keyEvent.key);
-			break;
-		
+			return notifyKeyReleased(keyEvent.key, keyEvent.keycode, keyEvent.scancode, keyEvent.codepoint);
 	}
+	return false;
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseEvent(const ofMouseEventArgs & mouseEvent){
+bool  ofCoreEvents::notifyMouseEvent(const ofMouseEventArgs & mouseEvent){
 	switch(mouseEvent.type){
 		case ofMouseEventArgs::Moved:
-			notifyMouseMoved(mouseEvent.x,mouseEvent.y);
-			break;
+			return notifyMouseMoved(mouseEvent.x,mouseEvent.y);
 		case ofMouseEventArgs::Dragged:
-			notifyMouseDragged(mouseEvent.x,mouseEvent.y,mouseEvent.button);
-			break;
+			return notifyMouseDragged(mouseEvent.x,mouseEvent.y,mouseEvent.button);
 		case ofMouseEventArgs::Pressed:
-			notifyMousePressed(mouseEvent.x,mouseEvent.y,mouseEvent.button);
-			break;
+			return notifyMousePressed(mouseEvent.x,mouseEvent.y,mouseEvent.button);
 		case ofMouseEventArgs::Released:
-			notifyMouseReleased(mouseEvent.x,mouseEvent.y,mouseEvent.button);
-			break;
+			return notifyMouseReleased(mouseEvent.x,mouseEvent.y,mouseEvent.button);
 		case ofMouseEventArgs::Scrolled:
-			notifyMouseScrolled(mouseEvent.x,mouseEvent.y,mouseEvent.scrollX,mouseEvent.scrollY);
-			break;
+			return notifyMouseScrolled(mouseEvent.x,mouseEvent.y,mouseEvent.scrollX,mouseEvent.scrollY);
 		case ofMouseEventArgs::Entered:
-			notifyMouseEntered(mouseEvent.x,mouseEvent.y);
-			break;
+			return notifyMouseEntered(mouseEvent.x,mouseEvent.y);
 		case ofMouseEventArgs::Exited:
-			notifyMouseExited(mouseEvent.x,mouseEvent.y);
-			break;
+			return notifyMouseExited(mouseEvent.x,mouseEvent.y);
 	}
+	return false;
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMousePressed(int x, int y, int button){
+bool ofCoreEvents::notifyMousePressed(int x, int y, int button){
     if( bPreMouseNotSet ){
 		previousMouseX	= x;
 		previousMouseY	= y;
@@ -395,11 +397,11 @@ void ofCoreEvents::notifyMousePressed(int x, int y, int button){
 
 
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Pressed,x,y,button);
-	ofNotifyEvent( mousePressed, mouseEventArgs );
+	return ofNotifyEvent( mousePressed, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseReleased(int x, int y, int button){
+bool ofCoreEvents::notifyMouseReleased(int x, int y, int button){
 	if( bPreMouseNotSet ){
 		previousMouseX	= x;
 		previousMouseY	= y;
@@ -414,11 +416,11 @@ void ofCoreEvents::notifyMouseReleased(int x, int y, int button){
 	pressedMouseButtons.erase(button);
 
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Released,x,y,button);
-	ofNotifyEvent( mouseReleased, mouseEventArgs );
+	return ofNotifyEvent( mouseReleased, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseDragged(int x, int y, int button){
+bool ofCoreEvents::notifyMouseDragged(int x, int y, int button){
 	if( bPreMouseNotSet ){
 		previousMouseX	= x;
 		previousMouseY	= y;
@@ -432,11 +434,11 @@ void ofCoreEvents::notifyMouseDragged(int x, int y, int button){
 	currentMouseY = y;
 
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Dragged,x,y,button);
-	ofNotifyEvent( mouseDragged, mouseEventArgs );
+	return ofNotifyEvent( mouseDragged, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseMoved(int x, int y){
+bool ofCoreEvents::notifyMouseMoved(int x, int y){
 	if( bPreMouseNotSet ){
 		previousMouseX	= x;
 		previousMouseY	= y;
@@ -450,54 +452,54 @@ void ofCoreEvents::notifyMouseMoved(int x, int y){
 	currentMouseY = y;
 
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Moved,x,y,0);
-	ofNotifyEvent( mouseMoved, mouseEventArgs );
+	return ofNotifyEvent( mouseMoved, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseScrolled(int x, int y, float scrollX, float scrollY){
+bool ofCoreEvents::notifyMouseScrolled(int x, int y, float scrollX, float scrollY){
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Scrolled,x,y);
 	mouseEventArgs.scrollX = scrollX;
 	mouseEventArgs.scrollY = scrollY;
-	ofNotifyEvent( mouseScrolled, mouseEventArgs );
+	return ofNotifyEvent( mouseScrolled, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseEntered(int x, int y){
+bool ofCoreEvents::notifyMouseEntered(int x, int y){
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Entered,x,y);
-	ofNotifyEvent( mouseEntered, mouseEventArgs );
+	return ofNotifyEvent( mouseEntered, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyMouseExited(int x, int y){
+bool ofCoreEvents::notifyMouseExited(int x, int y){
 	ofMouseEventArgs mouseEventArgs(ofMouseEventArgs::Exited,x,y);
-	ofNotifyEvent( mouseExited, mouseEventArgs );
+	return ofNotifyEvent( mouseExited, mouseEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyExit(){
-	ofNotifyEvent( exit, voidEventArgs );
+bool ofCoreEvents::notifyExit(){
+	return ofNotifyEvent( exit, voidEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyWindowResized(int width, int height){
+bool ofCoreEvents::notifyWindowResized(int width, int height){
 	ofResizeEventArgs resizeEventArgs(width,height);
-	ofNotifyEvent( windowResized, resizeEventArgs );
+	return ofNotifyEvent( windowResized, resizeEventArgs );
 }
 
 //------------------------------------------
-void ofCoreEvents::notifyDragEvent(ofDragInfo info){
-	ofNotifyEvent(fileDragEvent, info);
+bool ofCoreEvents::notifyDragEvent(ofDragInfo info){
+	return ofNotifyEvent(fileDragEvent, info);
 }
 
 //------------------------------------------
-void ofSendMessage(ofMessage msg){
-	ofNotifyEvent(ofEvents().messageEvent, msg);
+bool ofSendMessage(ofMessage msg){
+	return ofNotifyEvent(ofEvents().messageEvent, msg);
 }
 
 //------------------------------------------
-void ofSendMessage(string messageString){
+bool ofSendMessage(string messageString){
 	ofMessage msg(messageString);
-	ofSendMessage(msg);
+	return ofSendMessage(msg);
 }
 
 //------------------------------------------

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -71,7 +71,7 @@ public:
 	/// \brief The raw scan code returned by the keyboard, OS and hardware specific. 
 	int scancode;
 	/// \brief The Unicode code point you'd expect if this key combo (including modifier keys) was pressed in a text editor, or -1 for non-printable characters. 
-	unsigned int codepoint;
+	uint32_t codepoint;
 };
 
 class ofMouseEventArgs : public ofEventArgs, public ofVec2f {
@@ -243,27 +243,27 @@ class ofCoreEvents {
 	int getPreviousMouseY() const;
 
 	//  event notification only for internal OF use
-	void notifySetup();
-	void notifyUpdate();
-	void notifyDraw();
+	bool notifySetup();
+	bool notifyUpdate();
+	bool notifyDraw();
 
-	void notifyKeyPressed(int key, int keycode=-1, int scancode=-1, int codepoint=-1);
-	void notifyKeyReleased(int key, int keycode=-1, int scancode=-1, int codepoint=-1);
-	void notifyKeyEvent(const ofKeyEventArgs & keyEvent);
+	bool notifyKeyPressed(int key, int keycode=-1, int scancode=-1, uint32_t codepoint=0);
+	bool notifyKeyReleased(int key, int keycode=-1, int scancode=-1, uint32_t codepoint=0);
+	bool notifyKeyEvent(const ofKeyEventArgs & keyEvent);
 
-	void notifyMousePressed(int x, int y, int button);
-	void notifyMouseReleased(int x, int y, int button);
-	void notifyMouseDragged(int x, int y, int button);
-	void notifyMouseMoved(int x, int y);
-	void notifyMouseScrolled(int x, int y, float scrollX, float scrollY);
-	void notifyMouseEntered(int x, int y);
-	void notifyMouseExited(int x, int y);
-	void notifyMouseEvent(const ofMouseEventArgs & mouseEvent);
+	bool notifyMousePressed(int x, int y, int button);
+	bool notifyMouseReleased(int x, int y, int button);
+	bool notifyMouseDragged(int x, int y, int button);
+	bool notifyMouseMoved(int x, int y);
+	bool notifyMouseScrolled(int x, int y, float scrollX, float scrollY);
+	bool notifyMouseEntered(int x, int y);
+	bool notifyMouseExited(int x, int y);
+	bool notifyMouseEvent(const ofMouseEventArgs & mouseEvent);
 
-	void notifyExit();
-	void notifyWindowResized(int width, int height);
+	bool notifyExit();
+	bool notifyWindowResized(int width, int height);
 
-	void notifyDragEvent(ofDragInfo info);
+	bool notifyDragEvent(ofDragInfo info);
 
 private:
 	float targetRate;
@@ -278,8 +278,8 @@ private:
 	set<int> pressedKeys;
 };
 
-void ofSendMessage(ofMessage msg);
-void ofSendMessage(string messageString);
+bool ofSendMessage(ofMessage msg);
+bool ofSendMessage(string messageString);
 
 ofCoreEvents & ofEvents();
 

--- a/tests/events/events/src/main.cpp
+++ b/tests/events/events/src/main.cpp
@@ -156,6 +156,27 @@ class ofApp: public ofxUnitTestsApp{
 			test_eq(toggleForVoidListenerWithToken, false, "Unregistered void event with member function with release token");
 			test_eq(toggleVoidFunc, false, "Unregistered void event with c function");
 		}
+
+
+		{
+			ofEvent<const int> e;
+			auto listener = e.newListener([](const int & v){
+			});
+			auto listenerSender = e.newListener([](const void * sender, const int & v){
+			});
+			auto listenerBool = e.newListener([](const int & v){
+				return false;
+			});
+			auto listenerSenderBool = e.newListener([](const void * sender, const int & v){
+				return false;
+			});
+			e.notify(5);
+
+			ofEvent<void> voidE;
+			auto voidListener = voidE.newListener([]{
+
+			});
+		}
 	}
 };
 


### PR DESCRIPTION
Events: return true in notify if event is attended. We were using ofEventAttendedException cause it was the only way to stop the event propagation in poco but that's not necessary any more.

Also fix ambiguities on add/remove listeners for lambdas and plain functions and use all this in android

	