### PR TITLE
Fixed the ofSerial::buildDeviceList() method on OS X

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -152,8 +152,8 @@ void ofSerial::buildDeviceList(){
 
 	#ifdef TARGET_OSX
 
-		prefixMatch.push_back("cu.");
-		prefixMatch.push_back("tty.");
+		prefixMatch.push_back("/dev/cu.");
+		prefixMatch.push_back("/dev/tty.");
 
 	#endif
 


### PR DESCRIPTION
See the issue #5221