### PR TITLE
small ofxGui, minimize, maximize fix

### DIFF
--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -384,6 +384,7 @@ bool ofxGuiGroup::setValue(float mx, float my, bool bCheck){
 }
 
 void ofxGuiGroup::minimize(){
+	if(minimized) return;
 	minimized = true;
 	b.height = header + spacing + spacingNextElement + 1 /*border*/;
 	if(parent){
@@ -393,6 +394,7 @@ void ofxGuiGroup::minimize(){
 }
 
 void ofxGuiGroup::maximize(){
+	if(!minimized) return;
 	minimized = false;
     for(std::size_t i = 0; i < collection.size(); i++){
 		b.height += collection[i]->getHeight() + spacing;


### PR DESCRIPTION
added a if to abort minimize/maximize function if allready done.
the issue was when calling of maximize() in a loop, the following parameter group was replaced wrongly. 