### PR TITLE
ofVideoGrabber -- fix default bUseTexture behavior.

### DIFF
--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -6,7 +6,7 @@
 
 //--------------------------------------------------------------------
 ofVideoGrabber::ofVideoGrabber(){
-	bUseTexture			= false;
+	bUseTexture			= true;
 	requestedDeviceID	= -1;
 	internalPixelFormat = OF_PIXELS_RGB;
 	desiredFramerate 	= -1;

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -53,7 +53,7 @@ class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
 		bool				isFrameNew() const;
 		void				update();
 		void				close();	
-		bool				setup(int w, int h){return setup(w,h,true);}
+		bool				setup(int w, int h){return setup(w,h,bUseTexture);}
 		bool				setup(int w, int h, bool bTexture);
 		OF_DEPRECATED_MSG("Use setup instead",bool initGrabber(int w, int h){return setup(w,h);})
 		OF_DEPRECATED_MSG("Use setup instead",bool initGrabber(int w, int h, bool bTexture));


### PR DESCRIPTION
Currently if one calls

```cpp
ofVideoGrabber grabber;
grabber.setUseTexture(false);
// grabber.isUsingTexture() returns false.
```

then 
```cpp
grabber.setup(640, 480);
// grabber.isUsingTexture() returns true.
```
Rather than `setup()` assuming `true`, it should use the value that was (already) set by the user.  In order to avoid breaking existing setups, the default value of bUseTexture is set to true in the constructor.

This is related to #4811 