### PR TITLE
ofShader: add methods to change constant and defines values

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -1217,6 +1217,7 @@ void ofShader::setConstantb(const string & name, bool value){
             auto & shader = shader_pair.second;
             shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "const bool " + name + "=" + (value?"true":"false") + ";");
         }
+#ifndef TARGET_OPENGLES
         if(bLoadedAsXFB){
             auto settings = TransformFeedbackSettings();
             settings.bindDefaults = boundDefaults;
@@ -1227,13 +1228,16 @@ void ofShader::setConstantb(const string & name, bool value){
             settings.bufferMode = xfbBufferMode;
             setup(settings);
         }else{
+#endif
             auto settings = Settings();
             settings.bindDefaults = boundDefaults;
             for(auto & shader_pair: shaders){
                 settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
             }
             setup(settings);
+#ifndef TARGET_OPENGLES
         }
+#endif
     }
 #endif
 }

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -200,7 +200,7 @@ bool ofShader::load(std::filesystem::path vertName, std::filesystem::path fragNa
 #endif
 	if(ofIsGLProgrammableRenderer()){
 		bindDefaults();
-	}
+    }
 	return linkProgram();
 }
 
@@ -231,7 +231,7 @@ bool ofShader::setup(const Settings & settings) {
 	
 	if (ofIsGLProgrammableRenderer() && settings.bindDefaults) {
 		bindDefaults();
-	}
+    }
 
 	return linkProgram();
 }
@@ -257,9 +257,10 @@ bool ofShader::setup(const TransformFeedbackSettings & settings) {
 
 	if (ofIsGLProgrammableRenderer() && settings.bindDefaults) {
 		bindDefaults();
-	}
+    }
 
 	if (!settings.varyingsToCapture.empty()) {
+        varyingsToCapture = settings.varyingsToCapture;
 		std::vector<const char*> varyings(settings.varyingsToCapture.size());
 		std::transform(settings.varyingsToCapture.begin(), settings.varyingsToCapture.end(), varyings.begin(), [](const std::string & str) {
 			return str.c_str();
@@ -267,7 +268,9 @@ bool ofShader::setup(const TransformFeedbackSettings & settings) {
         glTransformFeedbackVaryings(getProgram(), varyings.size(), varyings.data(), settings.bufferMode);
 	}
 
-	return linkProgram();
+    xfbBufferMode = settings.bufferMode;
+    bLoadedAsXFB = linkProgram();
+    return bLoadedAsXFB;
 }
 #endif
 
@@ -722,7 +725,7 @@ void ofShader::bindAttribute(GLuint location, const string & name) const{
 }
 
 //--------------------------------------------------------------
-bool ofShader::bindDefaults() const{
+bool ofShader::bindDefaults(){
 	if(shaders.empty()) {
 		ofLogError("ofShader") << "bindDefaults(): trying to link GLSL program, but no shaders created yet";
 		return false;
@@ -731,6 +734,7 @@ bool ofShader::bindDefaults() const{
 		bindAttribute(ofShader::COLOR_ATTRIBUTE,::COLOR_ATTRIBUTE);
 		bindAttribute(ofShader::NORMAL_ATTRIBUTE,::NORMAL_ATTRIBUTE);
 		bindAttribute(ofShader::TEXCOORD_ATTRIBUTE,::TEXCOORD_ATTRIBUTE);
+        boundDefaults = true;
 		return true;
 	}
 
@@ -783,6 +787,9 @@ void ofShader::unload() {
 #endif
 	}
 	bLoaded = false;
+    boundDefaults = false;
+    bLoadedAsXFB = false;
+    varyingsToCapture.clear();
 }
 
 //--------------------------------------------------------------
@@ -1069,6 +1076,151 @@ void ofShader::setUniforms(const ofParameterGroup & parameters) const{
 			setUniforms((ofParameterGroup&)parameters[i]);
 		}
 	}
+}
+
+
+//--------------------------------------------------------------
+template<typename T>
+void ofShader::setDefineConstantTemp(const string & name, T value){
+#if (!defined(TARGET_LINUX) || defined(GCC_HAS_REGEX))
+    if(bLoaded){
+        std::regex re_define("#define[ \t]+" + name + "[ \t]+(([0-9]+)|(([0-9]*).([0-9]*)))");
+        for(auto & shader_pair: shaders){
+            auto & shader = shader_pair.second;
+            shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
+        }
+        if(bLoadedAsXFB){
+            auto settings = TransformFeedbackSettings();
+            settings.bindDefaults = boundDefaults;
+            settings.varyingsToCapture = varyingsToCapture;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            settings.bufferMode = xfbBufferMode;
+            setup(settings);
+        }else{
+            auto settings = Settings();
+            settings.bindDefaults = boundDefaults;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            setup(settings);
+        }
+    }
+#endif
+}
+
+//--------------------------------------------------------------
+void ofShader::setDefineConstant(const string & name, float value){
+    setDefineConstantTemp(name, value);
+}
+
+//--------------------------------------------------------------
+void ofShader::setDefineConstant(const string & name, int value){
+    setDefineConstantTemp(name, value);
+}
+
+//--------------------------------------------------------------
+void ofShader::setDefineConstant(const string & name, bool value){
+#if (!defined(TARGET_LINUX) || defined(GCC_HAS_REGEX))
+    if(bLoaded){
+        std::regex re_define("#define[ \t]+" + name + "[ \t]+(([0-1])|(true|false))");
+        for(auto & shader_pair: shaders){
+            auto & shader = shader_pair.second;
+            shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
+        }
+        if(bLoadedAsXFB){
+            auto settings = TransformFeedbackSettings();
+            settings.bindDefaults = boundDefaults;
+            settings.varyingsToCapture = varyingsToCapture;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            settings.bufferMode = xfbBufferMode;
+            setup(settings);
+        }else{
+            auto settings = Settings();
+            settings.bindDefaults = boundDefaults;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            setup(settings);
+        }
+    }
+#endif
+}
+
+
+
+//--------------------------------------------------------------
+template<typename T>
+void ofShader::setConstantTemp(const string & name, const string & type, T value){
+#if (!defined(TARGET_LINUX) || defined(GCC_HAS_REGEX))
+    if(bLoaded){
+        std::regex re_define("const[ \t]+" + type + "[ \t]+" + name + "[ \t]*=[ \t]*(([0-9]+)|(([0-9]*).([0-9]*)));");
+        for(auto & shader_pair: shaders){
+            auto & shader = shader_pair.second;
+            shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "const " + type + " " + name + " " + std::to_string(value) + ";");
+        }
+        if(bLoadedAsXFB){
+            auto settings = TransformFeedbackSettings();
+            settings.bindDefaults = boundDefaults;
+            settings.varyingsToCapture = varyingsToCapture;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            settings.bufferMode = xfbBufferMode;
+            setup(settings);
+        }else{
+            auto settings = Settings();
+            settings.bindDefaults = boundDefaults;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            setup(settings);
+        }
+    }
+#endif
+}
+
+//--------------------------------------------------------------
+void ofShader::setConstant1f(const string & name, float value){
+    setConstantTemp(name, "float", value);
+}
+
+//--------------------------------------------------------------
+void ofShader::setConstant1i(const string & name, int value){
+    setConstantTemp(name, "int", value);
+}
+
+//--------------------------------------------------------------
+void ofShader::setConstantb(const string & name, bool value){
+#if (!defined(TARGET_LINUX) || defined(GCC_HAS_REGEX))
+    if(bLoaded){
+        std::regex re_define("const[ \t]+bool[ \t]+" + name + "[ \t]*=[ \t]*(([0-1])|(true|false));");
+        for(auto & shader_pair: shaders){
+            auto & shader = shader_pair.second;
+            shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "const bool " + name + "=" + (value?"true":"false") + ";");
+        }
+        if(bLoadedAsXFB){
+            auto settings = TransformFeedbackSettings();
+            settings.bindDefaults = boundDefaults;
+            settings.varyingsToCapture = varyingsToCapture;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            settings.bufferMode = xfbBufferMode;
+            setup(settings);
+        }else{
+            auto settings = Settings();
+            settings.bindDefaults = boundDefaults;
+            for(auto & shader_pair: shaders){
+                settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
+            }
+            setup(settings);
+        }
+    }
+#endif
 }
 	
 //--------------------------------------------------------------

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -1089,6 +1089,7 @@ void ofShader::setDefineConstantTemp(const string & name, T value){
             auto & shader = shader_pair.second;
             shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
         }
+#ifndef TARGET_OPENGLES
         if(bLoadedAsXFB){
             auto settings = TransformFeedbackSettings();
             settings.bindDefaults = boundDefaults;
@@ -1099,13 +1100,16 @@ void ofShader::setDefineConstantTemp(const string & name, T value){
             settings.bufferMode = xfbBufferMode;
             setup(settings);
         }else{
+#endif
             auto settings = Settings();
             settings.bindDefaults = boundDefaults;
             for(auto & shader_pair: shaders){
                 settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
             }
             setup(settings);
+#ifndef TARGET_OPENGLES
         }
+#endif
     }
 #endif
 }
@@ -1129,6 +1133,7 @@ void ofShader::setDefineConstant(const string & name, bool value){
             auto & shader = shader_pair.second;
             shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
         }
+#ifndef TARGET_OPENGLES
         if(bLoadedAsXFB){
             auto settings = TransformFeedbackSettings();
             settings.bindDefaults = boundDefaults;
@@ -1139,13 +1144,16 @@ void ofShader::setDefineConstant(const string & name, bool value){
             settings.bufferMode = xfbBufferMode;
             setup(settings);
         }else{
+#endif
             auto settings = Settings();
             settings.bindDefaults = boundDefaults;
             for(auto & shader_pair: shaders){
                 settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
             }
             setup(settings);
+#ifndef TARGET_OPENGLES
         }
+#endif
     }
 #endif
 }
@@ -1162,6 +1170,7 @@ void ofShader::setConstantTemp(const string & name, const string & type, T value
             auto & shader = shader_pair.second;
             shader.expandedSource = std::regex_replace(shader.expandedSource, re_define, "const " + type + " " + name + " " + std::to_string(value) + ";");
         }
+#ifndef TARGET_OPENGLES
         if(bLoadedAsXFB){
             auto settings = TransformFeedbackSettings();
             settings.bindDefaults = boundDefaults;
@@ -1172,13 +1181,16 @@ void ofShader::setConstantTemp(const string & name, const string & type, T value
             settings.bufferMode = xfbBufferMode;
             setup(settings);
         }else{
+#endif
             auto settings = Settings();
             settings.bindDefaults = boundDefaults;
             for(auto & shader_pair: shaders){
                 settings.shaderSources[shader_pair.first] = shader_pair.second.expandedSource;
             }
             setup(settings);
+#ifndef TARGET_OPENGLES
         }
+#endif
     }
 #endif
 }

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -788,8 +788,11 @@ void ofShader::unload() {
 	}
 	bLoaded = false;
     boundDefaults = false;
+
+#ifndef TARGET_OPENGLES
     bLoadedAsXFB = false;
     varyingsToCapture.clear();
+#endif
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -127,10 +127,34 @@ public:
 	
 	void setUniforms(const ofParameterGroup & parameters) const;
 
+    /// Changes a numerical define value
+    ///
+    /// Allows to change a define in the shader declared like
+    ///
+    /// #define SOME_FEATURE 1
+    ///
+    /// calling setDefineConstant("SOME_FEATURE", 0);
+    ///
+    /// Be aware that this recompiles the shader which can be
+    /// slow if done often. This is only recommendable for
+    /// values that don't change very often and if they
+    /// were a uniform would introduce runtime evaluated
+    /// conditionals or similar which would slow down the shader
     void setDefineConstant(const string & name, float value);
     void setDefineConstant(const string & name, int value);
     void setDefineConstant(const string & name, bool value);
 
+
+    /// Changes a numerical define value
+    ///
+    /// Allows to change a define in the shader declared like
+    ///
+    /// const float somevalue=10;
+    ///
+    /// calling setConstant1f("somevalue", 20.f);
+    ///
+    /// Be aware that this recompiles the shader which can be
+    /// slow if done often.
     void setConstant1f(const string & name, float value);
     void setConstant1i(const string & name, int value);
     void setConstantb(const string & name, bool value);
@@ -222,10 +246,12 @@ public:
 private:
     GLuint program = 0;
     bool bLoaded = false;
-    bool bLoadedAsXFB = false;
     bool boundDefaults = false;
+#ifndef TARGET_OPENGLES
+    bool bLoadedAsXFB = false;
     GLuint xfbBufferMode = GL_INTERLEAVED_ATTRIBS;
     std::vector<std::string> varyingsToCapture;
+#endif
 
 	struct Shader{
 		GLenum type;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -127,6 +127,14 @@ public:
 	
 	void setUniforms(const ofParameterGroup & parameters) const;
 
+    void setDefineConstant(const string & name, float value);
+    void setDefineConstant(const string & name, int value);
+    void setDefineConstant(const string & name, bool value);
+
+    void setConstant1f(const string & name, float value);
+    void setConstant1i(const string & name, int value);
+    void setConstantb(const string & name, bool value);
+
 	// note: it may be more optimal to use a 4x4 matrix than a 3x3 matrix, if possible
 	void setUniformMatrix3f(const string & name, const glm::mat3 & m, int count = 1) const;
 	void setUniformMatrix4f(const string & name, const glm::mat4 & m, int count = 1) const;
@@ -188,7 +196,7 @@ public:
 	// binds default uniforms and attributes, only useful for
 	// fixed pipeline simulation under programmable renderer
 	// has to be called before linking
-	bool bindDefaults() const;
+    bool bindDefaults();
 
 	GLuint getProgram() const;
 	GLuint getShader(GLenum type) const;
@@ -212,8 +220,12 @@ public:
 
 
 private:
-	GLuint program;
-	bool bLoaded;
+    GLuint program = 0;
+    bool bLoaded = false;
+    bool bLoadedAsXFB = false;
+    bool boundDefaults = false;
+    GLuint xfbBufferMode = GL_INTERLEAVED_ATTRIBS;
+    std::vector<std::string> varyingsToCapture;
 
 	struct Shader{
 		GLenum type;
@@ -236,7 +248,11 @@ private:
 
 	void checkProgramInfoLog(GLuint program);
 	bool checkProgramLinkStatus(GLuint program);
-	void checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLevel);
+    void checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLevel);
+    template<typename T>
+    void setDefineConstantTemp(const string & name, T value);
+    template<typename T>
+    void setConstantTemp(const string & name, const std::string & type, T value);
 	
 	static string nameForType(GLenum type);
 	


### PR DESCRIPTION
in a shader with a define like:

```cpp
#define USE_SOME_FEATURE 1
```

you can now call:

```cpp
shader.setDefineConstant(USE_SOME_FEATURE, 0);
```

to disable it.

There's a similar method for const numerical or boolean values. in
this case the types are more strict similar to how setUniform* works.

This recompiles the shader so it's slow to use but it can be faster
than uniforms in several cases, usually when it's used for values
that won't change often and would introduce a conditional or a for
loop with bounds comming from a uniform which makes the compiler
unable to unroll the loop.