### PR TITLE
cosmetic fix in simpleShaderInteraction example

### DIFF
--- a/examples/shader/03_simpleShaderInteraction/src/ofApp.cpp
+++ b/examples/shader/03_simpleShaderInteraction/src/ofApp.cpp
@@ -63,7 +63,7 @@ void ofApp::draw(){
     // we can pass in four values into the shader at the same time as a float array.
     // we do this by passing a pointer reference to the first element in the array.
     // inside the shader these four values are set inside a vec4 object.
-    shader.setUniform4fv("mouseColor", &mouseColor[0]);
+    shader.setUniform4fv("mouseColor", mouseColor);
     
     ofTranslate(cx, cy);
 


### PR DESCRIPTION
while reading the shader examples, I noticed this line in examples/shader/03_simpleShaderInteraction/src/ofApp.cpp:

`shader.setUniform4fv("mouseColor", &mouseColor[0]);`

`mouseColor` itself is a pointer to the beginning of the array and I since I got a bit confused about why it's there, here is a PR where i changed `&mouseColor[0]` to `mouseColor`

hope I am correct about this
