### PR TITLE
Feature ofParameterGroup::remove(ofParameter)

### DIFF
--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -43,6 +43,10 @@ vector<string> ofAbstractParameter::getGroupHierarchyNames() const{
 	return hierarchy;
 }
 
+bool ofAbstractParameter::isReferenceTo(const ofAbstractParameter &other) const{
+	return getInternalObject() == other.getInternalObject();
+}
+
 ostream& operator<<(ostream& os, const ofAbstractParameter& p){
 	os << p.toString();
 	return os;

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -84,6 +84,22 @@ public:
 
 	void add(ofAbstractParameter & param);
 
+	void remove(ofAbstractParameter & param);
+	void remove(std::size_t index);
+	void remove(const std::string& name);
+
+	template<typename ParameterType>
+	void remove(ofParameter<ParameterType>& param){
+		std::for_each(obj->parameters.begin(), obj->parameters.end(), [&](shared_ptr<ofAbstractParameter>& p){
+			if(p->type() == param.type()){
+				auto other = static_pointer_cast<ofParameter<ParameterType>>(p);
+				if(param.isReferenceTo(*other)){
+					remove(param.getName());
+				}
+			}
+		});
+	}
+
 
 	void clear();
 
@@ -485,6 +501,8 @@ public:
 	void setSerializable(bool serializable);
 	shared_ptr<ofAbstractParameter> newReference() const;
 
+	bool isReferenceTo(const ofParameter<ParameterType>& other);
+
 	void setParent(ofParameterGroup & _parent);
 
 	const ofParameterGroup getFirstParent() const{
@@ -540,6 +558,7 @@ private:
 		bool serializable;
 		vector<weak_ptr<ofParameterGroup::Value>> parents;
 	};
+
 	shared_ptr<Value> obj;
 	std::function<void(const ParameterType & v)> setMethod;
 
@@ -881,7 +900,12 @@ void ofParameter<ParameterType>::makeReferenceTo(ofParameter<ParameterType> & mo
 
 template<typename ParameterType>
 shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::newReference() const{
-    return std::make_shared<ofParameter<ParameterType>>(*this);
+	return std::make_shared<ofParameter<ParameterType>>(*this);
+}
+
+template<typename ParameterType>
+bool ofParameter<ParameterType>::isReferenceTo(const ofParameter<ParameterType> &other){
+	return obj == other.obj;
 }
 
 template<typename ParameterType>

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -9,9 +9,37 @@ ofParameterGroup::ofParameterGroup()
 
 void ofParameterGroup::add(ofAbstractParameter & parameter){
 	shared_ptr<ofAbstractParameter> param = parameter.newReference();
+	const std::string name = param->getEscapedName();
+	if(obj->parametersIndex.find(name) != obj->parametersIndex.end()){
+		ofLogWarning() << "Adding another parameter with same name '" << param->getName() << "' to group '" << getName() << "'";
+	}
 	obj->parameters.push_back(param);
-	obj->parametersIndex[param->getEscapedName()] = obj->parameters.size()-1;
+	obj->parametersIndex[name] = obj->parameters.size()-1;
 	param->setParent(*this);
+}
+
+void ofParameterGroup::remove(ofAbstractParameter &param){
+	std::for_each(obj->parameters.begin(), obj->parameters.end(), [&](shared_ptr<ofAbstractParameter>& p){
+		//TODO: this is unsafe because it does not actually compare the two parameters
+		if(p->type() == param.type() && p->getName() == param.getName()){
+			remove(param.getName());
+		}
+	});
+}
+
+void ofParameterGroup::remove(size_t index){
+	if(index>obj->parameters.size()){
+		return;
+	}
+	remove(obj->parameters[index]->getName());
+}
+
+void ofParameterGroup::remove(const string &name){
+	if(!contains(name)){
+		return;
+	}
+	obj->parameters.erase(obj->parameters.begin() + obj->parametersIndex[name]);
+	obj->parametersIndex.erase(name);
 }
 
 void ofParameterGroup::clear(){

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -20,8 +20,7 @@ void ofParameterGroup::add(ofAbstractParameter & parameter){
 
 void ofParameterGroup::remove(ofAbstractParameter &param){
 	std::for_each(obj->parameters.begin(), obj->parameters.end(), [&](shared_ptr<ofAbstractParameter>& p){
-		//TODO: this is unsafe because it does not actually compare the two parameters
-		if(p->type() == param.type() && p->getName() == param.getName()){
+		if(p->isReferenceTo(param)){
 			remove(param.getName());
 		}
 	});
@@ -431,6 +430,10 @@ bool ofParameterGroup::isReadOnly() const{
 	return false;
 }
 
+const void* ofParameterGroup::getInternalObject() const{
+	return obj.get();
+}
+
 shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{
 	return std::make_shared<ofParameterGroup>(*this);
 }
@@ -474,4 +477,5 @@ vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGrou
 vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGroup::rend() const{
 	return obj->parameters.rend();
 }
+
 


### PR DESCRIPTION
This adds remove functions to ofParameterGroup. I didn't really know how to handle generic parameters so right now it just compares type and name. Currently this won't work if two children have the same name but it looks like this is an issue with the parameter group anyways, so I added a warning.

I also tried to automatically remove a child from a parent when the parameter gets dereferenced. Like:
```
ofParameterGroup group;
ofParameter<int>* test = new ofParameter<int>();
group.add(test->set("test", 10));
delete test;
```
This won't work though because parameter groups store their children as shared_ptr. This makes sense if a user does not keep track of all parameters themselves. But I feel like we usually do and at least for me this resulted in some unexpected behavior where I wasn't able to get rid of my parameters in the gui.  It is not really an issue though...