### PR TITLE
ofxKinect ssize_t typdef should be different for x64 and x86 on windows

### DIFF
--- a/addons/ofxKinect/libs/libfreenect/platform/windows/unistd.h
+++ b/addons/ofxKinect/libs/libfreenect/platform/windows/unistd.h
@@ -33,5 +33,9 @@
 // MSVC does not define this.
 #ifndef _SSIZE_T_
 #define _SSIZE_T_
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#else
 typedef long ssize_t;
+#endif
 #endif // _SSIZE_T_


### PR DESCRIPTION
As requested in #3062; I had trouble compiling ofxKinect on Windows x64 and this seems to fix.