### PR TITLE
Quick fixes

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -985,7 +985,7 @@ void ofGLProgrammableRenderer::setLineWidth(float lineWidth){
 	if(!currentStyle.bFill){
 		path.setStrokeWidth(lineWidth);
 	}
-	glLineWidth(lineWidth);
+	//glLineWidth(lineWidth);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/math/ofMatrix4x4.h
+++ b/libs/openFrameworks/math/ofMatrix4x4.h
@@ -672,7 +672,7 @@ public:
 
 inline bool ofMatrix4x4::isNaN() const {
 	
-#if (_MSC_VER) || defined (TARGET_ANDROID)
+#if defined (TARGET_ANDROID)
 #ifndef isnan
 #define isnan(a) ((a) != (a))
 #endif


### PR DESCRIPTION
* Commenting out call to `glLineWidth()` in programmable renderer. Calling it causes a GL error, which makes it a pain to debug other GL errors.
* `isnan()` appears to be defined for Visual Studio, implementing our own causes conflicts with external libs.