### PR TITLE
ofFbo: Add methods to begin without matrix flip

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -805,6 +805,39 @@ void ofFbo::begin(bool setupScreen) const{
 	}
 }
 
+
+//----------------------------------------------------------
+void ofFbo::begin() const {
+	auto renderer = settings.renderer.lock();
+	if (renderer) {
+		renderer->begin(*this, true);
+	}
+}
+
+//----------------------------------------------------------
+void ofFbo::beginNoPerspective() const {
+	auto renderer = settings.renderer.lock();
+	if (renderer) {
+		renderer->begin(*this, false);
+	}
+}
+
+//----------------------------------------------------------
+void ofFbo::beginNoMatrixFlip() const {
+	auto renderer = settings.renderer.lock();
+	if (renderer) {
+		renderer->beginNoMatrixFlip(*this);
+	}
+}
+
+//----------------------------------------------------------
+void ofFbo::beginNoMatrixFlipNoPerspective() const {
+	auto renderer = settings.renderer.lock();
+	if (renderer) {
+		renderer->beginNoMatrixFlipNoPerspective(*this);
+	}
+}
+
 //----------------------------------------------------------
 void ofFbo::end() const{
 	auto renderer = settings.renderer.lock();

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -801,13 +801,25 @@ void ofFbo::createAndAttachDepthStencilTexture(GLenum target, GLint internalform
 void ofFbo::begin(bool setupScreen) const{
 	auto renderer = settings.renderer.lock();
 	if(renderer){
-		renderer->begin(*this,setupScreen);
+        if(setupScreen){
+            renderer->begin(*this, ofFboBeginMode::Perspective | ofFboBeginMode::MatrixFlip);
+        }else{
+            renderer->begin(*this, ofFboBeginMode::NoDefaults);
+        }
 	}
 }
 
 
+void ofFbo::begin(ofFboBeginMode mode){
+    auto renderer = settings.renderer.lock();
+    if(renderer){
+        renderer->begin(*this, mode);
+    }
+}
+
+
 //----------------------------------------------------------
-void ofFbo::begin() const {
+/*void ofFbo::begin() const {
 	auto renderer = settings.renderer.lock();
 	if (renderer) {
 		renderer->begin(*this, true);
@@ -836,7 +848,7 @@ void ofFbo::beginNoMatrixFlipNoPerspective() const {
 	if (renderer) {
 		renderer->beginNoMatrixFlipNoPerspective(*this);
 	}
-}
+}*/
 
 //----------------------------------------------------------
 void ofFbo::end() const{

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -7,6 +7,7 @@ class ofFbo : public ofBaseDraws, public ofBaseHasTexture {
 public:
 	struct Settings;
 
+
 	ofFbo();
 	ofFbo(const ofFbo & mom);
 	ofFbo & operator=(const ofFbo & fbo);
@@ -46,6 +47,7 @@ public:
 	void setUseTexture(bool){ /*irrelevant*/ };
 	bool isUsingTexture() const {return true;}
 
+
 	/// \brief    Sets up the framebuffer and binds it for rendering.
 	/// \warning  This is a convenience method, and is considered unsafe 
 	///           in multi-window and/or multi-renderer scenarios.
@@ -53,7 +55,13 @@ public:
 	///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, bool setupPerspective) 
 	///           method instead.
 	/// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, bool setupPerspective) 
-	void begin(bool setupScreen=true) const;
+	OF_DEPRECATED_MSG("Use beginNoPerspective instead", void begin(bool setupScreen) const);
+
+	/// Bind fbo so 
+	void begin() const;
+	void beginNoPerspective() const;
+	void beginNoMatrixFlip() const;
+	void beginNoMatrixFlipNoPerspective() const;
 
 	/// \brief    Ends the current framebuffer render context.
 	/// \sa       void begin(bool setupScreen=true) const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -3,6 +3,20 @@
 #include "ofTexture.h"
 #include <stack>
 
+enum class ofFboBeginMode : short{
+    NoDefaults = 0,
+    Perspective = 1,
+    MatrixFlip = 2,
+};
+
+inline ofFboBeginMode operator | (ofFboBeginMode m1, ofFboBeginMode m2){
+    return static_cast<ofFboBeginMode>(int(m1) | int(m2));
+}
+
+inline bool operator & (ofFboBeginMode m1, ofFboBeginMode m2){
+    return static_cast<bool>(int(m1) & int(m2));
+}
+
 class ofFbo : public ofBaseDraws, public ofBaseHasTexture {
 public:
 	struct Settings;
@@ -48,20 +62,44 @@ public:
 	bool isUsingTexture() const {return true;}
 
 
-	/// \brief    Sets up the framebuffer and binds it for rendering.
+    /// Sets up the framebuffer and binds it for rendering.
+    ///
 	/// \warning  This is a convenience method, and is considered unsafe 
 	///           in multi-window and/or multi-renderer scenarios.
 	///           If you use more than one renderer, use each renderer's
-	///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, bool setupPerspective) 
+    ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode)
 	///           method instead.
-	/// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, bool setupPerspective) 
-	OF_DEPRECATED_MSG("Use beginNoPerspective instead", void begin(bool setupScreen) const);
+    /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode)
+    OF_DEPRECATED_MSG("Use begin(ofFboBeginMode::NoDefauls) instead", void begin(bool setupScreen) const);
 
-	/// Bind fbo so 
-	void begin() const;
-	void beginNoPerspective() const;
-	void beginNoMatrixFlip() const;
-	void beginNoMatrixFlipNoPerspective() const;
+
+    /// Sets up the framebuffer and binds it for rendering.
+    ///
+    /// The mode parameter indicates which defaults are set when binding
+    /// the fbo.
+    ///
+    /// The default ofFboBeginMode::Perspective | ofFboBeginMode::MatrixFlip
+    /// will set the screen perspective to the OF default for the fbo size, the
+    /// correct viewport to cover the full fbo and will flip the orientation
+    /// matrix in y so when drawing the fbo later or accesing it from a shader
+    /// it's correctly oriented
+    ///
+    /// Passing ofFboBeginMode::Perspetive will only set perspective and viewport
+    ///
+    /// Passing ofFboBeginMode::MatrixFlip won't set the perspective but will flip
+    /// the matrix.
+    ///
+    /// Passing ofFboBeginMode::NoDefaults won't change anything and just bind the fbo
+    /// and set it as current rendering surface in OF
+    ///
+    /// \warning  This is a convenience method, and is considered unsafe
+    ///           in multi-window and/or multi-renderer scenarios.
+    ///           If you use more than one renderer, use each renderer's
+    ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode)
+    ///           method instead.
+    /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode)
+    void begin(ofFboBeginMode mode = ofFboBeginMode::Perspective | ofFboBeginMode::MatrixFlip);
+
 
 	/// \brief    Ends the current framebuffer render context.
 	/// \sa       void begin(bool setupScreen=true) const;
@@ -199,4 +237,5 @@ private:
 #endif
 
 };
+
 

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1321,6 +1321,26 @@ void ofGLProgrammableRenderer::begin(const ofFbo & fbo, bool setupPerspective){
 }
 
 //----------------------------------------------------------
+void ofGLProgrammableRenderer::beginNoMatrixFlip(const ofFbo & fbo) {
+	pushView();
+	pushStyle();
+	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+	viewport();
+	setupScreenPerspective();
+	bind(fbo);
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::beginNoMatrixFlipNoPerspective(const ofFbo & fbo) {
+	pushView();
+	pushStyle();
+	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+	viewport();
+	uploadMatrices();
+	bind(fbo);
+}
+
+//----------------------------------------------------------
 void ofGLProgrammableRenderer::end(const ofFbo & fbo){
 	unbind(fbo);
 	matrixStack.setRenderSurface(*window);
@@ -1394,6 +1414,7 @@ void ofGLProgrammableRenderer::bind(const ofBaseMaterial & material){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::unbind(const ofBaseMaterial &){
     currentMaterial = nullptr;
+	beginDefaultShader();
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1307,36 +1307,20 @@ void ofGLProgrammableRenderer::unbind(const ofShader & shader){
 
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::begin(const ofFbo & fbo, bool setupPerspective){
+void ofGLProgrammableRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode){
 	pushView();
-	pushStyle();
-	matrixStack.setRenderSurface(fbo);
+    pushStyle();
+    if(mode & ofFboBeginMode::MatrixFlip){
+        matrixStack.setRenderSurface(fbo);
+    }else{
+        matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+    }
 	viewport();
-	if(setupPerspective){
+    if(mode & ofFboBeginMode::Perspective){
 		setupScreenPerspective();
 	}else{
 		uploadMatrices();
 	}
-	bind(fbo);
-}
-
-//----------------------------------------------------------
-void ofGLProgrammableRenderer::beginNoMatrixFlip(const ofFbo & fbo) {
-	pushView();
-	pushStyle();
-	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
-	viewport();
-	setupScreenPerspective();
-	bind(fbo);
-}
-
-//----------------------------------------------------------
-void ofGLProgrammableRenderer::beginNoMatrixFlipNoPerspective(const ofFbo & fbo) {
-	pushView();
-	pushStyle();
-	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
-	viewport();
-	uploadMatrices();
 	bind(fbo);
 }
 

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -193,6 +193,8 @@ public:
 	void unbind(const ofFbo & fbo);
 
 	void begin(const ofFbo & fbo, bool setupPerspective);
+	void beginNoMatrixFlip(const ofFbo & fbo);
+	void beginNoMatrixFlipNoPerspective(const ofFbo & fbo);
 	void end(const ofFbo & fbo);
 
 	ofStyle getStyle() const;

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -192,9 +192,7 @@ public:
 #endif
 	void unbind(const ofFbo & fbo);
 
-	void begin(const ofFbo & fbo, bool setupPerspective);
-	void beginNoMatrixFlip(const ofFbo & fbo);
-	void beginNoMatrixFlipNoPerspective(const ofFbo & fbo);
+    void begin(const ofFbo & fbo, ofFboBeginMode mode);
 	void end(const ofFbo & fbo);
 
 	ofStyle getStyle() const;

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -476,6 +476,34 @@ void ofGLRenderer::begin(const ofFbo & fbo, bool setupPerspective){
 }
 
 //----------------------------------------------------------
+void ofGLRenderer::beginNoMatrixFlip(const ofFbo & fbo) {
+	pushView();
+	pushStyle();
+	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+	viewport();
+	setupScreenPerspective();
+	bind(fbo);
+}
+
+//----------------------------------------------------------
+void ofGLRenderer::beginNoMatrixFlipNoPerspective(const ofFbo & fbo) {
+	pushView();
+	pushStyle();
+	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+	viewport();
+	glm::mat4 m;
+	glGetFloatv(GL_PROJECTION_MATRIX, glm::value_ptr(m));
+	m = matrixStack.getOrientationMatrixInverse() * m;
+	ofMatrixMode currentMode = matrixStack.getCurrentMatrixMode();
+	matrixStack.matrixMode(OF_MATRIX_PROJECTION);
+	matrixStack.loadMatrix(m);
+	glMatrixMode(GL_PROJECTION);
+	glLoadMatrixf(glm::value_ptr(matrixStack.getProjectionMatrix()));
+	matrixMode(currentMode);
+	bind(fbo);
+}
+
+//----------------------------------------------------------
 void ofGLRenderer::end(const ofFbo & fbo){
 	unbind(fbo);
 	matrixStack.setRenderSurface(*window);

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -454,12 +454,16 @@ void ofGLRenderer::unbind(const ofShader & shader){
 
 
 //----------------------------------------------------------
-void ofGLRenderer::begin(const ofFbo & fbo, bool setupPerspective){
+void ofGLRenderer::begin(const ofFbo & fbo, ofFboBeginMode mode){
 	pushView();
 	pushStyle();
-	matrixStack.setRenderSurface(fbo);
+    if(mode & ofFboBeginMode::MatrixFlip){
+        matrixStack.setRenderSurface(fbo);
+    }else{
+        matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
+    }
 	viewport();
-	if(setupPerspective){
+    if(mode & ofFboBeginMode::Perspective){
 		setupScreenPerspective();
 	}else{
 		glm::mat4 m;
@@ -472,34 +476,6 @@ void ofGLRenderer::begin(const ofFbo & fbo, bool setupPerspective){
 		glLoadMatrixf(glm::value_ptr(matrixStack.getProjectionMatrix()));
 		matrixMode(currentMode);
 	}
-	bind(fbo);
-}
-
-//----------------------------------------------------------
-void ofGLRenderer::beginNoMatrixFlip(const ofFbo & fbo) {
-	pushView();
-	pushStyle();
-	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
-	viewport();
-	setupScreenPerspective();
-	bind(fbo);
-}
-
-//----------------------------------------------------------
-void ofGLRenderer::beginNoMatrixFlipNoPerspective(const ofFbo & fbo) {
-	pushView();
-	pushStyle();
-	matrixStack.setRenderSurfaceNoMatrixFlip(fbo);
-	viewport();
-	glm::mat4 m;
-	glGetFloatv(GL_PROJECTION_MATRIX, glm::value_ptr(m));
-	m = matrixStack.getOrientationMatrixInverse() * m;
-	ofMatrixMode currentMode = matrixStack.getCurrentMatrixMode();
-	matrixStack.matrixMode(OF_MATRIX_PROJECTION);
-	matrixStack.loadMatrix(m);
-	glMatrixMode(GL_PROJECTION);
-	glLoadMatrixf(glm::value_ptr(matrixStack.getProjectionMatrix()));
-	matrixMode(currentMode);
 	bind(fbo);
 }
 

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -203,6 +203,8 @@ public:
 	void unbind(const ofCamera & camera);
 
 	void begin(const ofFbo & fbo, bool setupPerspective);
+	void beginNoMatrixFlip(const ofFbo & fbo);
+	void beginNoMatrixFlipNoPerspective(const ofFbo & fbo);
 	void end(const ofFbo & fbo);
 
 	void bind(const ofFbo & fbo);

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -202,9 +202,7 @@ public:
 	void unbind(const ofTexture & texture, int location);
 	void unbind(const ofCamera & camera);
 
-	void begin(const ofFbo & fbo, bool setupPerspective);
-	void beginNoMatrixFlip(const ofFbo & fbo);
-	void beginNoMatrixFlipNoPerspective(const ofFbo & fbo);
+    void begin(const ofFbo & fbo, ofFboBeginMode mode);
 	void end(const ofFbo & fbo);
 
 	void bind(const ofFbo & fbo);

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -1924,6 +1924,8 @@ public:
 	virtual void bindForBlitting(const ofFbo & fboSrc, ofFbo & fboDst, int attachmentPoint=0)=0;
 #endif
 	virtual void begin(const ofFbo & fbo, bool setupPerspective)=0;
+	virtual void beginNoMatrixFlip(const ofFbo & fbo) = 0;
+	virtual void beginNoMatrixFlipNoPerspective(const ofFbo & fbo) = 0;
 	virtual void end(const ofFbo & fbo)=0;
 
 };

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -36,7 +36,6 @@ class ofMesh_;
 using ofMesh = ofMesh_<ofDefaultVertexType, ofDefaultNormalType, ofDefaultColorType, ofDefaultTexCoordType>;
 
 class ofPath;
-class ofFbo;
 class of3dPrimitive;
 class ofLight;
 class ofMaterial;
@@ -48,6 +47,8 @@ class of3dGraphics;
 class ofVbo;
 class ofVboMesh;
 class ofSoundBuffer;
+class ofFbo;
+enum class ofFboBeginMode : short;
 
 
 bool ofIsVFlipped();
@@ -1923,9 +1924,7 @@ public:
 #ifndef TARGET_OPENGLES
 	virtual void bindForBlitting(const ofFbo & fboSrc, ofFbo & fboDst, int attachmentPoint=0)=0;
 #endif
-	virtual void begin(const ofFbo & fbo, bool setupPerspective)=0;
-	virtual void beginNoMatrixFlip(const ofFbo & fbo) = 0;
-	virtual void beginNoMatrixFlipNoPerspective(const ofFbo & fbo) = 0;
+    virtual void begin(const ofFbo & fbo, ofFboBeginMode mode)=0;
 	virtual void end(const ofFbo & fbo)=0;
 
 };

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -17,13 +17,21 @@ ofMatrixStack::ofMatrixStack(const ofAppBaseWindow * window)
 ,currentWindow(const_cast<ofAppBaseWindow*>(window))
 ,currentMatrixMode(OF_MATRIX_MODELVIEW)
 ,currentMatrix(&modelViewMatrix)
+,flipFboMatrix(true)
 {
 
 }
 
 void ofMatrixStack::setRenderSurface(const ofFbo & fbo){
 	currentFbo = const_cast<ofFbo*>(&fbo);
+	flipFboMatrix = true;
 	setOrientation(orientation,vFlipped);
+}
+
+void ofMatrixStack::setRenderSurfaceNoMatrixFlip(const ofFbo & fbo) {
+	currentFbo = const_cast<ofFbo*>(&fbo);
+	flipFboMatrix = false;
+	setOrientation(orientation, vFlipped);
 }
 
 void ofMatrixStack::setRenderSurface(const ofAppBaseWindow & window){
@@ -83,7 +91,7 @@ bool ofMatrixStack::isVFlipped() const{
 }
 
 bool ofMatrixStack::customMatrixNeedsFlip() const{
-	return vFlipped != bool(currentFbo);
+	return vFlipped != (bool(currentFbo) && flipFboMatrix);
 }
 
 int ofMatrixStack::getRenderSurfaceWidth() const{

--- a/libs/openFrameworks/utils/ofMatrixStack.h
+++ b/libs/openFrameworks/utils/ofMatrixStack.h
@@ -21,6 +21,7 @@ public:
 	ofMatrixStack(const ofAppBaseWindow * window);
 
 	void setRenderSurface(const ofFbo & fbo);
+	void setRenderSurfaceNoMatrixFlip(const ofFbo & fbo);
 	void setRenderSurface(const ofAppBaseWindow & window);
 
 	void setOrientation(ofOrientation orientation, bool vFlip);
@@ -96,6 +97,7 @@ private:
 	std::stack <glm::mat4> projectionMatrixStack;
 	std::stack <glm::mat4> textureMatrixStack;
 	std::stack <std::pair<ofOrientation,bool> > orientationStack;
+	bool flipFboMatrix;
 
 	int getRenderSurfaceWidth() const;
 	int getRenderSurfaceHeight() const;


### PR DESCRIPTION
We've had for a while a bool flag in ofFbo::begin to not set the fbo perspective matrix. That boolean parameter is confusing and doesn't solve the most complex cases.

This adds an enum to better control how the fbo is initialized. From the comments docs:

```cpp
    /// The mode parameter indicates which defaults are set when binding
    /// the fbo.
    ///
    /// The default ofFboBeginMode::Perspective | ofFboBeginMode::MatrixFlip
    /// will set the screen perspective to the OF default for the fbo size, the
    /// correct viewport to cover the full fbo and will flip the orientation
    /// matrix in y so when drawing the fbo later or accesing it from a shader
    /// it's correctly oriented
    ///
    /// Passing ofFboBeginMode::Perspetive will only set perspective and viewport
    ///
    /// Passing ofFboBeginMode::MatrixFlip won't set the perspective but will flip
    /// the matrix.
    ///
    /// Passing ofFboBeginMode::NoDefaults won't change anything and just bind the fbo
   /// and set it as current rendering surface in OF
```

a previous version i had added new methods instead of an enum like:

```
begin()
beginNoPerspective()
beginNoMatrixFlip()
beginNoMatrixFlipNoPerspective()
```

which could be relatively easier to use but the names are pretty long, specially the last oneand if we wanted to add any other options in the future it would complicate things a lot or force us to deprecate those methods and add the enum.