### PR TITLE
Android orientation event

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -22,6 +22,7 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.MulticastLock;
+import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -422,7 +423,8 @@ public class OFAndroid {
     public static native void cancelPressed();
     
     public static native void networkConnected(boolean conected);
-    
+
+	public static native void deviceOrientationChanged(int orientation);
 
     // static methods to be called from OF c++ code
     public static void setFullscreen(boolean fs){
@@ -461,9 +463,17 @@ public class OFAndroid {
     		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     		break;
     	case 270:
+			if (Build.VERSION.SDK_INT >= 9) {
+				ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
+				break;
+			}
     		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     		break;
     	case 180:
+			if (Build.VERSION.SDK_INT >= 9) {
+				ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT);
+				break;
+			}
     		ofActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     		break;
     	case -1:
@@ -763,6 +773,7 @@ public class OFAndroid {
     private static OFActivity ofActivity;
 //    private static OFAndroid instance;
     private static OFGestureListener gestureListener;
+	private static OFOrientationListener orientationListener;
 	static String packageName;
 	private static String dataPath;
 	public static boolean unpackingDone;
@@ -821,7 +832,18 @@ public class OFAndroid {
 	        glView.setOnTouchListener(gestureListener.touchListener);
 		}
 	}
-	
+
+	public static void enableOrientationChangeEvents(){
+		if(orientationListener == null)
+			orientationListener = new OFOrientationListener(getContext());
+		orientationListener.enable();
+	}
+
+	public static void disableOrientationChangeEvents(){
+		if(orientationListener != null)
+			orientationListener.disable();
+	}
+
 	public static void setupGL(int version){	
 		final int finalversion = version;
 		if(ofActivity == null)

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycleHelper.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycleHelper.java
@@ -202,8 +202,8 @@ public class OFAndroidLifeCycleHelper
 			
 			@Override
 			public void run() {
-				// TODO Auto-generated method stub
 				OFAndroid.enableTouchEvents();
+				OFAndroid.enableOrientationChangeEvents();
 			}
 		});
 	}
@@ -214,8 +214,8 @@ public class OFAndroidLifeCycleHelper
 			
 			@Override
 			public void run() {
-				// TODO Auto-generated method stub
 				OFAndroid.enableTouchEvents();
+				OFAndroid.enableOrientationChangeEvents();
 			}
 		});
 		OFAndroid.onRestart();
@@ -232,8 +232,8 @@ public class OFAndroidLifeCycleHelper
 			
 			@Override
 			public void run() {
-				// TODO Auto-generated method stub
 				OFAndroid.enableTouchEvents();
+				OFAndroid.enableOrientationChangeEvents();
 				glView.onResume();
 				synchronized (OFAndroidObject.ofObjects) {
 					for(OFAndroidObject object : OFAndroidObject.ofObjects){
@@ -260,8 +260,8 @@ public class OFAndroidLifeCycleHelper
 			
 			@Override
 			public void run() {
-				// TODO Auto-generated method stub
 				OFAndroid.disableTouchEvents();
+				OFAndroid.disableOrientationChangeEvents();
 
 				synchronized (OFAndroidObject.ofObjects) {
 					for(OFAndroidObject object : OFAndroidObject.ofObjects){
@@ -288,9 +288,9 @@ public class OFAndroidLifeCycleHelper
 			
 			@Override
 			public void run() {
-				// TODO Auto-generated method stub
 				OFAndroid.disableTouchEvents();
-				
+				OFAndroid.disableOrientationChangeEvents();
+
 				synchronized (OFAndroidObject.ofObjects) {
 					for(OFAndroidObject object : OFAndroidObject.ofObjects){
 						object.onStop();

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFOrientationListener.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFOrientationListener.java
@@ -1,0 +1,56 @@
+package cc.openframeworks;
+
+import android.content.Context;
+import android.util.Log;
+import android.view.Display;
+import android.view.OrientationEventListener;
+import android.view.Surface;
+import android.view.WindowManager;
+
+public class OFOrientationListener extends OrientationEventListener {
+    OFOrientationListener(Context context){
+        super(context);
+    }
+
+    private int lastOrientation;
+    private boolean firstCheck = true;
+
+    @Override
+    public void enable() {
+        checkOrientation();
+        super.enable();
+    }
+
+    @Override
+    public void onOrientationChanged(int orientation) {
+        checkOrientation();
+    }
+
+    private void checkOrientation(){
+        WindowManager windowManager = (WindowManager)OFAndroid.getContext().getSystemService(Context.WINDOW_SERVICE);
+        Display display = windowManager.getDefaultDisplay();
+
+        if(lastOrientation != display.getRotation() || firstCheck){
+            lastOrientation = display.getRotation();
+            firstCheck = false;
+
+            int ofOrientation;
+            switch (display.getRotation()) {
+                case Surface.ROTATION_90:
+                    ofOrientation = 3;
+                    break;
+                case Surface.ROTATION_180:
+                    ofOrientation = 2;
+                    break;
+                case Surface.ROTATION_270:
+                    ofOrientation = 4;
+                    break;
+                case Surface.ROTATION_0:
+                default:
+                    ofOrientation = 1;
+                    break;
+            }
+            OFAndroid.deviceOrientationChanged(ofOrientation);
+        }
+    }
+}

--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -600,6 +600,10 @@ Java_cc_openframeworks_OFAndroid_networkConnected( JNIEnv*  env, jobject  thiz, 
 	bool bConnected = (bool)connected;
 	ofNotifyEvent(ofxAndroidEvents().networkConnected,bConnected);
 }
+
+void
+Java_cc_openframeworks_OFAndroid_deviceOrientationChanged(JNIEnv*  env, jclass  thiz, jint orientation){
+	ofOrientation _orientation = (ofOrientation) orientation;
+	ofNotifyEvent(ofxAndroidEvents().deviceOrientationChanged,_orientation );
 }
-
-
+}

--- a/addons/ofxAndroid/src/ofxAndroidApp.h
+++ b/addons/ofxAndroid/src/ofxAndroidApp.h
@@ -38,4 +38,9 @@ public:
 	virtual void networkConnectedEvent(bool & connected){
 		networkConnected(connected);
 	}
+
+	virtual void deviceOrientationChanged(ofOrientation newOrientation){};
+	virtual void deviceOrientationChangedEvent(ofOrientation & newOrientation){
+		deviceOrientationChanged(newOrientation);
+	};
 };

--- a/addons/ofxAndroid/src/ofxAndroidUtils.h
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.h
@@ -145,6 +145,7 @@ public:
 	ofEvent<void> cancelPressed;
 	ofEvent<void> backPressed;
 	ofEvent<bool> networkConnected;
+	ofEvent<ofOrientation> deviceOrientationChanged;
 	ofEvent<void> pause;
 	ofEvent<void> resume;
 	ofEvent<void> unloadGL;

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -99,6 +99,7 @@ void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> a
 			ofAddListener(ofxAndroidEvents().unloadGL,androidApp,&ofxAndroidApp::unloadGL,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().reloadGL,androidApp,&ofxAndroidApp::reloadGL,OF_EVENT_ORDER_APP);
 			ofAddListener(ofxAndroidEvents().swipe,androidApp,&ofxAndroidApp::swipe,OF_EVENT_ORDER_APP);
+			ofAddListener(ofxAndroidEvents().deviceOrientationChanged,androidApp,&ofxAndroidApp::deviceOrientationChangedEvent,OF_EVENT_ORDER_APP);
 		}
 #endif
 	}
@@ -193,6 +194,7 @@ void ofMainLoop::exit(){
 			ofRemoveListener(ofxAndroidEvents().unloadGL,androidApp,&ofxAndroidApp::unloadGL,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().reloadGL,androidApp,&ofxAndroidApp::reloadGL,OF_EVENT_ORDER_APP);
 			ofRemoveListener(ofxAndroidEvents().swipe,androidApp,&ofxAndroidApp::swipe,OF_EVENT_ORDER_APP);
+			ofRemoveListener(ofxAndroidEvents().deviceOrientationChanged,androidApp,&ofxAndroidApp::deviceOrientationChangedEvent,OF_EVENT_ORDER_APP);
 		}
 #endif
 	}


### PR DESCRIPTION
Copy of #4516  solving merge conflict after android refactor

- Implements `deviceOrientationChanged(ofOrientation newOrientation)` in ofxAndroidApp like in iOS that gets called whenever the orientation on the app is changed
- Implements support for `ofSetOrientation(OF_ORIENTATION_90_RIGHT)` and `ofSetOrientation(OF_ORIENTATION_180)` (these were implemented as their flipped versions before)

Orientation event can be tested with following gist in ofApp.h

```{.cpp}
	void deviceOrientationChanged(ofOrientation newOrientation){
            ofLogNotice("ANGLE")<<ofOrientationToDegrees(newOrientation);
        }
```