### PR TITLE
Change signature of android sound stream getTickCount

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
@@ -174,7 +174,7 @@ void ofxAndroidSoundStream::close(){
 		ofLogError("ofxAndroidSoundStream") << "close(): couldn't get OFAndroidSoundStream instance or stop method";
 }
 
-long unsigned long ofxAndroidSoundStream::getTickCount() const{
+uint64_t ofxAndroidSoundStream::getTickCount() const{
 	return tickCount;
 }
 

--- a/addons/ofxAndroid/src/ofxAndroidSoundStream.h
+++ b/addons/ofxAndroid/src/ofxAndroidSoundStream.h
@@ -22,8 +22,8 @@ class ofxAndroidSoundStream : public ofBaseSoundStream{
 		void start();
 		void stop();
 		void close();
-		
-		long unsigned long getTickCount() const;
+
+		uint64_t getTickCount() const;
 
 		ofSoundDevice getInDevice() const{ return ofSoundDevice(); }
 		ofSoundDevice getOutDevice() const{ return ofSoundDevice(); }


### PR DESCRIPTION
Android signature return value was `long unsigned long`, [but should be `uint64_t`](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/sound/ofSoundStream.h#L166) 