### PR TITLE
Bugfix of true type font size for empty string

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1205,8 +1205,8 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 	    return ofRectangle(x,y,0,0);
 
 	ofRectangle bb(std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),0,0);
-	float maxX = std::numeric_limits<float>::min();
-	float maxY = std::numeric_limits<float>::min();
+	float maxX = -std::numeric_limits<float>::max();
+	float maxY = -std::numeric_limits<float>::max();
 	for(const auto & v: mesh.getVertices()){
 		bb.x = min(v.x,bb.x);
 		bb.y = min(v.y,bb.y);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1204,18 +1204,19 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 	if(mesh.getNumVertices() == 0)
 	    return ofRectangle(x,y,0,0);
 
-	ofRectangle bb(std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),0,0);
+	float minX = std::numeric_limits<float>::max();
+	float minY = std::numeric_limits<float>::max();
 	float maxX = -std::numeric_limits<float>::max();
 	float maxY = -std::numeric_limits<float>::max();
 	for(const auto & v: mesh.getVertices()){
-		bb.x = min(v.x,bb.x);
-		bb.y = min(v.y,bb.y);
+		minX = min(v.x,minX);
+		minY = min(v.y,minY);
 		maxX = max(v.x,maxX);
 		maxY = max(v.y,maxY);
 	}
-	bb.width = maxX - bb.x;
-	bb.height = maxY - bb.y;
-	return bb;
+	float width = maxX - minX;
+	float height = maxY - minY;
+	return ofRectangle(minX, minY, width, height);
 }
 
 //-----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1200,6 +1200,10 @@ float ofTrueTypeFont::stringWidth(const std::string& c) const{
 //-----------------------------------------------------------
 ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, float y, bool vflip) const{
 	ofMesh mesh = getStringMesh(c,x,y,vflip);
+
+	if(mesh.getNumVertices() == 0)
+	    return ofRectangle(x,y,0,0);
+
 	ofRectangle bb(std::numeric_limits<float>::max(),std::numeric_limits<float>::max(),0,0);
 	float maxX = std::numeric_limits<float>::min();
 	float maxY = std::numeric_limits<float>::min();


### PR DESCRIPTION
I noticed that stringWidth and stringHeight methods produce weird results when called with an empty string parameter. Simple test program:

```
ofTrueTypeFont font;

void ofApp::setup(){
    font.load("sans-serif", 10);
}

void ofApp::draw(){
    std::cout << font.stringWidth("text") << " " << font.stringWidth("") << " " << font.stringWidth(" ") << "       ";
    std::cout << font.stringHeight("text") << " " << font.stringHeight("") << " " << font.stringHeight(" ") << std::endl;
}
```

(The result should be 27 0 0   9 0 0).

The problem was caused by the fact that an empty string produces a mesh with no vertices, so the corners of the bounding box are not changed (the defaults are limits of float). Solved by a simple check.

Also, the std::numeric_limits<float>::min() is not the minimum value that can be represented with a float, but rather the smallest positive value (equal to 1E-37 or less, according to the standard). The minimum value is -std::numeric_limits<float>::max().

Besides this, I've done a bit of refactoring to keep consistency (I didn't really like the fact that, while computing what is basically the limits of the bounding box, the minimum values were the position of the rectangle and the maximum values were separate variables).


Note that "  " is considered the same as "". I'd say it's fine this way (it's nothing drawn, so it has no dimension in either case) but it might be a good moment to think a bit whether this is really wanted or not (a space is still a character, not emptiness).