### PR TITLE
ofLog: add debugview log channel

### DIFF
--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -20,6 +20,8 @@ static void noopDeleter(ofBaseLoggerChannel*){}
 #ifdef TARGET_ANDROID
 	#include "ofxAndroidLogChannel.h"
 	shared_ptr<ofBaseLoggerChannel> ofLog::channel = shared_ptr<ofxAndroidLogChannel>(new ofxAndroidLogChannel,std::ptr_fun(noopDeleter));
+#elif defined(TARGET_WIN32)
+	shared_ptr<ofBaseLoggerChannel> ofLog::channel = IsDebuggerPresent() ? shared_ptr<ofBaseLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)) : shared_ptr<ofBaseLoggerChannel>(new ofConsoleLoggerChannel, std::ptr_fun(noopDeleter));
 #else
 	shared_ptr<ofBaseLoggerChannel> ofLog::channel = shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter));
 #endif
@@ -57,6 +59,12 @@ void ofLogToFile(const std::filesystem::path & path, bool append){
 void ofLogToConsole(){
 	ofLog::setChannel(shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter)));
 }
+
+#ifdef TARGET_WIN32
+void ofLogToDebugView() {
+	ofLog::setChannel(shared_ptr<ofDebugViewLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)));
+}
+#endif
 
 //--------------------------------------------------
 ofLog::ofLog(){
@@ -292,6 +300,41 @@ void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const 
 	vfprintf(out, format, args);
 	fprintf(out, "\n");
 }
+
+
+#ifdef TARGET_WIN32
+#include <array>
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const string & message) {
+	// print to cerr for OF_LOG_ERROR and OF_LOG_FATAL_ERROR, everything else to cout 
+	stringstream out;
+	out << "[" << ofGetLogLevelName(level, true) << "] ";
+	// only print the module name if it's not ""
+	if (module != "") {
+		out << module << ": ";
+	}
+	out << message << endl;
+	OutputDebugStringA(out.str().c_str());
+}
+
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const char* format, ...) {
+	va_list args;
+	va_start(args, format);
+	log(level, module, format, args);
+	va_end(args);
+
+}
+
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const char* format, va_list args) {
+	std::array<char, 1024> logBuffer;
+	sprintf(logBuffer.data(), "[%s] ", ofGetLogLevelName(level, true).c_str());
+	if (module != "") {
+		sprintf(logBuffer.data(), "%s: ", module.c_str());
+	}
+	vsprintf(logBuffer.data(), format, args);
+	sprintf(logBuffer.data(), "\n");
+	OutputDebugStringA(logBuffer.data());
+}
+#endif
 
 //--------------------------------------------------
 ofFileLoggerChannel::ofFileLoggerChannel(){

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -214,6 +214,14 @@ void ofLogToFile(const std::filesystem::path & path, bool append=false);
 /// after ofLogToFile or ofSetLoggerChannel has been called.
 void ofLogToConsole();
 
+#ifdef TARGET_WIN32
+/// Set the logging to ouptut to windows debug view or visual studio console
+/// 
+/// This is the default state and can be called to reset console logging
+/// after ofLogToFile or ofSetLoggerChannel has been called.
+void ofLogToDebugView();
+#endif
+
 /// \brief Set the logger to use a custom logger channel.
 ///
 /// Custom logger channels must extend ofBaseLoggerChannel. Custom log channels
@@ -633,6 +641,18 @@ public:
 	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
 	void log(ofLogLevel level, const string & module, const char* format, va_list args);
 };
+
+#ifdef TARGET_WIN32
+/// A logger channel that logs its messages to windows debug view and visual studio output.
+class ofDebugViewLoggerChannel : public ofBaseLoggerChannel {
+public:
+	/// \brief Destroy the console logger channel.
+	virtual ~ofDebugViewLoggerChannel() {};
+	void log(ofLogLevel level, const string & module, const string & message);
+	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
+	void log(ofLogLevel level, const string & module, const char* format, va_list args);
+};
+#endif
 
 /// \brief A logger channel that logs its messages to a log file.
 class ofFileLoggerChannel: public ofBaseLoggerChannel{


### PR DESCRIPTION
allows to log to visual studio console and the debug view tool in windows instead of logging to the console window that opens with the application

by default when running in visual studio windows applications will use that logger otherwise they'll use the normal console log