### PR TITLE
transform feedback

### DIFF
--- a/examples/gl/transformFeedbackExample/bin/data/discard_frag.glsl
+++ b/examples/gl/transformFeedbackExample/bin/data/discard_frag.glsl
@@ -1,9 +1,0 @@
-#version 330
-
-//in vec4 position;
-in vec4 v_color;
-out vec4 fragColor;
-
-void main(){
-	fragColor = v_color;
-}

--- a/examples/gl/transformFeedbackExample/bin/data/discard_frag.glsl
+++ b/examples/gl/transformFeedbackExample/bin/data/discard_frag.glsl
@@ -1,0 +1,9 @@
+#version 330
+
+//in vec4 position;
+in vec4 v_color;
+out vec4 fragColor;
+
+void main(){
+	fragColor = v_color;
+}

--- a/examples/gl/transformFeedbackExample/bin/data/vert.glsl
+++ b/examples/gl/transformFeedbackExample/bin/data/vert.glsl
@@ -1,0 +1,39 @@
+#version 330
+
+out vec4 v_position;
+out vec4 v_color;
+uniform mat4 modelViewProjectionMatrix;
+in vec4  position;
+const float PI = 3.141592;
+
+float radicalInverse_VdC(uint bits) {
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10; // / 0x100000000
+}
+
+// http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
+vec2 hammersley(uint i, uint N) {
+    return vec2(float(i)/float(N), radicalInverse_VdC(i));
+}
+
+vec3 hemisphereSample_uniform(uint i, uint N){
+     vec2 E = hammersley(i,N);
+     float u = E.x;
+     float v = E.y;
+     float phi = v * 2.0 * PI;
+     float cosTheta = 1.0 - u;
+     float sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+     return vec3(cos(phi) * sinTheta, sin(phi) * sinTheta, cosTheta);
+}
+
+void main(){
+	vec3 pos = hemisphereSample_uniform(uint(gl_VertexID), uint(256));
+	v_position = vec4(pos * -600, 1.0);
+	v_color = vec4(pos, 1.0);
+	//gl_Position = modelViewProjectionMatrix * v_position;
+	//gl_PointSize = 4;
+}

--- a/examples/gl/transformFeedbackExample/bin/data/vert.glsl
+++ b/examples/gl/transformFeedbackExample/bin/data/vert.glsl
@@ -34,6 +34,4 @@ void main(){
 	vec3 pos = hemisphereSample_uniform(uint(gl_VertexID), uint(256));
 	v_position = vec4(pos * -600, 1.0);
 	v_color = vec4(pos, 1.0);
-	//gl_Position = modelViewProjectionMatrix * v_position;
-	//gl_PointSize = 4;
 }

--- a/examples/gl/transformFeedbackExample/src/main.cpp
+++ b/examples/gl/transformFeedbackExample/src/main.cpp
@@ -1,0 +1,15 @@
+#include "ofMain.h"
+#include "ofApp.h"
+
+//========================================================================
+int main( ){
+	ofGLWindowSettings settings;
+	settings.setGLVersion(4, 5);
+	ofCreateWindow(settings);
+
+	// this kicks off the running of my app
+	// can be OF_WINDOW or OF_FULLSCREEN
+	// pass in width and height too:
+	ofRunApp(new ofApp());
+
+}

--- a/examples/gl/transformFeedbackExample/src/main.cpp
+++ b/examples/gl/transformFeedbackExample/src/main.cpp
@@ -4,7 +4,7 @@
 //========================================================================
 int main( ){
 	ofGLWindowSettings settings;
-	settings.setGLVersion(4, 5);
+	settings.setGLVersion(3,3);
 	ofCreateWindow(settings);
 
 	// this kicks off the running of my app

--- a/examples/gl/transformFeedbackExample/src/ofApp.cpp
+++ b/examples/gl/transformFeedbackExample/src/ofApp.cpp
@@ -1,0 +1,105 @@
+#include "ofApp.h"
+
+
+constexpr int numVertices = 256;
+
+//--------------------------------------------------------------
+void ofApp::setup(){
+	ofMesh mesh;
+	mesh.setMode(OF_PRIMITIVE_POINTS);
+	mesh.getVertices().resize(numVertices);
+	ofSetBackgroundColor(0);
+
+	ofShader::TransformFeedbackSettings settings;
+	settings.shaderFiles[GL_VERTEX_SHADER] = "vert.glsl";
+	settings.bindDefaults = false;
+	settings.varyingsToCapture = { "v_position", "v_color" };
+	shader.setup(settings);
+
+
+	buffer.allocate(sizeof(glm::vec4) * 2 * numVertices, GL_STATIC_DRAW);
+
+	ofShader::TransformFeedbackBinding binding(buffer);
+	binding.index = 0;
+	binding.offset = 0;
+	binding.size = numVertices * sizeof(glm::vec4) * 2;
+	
+	shader.beginTransformFeedback(GL_POINTS, binding);
+	mesh.draw();
+	shader.endTransformFeedback(binding);
+
+	vbo.setVertexBuffer(buffer, 4, sizeof(glm::vec4) * 2, 0);
+	vbo.setColorBuffer(buffer, sizeof(glm::vec4) * 2, sizeof(glm::vec4));
+
+	ofEnablePointSprites();
+	glPointSize(4);
+	cam.setDistance(2400);
+	cam.orbit(80, 80, 2400, { 0.f, 0.f, 0.f });
+}
+
+//--------------------------------------------------------------
+void ofApp::update(){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::draw(){
+	cam.begin();
+	vbo.draw(GL_POINTS, 0, numVertices);
+	cam.end();
+}
+
+//--------------------------------------------------------------
+void ofApp::keyPressed(int key){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::keyReleased(int key){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseMoved(int x, int y ){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseDragged(int x, int y, int button){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mousePressed(int x, int y, int button){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseReleased(int x, int y, int button){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseEntered(int x, int y){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::mouseExited(int x, int y){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::windowResized(int w, int h){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::gotMessage(ofMessage msg){
+
+}
+
+//--------------------------------------------------------------
+void ofApp::dragEvent(ofDragInfo dragInfo){ 
+
+}

--- a/examples/gl/transformFeedbackExample/src/ofApp.h
+++ b/examples/gl/transformFeedbackExample/src/ofApp.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "ofMain.h"
+
+class ofApp : public ofBaseApp{
+
+	public:
+		void setup();
+		void update();
+		void draw();
+
+		void keyPressed(int key);
+		void keyReleased(int key);
+		void mouseMoved(int x, int y );
+		void mouseDragged(int x, int y, int button);
+		void mousePressed(int x, int y, int button);
+		void mouseReleased(int x, int y, int button);
+		void mouseEntered(int x, int y);
+		void mouseExited(int x, int y);
+		void windowResized(int w, int h);
+		void dragEvent(ofDragInfo dragInfo);
+		void gotMessage(ofMessage msg);
+		
+		ofShader shader;
+		ofVbo vbo;
+		ofBufferObject buffer;
+		ofEasyCam cam;
+};

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -15,6 +15,7 @@ class ofMatrix3x3;
 class ofParameterGroup;
 class ofBufferObject;
 
+
 class ofShader {
 public:
 	ofShader();
@@ -26,8 +27,42 @@ public:
 	
 	bool load(string shaderName);
 	bool load(string vertName, string fragName, string geomName="");
-	
-	
+#if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
+	bool loadCompute(string shaderName);
+#endif
+
+	struct Settings {
+		std::map<GLuint, std::string> shaderFiles;
+		std::map<GLuint, std::string> shaderSources;
+		bool bindDefaults = true;
+	};
+
+#if !defined(TARGET_OPENGLES)
+	struct TransformFeedbackSettings {
+		std::map<GLuint, std::string> shaderFiles;
+		std::map<GLuint, std::string> shaderSources;
+		std::vector<std::string> varyingsToCapture;
+		bool bindDefaults = true;
+		GLuint bufferMode = GL_INTERLEAVED_ATTRIBS; // GL_INTERLEAVED_ATTRIBS or GL_SEPARATE_ATTRIBS
+	};
+
+	struct TransformFeedbackBinding {
+		TransformFeedbackBinding(const ofBufferObject & buffer)
+		:buffer(buffer) {}
+
+		GLuint index = 0;
+		GLuint offset = 0;
+		GLuint size;
+	private:
+		const ofBufferObject & buffer;
+		friend class ofShader;
+	};
+#endif
+
+	bool setup(const Settings & settings);
+#if !defined(TARGET_OPENGLES)
+	bool setup(const TransformFeedbackSettings & settings);
+#endif
 	
 	// these are essential to call before linking the program with geometry shaders
 	void setGeometryInputType(GLenum type); // type: GL_POINTS, GL_LINES, GL_LINES_ADJACENCY_EXT, GL_TRIANGLES, GL_TRIANGLES_ADJACENCY_EXT
@@ -43,6 +78,15 @@ public:
 
 	void begin() const;
 	void end() const;
+
+#if !defined(TARGET_OPENGLES)
+	void beginTransformFeedback(GLenum mode) const;
+	void beginTransformFeedback(GLenum mode, const TransformFeedbackBinding & binding) const;
+	void beginTransformFeedback(GLenum mode, const std::vector<TransformFeedbackBinding> & binding) const;
+	void endTransformFeedback() const;
+	void endTransformFeedback(const TransformFeedbackBinding & binding) const;
+	void endTransformFeedback(const std::vector<TransformFeedbackBinding> & binding) const;
+#endif
 	
 #if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
 	void dispatchCompute(GLuint x, GLuint y, GLuint z) const;


### PR DESCRIPTION
Adds some utility methods and subclasses to ofShader to make transform feedback easy to use. there's also an example but mainly it involves:
- setting up the shader to be use with transform feedback, using setup(TransformFeedbackSettings)
- creating a buffer object with enough capacity, 
- create one or more bindings for the transform feedback with the buffer(s) using ofShader::TransformFeedbackBinding
- begin the shader for transform feedback passing the mode and the binding(s) using beginTransformFeedback
- end the shader for transform feedback passing the binding again

This allows to capture geometry modified on a vertex shader or even generated on a geometry or tessellation shader into an ofBufferObject to be used later without having to recalculate it.