### PR TITLE
bugfix for ofFile::create not working if file was not already opened Closes #5196

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -474,14 +474,14 @@ bool ofFile::create(){
 bool ofFile::create(const std::filesystem::path & path){
 	bool success = false;
 
-	if(!myFile.string().empty()){
-		auto oldmode = this->mode;
-		auto oldpath = this->path();
-		success = open(path,ofFile::WriteOnly,binary);
-		close();
+	auto oldmode = this->mode;
+	auto oldpath = this->path();
+	success = open(path,ofFile::WriteOnly,binary);
+	close();
+	if( oldpath.length() ){
 		open(oldpath,oldmode,binary);
 	}
-
+	
 	return success;
 }
 


### PR DESCRIPTION
Bugfix for ofFile::create not working if file was not already opened.
Closes #5196 

before this would fail
```
    ofFile tmp;
    tmp.create("testCreate.txt");

    cout << " does file exist? ( should be 1 ) " << ofFile::doesFileExist("testCreate.txt") << endl; ;
```

with this PR it works and still correctly sets the internal path back to the prior one if a prior path existed. 

ie: 
```
        ofFile tmp;
        tmp.open("false1.txt");
        tmp.create("testCreate.txt");
    
        cout << " does file exist? ( should be 1 ) " << ofFile::doesFileExist("testCreate.txt") << " my og path is  " << tmp.path() << endl; ;
```

produces:
```
 does file exist? ( should be 1 ) 1 my og path is  ../../../data/false1.txt
```
