### PR TITLE
Unregister GLFW callbacks when closing GLFWAppWindow

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -60,6 +60,14 @@ ofAppGLFWWindow::~ofAppGLFWWindow(){
 
 void ofAppGLFWWindow::close(){
 	if(windowP){
+                glfwSetMouseButtonCallback(windowP, nullptr);
+                glfwSetCursorPosCallback(windowP, nullptr);
+                glfwSetCursorEnterCallback(windowP, nullptr);
+                glfwSetKeyCallback(windowP, nullptr);
+                glfwSetWindowSizeCallback(windowP, nullptr);
+                glfwSetWindowCloseCallback(windowP, nullptr);
+                glfwSetScrollCallback(windowP, nullptr);
+                glfwSetDropCallback(windowP, nullptr);
 		//hide the window before we destroy it stops a flicker on OS X on exit.
 		glfwHideWindow(windowP);
 		glfwDestroyWindow(windowP);


### PR DESCRIPTION
bugfix #5096. The key_cb was trying to get the window being detroyed.
Tested on MSYS2 only.