### PR TITLE
Bugfix of true type font copying

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -581,8 +581,8 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(const ofTrueTypeFont& mom){
 		ofAddListener(ofxAndroidEvents().reloadGL,this,&ofTrueTypeFont::reloadTextures);
 	}
 #endif
-	settings = mom.settings;
 	bLoadedOk = mom.bLoadedOk;
+
 	charOutlines = mom.charOutlines;
 	charOutlinesNonVFlipped = mom.charOutlinesNonVFlipped;
 	charOutlinesContour = mom.charOutlinesContour;
@@ -594,11 +594,15 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(const ofTrueTypeFont& mom){
 	glyphBBox = mom.glyphBBox;
 	letterSpacing = mom.letterSpacing;
 	spaceSize = mom.spaceSize;
+	fontUnitScale = mom.fontUnitScale;
 
 	cps = mom.cps; // properties for each character
-
+	settings = mom.settings;
+	glyphIndexMap = mom.glyphIndexMap;
 	texAtlas = mom.texAtlas;
+	stringQuads = mom.stringQuads;
 	face = mom.face;
+
 	return *this;
 }
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -647,7 +647,6 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(ofTrueTypeFont&& mom){
 		ofAddListener(ofxAndroidEvents().reloadGL,this,&ofTrueTypeFont::reloadTextures);
 	}
 #endif
-	settings = mom.settings;
 	bLoadedOk = mom.bLoadedOk;
 
 	charOutlines = std::move(mom.charOutlines);
@@ -661,11 +660,14 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(ofTrueTypeFont&& mom){
 	glyphBBox = mom.glyphBBox;
 	letterSpacing = mom.letterSpacing;
 	spaceSize = mom.spaceSize;
+	fontUnitScale = mom.fontUnitScale;
 
 	cps = mom.cps; // properties for each character
-
+	settings = mom.settings;
+	glyphIndexMap = std::move(mom.glyphIndexMap);
 	texAtlas = mom.texAtlas;
-	face = mom.face;
+	stringQuads = mom.stringQuads;
+
 	return *this;
 }
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -562,9 +562,13 @@ ofTrueTypeFont::ofTrueTypeFont(const ofTrueTypeFont& mom)
 	glyphBBox = mom.glyphBBox;
 	letterSpacing = mom.letterSpacing;
 	spaceSize = mom.spaceSize;
+	fontUnitScale = mom.fontUnitScale;
 
 	cps = mom.cps; // properties for each character
+	settings = mom.settings;
+	glyphIndexMap = mom.glyphIndexMap;
 	texAtlas = mom.texAtlas;
+	stringQuads = mom.stringQuads;
 	face = mom.face;
 }
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -628,9 +628,13 @@ ofTrueTypeFont::ofTrueTypeFont(ofTrueTypeFont&& mom)
 	glyphBBox = mom.glyphBBox;
 	letterSpacing = mom.letterSpacing;
 	spaceSize = mom.spaceSize;
+	fontUnitScale = mom.fontUnitScale;
 
 	cps = mom.cps; // properties for each character
+	settings = mom.settings;
+	glyphIndexMap = std::move(mom.glyphIndexMap);
 	texAtlas = mom.texAtlas;
+	stringQuads = mom.stringQuads;
 	face = mom.face;
 }
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -568,7 +568,6 @@ ofTrueTypeFont::ofTrueTypeFont(const ofTrueTypeFont& mom)
 	settings = mom.settings;
 	glyphIndexMap = mom.glyphIndexMap;
 	texAtlas = mom.texAtlas;
-	stringQuads = mom.stringQuads;
 	face = mom.face;
 }
 
@@ -600,7 +599,6 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(const ofTrueTypeFont& mom){
 	settings = mom.settings;
 	glyphIndexMap = mom.glyphIndexMap;
 	texAtlas = mom.texAtlas;
-	stringQuads = mom.stringQuads;
 	face = mom.face;
 
 	return *this;
@@ -634,7 +632,6 @@ ofTrueTypeFont::ofTrueTypeFont(ofTrueTypeFont&& mom)
 	settings = mom.settings;
 	glyphIndexMap = std::move(mom.glyphIndexMap);
 	texAtlas = mom.texAtlas;
-	stringQuads = mom.stringQuads;
 	face = mom.face;
 }
 
@@ -666,7 +663,6 @@ ofTrueTypeFont & ofTrueTypeFont::operator=(ofTrueTypeFont&& mom){
 	settings = mom.settings;
 	glyphIndexMap = std::move(mom.glyphIndexMap);
 	texAtlas = mom.texAtlas;
-	stringQuads = mom.stringQuads;
 
 	return *this;
 }


### PR DESCRIPTION
The problem, described in issue #5123, was caused by the copy/assignment constructors of the ofTrueTypeFont that did not copy all the members to the target.

Since my familiarity with openFrameworks and C++ knowledge are limited, please check if my additions are relevant/do not have any side effects.

The bug was apparently fixed and did not cause any visible side effects. Tested on the small sample of code I've shown in the issue and on few examples (such as graphics/fontShapesExample and graphics/fontsExample).