### PR TITLE
MSYS2 locale support with boost::locale

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -4,7 +4,9 @@
 
 #include <chrono>
 #include <numeric>
-#include <boost/locale.hpp>
+#if defined(__MINGW32__)  //Use boost::locale on MSYS2 as MSYS2 only supports "C" locale natively (do not use GNU lib C"
+    #include <boost/locale.hpp>
+#endif
 #include <locale>
 
 #if !defined(TARGET_EMSCRIPTEN)
@@ -720,9 +722,12 @@ utf8::iterator<std::string::const_reverse_iterator> ofUTF8Iterator::rend() const
 static std::locale getLocale(const string & locale) {
 	std::locale loc;
 	try {
+#if defined(__MINGW32__) //Use to boost::locale on MSYS2
 		boost::locale::generator gen;
 		loc = gen(locale);
-		//loc = std::locale(locale.c_str());
+#else
+		loc = std::locale(locale.c_str());
+#endif
 	}
 	catch (...) {
 		ofLogWarning("ofUtils") << "Couldn't create locale " << locale << " using default, " << loc.name();
@@ -735,10 +740,13 @@ string ofToLower(const string & src, const string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
+#if defined(__MINGW32__) //Use to boost::locale on MSYS2
 		dst = boost::locale::to_lower(src,loc);
-		/*for(auto c: ofUTF8Iterator(src)){
+#else
+		for(auto c: ofUTF8Iterator(src)){
 			utf8::append(std::tolower<wchar_t>(c, loc), back_inserter(dst));
-		}*/
+		}
+#endif
 	}catch(...){
 	}
 	return dst;
@@ -749,10 +757,13 @@ string ofToUpper(const string & src, const string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
+#if defined(__MINGW32__) //Use to boost::locale on MSYS2
 		dst = boost::locale::to_upper(src,loc);
-		/*for(auto c: ofUTF8Iterator(src)){
+#else
+		for(auto c: ofUTF8Iterator(src)){
 			utf8::append(std::toupper<wchar_t>(c, loc), back_inserter(dst));
-		}*/
+		}
+#endif
 	}catch(...){
 	}
 	return dst;

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <numeric>
+#include <boost/locale.hpp>
 #include <locale>
 
 #if !defined(TARGET_EMSCRIPTEN)
@@ -719,7 +720,9 @@ utf8::iterator<std::string::const_reverse_iterator> ofUTF8Iterator::rend() const
 static std::locale getLocale(const string & locale) {
 	std::locale loc;
 	try {
-		loc = std::locale(locale.c_str());
+		boost::locale::generator gen;
+		loc = gen(locale);
+		//loc = std::locale(locale.c_str());
 	}
 	catch (...) {
 		ofLogWarning("ofUtils") << "Couldn't create locale " << locale << " using default, " << loc.name();
@@ -732,9 +735,10 @@ string ofToLower(const string & src, const string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
-		for(auto c: ofUTF8Iterator(src)){
+		dst = boost::locale::to_lower(src,loc);
+		/*for(auto c: ofUTF8Iterator(src)){
 			utf8::append(std::tolower<wchar_t>(c, loc), back_inserter(dst));
-		}
+		}*/
 	}catch(...){
 	}
 	return dst;
@@ -745,9 +749,10 @@ string ofToUpper(const string & src, const string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
-		for(auto c: ofUTF8Iterator(src)){
+		dst = boost::locale::to_upper(src,loc);
+		/*for(auto c: ofUTF8Iterator(src)){
 			utf8::append(std::toupper<wchar_t>(c, loc), back_inserter(dst));
-		}
+		}*/
 	}catch(...){
 	}
 	return dst;

--- a/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
+++ b/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
@@ -212,7 +212,7 @@ PLATFORM_HEADER_SEARCH_PATHS =
 PLATFORM_LIBRARIES += PocoNetSSL PocoNet PocoCrypto PocoUtil PocoXML PocoFoundation PocoZip PocoJSON PocoData PocoDataSQLite
 PLATFORM_LIBRARIES += ksuser opengl32 gdi32 msimg32 glu32 dsound winmm strmiids #dxguid  
 PLATFORM_LIBRARIES += uuid ole32 oleaut32 setupapi wsock32 ws2_32 Iphlpapi Comdlg32
-PLATFORM_LIBRARIES += freeimage boost_filesystem-mt boost_system-mt freetype cairo
+PLATFORM_LIBRARIES += freeimage boost_filesystem-mt boost_system-mt boost_locale-mt freetype cairo
 #PLATFORM_LIBRARIES += gstapp-1.0 gstvideo-1.0 gstbase-1.0 gstreamer-1.0 gobject-2.0 glib-2.0 intl
 
 #static libraries (fully qualified paths)


### PR DESCRIPTION
Switch to boost::locale as MSYS2 only support "C" locale natively.
Fixes issues #5087 and #5090 
Replace PR #5091 
