### PR TITLE
fixes to ofBackgroundGradient and ofThreadChannel

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -392,7 +392,7 @@ void ofBackground(int r, int g, int b, int a){
 
 //----------------------------------------------------------
 void ofBackgroundGradient(const ofColor& start, const ofColor& end, ofGradientMode mode) {
-	float w = ofGetWidth(), h = ofGetHeight();
+	float w = ofGetViewportWidth(), h = ofGetViewportHeight();
 	gradientMesh.clear();
 	gradientMesh.setMode(OF_PRIMITIVE_TRIANGLE_FAN);
 #ifndef TARGET_EMSCRIPTEN

--- a/libs/openFrameworks/utils/ofThreadChannel.h
+++ b/libs/openFrameworks/utils/ofThreadChannel.h
@@ -165,7 +165,8 @@ public:
 			return false;
 		}
 		if(queue.empty()){
-			if(condition.wait_for(lock,std::chrono::milliseconds(timeoutMs))==std::cv_status::timeout){
+			condition.wait_for(lock, std::chrono::milliseconds(timeoutMs));
+			if(queue.empty()) {
 				return false;
 			}
 		}


### PR DESCRIPTION
hey!
2 little fixes

1. ofBackgroundGradient currently uses ofGetWidth rather than ofGetViewportWidth, which means it doesnt' work with viewports.#5043
2. fix spurious wake in ofThreadChannel #4946 