### PR TITLE
add ofBoundingBox

### DIFF
--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -211,6 +211,20 @@ void of3dPrimitive::draw() const{
 	draw(OF_MESH_FILL);
 }
 
+ofBoundingBox of3dPrimitive::getBoundingBox() const{
+    ofBoundingBox boundingBox;
+    const vector<glm::vec3>& vertices  = getMesh().getVertices();
+    for(auto v : vertices){
+        if (v.x < boundingBox.min.x) boundingBox.min.x = v.x;
+        if (v.y < boundingBox.min.y) boundingBox.min.y = v.y;
+        if (v.z < boundingBox.min.z) boundingBox.min.z = v.z;
+         if (v.x > boundingBox.max.x) boundingBox.max.x = v.x;
+        if (v.y > boundingBox.max.y) boundingBox.max.y = v.y;
+        if (v.z > boundingBox.max.z) boundingBox.max.z = v.z;
+    }
+    return boundingBox;
+}
+
 //--------------------------------------------------------------
 void of3dPrimitive::drawNormals(float length, bool bFaceNormals) const{
     ofNode::transformGL(ofGetCurrentRenderer().get());

--- a/libs/openFrameworks/3d/of3dPrimitives.h
+++ b/libs/openFrameworks/3d/of3dPrimitives.h
@@ -60,6 +60,7 @@ public:
 
     void setUseVbo(bool useVbo);
     bool isUsingVbo() const;
+    ofBoundingBox getBoundingBox() const;
 protected:
 
     // useful when creating a new model, since it uses normalized tex coords //

--- a/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
+++ b/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
@@ -49,6 +49,11 @@ enum ofFboMode: short;
 enum ofLoopType: short;
 enum ofOrientation: short;
 
+struct ofBoundingBox{
+    glm::vec3 min = glm::vec3(0,0,0);
+    glm::vec3 max = glm::vec3(0,0,0);
+};
+
 /// \brief Contains general information about the style of ofGraphics
 /// elements such as color, line width and others.
 class ofStyle{


### PR DESCRIPTION
I've added a struct that contains the min and max vertices of a `of3dPrimitive`.
it can be used like this. Default values are initialized to (0.0, 0.0, 0.0).
When the primitive move, the bounding box does not get updated.

``` cpp
ofBoxPrimitive geometry;
geometry.computeBoundingBox();
cout << geometry.getBoundingBox().min.x << endl;
cout << geometry.getBoundingBox().max.y << endl;
```
