### PR TITLE
Android orientation event

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -32,6 +32,7 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.MulticastLock;
+import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
 import android.util.Log;
@@ -339,12 +340,14 @@ public class OFAndroid {
 	public void start(){
 		Log.i("OF","onStart");
 		enableTouchEvents();
+		enableOrientationChangeEvents();
 	}
 	
 	public void restart(){
 		Log.i("OF","onRestart");
 		enableTouchEvents();
 		onRestart();
+		enableOrientationChangeEvents();
         /*if(OFAndroidSoundStream.isInitialized() && OFAndroidSoundStream.wasStarted())
         	OFAndroidSoundStream.getInstance().start();*/
 	}
@@ -354,7 +357,8 @@ public class OFAndroid {
 	public void pause(){
 		Log.i("OF","onPause");
 		disableTouchEvents();
-		
+		disableOrientationChangeEvents();
+
 		onPause();
 
 		synchronized (OFAndroidObject.ofObjects) {
@@ -380,6 +384,7 @@ public class OFAndroid {
 		resumed = true;
 		Log.i("OF","onResume");
 		enableTouchEvents();
+		enableOrientationChangeEvents();
 		mGLView.onResume();
 		synchronized (OFAndroidObject.ofObjects) {
 			for(OFAndroidObject object : OFAndroidObject.ofObjects){
@@ -407,6 +412,7 @@ public class OFAndroid {
 		resumed = false;
 		Log.i("OF","onStop");
 		disableTouchEvents();
+		disableOrientationChangeEvents();
 		onStop();
 		
 		synchronized (OFAndroidObject.ofObjects) {
@@ -664,9 +670,10 @@ public class OFAndroid {
     public static native void cancelPressed();
     
     public static native void networkConnected(boolean conected);
-    
+	public static native void deviceOrientationChanged(int orientation);
 
-    // static methods to be called from OF c++ code
+
+	// static methods to be called from OF c++ code
     public static void setFullscreen(boolean fs){
     	//ofActivity.requestWindowFeature(Window.FEATURE_NO_TITLE);
     	//ofActivity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, 
@@ -699,10 +706,18 @@ public class OFAndroid {
     		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     		break;
     	case 270:
-    		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+				ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
+				break;
+			}
+			ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     		break;
     	case 180:
-    		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+				ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
+				break;
+			}
+			ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     		break;
     	case -1:
     		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
@@ -1012,6 +1027,7 @@ public class OFAndroid {
     private static OFActivity ofActivity;
     private static OFAndroid instance;
     private static OFGestureListener gestureListener;
+	private static OFOrientationListener orientationListener;
 	private static String packageName;
 	private static String dataPath;
 	public static boolean unpackingDone;
@@ -1064,7 +1080,15 @@ public class OFAndroid {
 	        mGLView.setOnTouchListener(gestureListener.touchListener);
 		}
 	}
-	
+
+	public static void enableOrientationChangeEvents(){
+		orientationListener.enable();
+	}
+
+	public static void disableOrientationChangeEvents(){
+		orientationListener.disable();
+	}
+
 	public static void initView(){        
         try {
         	Log.v("OF","trying to find class: "+packageName+".R$layout");
@@ -1089,6 +1113,7 @@ public class OFAndroid {
 			@Override
 			public void run() {
 				gestureListener = new OFGestureListener(ofActivity);
+				orientationListener = new OFOrientationListener(getContext());
 		        OFEGLConfigChooser.setGLESVersion(finalversion);
 		        initView();
 		        instance.resume();

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFOrientationListener.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFOrientationListener.java
@@ -1,0 +1,55 @@
+package cc.openframeworks;
+
+import android.content.Context;
+import android.view.Display;
+import android.view.OrientationEventListener;
+import android.view.Surface;
+import android.view.WindowManager;
+
+public class OFOrientationListener extends OrientationEventListener {
+    OFOrientationListener(Context context){
+        super(context);
+    }
+
+    private int lastOrientation;
+    private boolean firstCheck = true;
+
+    @Override
+    public void enable() {
+        checkOrientation();
+        super.enable();
+    }
+
+    @Override
+    public void onOrientationChanged(int orientation) {
+        checkOrientation();
+    }
+
+    private void checkOrientation(){
+        WindowManager windowManager = (WindowManager)OFAndroid.getContext().getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+
+        if(lastOrientation != display.getRotation() || firstCheck){
+            lastOrientation = display.getRotation();
+            firstCheck = false;
+
+            int ofOrientation;
+            switch (display.getRotation()) {
+                case Surface.ROTATION_90:
+                    ofOrientation = 3;
+                    break;
+                case Surface.ROTATION_180:
+                    ofOrientation = 2;
+                    break;
+                case Surface.ROTATION_270:
+                    ofOrientation = 4;
+                    break;
+                case Surface.ROTATION_0:
+                default:
+                    ofOrientation = 1;
+                    break;
+            }
+            OFAndroid.deviceOrientationChanged(ofOrientation);
+        }
+    }
+}

--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -589,6 +589,12 @@ Java_cc_openframeworks_OFAndroid_networkConnected( JNIEnv*  env, jobject  thiz, 
 	bool bConnected = (bool)connected;
 	ofNotifyEvent(ofxAndroidEvents().networkConnected,bConnected);
 }
+
+void
+Java_cc_openframeworks_OFAndroid_deviceOrientationChanged(JNIEnv*  env, jclass  thiz, jint orientation){
+    ofOrientation _orientation = (ofOrientation) orientation;
+    ofNotifyEvent(ofxAndroidEvents().deviceOrientationChanged,_orientation );
+}
 }
 
 

--- a/addons/ofxAndroid/src/ofxAndroidApp.h
+++ b/addons/ofxAndroid/src/ofxAndroidApp.h
@@ -38,4 +38,9 @@ public:
 	virtual void networkConnectedEvent(bool & connected){
 		networkConnected(connected);
 	}
+
+	virtual void deviceOrientationChanged(ofOrientation newOrientation){};
+    virtual void deviceOrientationChangedEvent(ofOrientation & newOrientation){
+        deviceOrientationChanged(newOrientation);
+    };
 };

--- a/addons/ofxAndroid/src/ofxAndroidUtils.h
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.h
@@ -143,6 +143,7 @@ public:
 	ofEvent<void> cancelPressed;
 	ofEvent<void> backPressed;
 	ofEvent<bool> networkConnected;
+	ofEvent<ofOrientation> deviceOrientationChanged;
 	ofEvent<void> pause;
 	ofEvent<void> resume;
 	ofEvent<void> unloadGL;

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -96,6 +96,7 @@ void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> a
 			ofAddListener(ofxAndroidEvents().cancelPressed,androidApp,&ofxAndroidApp::cancelPressed,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().backPressed,androidApp,&ofxAndroidApp::backPressed,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().networkConnected,androidApp,&ofxAndroidApp::networkConnectedEvent,OF_EVENT_ORDER_APP);
+			ofAddListener(ofxAndroidEvents().deviceOrientationChanged,androidApp,&ofxAndroidApp::deviceOrientationChangedEvent,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().pause,androidApp,&ofxAndroidApp::pause,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().resume,androidApp,&ofxAndroidApp::resume,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().unloadGL,androidApp,&ofxAndroidApp::unloadGL,OF_EVENT_ORDER_APP);
@@ -187,6 +188,7 @@ void ofMainLoop::exit(){
 			ofRemoveListener(ofxAndroidEvents().cancelPressed,androidApp,&ofxAndroidApp::cancelPressed,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().backPressed,androidApp,&ofxAndroidApp::backPressed,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().networkConnected,androidApp,&ofxAndroidApp::networkConnectedEvent,OF_EVENT_ORDER_APP);
+			ofRemoveListener(ofxAndroidEvents().deviceOrientationChanged,androidApp,&ofxAndroidApp::deviceOrientationChangedEvent,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().pause,androidApp,&ofxAndroidApp::pause,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().resume,androidApp,&ofxAndroidApp::resume,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().unloadGL,androidApp,&ofxAndroidApp::unloadGL,OF_EVENT_ORDER_APP);


### PR DESCRIPTION
Copy of #4516, recreated after the android refactor so it can get merged.

- Implements `deviceOrientationChanged(ofOrientation newOrientation)` in ofxAndroidApp like in iOS that gets called whenever the orientation on the app is changed
- Implements support for `ofSetOrientation(OF_ORIENTATION_90_RIGHT)` and `ofSetOrientation(OF_ORIENTATION_180)` (these were implemented as their flipped versions before)

Test orientation event with this snippet in a `ofApp.h`: 

```{.cpp}
void deviceOrientationChanged(ofOrientation newOrientation){
    ofLogNotice("ANGLE")<<ofOrientationToDegrees(newOrientation);
}
```