### PR TITLE
handle negative framerate requests

### DIFF
--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -182,7 +182,7 @@ void ofCoreEvents::setFrameRate(int _targetRate){
 
 	// --- > f / s
 
-	if (_targetRate == 0){
+	if (_targetRate <= 0){
 		bFrameRateSet = false;
 	}else{
 		bFrameRateSet	= true;


### PR DESCRIPTION
Currently, supplying a negative framerate to `ofSetFrameRate()` will produce the following segfault:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7ffacb0 in clock_gettime ()
```

This PR allows negative framerates to make time go backwards.

Just kidding.

Uses existing handler to mark the framerate as "not set".