### PR TITLE
Android - Fix compilation error on OS X

### DIFF
--- a/libs/openFrameworksCompiled/project/android/config.android.default.mk
+++ b/libs/openFrameworksCompiled/project/android/config.android.default.mk
@@ -446,7 +446,7 @@ PLATFORM_LIBRARY_SEARCH_PATHS =
 
 PLATFORM_CC=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/clang
 PLATFORM_CXX=$(NDK_ROOT)/toolchains/$(TOOLCHAIN)/prebuilt/$(HOST_PLATFORM)/bin/clang++
-PLATFORM_AR=ar
+PLATFORM_AR=$(NDK_ROOT)/toolchains/arm-linux-androideabi-4.9/prebuilt/$(HOST_PLATFORM)/arm-linux-androideabi/bin/ar
 PLATFORM_LD=$(NDK_ROOT)/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/arm-linux-androideabi/bin/ld
 
 #ifeq (,$(findstring MINGW32_NT,$(shell uname)))


### PR DESCRIPTION
The ar command is apparently not configured to create compatible .a file and thus the linking fails on OSX.

I fixed the error by giving the path to ar explicitly. I hope this line is properly generalized and will work on other OSs. I only have access to OSX right now.