### PR TITLE
implemented move constructor for ofImage

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -648,6 +648,30 @@ ofImage_<PixelType>::ofImage_(ofImage_<PixelType>&& mom){
 
 //----------------------------------------------------------
 template<typename PixelType>
+ofImage_<PixelType>& ofImage_<PixelType>::operator=(ofImage_<PixelType>&& mom){
+    if(&mom==this) return *this;
+
+    pixels      = std::move(mom.pixels);
+    tex         = std::move(mom.tex);
+
+    bUseTexture = mom.bUseTexture;
+    width       = mom.width;
+    height      = mom.height;
+    bpp         = mom.bpp;
+    type        = mom.type;
+
+    mom.clear(); //clear remaining flags and sizes from the mom
+
+    #if defined(TARGET_ANDROID)
+    ofAddListener(ofxAndroidEvents().unloadGL,this,&ofImage_<PixelType>::unloadTexture);
+    ofAddListener(ofxAndroidEvents().reloadGL,this,&ofImage_<PixelType>::update);
+    #endif
+
+    return *this;
+}
+
+//----------------------------------------------------------
+template<typename PixelType>
 ofImage_<PixelType>::~ofImage_(){
 	clear();
 }

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -629,8 +629,16 @@ ofImage_<PixelType>::ofImage_(const ofImage_<PixelType>& mom) {
 //----------------------------------------------------------
 template<typename PixelType>
 ofImage_<PixelType>::ofImage_(ofImage_<PixelType>&& mom){
-    clear();
-    clone(mom);
+    pixels      = std::move(mom.pixels);
+    tex         = std::move(mom.tex);
+
+    bUseTexture = mom.bUseTexture;
+    width       = mom.width;
+    height      = mom.height;
+    bpp         = mom.bpp;
+    type        = mom.type;
+
+    mom.clear(); //clear remaining flags and sizes from the mom
 
     #if defined(TARGET_ANDROID)
     ofAddListener(ofxAndroidEvents().unloadGL,this,&ofImage_<PixelType>::unloadTexture);

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -599,6 +599,9 @@ public:
     template<typename SrcType>
     ofImage_<PixelType>& operator= (const ofImage_<SrcType>& mom);
     
+    //move assignment
+    ofImage_<PixelType>& operator=(ofImage_<PixelType>&& mom);
+
     /// \}
     ///< \sa ofImageType
     


### PR DESCRIPTION
Currently, `ofImage`'s move constructor performs a clone, as noted in #5034. This PR uses `std::move` to move pixel and texture data from the parent image. The parent is left `clear()`ed after the move.

I tested it with this app, on Fedora with gcc:

```c++
#pragma once
#include "ofMain.h"

class ofApp : public ofBaseApp{
	public:

    void setup(){
        a.load("of.png");
        ofSetFrameRate(1);
    };

	void draw(){
        ofBackground(0);
        ofImage b = a;

        ofImage c = std::move(b); // tests move constructor
        //ofImage c; c = std::move(b); // tests move assignment

        b.draw(0, 0); //should always draw black and print "ofGLRenderer: drawing an unallocated texture"
        c.draw(256, 0); //should draw correctly
    };

    private:
        ofImage a;
};
```