### PR TITLE
ofGLUtils: ofEnable/DisableGLDebugLog: Enables OpenGL debug log

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -800,14 +800,14 @@ void ofReloadGLResources(){
 #endif
 
 namespace{
-	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void * user){
+	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, void * user){
 		ofLogNotice("GL DEBUG") << message;
 	}
 }
 
 void ofEnableGLDebugLog(){
 	glEnable(GL_DEBUG_OUTPUT);
-	glDebugMessageCallback(gl_debug_callback, nullptr);
+	glDebugMessageCallback((GLDEBUGPROC)gl_debug_callback, nullptr);
 }
 
 void ofDisableGLDebugLog(){

--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -799,6 +799,7 @@ void ofReloadGLResources(){
 }
 #endif
 
+#ifndef TARGET_OPENGLES
 namespace{
 	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, void * user){
 		ofLogNotice("GL DEBUG") << message;
@@ -813,3 +814,4 @@ void ofEnableGLDebugLog(){
 void ofDisableGLDebugLog(){
 	glDisable(GL_DEBUG_OUTPUT);
 }
+#endif

--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -6,6 +6,7 @@
 #include "ofShader.h"
 #include "ofBaseTypes.h"
 #include "ofRendererCollection.h"
+#include "ofLog.h"
 
 //---------------------------------
 int ofGetGlInternalFormat(const ofPixels& pix) {
@@ -680,8 +681,6 @@ void ofSetPixelStoreiAlignment(GLenum pname, int stride){
     }
 }
 
-
-
 vector<string> ofGLSupportedExtensions(){
 #ifdef TARGET_OPENGLES
 	char* extensions = (char*)glGetString(GL_EXTENSIONS);
@@ -800,3 +799,17 @@ void ofReloadGLResources(){
 }
 #endif
 
+namespace{
+	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void * user){
+		ofLogNotice("GL DEBUG") << message;
+	}
+}
+
+void ofEnableGLDebugLog(){
+	glEnable(GL_DEBUG_OUTPUT);
+	glDebugMessageCallback(gl_debug_callback, nullptr);
+}
+
+void ofDisableGLDebugLog(){
+	glDisable(GL_DEBUG_OUTPUT);
+}

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -88,6 +88,8 @@ int ofGetGlFormat(const ofPixels_<T> & pixels) {
 
 string ofGLSLVersionFromGL(int major, int minor);
 
+void ofEnableGLDebugLog();
+void ofDisableGLDebugLog();
 
 #ifndef TARGET_OPENGLES
 	#define GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS			GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -88,8 +88,10 @@ int ofGetGlFormat(const ofPixels_<T> & pixels) {
 
 string ofGLSLVersionFromGL(int major, int minor);
 
+#ifndef TARGET_OPENGLES
 void ofEnableGLDebugLog();
 void ofDisableGLDebugLog();
+#endif
 
 #ifndef TARGET_OPENGLES
 	#define GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS			GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT


### PR DESCRIPTION
Shows internal GL errors on the console. The log depends on the specific
driver but is of great help catching GL errors