### PR TITLE
fix Tess crash on teardown

### DIFF
--- a/libs/openFrameworks/graphics/ofTessellator.cpp
+++ b/libs/openFrameworks/graphics/ofTessellator.cpp
@@ -59,7 +59,10 @@ ofTessellator::ofTessellator()
 
 //----------------------------------------------------------
 ofTessellator::~ofTessellator(){
-	tessDeleteTess(cacheTess);
+	if ( cacheTess ){
+		tessDeleteTess( cacheTess );
+		cacheTess = nullptr;
+	}
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofTessellator.h
+++ b/libs/openFrameworks/graphics/ofTessellator.h
@@ -54,7 +54,7 @@ private:
 	void performTessellation(ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D );
 	void init();
 
-	TESStesselator * cacheTess;
+	TESStesselator * cacheTess = nullptr;
 	TESSalloc tessAllocator;
 };
 


### PR DESCRIPTION
- in rare cases Tess has the ability to cause a crash on app teardown,
  because the desctructor attempts to free an internal tesselator object
  repeatedly.
  
  This patch addresses this by checking for the pointer holding the
  Tesselator to be valid before freeing the object. After free, it nulls
  the pointer so that an object already freed cannot be freed again.
