### PR TITLE
fix ofLog padding so that it is correctly initialised between dynamically loaded exe's

### DIFF
--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -6,7 +6,10 @@
 static ofLogLevel currentLogLevel =  OF_LOG_NOTICE;
 
 bool ofLog::bAutoSpace = false;
-string ofLog::padding = "";
+string & ofLog::getPadding() {
+	static string padding = "";
+	return padding;
+}
 
 static map<string,ofLogLevel> & getModules(){
 	static map<string,ofLogLevel> * modules = new map<string,ofLogLevel>;
@@ -90,10 +93,10 @@ ofLog::ofLog(ofLogLevel level, const char* format, ...){
 void ofLog::setAutoSpace(bool autoSpace){
 	bAutoSpace = autoSpace;
 	if(bAutoSpace){
-		padding = " ";
+		ofLog::getPadding() = " ";
 	}
 	else{
-		padding = "";
+		ofLog::getPadding() = "";
 	}
 }
 

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -434,7 +434,7 @@ class ofLog{
 		/// \returns A reference to itself.
 		template <class T> 
 			ofLog& operator<<(const T& value){
-			message << value << padding;
+			message << value << getPadding();
 			return *this;
 		}
 	
@@ -486,7 +486,7 @@ class ofLog{
 		ofLog(ofLog const&) {}        					// not defined, not copyable
 		ofLog& operator=(ofLog& from) {return *this;}	// not defined, not assignable
 		
-		static string padding; ///< The padding between std::ostream calls.
+		static string & getPadding(); ///< The padding between std::ostream calls.
 };
 
 


### PR DESCRIPTION
hey!

here's a small fix which makes the static padding variable dll-safe
i.e. when you're dynamically loading a library which itself links openFrameworks

elliot