### PR TITLE
Added copy ippicv phase to apothecary script.

### DIFF
--- a/addons/ofxOpenCv/scripts/formulas/opencv.sh
+++ b/addons/ofxOpenCv/scripts/formulas/opencv.sh
@@ -666,6 +666,21 @@ function copy() {
       cp -v build_vs_${ARCH}/3rdparty/lib/Release/*.lib "${DEPLOY_PATH}/Release"
       cp -v build_vs_${ARCH}/3rdparty/lib/Debug/*.lib "${DEPLOY_PATH}/Debug"
 
+      #copy the ippicv includes and lib
+      IPPICV_SRC=3rdparty/ippicv/unpack/ippicv_win
+      IPPICV_DST=$1/../ippicv
+      if [ $ARCH == 32 ] ; then
+        IPPICV_PLATFORM="ia32"
+        IPPICV_DEPLOY="${IPPICV_DST}/lib/$TYPE/Win32"
+      elif [ $ARCH == 64 ] ; then
+        IPPICV_PLATFORM="intel64"
+        IPPICV_DEPLOY="${IPPICV_DST}/lib/$TYPE/x64"
+      fi
+      mkdir -p ${IPPICV_DST}/include
+      cp -R ${IPPICV_SRC}/include/ ${IPPICV_DST}/
+      mkdir -p ${IPPICV_DEPLOY}
+      cp -v ${IPPICV_SRC}/lib/${IPPICV_PLATFORM}/*.lib "${IPPICV_DEPLOY}"
+
   elif [[ "$TYPE" == "ios" || "$TYPE" == "tvos" ]] ; then
     # Standard *nix style copy.
     # copy headers


### PR DESCRIPTION
This will add an `ippicv` folder at the same level as the `opencv` folder. Both of these need to be copied into the `addons/ofxOpenCv/libs` folder. See #4981 and #5081 for discussion.