### PR TITLE
fix OF0.9.3 compilation issue with latest MSYS2 releases

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -11,6 +11,7 @@
 	#include <tchar.h>
 	#include <iostream>
 	#include <string.h>
+	#include <devpropdef.h>
 	#include <setupapi.h>
 	#include <regstr.h>
 	/// \cond INTERNAL


### PR DESCRIPTION
fixes #5182. 
New functions in setupapi.h require definitions from devpropdef.h