### PR TITLE
Appveyor : add Msys2 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,19 +1,50 @@
 version: 1.0.{build}
 os: Visual Studio 2015 RC
+
+environment:
+  global:
+    APPVEYOR_OS_NAME: windows
+  matrix:
+  #MSYS2 Building
+    - BUILDER: MSYS2
+  #VisualStudio Building
+    - BUILDER : VS 
+    
 configuration: Debug
 platform:
 - x86
 - x64
 shallow_clone: true
-clone_depth: 10
-environment:
-  PATH: C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
-build:
-  project: libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
-  parallel: true
-  verbosity: minimal
+clone_depth: 10  
+
+init:
+- set MSYS2_PATH=c:\msys64
+- set CHERE_INVOKING=1
+- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Sy pacman"'
+- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Syuu"'
+- if "%BUILDER%_%PLATFORM%"=="MSYS2_x86" set MSYSTEM=MINGW32
+- if "%BUILDER%_%PLATFORM%"=="MSYS2_x64" set MSYSTEM=MINGW64
+
+
+- IF "BUILDER"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+  
+install:
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/msys2/install_dependencies.sh --noconfirm")
+
+build_script:
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/msys2/compileOF.sh")
+   
+- ps: |
+    if ($env:BUILDER -eq "VS") {
+      msbuild libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    }
+
 test_script:
-- cmd: >-
-    cd scripts/ci/vs
-    
-    run_tests.bat
+- ps: |
+    if ($env:BUILDER -eq "VS") {
+      cd scripts/ci/vs
+      .\run_tests.bat
+    }
+
+cache:
+  - C:\msys64

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ build_script:
     }
 
 test_script:
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/run_tests.sh")
 - ps: |
     if ($env:BUILDER -eq "VS") {
       cd scripts/ci/vs

--- a/scripts/ci/msys2/install.sh
+++ b/scripts/ci/msys2/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ev #verbose; exit immediatly
+ROOT=$(pwd -P)
+
+$ROOT/scripts/msys2/install_dependencies.sh --noconfirm

--- a/scripts/ci/msys2/run_tests.sh
+++ b/scripts/ci/msys2/run_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ev
+ROOT=$(pwd -P)
+
+echo "**** Running unit tests ****"
+cd $ROOT/tests
+for group in *; do
+	if [ -d $group ]; then
+		for test in $group/*; do
+			if [ -d $test ]; then
+				cd $test
+				cp ../../../scripts/templates/msys2/Makefile .
+				cp ../../../scripts/templates/msys2/config.make .
+				make Debug
+				cd bin
+				binname=$(basename ${test})
+                #gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug
+				./${binname}_debug.exe
+				errorcode=$?
+				if [[ $errorcode -ne 0 ]]; then
+					exit $errorcode
+				fi
+				cd $ROOT/tests
+			fi
+		done
+	fi
+done

--- a/scripts/msys2/compileOF.sh
+++ b/scripts/msys2/compileOF.sh
@@ -17,14 +17,22 @@ while getopts tj: opt ; do
 	esac
 done
 
-if [ "$MSYSTEM" != "MINGW32" ]
+if [ "${MSYSTEM:0:5}" != "MINGW" ]
 then
-	echo "This is not a MINGW32 shell!"
-	echo "Please launch compileOF.sh from a MINGW32 shell."
+	echo "This is not a MINGW(32|64) shell!"
+	echo "Please launch compileOF.sh from a MINGW(32|64) shell."
 	exit 1
 fi
 
 cd ${SCRIPTPATH}/../../libs/openFrameworksCompiled/project
+
+if [ -v CI ]; then
+	echo "Building in CI mode"
+	make  Debug
+	exit_code=$?
+	exit $exit_code
+fi
+ 
 make -j$JOBS Debug
 exit_code=$?
 if [ $exit_code != 0 ]; then

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -35,11 +35,13 @@ if [ "$NOT_HAS_PATH" -ne "0" ]; then
 fi
 
 arch=i686
-
-pacman -Sy
-pacman -Su
-pacman -S $confirm ca-certificates
-pacman -Sy $confirm --needed make mingw-w64-$arch-gcc mingw-w64-$arch-glew mingw-w64-$arch-freeglut mingw-w64-$arch-freeimage mingw-w64-$arch-opencv mingw-w64-$arch-assimp mingw-w64-$arch-boost mingw-w64-$arch-cairo mingw-w64-$arch-clang mingw-w64-$arch-gdb mingw-w64-$arch-zlib  mingw-w64-$arch-tools mingw-w64-$arch-pkg-config mingw-w64-$arch-poco mingw-w64-$arch-glfw
+if [ "x$CI" == "x" ]; then 
+  echo "Running without CI"
+#	pacman -Sy
+#	pacman -Su
+fi
+pacman -S $confirm --needed mingw-w64-$arch-harfbuzz
+pacman -S $confirm --needed ca-certificates make mingw-w64-$arch-gcc mingw-w64-$arch-glew mingw-w64-$arch-freeglut mingw-w64-$arch-FreeImage mingw-w64-$arch-opencv mingw-w64-$arch-assimp mingw-w64-$arch-boost mingw-w64-$arch-cairo mingw-w64-$arch-clang mingw-w64-$arch-gdb mingw-w64-$arch-zlib  mingw-w64-$arch-tools mingw-w64-$arch-pkg-config mingw-w64-$arch-poco mingw-w64-$arch-glfw
 
 # this would install gstreamer which can be used in mingw too
 #pacman -Sy mingw-w64-$arch-gst-libav mingw-w64-$arch-gst-plugins-bad mingw-w64-$arch-gst-plugins-base mingw-w64-$arch-gst-plugins-good mingw-w64-$arch-gst-plugins-ugly mingw-w64-$arch-gstreamer


### PR DESCRIPTION
Add MSYS2 32 and 64b bits building.
64 bits currently fails.
32 bits fails on string tests (see issue #5087)