### PR TITLE
ofxiOSEAGLView - reset touches dictionary before the view appears

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.h
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.h
@@ -34,6 +34,7 @@ class ofAppiOSWindow;
 - (void)updateDimensions;
 - (void)destroy;
 - (CGPoint)orientateTouchPoint:(CGPoint)touchPoint;
+- (void) resetTouches;
 
 @end
 

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -232,6 +232,12 @@ static ofxiOSEAGLView * _instanceRef = nil;
 }
 
 //------------------------------------------------------
+
+-(void) resetTouches {
+
+	[activeTouches removeAllObjects];
+}
+
 - (void)touchesBegan:(NSSet *)touches 
            withEvent:(UIEvent *)event{
     

--- a/addons/ofxiOS/src/core/ofxiOSViewController.mm
+++ b/addons/ofxiOS/src/core/ofxiOSViewController.mm
@@ -67,6 +67,7 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self.glView startAnimation];
+	[self.glView resetTouches];
 }
 
 - (void)viewDidAppear:(BOOL)animated {


### PR DESCRIPTION
I have a hybrid c++/ObjectC app, so I have additional, non OF view controllers. I had a weird bug that if I have a finger down while going to a different view controller, that touch id is gone forever, and won’t be received again. This created issues with gesture recognition. I propose a small fix - to reset the touches dictionary in viewWIllAppear. I tested it in production scenarios and it works great. I saw no adverse affects for this. And it’s also a straight forward.
