### PR TITLE
Refactor every load/save method and ofFilePath to use filesystem::path

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
@@ -43,7 +43,7 @@ ofxAndroidSoundPlayer::~ofxAndroidSoundPlayer(){
 
 
 //------------------------------------------------------------
-bool ofxAndroidSoundPlayer::load(string fileName, bool stream){
+bool ofxAndroidSoundPlayer::load(std::filesystem::path fileName, bool stream){
 	if(!javaSoundPlayer){
 		ofLogError("ofxAndroidSoundPlayer") << "loadSound(): java SoundPlayer not loaded";
 		return false;

--- a/addons/ofxAndroid/src/ofxAndroidSoundPlayer.h
+++ b/addons/ofxAndroid/src/ofxAndroidSoundPlayer.h
@@ -8,7 +8,7 @@ public:
 	ofxAndroidSoundPlayer();
 	virtual ~ofxAndroidSoundPlayer();
 
-	bool load(string fileName, bool stream = false);
+	bool load(std::filesystem::path fileName, bool stream = false);
 	void unload();
 	void play();
 	void stop();

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -37,7 +37,7 @@ ofxEmscriptenSoundPlayer::~ofxEmscriptenSoundPlayer(){
 }
 
 
-bool ofxEmscriptenSoundPlayer::load(string fileName, bool stream){
+bool ofxEmscriptenSoundPlayer::load(std::filesystem::path fileName, bool stream){
 	if(context!=-1){
 		sound = html5audio_sound_load(context,ofToDataPath(fileName).c_str());
 	}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
@@ -8,7 +8,7 @@ public:
 	~ofxEmscriptenSoundPlayer();
 
 
-	bool load(string fileName, bool stream = false);
+	bool load(std::filesystem::path fileName, bool stream = false);
 	void unload();
 	void play();
 	void stop();

--- a/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.cpp
@@ -28,12 +28,12 @@ int ofxEmscriptenURLFileLoader::getAsync(const string &  url, const string &  na
 	return req->getId();
 }
 
-ofHttpResponse ofxEmscriptenURLFileLoader::saveTo(const string &  url, const string &  path){
+ofHttpResponse ofxEmscriptenURLFileLoader::saveTo(const string &  url, const std::filesystem::path &  path){
 	saveAsync(url,path);
 	return ofHttpResponse();
 }
 
-int ofxEmscriptenURLFileLoader::saveAsync(const string &  url, const string &  path){
+int ofxEmscriptenURLFileLoader::saveAsync(const string &  url, const std::filesystem::path &  path){
 	ofHttpRequest * req = new ofHttpRequest(url,url,true);
 #if __EMSCRIPTEN_major__>1 || (__EMSCRIPTEN_major__==1 && __EMSCRIPTEN_minor__>22)
 	emscripten_async_wget2(url.c_str(), path.c_str(), "GET", "", req, &onload_file_cb, &onerror_file_cb, NULL);

--- a/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.h
@@ -14,8 +14,8 @@ public:
 	virtual ~ofxEmscriptenURLFileLoader();
 	ofHttpResponse get(const string &  url);
 	int getAsync(const string &  url, const string &  name=""); // returns id
-	ofHttpResponse saveTo(const string &  url, const string &  path);
-	int saveAsync(const string &  url, const string &  path);
+	ofHttpResponse saveTo(const string &  url, const std::filesystem::path &  path);
+	int saveAsync(const string &  url, const std::filesystem::path &  path);
 	ofHttpResponse handleRequest(const ofHttpRequest & request);
 	int handleRequestAsync(const ofHttpRequest & request);
 	void remove(int id);

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -85,12 +85,13 @@ ofxOpenALSoundPlayer::~ofxOpenALSoundPlayer() {
 
 //--------------------------------------------------------------
 
-bool ofxOpenALSoundPlayer::load(string fileName, bool stream) {
+bool ofxOpenALSoundPlayer::load(std::filesystem::path filePath, bool stream) {
 	
 	if(!SoundEngineInitialized) {
 		ofxOpenALSoundPlayer::initializeSoundEngine();
 	}
 	
+    auto fileName = filePath.string();
 	if( fileName.length()-3 == fileName.rfind("mp3") )
 		iAmAnMp3=true;
 	

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
@@ -61,7 +61,7 @@ public:
 	ofxOpenALSoundPlayer();
 	~ofxOpenALSoundPlayer();
 	
-	bool	load(string fileName, bool stream=false);
+	bool	load(std::filesystem::path fileName, bool stream=false);
 	void	unload();
 
 	void	play();

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
@@ -15,7 +15,7 @@ public:
     ofxiOSSoundPlayer();
     ~ofxiOSSoundPlayer();
     
-    bool load(string fileName, bool stream = false);
+    bool load(std::filesystem::path fileName, bool stream = false);
     void unload();
     void play();
     void stop();

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
@@ -16,7 +16,7 @@ ofxiOSSoundPlayer::~ofxiOSSoundPlayer() {
     unload();
 }
 
-bool ofxiOSSoundPlayer::load(string fileName, bool stream) {
+bool ofxiOSSoundPlayer::load(std::filesystem::path fileName, bool stream) {
     if(soundPlayer != NULL) {
         unload();
     }

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -639,7 +639,7 @@ public:
 	///
 	/// It expects that the file will be in the [PLY Format](http://en.wikipedia.org/wiki/PLY_(file_format)).
 	/// It will only load meshes saved in the PLY ASCII format; the binary format is not supported.
-	void load(string path);
+    void load(std::filesystem::path path);
 
 	///  \brief Saves the mesh at the passed path in the [PLY Format](http://en.wikipedia.org/wiki/PLY_(file_format)).
 	///
@@ -650,7 +650,7 @@ public:
 	///  If you're planning on reloading the mesh into ofMesh, ofMesh currently only supports loading the ASCII format.
 	///
 	///  For more information, see the [PLY format specification](http://paulbourke.net/dataformats/ply/).
-	void save(string path, bool useBinary = false) const;
+    void save(std::filesystem::path path, bool useBinary = false) const;
 
 	/// \}
 

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1024,7 +1024,7 @@ void ofMesh_<V,N,C,T>::append(const ofMesh_<V,N,C,T> & mesh){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::load(string path){
+void ofMesh_<V,N,C,T>::load(std::filesystem::path path){
 	ofFile is(path, ofFile::ReadOnly);
 	auto & data = *this;
 
@@ -1264,7 +1264,7 @@ void ofMesh_<V,N,C,T>::load(string path){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::save(string path, bool useBinary) const{
+void ofMesh_<V,N,C,T>::save(std::filesystem::path path, bool useBinary) const{
 	ofFile os(path, ofFile::WriteOnly);
 	const auto & data = *this;
 

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -180,12 +180,12 @@ ofShader & ofShader::operator=(ofShader && mom){
 }
 
 //--------------------------------------------------------------
-bool ofShader::load(string shaderName) {
-	return load(shaderName + ".vert", shaderName + ".frag");
+bool ofShader::load(std::filesystem::path shaderName) {
+    return load(shaderName.string() + ".vert", shaderName.string() + ".frag");
 }
 
 //--------------------------------------------------------------
-bool ofShader::load(string vertName, string fragName, string geomName) {
+bool ofShader::load(std::filesystem::path vertName, std::filesystem::path fragName, std::filesystem::path geomName) {
 	if(vertName.empty() == false) setupShaderFromFile(GL_VERTEX_SHADER, vertName);
 	if(fragName.empty() == false) setupShaderFromFile(GL_FRAGMENT_SHADER, fragName);
 #ifndef TARGET_OPENGLES
@@ -199,7 +199,7 @@ bool ofShader::load(string vertName, string fragName, string geomName) {
 
 #if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
 //--------------------------------------------------------------
-bool ofShader::loadCompute(string shaderName) {
+bool ofShader::loadCompute(std::filesystem::path shaderName) {
 	return setupShaderFromFile(GL_COMPUTE_SHADER, shaderName) && linkProgram();
 }
 #endif
@@ -265,7 +265,7 @@ bool ofShader::setup(const TransformFeedbackSettings & settings) {
 #endif
 
 //--------------------------------------------------------------
-bool ofShader::setupShaderFromFile(GLenum type, string filename) {
+bool ofShader::setupShaderFromFile(GLenum type, std::filesystem::path filename) {
 	ofBuffer buffer = ofBufferFromFile(filename);
 	// we need to make absolutely sure to have an absolute path here, so that any #includes
 	// within the shader files have a root directory to traverse from.
@@ -519,7 +519,8 @@ void ofShader::checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLeve
 			std::smatch matches;
 			string infoString = ofTrim(infoBuffer);
 			if (std::regex_search(infoString, matches, intel) || std::regex_search(infoString, matches, nvidia_ati)){
-				ofBuffer buf = shaders[type].expandedSource;
+                ofBuffer buf;
+                buf.set(shaders[type].expandedSource);
 				ofBuffer::Line line = buf.getLines().begin();
 				int  offendingLineNumber = ofToInt(matches[1]);
 				ostringstream msg;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -25,21 +25,21 @@ public:
     ofShader(ofShader && shader);
     ofShader & operator=(ofShader && shader);
 	
-	bool load(string shaderName);
-	bool load(string vertName, string fragName, string geomName="");
+    bool load(std::filesystem::path shaderName);
+    bool load(std::filesystem::path vertName, std::filesystem::path fragName, std::filesystem::path geomName="");
 #if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
-	bool loadCompute(string shaderName);
+    bool loadCompute(std::filesystem::path shaderName);
 #endif
 
 	struct Settings {
-		std::map<GLuint, std::string> shaderFiles;
+        std::map<GLuint, std::filesystem::path> shaderFiles;
 		std::map<GLuint, std::string> shaderSources;
 		bool bindDefaults = true;
 	};
 
 #if !defined(TARGET_OPENGLES)
 	struct TransformFeedbackSettings {
-		std::map<GLuint, std::string> shaderFiles;
+        std::map<GLuint, std::filesystem::path> shaderFiles;
 		std::map<GLuint, std::string> shaderSources;
 		std::vector<std::string> varyingsToCapture;
 		bool bindDefaults = true;
@@ -179,7 +179,7 @@ public:
 	// these methods create and compile a shader from source or file
 	// type: GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, GL_GEOMETRY_SHADER_EXT etc.
 	bool setupShaderFromSource(GLenum type, string source, string sourceDirectoryPath = "");
-	bool setupShaderFromFile(GLenum type, string filename);
+    bool setupShaderFromFile(GLenum type, std::filesystem::path filename);
 	
 	// links program with all compiled shaders
 	bool linkProgram();

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -181,19 +181,19 @@ static int getJpegOptionFromImageLoadSetting(const ofImageLoadSettings &settings
 }
 
 template<typename PixelType>
-static bool loadImage(ofPixels_<PixelType> & pix, const std::string& _fileName, const ofImageLoadSettings& settings){
+static bool loadImage(ofPixels_<PixelType> & pix, const std::filesystem::path& _fileName, const ofImageLoadSettings& settings){
 	ofInitFreeImage();
 
 #ifndef TARGET_EMSCRIPTEN
 	Poco::URI uri;
 	try {
-		uri = Poco::URI(_fileName);
+        uri = Poco::URI(_fileName.string());
 	} catch(const std::exception & exc){
 		ofLogError("ofImage") << "loadImage(): malformed uri when loading image from uri \"" << _fileName << "\": " << exc.what();
 		return false;
 	}
 	if(uri.getScheme() == "http" || uri.getScheme() == "https"){
-		return ofLoadImage(pix, ofLoadURL(_fileName).data);
+        return ofLoadImage(pix, ofLoadURL(_fileName.string()).data);
 	}
 #endif
 	
@@ -285,7 +285,7 @@ static bool loadImage(ofPixels_<PixelType> & pix, const ofBuffer & buffer, const
 }
 
 //----------------------------------------------------------------
-bool ofLoadImage(ofPixels & pix, const std::string& path, const ofImageLoadSettings &settings) {
+bool ofLoadImage(ofPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings) {
 	return loadImage(pix, path, settings);
 }
 
@@ -295,7 +295,7 @@ bool ofLoadImage(ofPixels & pix, const ofBuffer & buffer, const ofImageLoadSetti
 }
 
 //----------------------------------------------------------------
-bool ofLoadImage(ofShortPixels & pix, const std::string& path, const ofImageLoadSettings &settings) {
+bool ofLoadImage(ofShortPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings) {
 	return loadImage(pix, path, settings);
 }
 
@@ -305,7 +305,7 @@ bool ofLoadImage(ofShortPixels & pix, const ofBuffer & buffer, const ofImageLoad
 }
 
 //----------------------------------------------------------------
-bool ofLoadImage(ofFloatPixels & pix, const std::string& path, const ofImageLoadSettings &settings) {
+bool ofLoadImage(ofFloatPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings) {
 	return loadImage(pix, path, settings);
 }
 
@@ -315,7 +315,7 @@ bool ofLoadImage(ofFloatPixels & pix, const ofBuffer & buffer, const ofImageLoad
 }
 
 //----------------------------------------------------------------
-bool ofLoadImage(ofTexture & tex, const std::string& path, const ofImageLoadSettings &settings){
+bool ofLoadImage(ofTexture & tex, const std::filesystem::path& path, const ofImageLoadSettings &settings){
 	ofPixels pixels;
 	bool loaded = ofLoadImage(pixels, path, settings);
 	if(loaded){
@@ -338,7 +338,7 @@ bool ofLoadImage(ofTexture & tex, const ofBuffer & buffer, const ofImageLoadSett
 
 //----------------------------------------------------------------
 template<typename PixelType>
-static void saveImage(const ofPixels_<PixelType> & _pix, const std::string& _fileName, ofImageQualityType qualityLevel) {
+static void saveImage(const ofPixels_<PixelType> & _pix, const std::filesystem::path& _fileName, ofImageQualityType qualityLevel) {
 	// Make a local copy.
 	ofPixels_<PixelType> pix = _pix;
 
@@ -412,17 +412,17 @@ static void saveImage(const ofPixels_<PixelType> & _pix, const std::string& _fil
 }
 
 //----------------------------------------------------------------
-void ofSaveImage(const ofPixels & pix, const std::string& fileName, ofImageQualityType qualityLevel){
+void ofSaveImage(const ofPixels & pix, const std::filesystem::path& fileName, ofImageQualityType qualityLevel){
 	saveImage(pix,fileName,qualityLevel);
 }
 
 //----------------------------------------------------------------
-void ofSaveImage(const ofFloatPixels & pix, const std::string& fileName, ofImageQualityType qualityLevel) {
+void ofSaveImage(const ofFloatPixels & pix, const std::filesystem::path& fileName, ofImageQualityType qualityLevel) {
 	saveImage(pix,fileName,qualityLevel);
 }
 
 //----------------------------------------------------------------
-void ofSaveImage(const ofShortPixels & pix, const std::string& fileName, ofImageQualityType qualityLevel) {
+void ofSaveImage(const ofShortPixels & pix, const std::filesystem::path& fileName, ofImageQualityType qualityLevel) {
 	saveImage(pix,fileName,qualityLevel);
 }
 
@@ -572,22 +572,7 @@ ofImage_<PixelType>::ofImage_(const ofPixels_<PixelType> & pix){
 }
 
 template<typename PixelType>
-ofImage_<PixelType>::ofImage_(const ofFile & file, const ofImageLoadSettings &settings){
-	width						= 0;
-	height						= 0;
-	bpp							= 0;
-	type						= OF_IMAGE_UNDEFINED;
-	bUseTexture					= true;		// the default is, yes, use a texture
-
-	//----------------------- init free image if necessary
-	ofInitFreeImage();
-
-
-	load(file, settings);
-}
-
-template<typename PixelType>
-ofImage_<PixelType>::ofImage_(const std::string & fileName, const ofImageLoadSettings &settings){
+ofImage_<PixelType>::ofImage_(const std::filesystem::path & fileName, const ofImageLoadSettings &settings){
 	width						= 0;
 	height						= 0;
 	bpp							= 0;
@@ -678,19 +663,13 @@ ofImage_<PixelType>::~ofImage_(){
 
 //----------------------------------------------------------
 template<typename PixelType>
-bool ofImage_<PixelType>::load(const ofFile & file, const ofImageLoadSettings &settings){
-	return load(file.getAbsolutePath(), settings);
-}
-
-//----------------------------------------------------------
-template<typename PixelType>
 bool ofImage_<PixelType>::loadImage(const ofFile & file){
 	return load(file);
 }
 
 //----------------------------------------------------------
 template<typename PixelType>
-bool ofImage_<PixelType>::load(const std::string& fileName, const ofImageLoadSettings &settings){
+bool ofImage_<PixelType>::load(const std::filesystem::path& fileName, const ofImageLoadSettings &settings){
 	#if defined(TARGET_ANDROID)
 	ofAddListener(ofxAndroidEvents().unloadGL,this,&ofImage_<PixelType>::unloadTexture);
 	ofAddListener(ofxAndroidEvents().reloadGL,this,&ofImage_<PixelType>::update);
@@ -736,20 +715,14 @@ bool ofImage_<PixelType>::loadImage(const ofBuffer & buffer){
 
 //----------------------------------------------------------
 template<typename PixelType>
-void ofImage_<PixelType>::save(const std::string& fileName, ofImageQualityType qualityLevel) const {
+void ofImage_<PixelType>::save(const std::filesystem::path& fileName, ofImageQualityType qualityLevel) const {
 	ofSaveImage(pixels, fileName, qualityLevel);
 }
 
 //----------------------------------------------------------
 template<typename PixelType>
-void ofImage_<PixelType>::save(ofBuffer & buffer, ofImageQualityType qualityLevel) const {
-	ofSaveImage(pixels, buffer, qualityLevel);
-}
-
-//----------------------------------------------------------
-template<typename PixelType>
-void ofImage_<PixelType>::save(const ofFile & file, ofImageQualityType compressionLevel) const {
-	ofSaveImage(pixels,file.getAbsolutePath(),compressionLevel);
+void ofImage_<PixelType>::save(ofBuffer & buffer, ofImageFormat imageFormat, ofImageQualityType qualityLevel) const {
+    ofSaveImage(pixels, buffer, imageFormat, qualityLevel);
 }
 
 //----------------------------------------------------------
@@ -761,7 +734,7 @@ void ofImage_<PixelType>::saveImage(const std::string& fileName, ofImageQualityT
 //----------------------------------------------------------
 template<typename PixelType>
 void ofImage_<PixelType>::saveImage(ofBuffer & buffer, ofImageQualityType qualityLevel) const {
-	save(buffer, qualityLevel);
+    save(buffer, OF_IMAGE_FORMAT_PNG, qualityLevel);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -132,27 +132,27 @@ struct ofImageLoadSettings {
 
 
 /// \todo Needs documentation.
-bool ofLoadImage(ofPixels & pix, const std::string& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+bool ofLoadImage(ofPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 bool ofLoadImage(ofPixels & pix, const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
-bool ofLoadImage(ofFloatPixels & pix, const std::string& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+bool ofLoadImage(ofFloatPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 bool ofLoadImage(ofFloatPixels & pix, const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
-bool ofLoadImage(ofShortPixels & pix, const std::string& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+bool ofLoadImage(ofShortPixels & pix, const std::filesystem::path& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 bool ofLoadImage(ofShortPixels & pix, const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 
 /// \todo Needs documentation.
-bool ofLoadImage(ofTexture & tex, const std::string& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+bool ofLoadImage(ofTexture & tex, const std::filesystem::path& path, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 bool ofLoadImage(ofTexture & tex, const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
 
 /// \todo Needs documentation.
-void ofSaveImage(const ofPixels & pix, const std::string& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
+void ofSaveImage(const ofPixels & pix, const std::filesystem::path& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 void ofSaveImage(const ofPixels & pix, ofBuffer & buffer, ofImageFormat format = OF_IMAGE_FORMAT_PNG, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 
 /// \todo Needs documentation.
-void ofSaveImage(const ofFloatPixels & pix, const std::string& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
+void ofSaveImage(const ofFloatPixels & pix, const std::filesystem::path& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 void ofSaveImage(const ofFloatPixels & pix, ofBuffer & buffer, ofImageFormat format = OF_IMAGE_FORMAT_PNG, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 
 /// \todo Needs documentation.
-void ofSaveImage(const ofShortPixels & pix, const std::string& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
+void ofSaveImage(const ofShortPixels & pix, const std::filesystem::path& path, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 void ofSaveImage(const ofShortPixels & pix, ofBuffer & buffer, ofImageFormat format = OF_IMAGE_FORMAT_PNG, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 
 /// \brief Deallocates FreeImage resources.
@@ -171,8 +171,7 @@ public:
     ofImage_();
     
     ofImage_(const ofPixels_<PixelType> & pix);
-    ofImage_(const ofFile & file, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
-    ofImage_(const std::string & fileName, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+    ofImage_(const std::filesystem::path & fileName, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
     ofImage_(const ofImage_<PixelType>& mom);
     ofImage_(ofImage_<PixelType>&& mom);
     
@@ -223,7 +222,7 @@ public:
     /// the data folder.
     /// \param settings Load options
     /// \returns true if image loaded correctly.
-    bool load(const std::string& fileName, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
+    bool load(const std::filesystem::path& fileName, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
     
     /// \brief Loads an image from an ofBuffer instance created by, for
     /// instance, ofFile::readToBuffer().
@@ -231,13 +230,6 @@ public:
     /// This actually loads the image data into an ofPixels object and then
     /// into the texture.
     bool load(const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
-    
-    /// \brief Loads an image from an ofFile instance created by, for
-    /// instance, ofDirectory::getFiles().
-    ///
-    /// This actually loads the image data into an ofPixels object and then
-    /// into the texture.
-    bool load(const ofFile & file, const ofImageLoadSettings &settings = ofImageLoadSettings::defaultSetting);
     
     OF_DEPRECATED_MSG("Use load instead",bool loadImage(const std::string& fileName));
     OF_DEPRECATED_MSG("Use load instead",bool loadImage(const ofBuffer & buffer));
@@ -608,20 +600,14 @@ public:
     ///
     /// \param fileName Saves image to this path, relative to the data folder.
     /// \param compressionLevel The ofImageQualityType.
-    void save(const std::string & fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
+    void save(const std::filesystem::path & fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
     
     /// \brief This saves the image to the ofBuffer passed with the image
     /// quality specified by compressionLevel.
     ///
     /// \param buffer ofBuffer to save image to.
     /// \param compressionLevel The ofImageQualityType.
-    void save(ofBuffer & buffer, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
-    
-    /// \brief This saves the image to the ofFile passed with the image quality specified by compressionLevel.
-    /// \param file ofFile to save image to.
-    /// \param compressionLevel The different compression levels are: `OF_IMAGE_QUALITY_BEST`, `OF_IMAGE_QUALITY_HIGH`,
-    /// `OF_IMAGE_QUALITY_MEDIUM`, `OF_IMAGE_QUALITY_LOW`, `OF_IMAGE_QUALITY_WORST`
-    void save(const ofFile & file, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
+    void save(ofBuffer & buffer, ofImageFormat imageFormat = OF_IMAGE_FORMAT_PNG, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
     
     OF_DEPRECATED_MSG("Use save instead",void saveImage(const std::string& fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const);
     OF_DEPRECATED_MSG("Use save instead",void saveImage(ofBuffer & buffer, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -473,7 +473,7 @@ static bool loadFontFace(std::filesystem::path fontname, FT_Face & face, std::fi
 		ofLogVerbose("ofTrueTypeFont") << "loadFontFace(): \"" << fontname << "\" not a file in data loading system font from \"" << filename << "\"";
 	}
 	FT_Error err;
-	err = FT_New_Face( library, filename.c_str(), fontID, &face );
+    err = FT_New_Face( library, filename.string().c_str(), fontID, &face );
 	if (err) {
 		// simple error table in lieu of full table (see fterrors.h)
 		string errorString = "unknown freetype";

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -439,13 +439,13 @@ static std::string linuxFontPathByName(const std::string& fontname){
 #endif
 
 //-----------------------------------------------------------
-static bool loadFontFace(string fontname, int _fontSize, FT_Face & face, string & filename){
+static bool loadFontFace(std::filesystem::path fontname, FT_Face & face, std::filesystem::path & filename){
 	filename = ofToDataPath(fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
 	int fontID = 0;
 	if(!fontFile.exists()){
 #ifdef TARGET_LINUX
-		filename = linuxFontPathByName(fontname);
+        filename = linuxFontPathByName(fontname.string());
 #elif defined(TARGET_OSX)
 		if(fontname==OF_TTF_SANS){
 			fontname = "Helvetica Neue";
@@ -455,7 +455,7 @@ static bool loadFontFace(string fontname, int _fontSize, FT_Face & face, string 
 		}else if(fontname==OF_TTF_MONO){
 			fontname = "Menlo Regular";
 		}
-		filename = osxFontPathByName(fontname);
+        filename = osxFontPathByName(fontname.string());
 #elif defined(TARGET_WIN32)
 		if(fontname==OF_TTF_SANS){
 			fontname = "Arial";
@@ -464,7 +464,7 @@ static bool loadFontFace(string fontname, int _fontSize, FT_Face & face, string 
 		}else if(fontname==OF_TTF_MONO){
 			fontname = "Courier New";
 		}
-		filename = winFontPathByName(fontname);
+        filename = winFontPathByName(fontname.string());
 #endif
 		if(filename == "" ){
 			ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't find font \"" << fontname << "\"";
@@ -757,7 +757,7 @@ ofTrueTypeFont::glyph ofTrueTypeFont::loadGlyph(uint32_t utf8) const{
 }
 
 //-----------------------------------------------------------
-bool ofTrueTypeFont::load(string filename, int fontSize, bool antialiased, bool fullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
+bool ofTrueTypeFont::load(std::filesystem::path filename, int fontSize, bool antialiased, bool fullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
 	ofTtfSettings settings(filename,fontSize);
 	settings.antialiased = antialiased;
 	settings.contours = makeContours;
@@ -787,7 +787,7 @@ bool ofTrueTypeFont::load(const ofTtfSettings & _settings){
 
 	//--------------- load the library and typeface
 	FT_Face loadFace;
-	if(!loadFontFace(settings.fontName,settings.fontSize,loadFace,settings.fontName)){
+    if(!loadFontFace(settings.fontName, loadFace, settings.fontName)){
 		return false;
 	}
 	face = std::shared_ptr<struct FT_FaceRec_>(loadFace,FT_Done_Face);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -120,11 +120,11 @@ class ofTtfSettings{
 	vector<ofUnicode::range> ranges;
 
 public:
-	ofTtfSettings(const string & name, int size)
+    ofTtfSettings(const std::filesystem::path & name, int size)
 	:fontName(name)
 	,fontSize(size){}
 
-	string fontName;
+    std::filesystem::path fontName;
 	int fontSize;
 	bool antialiased = true;
 	bool contours = false;
@@ -183,7 +183,7 @@ public:
     /// \param simplifyAmt the amount to simplify the vector contours.  Larger number means more simplified.
     /// \param dpi the dots per inch used to specify rendering size.
 	/// \returns true if the font was loaded correctly.
-	bool load(string filename,
+    bool load(std::filesystem::path filename,
                   int fontsize,
                   bool _bAntiAliased=true,
                   bool _bFullCharacterSet=true,

--- a/libs/openFrameworks/sound/ofBaseSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofBaseSoundPlayer.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "ofConstants.h"
+#include "ofFileUtils.h"
 
 
 
@@ -15,7 +16,7 @@ public:
 	ofBaseSoundPlayer(){};
 	virtual ~ofBaseSoundPlayer(){};
 	
-	virtual bool load(string fileName, bool stream = false)=0;
+    virtual bool load(std::filesystem::path fileName, bool stream = false)=0;
 	virtual void unload()=0;
 	virtual void play() = 0;
 	virtual void stop() = 0;

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
@@ -185,7 +185,7 @@ void ofFmodSoundPlayer::closeFmod(){
 }
 
 //------------------------------------------------------------
-bool ofFmodSoundPlayer::load(string fileName, bool stream){
+bool ofFmodSoundPlayer::load(std::filesystem::path fileName, bool stream){
 
 	fileName = ofToDataPath(fileName);
 

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
@@ -214,7 +214,7 @@ bool ofFmodSoundPlayer::load(std::filesystem::path fileName, bool stream){
 	int fmodFlags =  FMOD_SOFTWARE;
 	if(stream)fmodFlags =  FMOD_SOFTWARE | FMOD_CREATESTREAM;
 
-	result = FMOD_System_CreateSound(sys, fileName.c_str(),  fmodFlags, nullptr, &sound);
+    result = FMOD_System_CreateSound(sys, fileName.string().c_str(),  fmodFlags, nullptr, &sound);
 
 	if (result != FMOD_OK){
 		bLoadedOk = false;

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -4,6 +4,7 @@
 
 
 #include "ofBaseSoundPlayer.h"
+#include "ofFileUtils.h"
 
 
 extern "C" {
@@ -40,7 +41,7 @@ class ofFmodSoundPlayer : public ofBaseSoundPlayer {
 		ofFmodSoundPlayer();
 		virtual ~ofFmodSoundPlayer();
 
-		bool load(string fileName, bool stream = false);
+        bool load(std::filesystem::path fileName, bool stream = false);
 		void unload();
 		void play();
 		void stop();

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -171,7 +171,7 @@ void ofOpenALSoundPlayer::close(){
 }
 
 // ----------------------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfReadFile(string path, vector<short> & buffer, vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfReadFile(std::filesystem::path path, vector<short> & buffer, vector<float> & fftAuxBuffer){
 	SF_INFO sfInfo;
 	SNDFILE* f = sf_open(path.c_str(),SFM_READ,&sfInfo);
 	if(!f){
@@ -225,7 +225,7 @@ bool ofOpenALSoundPlayer::sfReadFile(string path, vector<short> & buffer, vector
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123ReadFile(string path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123ReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	int err = MPG123_OK;
 	mpg123_handle * f = mpg123_new(nullptr,&err);
 	if(mpg123_open(f,path.c_str())!=MPG123_OK){
@@ -263,7 +263,7 @@ bool ofOpenALSoundPlayer::mpg123ReadFile(string path,vector<short> & buffer,vect
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfStream(string path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfStream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	if(!streamf){
 		SF_INFO sfInfo;
 		streamf = sf_open(path.c_str(),SFM_READ,&sfInfo);
@@ -326,7 +326,7 @@ bool ofOpenALSoundPlayer::sfStream(string path,vector<short> & buffer,vector<flo
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123Stream(string path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123Stream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	if(!mp3streamf){
 		int err = MPG123_OK;
 		mp3streamf = mpg123_new(nullptr,&err);
@@ -377,7 +377,7 @@ bool ofOpenALSoundPlayer::mpg123Stream(string path,vector<short> & buffer,vector
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::stream(string fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::stream(std::filesystem::path fileName, vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)=="mp3" || ofFilePath::getFileExt(fileName)=="MP3" || mp3streamf){
 		if(!mpg123Stream(fileName,buffer,fftAuxBuffer)) return false;
@@ -397,7 +397,7 @@ bool ofOpenALSoundPlayer::stream(string fileName, vector<short> & buffer){
 	return true;
 }
 
-bool ofOpenALSoundPlayer::readFile(string fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::readFile(std::filesystem::path fileName, vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)!="mp3" && ofFilePath::getFileExt(fileName)!="MP3"){
 		if(!sfReadFile(fileName,buffer,fftAuxBuffer)) return false;
@@ -420,7 +420,7 @@ bool ofOpenALSoundPlayer::readFile(string fileName, vector<short> & buffer){
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::load(string fileName, bool is_stream){
+bool ofOpenALSoundPlayer::load(std::filesystem::path fileName, bool is_stream){
 
 	fileName = ofToDataPath(fileName);
 

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -6,6 +6,7 @@
 #include "ofBaseSoundPlayer.h"
 #include "ofEvents.h"
 #include "ofThread.h"
+#include "ofFileUtils.h"
 
 #if defined (TARGET_OF_IOS) || defined (TARGET_OSX)
 #include <OpenAL/al.h>
@@ -50,7 +51,7 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		ofOpenALSoundPlayer();
 		virtual ~ofOpenALSoundPlayer();
 
-		bool load(string fileName, bool stream = false);
+        bool load(std::filesystem::path fileName, bool stream = false);
 		void unload();
 		void play();
 		void stop();
@@ -94,15 +95,15 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		static void runWindow(vector<float> & signal);
 		static void initSystemFFT(int bands);
 
-		bool sfReadFile(string path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-		bool sfStream(string path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool sfReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool sfStream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
 #ifdef OF_USING_MPG123
-		bool mpg123ReadFile(string path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-		bool mpg123Stream(string path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool mpg123ReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool mpg123Stream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
 #endif
 
-		bool readFile(string fileName,vector<short> & buffer);
-		bool stream(string fileName, vector<short> & buffer);
+        bool readFile(std::filesystem::path fileName,vector<short> & buffer);
+        bool stream(std::filesystem::path fileName, vector<short> & buffer);
 
 		bool isStreaming;
 		bool bMultiPlay;

--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -76,7 +76,7 @@ shared_ptr<ofBaseSoundPlayer> ofSoundPlayer::getPlayer(){
 }
 
 //--------------------------------------------------------------------
-bool ofSoundPlayer::load(string fileName, bool stream){
+bool ofSoundPlayer::load(std::filesystem::path fileName, bool stream){
 	if( player ){
 		return player->load(fileName, stream);
 	}

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -87,7 +87,7 @@ public:
     ///
     /// \param fileName Path to the sound file, relative to your app's data folder.
     /// \param stream set "true" to enable streaming from disk (for large files).
-    bool load(string fileName, bool stream = false);
+    bool load(std::filesystem::path fileName, bool stream = false);
     OF_DEPRECATED_MSG("Use load",bool loadSound(string fileName, bool stream = false));
 
     /// \brief Stops and unloads the current sound.

--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -167,7 +167,9 @@ void ofSoundStream::setDeviceID(int deviceID){
 
 //------------------------------------------------------------
 void ofSoundStream::setDevice(const ofSoundDevice &device) {
-	setDeviceID(device.deviceID);
+    if( soundStream ){
+        tmpDeviceId = device.deviceID;
+    }
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -464,7 +464,7 @@ public:
 	/// \param name The name of the video resource to load.
 	/// \returns True if the video was loaded successfully.
 	/// \sa loadAsync()
-	virtual bool				load(string name) = 0;
+    virtual bool				load(string name) = 0;
 	/// \brief Asynchronously load a video resource by name.
 	///
 	/// The list of supported video types and sources (e.g. rtsp:// sources) is
@@ -475,7 +475,7 @@ public:
 	///
 	/// \param name The name of the video resource to load.
 	/// \sa isLoaded()
-	virtual void				loadAsync(string name);
+    virtual void				loadAsync(string name);
 	
 	/// \brief Play the video from the current playhead position.
 	/// \sa getPosition()
@@ -1954,14 +1954,14 @@ public:
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \param path file path to save to
 	/// \return HTTP response on success or failure
-	virtual ofHttpResponse saveTo(const string& url, const string& path)=0;
+    virtual ofHttpResponse saveTo(const string& url, const std::filesystem::path& path)=0;
 	
 	/// \brief make an asynchronous HTTP request and save the response data to a file
 	/// will not block, placed in a queue and run using a background thread
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \param path file path to save to
 	/// \returns unique id for the active HTTP request
-	virtual int saveAsync(const string& url, const string& path)=0;
+    virtual int saveAsync(const string& url, const std::filesystem::path& path)=0;
 	
 	/// \brief remove an active HTTP request from the queue
 	/// \param unique HTTP request id

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -31,12 +31,6 @@ ofBuffer::ofBuffer(const char * _buffer, std::size_t size)
 }
 
 //--------------------------------------------------
-ofBuffer::ofBuffer(const string & text)
-:buffer(text.begin(),text.end())
-,currentLine(end(),end()){
-}
-
-//--------------------------------------------------
 ofBuffer::ofBuffer(istream & stream, size_t ioBlockSize)
 :currentLine(end(),end()){
 	set(stream, ioBlockSize);
@@ -330,13 +324,13 @@ istream & operator>>(istream & istr, ofBuffer & buf){
 }
 
 //--------------------------------------------------
-ofBuffer ofBufferFromFile(const string & path, bool binary){
+ofBuffer ofBufferFromFile(const std::filesystem::path & path, bool binary){
 	ofFile f(path,ofFile::ReadOnly, binary);
 	return ofBuffer(f);
 }
 
 //--------------------------------------------------
-bool ofBufferToFile(const string & path, const ofBuffer& buffer, bool binary){
+bool ofBufferToFile(const std::filesystem::path & path, const ofBuffer& buffer, bool binary){
 	ofFile f(path, ofFile::WriteOnly, binary);
 	return buffer.writeTo(f);
 }
@@ -1378,8 +1372,8 @@ vector<ofFile>::const_reverse_iterator ofDirectory::rend() const{
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::addLeadingSlash(const std::string& _path){
-	std::string path = _path;
+string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
+    auto path = _path.string();
 	auto sep = std::filesystem::path("/").make_preferred();
 	if(!path.empty()){
 		if(ofToString(path[0]) != sep.string()){
@@ -1390,9 +1384,8 @@ string ofFilePath::addLeadingSlash(const std::string& _path){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::addTrailingSlash(const std::string& _path){
-	std::string path = _path;
-	path = std::filesystem::path(path).make_preferred().string();
+string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
+    auto path = std::filesystem::path(_path).make_preferred().string();
 	auto sep = std::filesystem::path("/").make_preferred();
 	if(!path.empty()){
 		if(ofToString(path.back()) != sep.string()){
@@ -1404,32 +1397,32 @@ string ofFilePath::addTrailingSlash(const std::string& _path){
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getFileExt(const std::string& filename){
+string ofFilePath::getFileExt(const std::filesystem::path& filename){
 	return ofFile(filename,ofFile::Reference).getExtension();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::removeExt(const std::string& filename){
+string ofFilePath::removeExt(const std::filesystem::path& filename){
 	return ofFilePath::join(getEnclosingDirectory(filename,false), ofFile(filename,ofFile::Reference).getBaseName());
 }
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getPathForDirectory(const std::string& path){
+string ofFilePath::getPathForDirectory(const std::filesystem::path& path){
 	// if a trailing slash is missing from a path, this will clean it up
 	// if it's a windows-style "\" path it will add a "\"
 	// if it's a unix-style "/" path it will add a "/"
 	auto sep = std::filesystem::path("/").make_preferred();
-	if(!path.empty() && ofToString(path.back())!=sep.string()){
-		return (std::filesystem::path(path) / sep).string();
+    if(!path.empty() && ofToString(path.string().back())!=sep.string()){
+        return (path / sep).string();
 	}else{
-		return path;
+        return path.string();
 	}
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::removeTrailingSlash(const std::string& _path){
-	std::string path = _path;
+string ofFilePath::removeTrailingSlash(const std::filesystem::path& _path){
+    auto path = _path.string();
 	if(path.length() > 0 && (path[path.length() - 1] == '/' || path[path.length() - 1] == '\\')){
 		path = path.substr(0, path.length() - 1);
 	}
@@ -1438,24 +1431,24 @@ string ofFilePath::removeTrailingSlash(const std::string& _path){
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getFileName(const std::string& _filePath, bool bRelativeToData){
-	std::string filePath = _filePath;
+string ofFilePath::getFileName(const std::filesystem::path& _filePath, bool bRelativeToData){
+    std::string filePath = _filePath.string();
 
 	if(bRelativeToData){
-		filePath = ofToDataPath(filePath);
+        filePath = ofToDataPath(_filePath);
 	}
 
 	return std::filesystem::path(filePath).filename().string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getBaseName(const std::string& filePath){
+string ofFilePath::getBaseName(const std::filesystem::path& filePath){
 	return ofFile(filePath,ofFile::Reference).getBaseName();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getEnclosingDirectory(const std::string& _filePath, bool bRelativeToData){
-	std::string filePath = _filePath;
+string ofFilePath::getEnclosingDirectory(const std::filesystem::path& _filePath, bool bRelativeToData){
+    std::string filePath = _filePath.string();
 	if(bRelativeToData){
 		filePath = ofToDataPath(filePath);
 	}
@@ -1463,12 +1456,12 @@ string ofFilePath::getEnclosingDirectory(const std::string& _filePath, bool bRel
 }
 
 //------------------------------------------------------------------------------------------------------------
-bool ofFilePath::createEnclosingDirectory(const std::string& filePath, bool bRelativeToData, bool bRecursive) {
+bool ofFilePath::createEnclosingDirectory(const std::filesystem::path& filePath, bool bRelativeToData, bool bRecursive) {
 	return ofDirectory::createDirectory(ofFilePath::getEnclosingDirectory(filePath), bRelativeToData, bRecursive);
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getAbsolutePath(const std::string& path, bool bRelativeToData){
+string ofFilePath::getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData){
 	if(bRelativeToData){
 		return ofToDataPath(path, true);
 	}else{
@@ -1482,7 +1475,7 @@ string ofFilePath::getAbsolutePath(const std::string& path, bool bRelativeToData
 
 
 //------------------------------------------------------------------------------------------------------------
-bool ofFilePath::isAbsolute(const std::string& path){
+bool ofFilePath::isAbsolute(const std::filesystem::path& path){
 	return std::filesystem::path(path).is_absolute();
 }
 
@@ -1492,7 +1485,7 @@ string ofFilePath::getCurrentWorkingDirectory(){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::join(const std::string& path1, const std::string& path2){
+string ofFilePath::join(const std::filesystem::path& path1, const std::filesystem::path& path2){
 	return (std::filesystem::path(path1) / std::filesystem::path(path2)).string();
 }
 
@@ -1547,7 +1540,7 @@ string ofFilePath::getUserHomeDir(){
 	#endif
 }
 
-string ofFilePath::makeRelative(const std::string & from, const std::string & to){
+string ofFilePath::makeRelative(const std::filesystem::path & from, const std::filesystem::path & to){
 	auto pathFrom = std::filesystem::absolute( from );
 	auto pathTo = std::filesystem::absolute( to );
 	std::filesystem::path ret;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -29,12 +29,7 @@ public:
 	/// \param _size the number of bytes to read
 	/// \warning buffer *must* not be NULL
 	/// \warning _size *must* be <= the number of bytes allocated in _buffer
-	ofBuffer(const char * buffer, std::size_t size);
-	
-	/// \brief Create a buffer and set its contents from a string.
-	///
-	/// \param text string to copy data from
-	ofBuffer(const string & text);
+    ofBuffer(const char * buffer, std::size_t size);
 	
 	/// \brief Create a buffer and set its contents from an input stream.
 	///
@@ -219,7 +214,7 @@ private:
 /// \param path file to open
 /// \param binary set to false if you are reading a text file & want lines
 /// split at endline characters automatically
-ofBuffer ofBufferFromFile(const string & path, bool binary=true);
+ofBuffer ofBufferFromFile(const std::filesystem::path & path, bool binary=true);
 
 //--------------------------------------------------
 /// \brief Write the contents of a buffer to a file at path.
@@ -230,7 +225,7 @@ ofBuffer ofBufferFromFile(const string & path, bool binary=true);
 /// \param buffer data source to write from
 /// \param binary set to false if you are writing a text file & want lines
 /// split at endline characters automatically
-bool ofBufferToFile(const string & path, const ofBuffer& buffer, bool binary=true);
+bool ofBufferToFile(const std::filesystem::path & path, const ofBuffer& buffer, bool binary=true);
 
 //--------------------------------------------------
 /// \class ofFilePath
@@ -244,32 +239,32 @@ public:
 	///
 	/// \param filename file path
 	/// \returns filename extension only
-	static string getFileExt(const std::string& filename);
+    static string getFileExt(const std::filesystem::path& filename);
 	
 	/// \brief Remove extension from a filename, ie. "duck.jpg" ->"duck".
 	///
 	/// \param filename file path
 	/// \returns filename without extension
-	static string removeExt(const std::string& filename);
+    static string removeExt(const std::filesystem::path& filename);
 	
 	/// \brief Prepend path with a slash, ie. "images" -> "/images".
 	///
 	/// \param path file or directory path
 	/// \returns slah + path
-	static string addLeadingSlash(const std::string& path);
+    static string addLeadingSlash(const std::filesystem::path& path);
 	
 	/// \brief Append path with a slash, ie. "images" -> "images/".
 	///
 	/// \param path directory path
 	/// \returns path + slash
-	static string addTrailingSlash(const std::string& path);
+    static string addTrailingSlash(const std::filesystem::path& path);
 	
 	/// \brief Remove a path's trailing slash (if found),
 	/// ie. "images/" -> "images".
 	///
 	/// \param path directory path
 	/// \returns path minus trailing slash
-	static string removeTrailingSlash(const std::string& path);
+    static string removeTrailingSlash(const std::filesystem::path& path);
 	
 	/// \brief Cleaned up a directory path by adding a trailing slash if needed.
 	///
@@ -278,7 +273,7 @@ public:
 	///
 	/// \param path directory path
 	/// \returns cleaned path + trailing slash (if needed)
-	static string getPathForDirectory(const std::string& path);
+    static string getPathForDirectory(const std::filesystem::path& path);
 	
 	/// \brief Get the absolute, full path for a given path,
 	/// ie. "images" -> "/Users/mickey/of/apps/myApps/Donald/bin/data/images".
@@ -288,7 +283,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	/// \returns absolute path
-	static string getAbsolutePath(const std::string& path, bool bRelativeToData = true);
+    static string getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData = true);
 
 	/// \brief Check if a path is an absolute (aka a full path),
 	/// ie. "images" -> false,
@@ -296,7 +291,7 @@ public:
 	///
 	/// \param path file or directory path
 	/// \returns true if the path is an absolute path
-	static bool isAbsolute(const std::string& path);
+    static bool isAbsolute(const std::filesystem::path& path);
 	
 	/// \brief Get the filename of a given path by stripping the parent
 	/// directories ie. "images/duck.jpg" -> "duck.jpg", assumes the path is in
@@ -307,7 +302,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	/// \returns filename
-	static string getFileName(const std::string& filePath, bool bRelativeToData = true);
+    static string getFileName(const std::filesystem::path& filePath, bool bRelativeToData = true);
 	
 	/// \brief Get a file path without its last component,
 	/// ie. "images/duck.jpg" -> "images" and
@@ -315,7 +310,7 @@ public:
 	///
 	/// \param filePath file path
 	/// \returns basename
-	static string getBaseName(const std::string& filePath);
+    static string getBaseName(const std::filesystem::path& filePath);
 
 	/// \brief Get the enclosing parent directory of a path,
 	/// ie. "images/duck.jpg" -> "images", assumes the path is in the data
@@ -326,7 +321,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	///\returns enclosing directory
-	static string getEnclosingDirectory(const std::string& filePath, bool bRelativeToData = true);
+    static string getEnclosingDirectory(const std::filesystem::path& filePath, bool bRelativeToData = true);
 	
 	/// \brief Create the enclosing parent directory of a path, ie.
 	/// "images" is the enclosing directory of "duck.jpg" = "images/duck.jpg".
@@ -340,7 +335,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	/// \returns true if the enclosing directory was created
-	static bool createEnclosingDirectory(const std::string& filePath, bool bRelativeToData = true, bool bRecursive = true);
+    static bool createEnclosingDirectory(const std::filesystem::path& filePath, bool bRelativeToData = true, bool bRecursive = true);
 	
 	/// \brief Get the full path to the app's current working directory.
 	///
@@ -358,7 +353,7 @@ public:
 	/// \param path1 left half of the path to join
 	/// \param path2 right half of the path to join
 	/// \returns joined path
-	static string join(const std::string& path1, const std::string& path2);
+    static string join(const std::filesystem::path& path1, const std::filesystem::path& path2);
 	
 	/// \brief Get the full path to the application's executable file.
 	///
@@ -393,7 +388,7 @@ public:
 	/// \param from starting path
 	/// \param to destination path
 	/// \returns relative path
-	static string makeRelative(const std::string & from, const std::string & to);
+    static string makeRelative(const std::filesystem::path & from, const std::filesystem::path & to);
 };
 
 /// \class ofFile

--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -49,7 +49,7 @@ ofLogLevel ofGetLogLevel(string module){
 }
 
 //--------------------------------------------------
-void ofLogToFile(const string & path, bool append){
+void ofLogToFile(const std::filesystem::path & path, bool append){
 	ofLog::setChannel(shared_ptr<ofFileLoggerChannel>(new ofFileLoggerChannel(path,append)));
 }
 
@@ -297,7 +297,7 @@ void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const 
 ofFileLoggerChannel::ofFileLoggerChannel(){
 }
 
-ofFileLoggerChannel::ofFileLoggerChannel(const string & path, bool append){
+ofFileLoggerChannel::ofFileLoggerChannel(const std::filesystem::path & path, bool append){
 	setFile(path,append);
 }
 
@@ -309,7 +309,7 @@ void ofFileLoggerChannel::close(){
 	file.close();
 }
 
-void ofFileLoggerChannel::setFile(const string & path,bool append){
+void ofFileLoggerChannel::setFile(const std::filesystem::path & path,bool append){
 	file.open(path,append?ofFile::Append:ofFile::WriteOnly);
 	file << endl;
 	file << endl;

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -206,7 +206,7 @@ class ofBaseLoggerChannel;
 /// \brief Set the logging to output to a file instead of the console.
 /// \param path The path to the log file to use.
 /// \param append True if you want to append to the existing file.
-void ofLogToFile(const string & path, bool append=false);
+void ofLogToFile(const std::filesystem::path & path, bool append=false);
 
 /// \brief Set the logging to ouptut to the console.
 /// 
@@ -393,7 +393,7 @@ class ofLog{
 		/// \param format The printf-style format string.
 		ofLog(ofLogLevel level, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 		
-		/// \}
+		/// \}
 	
 		//--------------------------------------------------
 		/// \name Logging configuration
@@ -643,7 +643,7 @@ public:
 	/// \brief Create an ofFileLoggerChannel with parameters.
 	/// \param path The file path for the log file.
 	/// \param append True if the log data should be added to an existing file.
-	ofFileLoggerChannel(const string & path, bool append);
+    ofFileLoggerChannel(const std::filesystem::path & path, bool append);
 
 	/// \brief Destroy the file logger channel.
 	virtual ~ofFileLoggerChannel();
@@ -651,7 +651,7 @@ public:
 	/// \brief Set the log file.
 	/// \param path The file path for the log file.
 	/// \param append True if the log data should be added to an existing file.
-	void setFile(const string & path,bool append=false);
+    void setFile(const std::filesystem::path & path,bool append=false);
 
 	void log(ofLogLevel level, const string & module, const string & message);
 	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -45,8 +45,8 @@ public:
 	ofURLFileLoaderImpl();
     ofHttpResponse get(const string& url);
     int getAsync(const string& url, const string& name=""); // returns id
-    ofHttpResponse saveTo(const string& url, const string& path);
-    int saveAsync(const string& url, const string& path);
+    ofHttpResponse saveTo(const string& url, const std::filesystem::path& path);
+    int saveAsync(const string& url, const std::filesystem::path& path);
 	void remove(int id);
 	void clear();
     void stop();
@@ -102,13 +102,13 @@ int ofURLFileLoaderImpl::getAsync(const string& url, const string& name){
 }
 
 
-ofHttpResponse ofURLFileLoaderImpl::saveTo(const string& url, const string& path){
-    ofHttpRequest request(url,path,true);
+ofHttpResponse ofURLFileLoaderImpl::saveTo(const string& url, const std::filesystem::path& path){
+    ofHttpRequest request(url,path.string(),true);
     return handleRequest(request);
 }
 
-int ofURLFileLoaderImpl::saveAsync(const string& url, const string& path){
-	ofHttpRequest request(url,path,true);
+int ofURLFileLoaderImpl::saveAsync(const string& url, const std::filesystem::path& path){
+    ofHttpRequest request(url,path.string(),true);
 	requests.send(request);
 	start();
 	return request.getId();
@@ -268,11 +268,11 @@ int ofURLFileLoader::getAsync(const string& url, const string& name){
 	return impl->getAsync(url,name);
 }
 
-ofHttpResponse ofURLFileLoader::saveTo(const string& url, const string& path){
+ofHttpResponse ofURLFileLoader::saveTo(const string& url, const std::filesystem::path & path){
 	return impl->saveTo(url,path);
 }
 
-int ofURLFileLoader::saveAsync(const string& url, const string& path){
+int ofURLFileLoader::saveAsync(const string& url, const std::filesystem::path & path){
 	return impl->saveAsync(url,path);
 }
 

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -66,7 +66,7 @@ int ofLoadURLAsync(const string& url, const string& name=""); // returns id
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \param path file path to save to
 /// \return HTTP response on success or failure
-ofHttpResponse ofSaveURLTo(const string& url, const string& path);
+ofHttpResponse ofSaveURLTo(const string& url, const std::filesystem::path& path);
 
 /// make an asynchronous HTTP request for a url and save the response to a file at path
 /// \returns unique request id for the active HTTP request
@@ -76,7 +76,7 @@ ofHttpResponse ofSaveURLTo(const string& url, const string& path);
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \param path file path to save to
 /// \returns unique id for the active HTTP request
-int ofSaveURLAsync(const string& url, const string& path);
+int ofSaveURLAsync(const string& url, const std::filesystem::path& path);
 
 /// \brief remove an active HTTP request from the queue
 /// \param unique HTTP request id
@@ -127,14 +127,14 @@ class ofURLFileLoader  {
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \param path file path to save to
 		/// \return HTTP response on success or failure
-		ofHttpResponse saveTo(const string& url, const string& path);
+        ofHttpResponse saveTo(const string& url, const std::filesystem::path& path);
 	
 		/// \brief make an asynchronous HTTP request and save the response data to a file
 		/// will not block, placed in a queue and run using a background thread
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \param path file path to save to
 		/// \returns unique id for the active HTTP request
-		int saveAsync(const string& url, const string& path);
+        int saveAsync(const string& url, const std::filesystem::path& path);
 	
 		/// \brief remove an active HTTP request from the queue
 		/// \param unique HTTP request id

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -332,11 +332,11 @@ void ofSetDataPathRoot(const string& newRoot){
 }
 
 //--------------------------------------------------
-string ofToDataPath(const string& path, bool makeAbsolute){
+string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
 	if (!enableDataPath)
-		return path;
+        return path.string();
 
-    bool hasTrailingSlash = !path.empty() && std::filesystem::path(path).generic_string().back()=='/';
+    bool hasTrailingSlash = !path.empty() && path.generic_string().back()=='/';
 
 	// if our Current Working Directory has changed (e.g. file open dialog)
 #ifdef TARGET_WIN32

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -171,7 +171,7 @@ void ofDisableDataPath();
 /// \param path The path to make relative to the data/ folder.
 /// \param absolute Set to true to return an absolute path.
 /// \returns the new path, unless paths were disabled with ofDisableDataPath().
-string ofToDataPath(const string& path, bool absolute=false);
+string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
 
 /// \brief Reset the working directory to the platform default.
 ///

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -39,7 +39,7 @@ ofXml::ofXml(){
 }
 
 
-bool ofXml::load(const string & path){
+bool ofXml::load(const std::filesystem::path & path){
 	ofFile file(path, ofFile::ReadOnly);
 	if(!file.exists()){
 		ofLogError("ofXml") << "couldn't load, \"" << file.getFileName() << "\" not found";
@@ -50,8 +50,9 @@ bool ofXml::load(const string & path){
 }
 
 
-bool ofXml::save(const string & path){
-    ofBuffer buffer(toString());
+bool ofXml::save(const std::filesystem::path & path){
+    ofBuffer buffer;
+    buffer.set(toString());
     ofFile file(path, ofFile::WriteOnly);
     return file.writeFromBuffer(buffer);
 }

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -38,8 +38,8 @@ public:
     ofXml( const ofXml& rhs );
     const ofXml& operator =( const ofXml& rhs );
 
-	bool load(const string & path);
-	bool save(const string & path);
+    bool load(const std::filesystem::path & path);
+    bool save(const std::filesystem::path & path);
 
     bool            addChild( const string& path );
     void            addXml( ofXml& xml, bool copyAll = false);

--- a/tests/utils/buffer/src/main.cpp
+++ b/tests/utils/buffer/src/main.cpp
@@ -27,7 +27,8 @@ class ofApp: public ofxUnitTestsApp{
 			ofLogNotice() << "-------------------";
 			ofLogNotice() << "text constructor allocator";
 			std::string text("This is a text test");
-			ofBuffer buffer(text);
+			ofBuffer buffer;
+			buffer.set(text);
 			test_eq(buffer.size(), text.size(), "constructor does correct allocation");
 			test(buffer.end() == buffer.begin() + text.size(), "correct boundaries");
 			bool bufferEqual = true;


### PR DESCRIPTION
Old code should work unmodified and it allows to use all the facilities of
filesystem path without having to convert to string before passing the path.

For example:

```cpp
std::string shaderPath = ofFilePath::join(somepath, "shader.vert");
ofShader shader;
shader.setupFromFile(GL_VERTEX_SHADER, shaderPath);
```

can now be:

```cpp
ofShader shader;
shader.setupFromFile(GL_VERTEX_SHADER, somepath / "shader.vert");
```