### PR TITLE
Bugfix/android vram memory leak

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -197,10 +197,11 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 			camera.setPreviewCallback(null);
 			try {
 				if (Build.VERSION.SDK_INT >= 11) {
-					camera.setPreviewTexture(surfaceTexture);
+					camera.setPreviewTexture(null);
 				}
 			} catch (Exception e) {
 			}
+			surfaceTexture.release();
 			camera.release();
 			//orientationListener.disable();
 			initialized = false;

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -154,6 +154,7 @@ ofxAndroidVideoGrabber::~ofxAndroidVideoGrabber(){
 
 void ofxAndroidVideoGrabber::Data::onAppPause(){
 	appPaused = true;
+	glDeleteTextures(1, &texture.texData.textureID);
 	texture.texData.textureID = 0;
 	ofLogVerbose("ofxAndroidVideoGrabber") << "ofPauseVideoGrabbers(): releasing textures";
 }


### PR DESCRIPTION
The camera's texture doesn't get deallocated, causing a pretty big memory leak when the app is paused/resumed several times. In theory, the texture should eventually deallocate automatically, but I haven't seen this occur.