### PR TITLE
push and pop styling when drawing OpenCV blobs

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvBlob.h
+++ b/addons/ofxOpenCv/src/ofxCvBlob.h
@@ -37,6 +37,7 @@ class ofxCvBlob {
 
         //----------------------------------------
         void draw(float x = 0, float y = 0){
+            ofPushStyle();
             ofNoFill();
             ofSetHexColor(0x00FFFF);
             ofBeginShape();
@@ -46,5 +47,6 @@ class ofxCvBlob {
             ofEndShape(true);
             ofSetHexColor(0xff0099);
             ofDrawRectangle(x + boundingRect.x, y + boundingRect.y, boundingRect.width, boundingRect.height);
+            ofPopStyle();
         }
 };


### PR DESCRIPTION
Currently, calling `ofxCvBlob.draw()` will leave the drawing color set to `0xff0099` (pink) with no fill. This PR simply adds push/pop style guards in the blobs drawing function, to prevent trampling the users styles.