### PR TITLE
close gstreamer pipline after load() was not successful 

### DIFF
--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -44,9 +44,12 @@ GMainLoop * ofGstUtils::getGstMainLoop(){
 }
 
 void ofGstUtils::quitGstMainLoop(){
-	mainLoop->quit();
-	delete mainLoop;
-	mainLoop=0;
+	if(mainLoop)
+	{
+		mainLoop->quit();
+		delete mainLoop;
+		mainLoop=0;
+	}
 }
 
 
@@ -524,6 +527,17 @@ void ofGstUtils::close(){
 	}
 
 	bLoaded = false;
+}
+
+void ofGstUtils::closePipeline() {
+
+    gst_element_set_state(GST_ELEMENT(gstPipeline), GST_STATE_NULL);
+    gst_element_get_state(gstPipeline,NULL,NULL,2*GST_SECOND);
+    ofGstUtils::quitGstMainLoop();
+    if(busWatchID!=0) g_source_remove(busWatchID);
+    gst_object_unref(gstPipeline);
+    gstPipeline = NULL;
+    gstSink = NULL;
 }
 
 /*static string getName(GstState state){
@@ -1382,3 +1396,4 @@ void ofGstVideoUtils::eos_cb(){
 }
 
 #endif
+

--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -70,6 +70,7 @@ public:
 	uint64_t getMaxLatencyNanos() const;
 
 	virtual void close();
+	void closePipeline();
 
 	void setSinkListener(ofGstAppSink * appsink);
 
@@ -265,4 +266,5 @@ public:
 };
 
 #endif
+
 


### PR DESCRIPTION
When trying to load a video that does not exist using the gstreamer video player on linux, a unix socket is created and never closed which can lead to crashing the app. This should fix it. 
See #5189 for details.