### PR TITLE
Bugfix of true type font set space size

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1126,8 +1126,13 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 				if(prevC>0){
 					pos.x += getKerning(c,prevC);// * directionX;
 				}
-				f(c,pos);
-				pos.x += props.advance * letterSpacing * directionX;
+				if(settings.direction == ofTtfSettings::LeftToRight){
+				    f(c,pos);
+				    pos.x += props.advance * letterSpacing * directionX;
+				}else{
+				    pos.x += props.advance * letterSpacing * directionX;
+				    f(c,pos);
+				}
 				prevC = c;
 			}
 		}catch(...){

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1115,7 +1115,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 				pos.y += lineHeight*newLineDirection;
 				pos.x = x ; //reset X Pos back to zero
 				prevC = 0;
-			}if (c == '\t') {
+			} else if (c == '\t') {
 				pos.x += getGlyphProperties(' ').advance * letterSpacing * 4 * directionX;
 				prevC = c;
 			} else if (c == ' ') {

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -524,7 +524,7 @@ ofTrueTypeFont::ofTrueTypeFont()
 :settings("",0){
 	bLoadedOk		= false;
 	letterSpacing = 1;
-	spaceSize = 0;
+	spaceSize = 1;
 	fontUnitScale = 1;
 	stringQuads.setMode(OF_PRIMITIVE_TRIANGLES);
 	ascenderHeight = 0;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1118,6 +1118,9 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 			}if (c == '\t') {
 				pos.x += getGlyphProperties(' ').advance * letterSpacing * 4 * directionX;
 				prevC = c;
+			} else if (c == ' ') {
+				pos.x += getGlyphProperties(' ').advance * letterSpacing * directionX * spaceSize;
+				prevC = c;
 			} else if(isValidGlyph(c)) {
 				const auto & props = getGlyphProperties(c);
 				if(prevC>0){


### PR DESCRIPTION
Ok, so after a bit of digging I found out that:

- long time ago, the spaceSize was initialized with 1 and space was treated as a separate case when drawing a character.
- for some reasons I don't fully understand, someone decided to change that. spaceSize was now initialized with 0 and there was a check (if space size is set, draw the standard space, otherwise draw the scaled one).
- after some time, at a refactor, that case was gone.

So, I reinserted that check and initialized spaceSize with 1 (thus, there is just one case, not 2).

A bit off-topic, there was an if with some weird indentation. I assumed there should have been an else.