### PR TITLE
Remove deprecated ofRotate*() functions and replace with updated ofRo…

### DIFF
--- a/examples/3d/3DPrimitivesExample/src/ofApp.cpp
+++ b/examples/3d/3DPrimitivesExample/src/ofApp.cpp
@@ -5,13 +5,13 @@ void ofApp::setup(){
 
 	ofSetVerticalSync(true);
 	ofBackground(20);
-    
+
     // GL_REPEAT for texture wrap only works with NON-ARB textures //
     ofDisableArbTex();
     texture.load("of.png");
     texture.getTexture().setTextureWrap( GL_REPEAT, GL_REPEAT );
     vidGrabber.setup(640, 480, true);
-    
+
     bFill       = true;
     bWireframe  = true;
     bDrawNormals= false;
@@ -20,10 +20,10 @@ void ofApp::setup(){
     bHelpText   = true;
     bMousePressed   = false;
     bSplitFaces = false;
-    
+
     float width     = ofGetWidth() * .12;
     float height    = ofGetHeight() * .12;
-    
+
 
     plane.set( width*1.5, height*1.5 );
     box.set( width*1.25 );
@@ -31,26 +31,26 @@ void ofApp::setup(){
     icoSphere.setRadius( width );
     cylinder.set(width*.7, height*2.2);
     cone.set( width*.75, height*2.2 );
-    
+
     mode = 0;
-    
+
     ofSetSmoothLighting(true);
     pointLight.setDiffuseColor( ofFloatColor(.85, .85, .55) );
     pointLight.setSpecularColor( ofFloatColor(1.f, 1.f, 1.f));
-    
+
     pointLight2.setDiffuseColor( ofFloatColor( 238.f/255.f, 57.f/255.f, 135.f/255.f ));
     pointLight2.setSpecularColor(ofFloatColor(.8f, .8f, .9f));
-    
+
     pointLight3.setDiffuseColor( ofFloatColor(19.f/255.f,94.f/255.f,77.f/255.f) );
     pointLight3.setSpecularColor( ofFloatColor(18.f/255.f,150.f/255.f,135.f/255.f) );
-    
+
     // shininess is a value between 0 - 128, 128 being the most shiny //
     material.setShininess( 120 );
     // the light highlight of the material //
     material.setSpecularColor(ofColor(255, 255, 255, 255));
-    
+
     ofSetSphereResolution(24);
-    
+
 }
 
 //--------------------------------------------------------------
@@ -58,13 +58,13 @@ void ofApp::update() {
     pointLight.setPosition((ofGetWidth()*.5)+ cos(ofGetElapsedTimef()*.5)*(ofGetWidth()*.3), ofGetHeight()/2, 500);
     pointLight2.setPosition((ofGetWidth()*.5)+ cos(ofGetElapsedTimef()*.15)*(ofGetWidth()*.3),
                             ofGetHeight()*.5 + sin(ofGetElapsedTimef()*.7)*(ofGetHeight()), -300);
-    
+
     pointLight3.setPosition(
                             cos(ofGetElapsedTimef()*1.5) * ofGetWidth()*.5,
                             sin(ofGetElapsedTimef()*1.5f) * ofGetWidth()*.5,
                             cos(ofGetElapsedTimef()*.2) * ofGetWidth()
     );
-    
+
 	//ofSetWindowTitle("Framerate: "+ofToString(ofGetFrameRate(), 0));
     if(mode == 2 || ofGetElapsedTimef() < 10) {
         vidGrabber.update();
@@ -74,16 +74,16 @@ void ofApp::update() {
 //--------------------------------------------------------------
 void ofApp::draw() {
 	ofSetDrawBitmapMode(OF_BITMAPMODE_MODEL_BILLBOARD);
-    
+
     float spinX = sin(ofGetElapsedTimef()*.35f);
     float spinY = cos(ofGetElapsedTimef()*.075f);
-    
+
     if(bMousePressed) {
         spinX = spinY = 0.0f;
     }
-    
+
     ofEnableDepthTest();
-    
+
     ofEnableLighting();
     pointLight.enable();
     pointLight2.enable();
@@ -99,14 +99,14 @@ void ofApp::draw() {
 
     if(mode == 1 || mode == 3) texture.getTexture().bind();
     if(mode == 2) vidGrabber.getTexture().bind();
-    
-    
+
+
     // Plane //
     plane.setPosition(ofGetWidth()*.2, ofGetHeight()*.25, 0);
     plane.rotate(spinX, 1.0, 0.0, 0.0);
     plane.rotate(spinY, 0, 1.0, 0.0);
-    
-    
+
+
     if(mode == 3) {
         deformPlane = plane.getMesh();
         // x = columns, y = rows //
@@ -130,7 +130,7 @@ void ofApp::draw() {
         // and the wireframe will be drawn in black
         material.begin();
     }
-    
+
     if(bFill) {
         material.begin();
         ofFill();
@@ -150,14 +150,14 @@ void ofApp::draw() {
 		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z+1);
         plane.drawWireframe();
 		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z-1);
-        
+
     }
 
     // Box //
     box.setPosition(ofGetWidth()*.5, ofGetHeight()*.25, 0);
     box.rotate(spinX, 1.0, 0.0, 0.0);
     box.rotate(spinY, 0, 1.0, 0.0);
-    
+
     if(bFill) {
         material.begin();
         ofFill();
@@ -183,18 +183,18 @@ void ofApp::draw() {
         box.drawWireframe();
         box.setScale(1.f);
     }
-    
-    
+
+
     // Sphere //
     sphere.setPosition(ofGetWidth()*.8f, ofGetHeight()*.25, 0);
     sphere.rotate(spinX, 1.0, 0.0, 0.0);
     sphere.rotate(spinY, 0, 1.0, 0.0);
-    
+
     if(mode == 3) {
         sphere.setMode( OF_PRIMITIVE_TRIANGLES );
         triangles = sphere.getMesh().getUniqueFaces();
     }
-    
+
     if(bFill) {
         material.begin();
         ofFill();
@@ -224,21 +224,21 @@ void ofApp::draw() {
         sphere.drawWireframe();
         sphere.setScale(1.f);
     }
-    
-    
+
+
     // ICO Sphere //
     icoSphere.setPosition(ofGetWidth()*.2, ofGetHeight()*.75, 0);
     icoSphere.rotate(spinX, 1.0, 0.0, 0.0);
     icoSphere.rotate(spinY, 0, 1.0, 0.0);
-    
+
     if(mode == 3) {
         triangles = icoSphere.getMesh().getUniqueFaces();
     }
-    
+
     if(bFill) {
         material.begin();
         ofFill();
-        
+
         if(mode == 3) {
             float angle = (ofGetElapsedTimef() * 1.4);
             ofVec3f faceNormal;
@@ -251,7 +251,7 @@ void ofApp::draw() {
             }
             icoSphere.getMesh().setFromTriangles( triangles );
         }
-        
+
         icoSphere.draw();
         material.end();
     }
@@ -263,15 +263,15 @@ void ofApp::draw() {
         icoSphere.drawWireframe();
         icoSphere.setScale(1.f);
     }
-    
-    
+
+
     // Cylinder //
     if(mode == 3) {
         topCap      = cylinder.getTopCapMesh();
         bottomCap   = cylinder.getBottomCapMesh();
         body        = cylinder.getCylinderMesh();
     }
-    
+
     cylinder.setPosition(ofGetWidth()*.5, ofGetHeight()*.75, 0);
     cylinder.rotate(spinX, 1.0, 0.0, 0.0);
     cylinder.rotate(spinY, 0, 1.0, 0.0);
@@ -311,13 +311,13 @@ void ofApp::draw() {
         cylinder.drawWireframe();
         cylinder.setScale(1.0f);
     }
-    
-    
+
+
     // Cone //
     cone.setPosition(ofGetWidth()*.8, ofGetHeight()*.75, 0);
     cone.rotate(spinX, 1.0, 0.0, 0.0);
     cone.rotate(spinY, 0, 1.0, 0.0);
-    
+
     if(mode == 3) {
         bottomCap   = cone.getCapMesh();
         body        = cone.getConeMesh();
@@ -330,14 +330,14 @@ void ofApp::draw() {
             ofPushMatrix();
             if(bottomCap.getNumNormals() > 0 ) {
                 ofTranslate( bottomCap.getNormal(0) * cone.getHeight()*.5 );
-                ofRotate( sin(ofGetElapsedTimef()*5) * RAD_TO_DEG, 1, 0, 0);
+                ofRotateDeg( sin(ofGetElapsedTimef()*5) * RAD_TO_DEG, 1, 0, 0);
                 bottomCap.draw();
             }
             ofPopMatrix();
-            
+
             ofPushMatrix();
-            ofRotate(90, 1, 0, 0);
-            ofRotate( (cos(ofGetElapsedTimef()*6) +1)*.5 * 360 , 1, 0, 0 );
+            ofRotateDeg(90, 1, 0, 0);
+            ofRotateDeg( (cos(ofGetElapsedTimef()*6) +1)*.5 * 360 , 1, 0, 0 );
             body.draw();
             ofPopMatrix();
             cone.restoreTransformGL();
@@ -358,13 +358,13 @@ void ofApp::draw() {
     if(!bFill && bWireframe){
         material.end();
     }
-    
+
     if(mode == 1 || mode == 3) texture.getTexture().unbind();
     if(mode == 2) vidGrabber.getTexture().unbind();
-    
+
     material.end();
     ofDisableLighting();
-    
+
     if(bDrawLights) {
         ofFill();
         ofSetColor(pointLight.getDiffuseColor());
@@ -374,7 +374,7 @@ void ofApp::draw() {
         ofSetColor(pointLight3.getDiffuseColor());
         pointLight3.draw();
     }
-    
+
     if(bDrawNormals) {
         ofSetColor(225, 0, 255);
         plane.drawNormals(20, bSplitFaces);
@@ -392,43 +392,43 @@ void ofApp::draw() {
         cylinder.drawAxes(cylinder.getHeight()+30);
         cone.drawAxes(cone.getHeight()+30);
     }
-    
+
     ofDisableDepthTest();
-    
+
     ofFill();
-    
+
     ofSetColor(0);
     ofDrawRectangle(plane.getPosition().x-154, plane.getPosition().y + 120, 140, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofPlanePrimitive", plane.getPosition().x-150, plane.getPosition().y+136 );
-    
+
     ofSetColor(0);
     ofDrawRectangle(box.getPosition().x-154, box.getPosition().y + 120, 126, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofBoxPrimitive", box.getPosition().x-150, box.getPosition().y+136 );
-    
+
     ofSetColor(0);
     ofDrawRectangle(sphere.getPosition().x-154, sphere.getPosition().y + 120, 148, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofSpherePrimitive", sphere.getPosition().x-150, sphere.getPosition().y+136 );
-    
+
     ofSetColor(0);
     ofDrawRectangle(icoSphere.getPosition().x-154, icoSphere.getPosition().y + 120, 168, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofIcoSpherePrimitive", icoSphere.getPosition().x-150, icoSphere.getPosition().y+136 );
-    
+
     ofSetColor(0);
     ofDrawRectangle(cylinder.getPosition().x-154, cylinder.getPosition().y + 120, 160, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofCylinderPrimitive", cylinder.getPosition().x-150, cylinder.getPosition().y+136 );
-    
+
     ofSetColor(0);
     ofDrawRectangle(cone.getPosition().x-154, cone.getPosition().y + 120, 136, 24);
     ofSetColor(255);
     ofDrawBitmapString("ofConePrimitive", cone.getPosition().x-150, cone.getPosition().y+136 );
-    
-    
-    
+
+
+
     if(bHelpText) {
         stringstream ss;
         ss << "FPS: " << ofToString(ofGetFrameRate(),0) << endl << endl;
@@ -438,16 +438,16 @@ void ofApp::draw() {
         ss <<"(a): Draw Axes"<<endl<<"(l): Render lights" << endl <<"(h): Toggle help."<<endl;
         ofDrawBitmapString(ss.str().c_str(), 20, 20);
     }
-    
-    
-    
-    
-    
+
+
+
+
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key) {
-    
+
 	switch(key) {
 		case 'f':
 			ofToggleFullscreen();
@@ -525,48 +525,48 @@ void ofApp::keyPressed(int key) {
             break;
         case 'z':
             bSplitFaces = !bSplitFaces;
-            
+
             if(mode == 3) bSplitFaces = false;
-            
+
             if(bSplitFaces) {
                 sphere.setMode( OF_PRIMITIVE_TRIANGLES );
                 vector<ofMeshFace> triangles = sphere.getMesh().getUniqueFaces();
                 sphere.getMesh().setFromTriangles( triangles, true );
-                
+
                 icoSphere.setMode( OF_PRIMITIVE_TRIANGLES );
                 triangles = icoSphere.getMesh().getUniqueFaces();
                 icoSphere.getMesh().setFromTriangles(triangles, true);
-                
+
                 plane.setMode( OF_PRIMITIVE_TRIANGLES );
                 triangles = plane.getMesh().getUniqueFaces();
                 plane.getMesh().setFromTriangles(triangles, true);
-                
+
                 cylinder.setMode( OF_PRIMITIVE_TRIANGLES );
                 triangles = cylinder.getMesh().getUniqueFaces();
                 cylinder.getMesh().setFromTriangles(triangles, true);
-                
+
                 cone.setMode( OF_PRIMITIVE_TRIANGLES );
                 triangles = cone.getMesh().getUniqueFaces();
                 cone.getMesh().setFromTriangles(triangles, true);
-                
+
                 box.setMode( OF_PRIMITIVE_TRIANGLES );
                 triangles = box.getMesh().getUniqueFaces();
                 box.getMesh().setFromTriangles(triangles, true);
-                
+
             } else {
                 // vertex normals are calculated with creation, set resolution //
                 sphere.setResolution( sphere.getResolution() );
-                
+
                 icoSphere.setResolution( icoSphere.getResolution() );
                 plane.setResolution( plane.getNumColumns(), plane.getNumRows() );
-                
+
                 cylinder.setResolution( cylinder.getResolutionRadius(), cylinder.getResolutionHeight(), cylinder.getResolutionCap() );
                 cone.setResolution( cone.getResolutionRadius(), cone.getResolutionHeight(), cone.getResolutionCap() );
                 box.setResolution( box.getResolutionWidth() );
             }
             break;
 	}
-    
+
     if(mode == 1) {
         // resize the plane to the size of the texture //
         plane.resizeToTexture( texture.getTexture() );
@@ -577,7 +577,7 @@ void ofApp::keyPressed(int key) {
         cylinder.mapTexCoordsFromTexture( texture.getTexture() );
         cone.mapTexCoordsFromTexture( texture.getTexture() );
     }
-    
+
     if(mode == 2) {
         plane.resizeToTexture( vidGrabber.getTexture(), .5 );
         box.mapTexCoordsFromTexture( vidGrabber.getTexture() );
@@ -586,12 +586,12 @@ void ofApp::keyPressed(int key) {
         cylinder.mapTexCoordsFromTexture( vidGrabber.getTexture() );
         cone.mapTexCoordsFromTexture( vidGrabber.getTexture() );
     }
-    
-    // 
+
+    //
     if( mode == 3 ) {
-        
+
         bSplitFaces = false;
-        
+
         // if the faces were split, we can get some weird results, since we
         // might not know what the new strides were,
         // so reset the primitives by calling their setMode function
@@ -602,17 +602,17 @@ void ofApp::keyPressed(int key) {
         cone.setMode( OF_PRIMITIVE_TRIANGLE_STRIP );
         // box only supports triangles //
         box.setMode( OF_PRIMITIVE_TRIANGLES );
-        
+
         plane.setMode( OF_PRIMITIVE_TRIANGLE_STRIP );
         plane.mapTexCoords(0, 0, 5, 5);
-        
-        // rebuild the box, 
+
+        // rebuild the box,
         box.mapTexCoords(0, 0, 5, 5);
         sphere.mapTexCoords(0, 0, 5, 5);
         icoSphere.mapTexCoords(0, 0, 5, 5);
         cylinder.mapTexCoords(0, 0, 5, 5);
         cone.mapTexCoords(0, 0, 5, 5);
-        
+
         // store the box sides so that we can manipulate them later //
         for(int i = 0; i < ofBoxPrimitive::SIDES_TOTAL; i++ ) {
             boxSides[i] = box.getSideMesh( i );
@@ -628,7 +628,7 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -668,6 +668,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/assimpExample/src/ofApp.cpp
+++ b/examples/3d/assimpExample/src/ofApp.cpp
@@ -10,7 +10,7 @@ void ofApp::setup(){
     bAnimate = false;
     bAnimateMouse = false;
     animationPosition = 0;
-    
+
     model.loadModel("astroBoy_walk.dae", false);
     model.setPosition(ofGetWidth() * 0.5, (float)ofGetHeight() * 0.75 , 0);
     model.setLoopStateForAllAnimations(OF_LOOP_NORMAL);
@@ -18,15 +18,15 @@ void ofApp::setup(){
     if(!bAnimate) {
         model.setPausedForAllAnimations(true);
     }
-    
+
     bHelpText = true;
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
     model.update();
-    
+
     if(bAnimateMouse) {
         model.setPositionForAllAnimations(animationPosition);
     }
@@ -37,11 +37,11 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
     ofSetColor(255);
-    
+
     ofEnableBlendMode(OF_BLENDMODE_ALPHA);
-    
+
 	ofEnableDepthTest();
-#ifndef TARGET_PROGRAMMABLE_GL    
+#ifndef TARGET_PROGRAMMABLE_GL
     glShadeModel(GL_SMOOTH); //some model / light stuff
 #endif
     light.enable();
@@ -49,23 +49,23 @@ void ofApp::draw(){
 
     ofPushMatrix();
     ofTranslate(model.getPosition().x+100, model.getPosition().y, 0);
-    ofRotate(-mouseX, 0, 1, 0);
+    ofRotateDeg(-mouseX, 0, 1, 0);
     ofTranslate(-model.getPosition().x, -model.getPosition().y, 0);
     model.drawFaces();
     ofPopMatrix();
-#ifndef TARGET_PROGRAMMABLE_GL    
+#ifndef TARGET_PROGRAMMABLE_GL
     glEnable(GL_NORMALIZE);
 #endif
     ofPushMatrix();
     ofTranslate(model.getPosition().x-300, model.getPosition().y, 0);
-    ofRotate(-mouseX, 0, 1, 0);
+    ofRotateDeg(-mouseX, 0, 1, 0);
     ofTranslate(-model.getPosition().x, -model.getPosition().y, 0);
-    
+
     ofxAssimpMeshHelper & meshHelper = model.getMeshHelper(0);
-    
+
     ofMultMatrix(model.getModelMatrix());
     ofMultMatrix(meshHelper.matrix);
-    
+
     ofMaterial & material = meshHelper.material;
     if(meshHelper.hasTexture()){
         meshHelper.getTextureRef().bind();
@@ -77,12 +77,12 @@ void ofApp::draw(){
         meshHelper.getTextureRef().unbind();
     }
     ofPopMatrix();
-    
+
     ofDisableDepthTest();
     light.disable();
     ofDisableLighting();
     ofDisableSeparateSpecularLight();
-    
+
     if(bHelpText){
     ofSetColor(255, 255, 255 );
     stringstream ss;

--- a/examples/3d/easyCamExample/src/ofApp.cpp
+++ b/examples/3d/easyCamExample/src/ofApp.cpp
@@ -3,39 +3,39 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofSetVerticalSync(true);
-	
+
 	// this uses depth information for occlusion
 	// rather than always drawing things on top of each other
 	ofEnableDepthTest();
-	
+
 	// this sets the camera's distance from the object
 	cam.setDistance(100);
-	
+
 	ofSetCircleResolution(64);
 	bHelpText = true;
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	
-	cam.begin();		
-	ofRotateX(ofRadToDeg(.5));
-	ofRotateY(ofRadToDeg(-.5));
-	
+
+	cam.begin();
+	ofRotateXRad(.5);
+	ofRotateYRad(-.5);
+
 	ofBackground(0);
-	
+
 	ofSetColor(255,0,0);
 	ofFill();
 	ofDrawBox(30);
 	ofNoFill();
 	ofSetColor(0);
 	ofDrawBox(30);
-	
+
 	ofPushMatrix();
 	ofTranslate(0,0,20);
 	ofSetColor(0,0,255);
@@ -48,7 +48,7 @@ void ofApp::draw(){
 	cam.end();
 	drawInteractionArea();
 	ofSetColor(255);
-	
+
     if (bHelpText) {
         stringstream ss;
         ss << "FPS: " << ofToString(ofGetFrameRate(),0) <<endl<<endl;
@@ -62,7 +62,7 @@ void ofApp::draw(){
         ss <<"(h): Toggle help."<<endl;
         ofDrawBitmapString(ss.str().c_str(), 20, 20);
     }
-    
+
 }
 //--------------------------------------------------------------
 void ofApp::drawInteractionArea(){
@@ -70,7 +70,7 @@ void ofApp::drawInteractionArea(){
 	float r = MIN(vp.width, vp.height) * 0.5f;
 	float x = vp.width * 0.5f;
 	float y = vp.height * 0.5f;
-	
+
 	ofPushStyle();
 	ofSetLineWidth(3);
 	ofSetColor(255, 255, 0);
@@ -88,7 +88,7 @@ void ofApp::keyPressed(int key){
 			if(cam.getMouseInputEnabled()) cam.disableMouseInput();
 			else cam.enableMouseInput();
 			break;
-			
+
 		case 'F':
 		case 'f':
 			ofToggleFullscreen();
@@ -102,27 +102,27 @@ void ofApp::keyPressed(int key){
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -137,15 +137,15 @@ void ofApp::mouseExited(int x, int y){
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
-	
+void ofApp::dragEvent(ofDragInfo dragInfo){
+
 }

--- a/examples/3d/modelNoiseExample/src/ofApp.cpp
+++ b/examples/3d/modelNoiseExample/src/ofApp.cpp
@@ -16,21 +16,21 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	
+
 	ofSetFrameRate(60);
 	ofSetVerticalSync(true);
 	ofBackground(50, 50, 50, 0);
 
 	//we need to call this for textures to work on models
     ofDisableArbTex();
-	
+
 	//this makes sure that the back of the model doesn't show through the front
 	ofEnableDepthTest();
 
 	//now we load our model
 	model.loadModel("dog/dog.3ds");
 	model.setPosition(ofGetWidth()*.5, ofGetHeight() * 0.75, 0);
-	
+
 	light.enable();
     light.setPosition(model.getPosition() + ofPoint(0, 0, 1600));
 }
@@ -43,34 +43,34 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
     ofSetColor(255, 255, 255, 255);
-	
+
 	//first let's just draw the model with the model object
 	//drawWithModel();
-	
+
 	//then we'll learn how to draw it manually so that we have more control over the data
 	drawWithMesh();
 }
 
 //draw the model the built-in way
 void ofApp::drawWithModel(){
-	
+
 	//get the position of the model
 	ofVec3f position = model.getPosition();
 
 	//save the current view
 	ofPushMatrix();
-	
+
 	//center ourselves there
 	ofTranslate(position);
-	ofRotate(-ofGetMouseX(), 0, 1, 0);
-	ofRotate(90,1,0,0);
+	ofRotateDeg(-ofGetMouseX(), 0, 1, 0);
+	ofRotateDeg(90,1,0,0);
 	ofTranslate(-position);
-	
+
 	//draw the model
 	model.drawFaces();
-	
+
 	//restore the view position
-    ofPopMatrix();	
+    ofPopMatrix();
 }
 
 //draw the model manually
@@ -87,31 +87,31 @@ void ofApp::drawWithMesh(){
     if( bHasTexture ) {
         texture = model.getTextureForMesh(0);
     }
-    
-	ofMaterial material = model.getMaterialForMesh(0);
-	
-    ofPushMatrix();
-	
-	//translate and scale based on the positioning. 
-	ofTranslate(position);
-	ofRotate(-ofGetMouseX(), 0, 1, 0);
-	ofRotate(90,1,0,0);
 
-	
+	ofMaterial material = model.getMaterialForMesh(0);
+
+    ofPushMatrix();
+
+	//translate and scale based on the positioning.
+	ofTranslate(position);
+	ofRotateDeg(-ofGetMouseX(), 0, 1, 0);
+	ofRotateDeg(90,1,0,0);
+
+
 	ofScale(normalizedScale, normalizedScale, normalizedScale);
 	ofScale(scale.x,scale.y,scale.z);
-	
+
 	//modify mesh with some noise
 	float liquidness = 5;
 	float amplitude = mouseY/100.0;
-	float speedDampen = 5;		
+	float speedDampen = 5;
 	vector<ofVec3f>& verts = mesh.getVertices();
 	for(unsigned int i = 0; i < verts.size(); i++){
 		verts[i].x += ofSignedNoise(verts[i].x/liquidness, verts[i].y/liquidness,verts[i].z/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 		verts[i].y += ofSignedNoise(verts[i].z/liquidness, verts[i].x/liquidness,verts[i].y/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 		verts[i].z += ofSignedNoise(verts[i].y/liquidness, verts[i].z/liquidness,verts[i].x/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 	}
-		
+
 	//draw the model manually
 	if(bHasTexture) texture.bind();
 	material.begin();
@@ -119,7 +119,7 @@ void ofApp::drawWithMesh(){
 	mesh.drawFaces();
 	material.end();
 	if(bHasTexture) texture.unbind();
-	
+
 	ofPopMatrix();
 
 }
@@ -175,6 +175,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/ofBoxExample/src/ofApp.cpp
+++ b/examples/3d/ofBoxExample/src/ofApp.cpp
@@ -7,15 +7,15 @@ void ofApp::setup(){
 	// this uses depth information for occlusion
 	// rather than always drawing things on top of each other
 	ofEnableDepthTest();
-	
+
 	// ofBox uses texture coordinates from 0-1, so you can load whatever
 	// sized images you want and still use them to texture your box
 	// but we have to explicitly normalize our tex coords here
 	ofEnableNormalizedTexCoords();
-	
+
 	// loads the OF logo from disk
 	ofLogo.load("of.png");
-	
+
 	// draw the ofBox outlines with some weight
 	ofSetLineWidth(10);
 }
@@ -28,45 +28,45 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofBackground(0, 0, 0);
-	
+
 	float movementSpeed = .1;
 	float cloudSize = ofGetWidth() / 2;
 	float maxBoxSize = 100;
 	float spacing = 1;
 	int boxCount = 100;
-	
+
 	cam.begin();
-	
+
 	for(int i = 0; i < boxCount; i++) {
 		ofPushMatrix();
-		
+
 		float t = (ofGetElapsedTimef() + i * spacing) * movementSpeed;
 		ofVec3f pos(
 			ofSignedNoise(t, 0, 0),
 			ofSignedNoise(0, t, 0),
 			ofSignedNoise(0, 0, t));
-		
+
 		float boxSize = maxBoxSize * ofNoise(pos.x, pos.y, pos.z);
-		
+
 		pos *= cloudSize;
 		ofTranslate(pos);
-		ofRotateX(pos.x);
-		ofRotateY(pos.y);
-		ofRotateZ(pos.z);
-		
+		ofRotateXDeg(pos.x);
+		ofRotateYDeg(pos.y);
+		ofRotateZDeg(pos.z);
+
 		ofLogo.bind();
 		ofFill();
 		ofSetColor(255);
 		ofDrawBox(boxSize);
 		ofLogo.unbind();
-		
+
 		ofNoFill();
 		ofSetColor(ofColor::fromHsb(sinf(t) * 128 + 128, 255, 255));
 		ofDrawBox(boxSize * 1.1f);
-		
+
 		ofPopMatrix();
 	}
-	
+
 	cam.end();
 }
 
@@ -122,6 +122,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/orientationExample/src/ofApp.cpp
+++ b/examples/3d/orientationExample/src/ofApp.cpp
@@ -4,20 +4,20 @@
 	rotateToNormal will rotate everything using ofRotate. the rotation amount
 	and axis are generated using an ofQuaternion. the trick is to use ofQuaternion
 	to determine the rotation that is required from a standard axis (0,0,1) to the
-	desired normal vector, then apply that rotation. 
+	desired normal vector, then apply that rotation.
 */
 //--------------------------------------------------------------
 void rotateToNormal(ofVec3f normal) {
 	normal.normalize();
-	
+
 	float rotationAmount;
 	ofVec3f rotationAngle;
 	ofQuaternion rotation;
-	
+
 	ofVec3f axis(0, 0, 1);
 	rotation.makeRotate(axis, normal);
 	rotation.getRotate(rotationAmount, rotationAngle);
-	ofRotate(rotationAmount, rotationAngle.x, rotationAngle.y, rotationAngle.z);
+	ofRotateDeg(rotationAmount, rotationAngle.x, rotationAngle.y, rotationAngle.z);
 }
 
 //--------------------------------------------------------------
@@ -30,21 +30,21 @@ void ofApp::setup(){
 //--------------------------------------------------------------
 void ofApp::update(){
 	previous = current;
-	
-	// generate a noisy 3d position over time 
+
+	// generate a noisy 3d position over time
 	float t = (2 + ofGetElapsedTimef()) * .1;
 	current.x = ofSignedNoise(t, 0, 0);
 	current.y = ofSignedNoise(0, t, 0);
 	current.z = ofSignedNoise(0, 0, t);
 	current *= 400; // scale from -1,+1 range to -400,+400
-	
+
 	// add the current position to the pathVertices deque
 	pathVertices.push_back(current);
 	// if we have too many vertices in the deque, get rid of the oldest ones
 	while(pathVertices.size() > 200) {
 		pathVertices.pop_front();
 	}
-	
+
 	// clear the pathLines ofMesh from any old vertices
 	pathLines.clear();
 	// add all the vertices from pathVertices
@@ -58,25 +58,25 @@ void ofApp::draw(){
 	ofColor cyan = ofColor::fromHex(0x00abec);
 	ofColor magenta = ofColor::fromHex(0xec008c);
 	ofColor yellow = ofColor::fromHex(0xffee00);
-	
+
 	ofBackgroundGradient(magenta * .6, magenta * .4);
 	ofNoFill();
-	
+
 	easyCam.begin();
-	ofRotateX(15);
+	ofRotateXDeg(15);
 
 	ofSetColor(0);
 	ofDrawGrid(500, 10, false, false, true, false);
-	
+
 	// draw the path of the box
 	ofSetLineWidth(2);
 	ofSetColor(cyan);
 	pathLines.draw();
-	
+
 	// draw a line connecting the box to the grid
 	ofSetColor(yellow);
 	ofDrawLine(current.x, current.y, current.z, current.x, 0, current.z);
-	
+
 	ofTranslate(current.x, current.y, current.z);
     if( (current - previous ).length() > 0.0 ){
         // translate and rotate every 3D object after this line to the current position and orientation of our line, but only if the line is longer than 0 or has a length
@@ -85,7 +85,7 @@ void ofApp::draw(){
 	ofSetColor(255);
 	ofDrawBox(32);
 	ofDrawAxis(32);
-	
+
 	easyCam.end();
 }
 
@@ -140,6 +140,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/pointCloudExample/src/ofApp.cpp
+++ b/examples/3d/pointCloudExample/src/ofApp.cpp
@@ -3,13 +3,13 @@
 //--------------------------------------------------------------
 void ofApp::setup() {
 	ofSetVerticalSync(true);
-	
+
 	// load an image from disk
 	img.load("linzer.png");
-	
+
 	// we're going to load a ton of points into an ofMesh
 	mesh.setMode(OF_PRIMITIVE_POINTS);
-	
+
 	// loop through the image in the x and y axes
 	int skip = 4; // load a subset of the points
 	for(int y = 0; y < img.getHeight(); y += skip) {
@@ -39,11 +39,11 @@ void ofApp::update() {
 //--------------------------------------------------------------
 void ofApp::draw() {
 	ofBackgroundGradient(ofColor::gray, ofColor::black, OF_GRADIENT_CIRCULAR);
-	
+
 	// even points can overlap with each other, let's avoid that
 	cam.begin();
 	ofScale(2, -2, 2); // flip the y axis and zoom in a bit
-	ofRotateY(90);
+	ofRotateYDeg(90);
 	ofTranslate(-img.getWidth() / 2, -img.getHeight() / 2);
 	mesh.draw();
 	cam.end();
@@ -100,6 +100,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/quaternionArcballExample/src/ofApp.cpp
+++ b/examples/3d/quaternionArcballExample/src/ofApp.cpp
@@ -26,20 +26,20 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	
+
 	//translate so that 0,0 is the center of the screen
     ofPushMatrix();
-    ofTranslate(ofGetWidth()/2, ofGetHeight()/2, 40);  
+    ofTranslate(ofGetWidth()/2, ofGetHeight()/2, 40);
 	//Extract the rotation from the current rotation
-    ofVec3f axis;  
-    float angle;  
-    curRot.getRotate(angle, axis);  
-	
+    ofVec3f axis;
+    float angle;
+    curRot.getRotate(angle, axis);
+
 	//apply the quaternion's rotation to the viewport and draw the sphere
-	ofRotate(angle, axis.x, axis.y, axis.z);  
+	ofRotateDeg(angle, axis.x, axis.y, axis.z);  
 	ofDrawSphere(0, 0, 0, 200);
-	
-	ofPopMatrix();  
+
+	ofPopMatrix();
 }
 
 //--------------------------------------------------------------
@@ -58,14 +58,14 @@ void ofApp::mouseMoved(int x, int y ){
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 	//every time the mouse is dragged, track the change
 	//accumulate the changes inside of curRot through multiplication
-    ofVec2f mouse(x,y);  
-    ofQuaternion yRot((x-lastMouse.x)*dampen, ofVec3f(0,1,0));  
-    ofQuaternion xRot((y-lastMouse.y)*dampen, ofVec3f(-1,0,0));  
-    curRot *= yRot*xRot;  
-    lastMouse = mouse;  
+    ofVec2f mouse(x,y);
+    ofQuaternion yRot((x-lastMouse.x)*dampen, ofVec3f(0,1,0));
+    ofQuaternion xRot((y-lastMouse.y)*dampen, ofVec3f(-1,0,0));
+    curRot *= yRot*xRot;
+    lastMouse = mouse;
 }
 
 //--------------------------------------------------------------
@@ -100,6 +100,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/3d/quaternionLatLongExample/src/ofApp.cpp
+++ b/examples/3d/quaternionLatLongExample/src/ofApp.cpp
@@ -10,26 +10,26 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	
+
 	ofSetFrameRate(30);
 	ofEnableAlphaBlending();
 	ofNoFill();
-	
-	// create little objects for each city. 
-	// A Lat/Lon like this: 
+
+	// create little objects for each city.
+	// A Lat/Lon like this:
 	// Lewiston, Idaho 	W 46 24' N 117 2'
 	// This translate to angles and degrees (1 degree = 1/60. of an angle)
 	// West and South are negative values
-	
+
 	// here is a list of big cities and their positions
 	// http://www.infoplease.com/ipa/A0001796.html
-	
+
 	City newyork = { "new york", 40+47/60., -73 + 58/60. };
 	City tokyo = { "tokyo", 35 + 40./60, 139 + 45/60. };
 	City london = { "london", 51 + 32/60., -5./60. };
 	City shanghai = { "shanghai", 31 + 10/60., 121 + 28/60. };
 	City buenosaires = { "buenos aires", -34 + 35/60., -58 + 22/60. };
-	City melbourne = { "melbourne" , -37 + 47/60., 144 + 58/60. };	
+	City melbourne = { "melbourne" , -37 + 47/60., 144 + 58/60. };
 	City detroit = { "detroit", 42 + 19/60., -83 + 2 / 60. };
 
 	cities.push_back( newyork );
@@ -43,51 +43,51 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::update(){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofBackground(0);
-	
+
 	ofPushMatrix();
-	
+
 	//translate so that the center of the screen is 0,0
 	ofTranslate(ofGetWidth()/2, ofGetHeight()/2);
 	ofSetColor(255, 255, 255, 20);
-	
+
 	//draw a translucent wireframe sphere (ofNoFill() is on)
 	ofPushMatrix();
 	//add an extra spin at the rate of 1 degree per frame
-	ofRotate(ofGetFrameNum(), 0, 1, 0);
+	ofRotateDeg(ofGetFrameNum(), 0, 1, 0);
 	ofDrawSphere(0, 0, 0, 300);
 	ofPopMatrix();
-	
-	ofSetColor(255);	
+
+	ofSetColor(255);
 	for(unsigned int i = 0; i < cities.size(); i++){
-		
+
 		//three rotations
 		//two to represent the latitude and lontitude of the city
-		//a third so that it spins along with the spinning sphere 
+		//a third so that it spins along with the spinning sphere
 		ofQuaternion latRot, longRot, spinQuat;
 		latRot.makeRotate(cities[i].latitude, 1, 0, 0);
 		longRot.makeRotate(cities[i].longitude, 0, 1, 0);
 		spinQuat.makeRotate(ofGetFrameNum(), 0, 1, 0);
-		
+
 		//our starting point is 0,0, on the surface of our sphere, this is where the meridian and equator meet
 		ofVec3f center = ofVec3f(0,0,300);
 		//multiplying a quat with another quat combines their rotations into one quat
 		//multiplying a quat to a vector applies the quat's rotation to that vector
 		//so to to generate our point on the sphere, multiply all of our quaternions together then multiple the centery by the combined rotation
 		ofVec3f worldPoint = latRot * longRot * spinQuat * center;
-		
+
 		//draw it and label it
 		ofDrawLine(ofVec3f(0,0,0), worldPoint);
 
 		//set the bitmap text mode billboard so the points show up correctly in 3d
 		ofDrawBitmapString(cities[i].name, worldPoint );
 	}
-	
+
 	ofPopMatrix();
 }
 
@@ -142,6 +142,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/android/androidAssimpExample/src/ofApp.cpp
+++ b/examples/android/androidAssimpExample/src/ofApp.cpp
@@ -30,7 +30,7 @@ void ofApp::setup(){
 //--------------------------------------------------------------
 void ofApp::update(){
     model.update();
-    
+
     if(bAnimateMouse) {
         model.setPositionForAllAnimations(animationPosition);
     }
@@ -44,7 +44,7 @@ void ofApp::draw(){
 
     ofPushMatrix();
     ofTranslate(model.getPosition().x+100, model.getPosition().y, 0);
-    ofRotate(-mouseX, 0, 1, 0);
+    ofRotateDeg(-mouseX, 0, 1, 0);
     ofTranslate(-model.getPosition().x, -model.getPosition().y, 0);
     model.drawFaces();
     ofPopMatrix();
@@ -53,7 +53,7 @@ void ofApp::draw(){
 
     ofPushMatrix();
     ofTranslate(model.getPosition().x-300, model.getPosition().y, 0);
-    ofRotate(-mouseX, 0, 1, 0);
+    ofRotateDeg(-mouseX, 0, 1, 0);
     ofTranslate(-model.getPosition().x, -model.getPosition().y, 0);
 
     ofxAssimpMeshHelper & meshHelper = model.getMeshHelper(0);

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -47,7 +47,7 @@ void ofApp::update(){
 }
 
 //--------------------------------------------------------------
-void ofApp::draw(){    
+void ofApp::draw(){
 	// Calculate aspect ratio of grabber image
 	float grabberAspectRatio = grabber.getWidth() / grabber.getHeight();
 
@@ -61,14 +61,14 @@ void ofApp::draw(){
 
 	if(cameraFacingFront) {
 		// If the camera is front, then rotate clockwise
-		ofRotate(appOrientation);
+		ofRotateDeg(appOrientation);
 	} else {
 		// If the camera is backfacing, then rotate counter clockwise
-		ofRotate(-appOrientation);
+		ofRotateDeg(-appOrientation);
 	}
 
 	// Rotate the cameras orientation offset
-	ofRotate(cameraOrientation);
+	ofRotateDeg(cameraOrientation);
 
 	int width = ofGetWidth();
 	int height = ofGetHeight();
@@ -115,13 +115,13 @@ void ofApp::draw(){
 }
 
 //--------------------------------------------------------------
-void ofApp::keyPressed  (int key){ 
-	
+void ofApp::keyPressed  (int key){
+
 }
 
 //--------------------------------------------------------------
-void ofApp::keyReleased(int key){ 
-	
+void ofApp::keyReleased(int key){
+
 }
 
 //--------------------------------------------------------------

--- a/examples/android/androidVBOExample/src/ofApp.cpp
+++ b/examples/android/androidVBOExample/src/ofApp.cpp
@@ -81,8 +81,8 @@ void ofApp::draw() {
 	ofPushMatrix();
 	ofTranslate(ofGetWidth()/2, ofGetHeight()/2, zoom);
 
-	ofRotate(mouseX, 1, 0, 0);
-	ofRotate(mouseY, 0, 1, 1);
+	ofRotateDeg(mouseX, 1, 0, 0);
+	ofRotateDeg(mouseY, 0, 1, 1);
 
 
 	// the lines

--- a/examples/events/customEventExample/src/Bug.h
+++ b/examples/events/customEventExample/src/Bug.h
@@ -2,30 +2,30 @@
 #include "ofMain.h"
 
 class Bug {
-    
-public:  
-    
+
+public:
+
     ofVec2f          pos, vel;
     float            size;
     vector <ofVec2f> squashPts;
     bool             bSquashed;
     bool             bRemove;
     float            timeBugKilled;
-    
-    Bug() {        
-        
+
+    Bug() {
+
         bRemove       = false;
         bSquashed     = false;
         size          = 10;
         timeBugKilled = 0;
-        
+
         // make a squash shape
         int nPts = 10;
         for(int i=0; i<nPts; i++) {
             squashPts.push_back(ofVec2f(ofRandom(-4, 4), ofRandom(-4, 4)));
         }
     }
-    
+
     void update() {
         if(!bSquashed) {
             pos += vel;
@@ -40,37 +40,37 @@ public:
             }
         }
     }
-    
+
     void draw() {
-        
-        ofSetHexColor(0x688736);               
+
+        ofSetHexColor(0x688736);
 
         // the bug
         if(!bSquashed) {
             ofPushMatrix();
             ofTranslate(pos);
-            
+
             float angle = 90+ofRadToDeg(atan2(vel.y, vel.x));
-            ofRotateZ(angle);
-            
+            ofRotateZDeg(angle);
+
             ofDrawEllipse(0, 0, 5, 3);
             ofDrawLine(+1, 0, +3, -4);
             ofDrawLine(-1, 0, -3, -4);
-            
+
             ofDrawEllipse(0, +3, 3, 4);
             ofDrawEllipse(0, +6, 3, 3);
             ofDrawEllipse(0, +8, 2, 3);
-            
+
             ofDrawLine(0, +3, +4, +3);
             ofDrawLine(0, +5, +4, +5);
             ofDrawLine(0, +6, +4, +7);
-            
+
             ofDrawLine(0, +3, -4, +3);
             ofDrawLine(0, +5, -4, +5);
             ofDrawLine(0, +6, -4, +7);
             ofPopMatrix();
         }
-        
+
         // the squash
         else {
             ofSetHexColor(0xE32289);
@@ -78,7 +78,7 @@ public:
 				ofDrawCircle(pos + squashPts[i], 2);
             }
         }
-        
-        
+
+
     }
 };

--- a/examples/events/customEventExample/src/ofApp.cpp
+++ b/examples/events/customEventExample/src/ofApp.cpp
@@ -2,40 +2,40 @@
 
 
 /*
- 
- This example demonstrates a simple game. We have a GameEvent class that is 
- used to store the bullet and bug that just collided. 
- 
- 
+
+ This example demonstrates a simple game. We have a GameEvent class that is
+ used to store the bullet and bug that just collided.
+
+
  Topics:
  ofEventArgs
  ofAddListener
  ofRemove
  vector math
  objects & classes
- 
+
  by: Todd Vanderlin
- 
+
  */
 
 //--------------------------------------------------------------
 bool ofApp::shouldRemoveBullet(Bullet &b) {
-    
+
     if(b.bRemove) return true;
-    
-    
+
+
     bool bRemove = false;
-    
+
     // get the rectangle of the OF world
     ofRectangle rec = ofGetCurrentViewport();
-    
+
     // check if the bullet is inside the world
     if(rec.inside(b.pos) == false) {
         bRemove = true;
     }
-    
-    
-    
+
+
+
     return bRemove;
 }
 
@@ -46,107 +46,107 @@ bool ofApp::shouldRemoveBug(Bug &b) {
 
 //--------------------------------------------------------------
 void ofApp::setup() {
-    
+
     ofBackgroundHex(0xc5c9b2);
     ofSetFrameRate(60);
-    
+
     bFire = false;
     bugsKilled = 0;
     maxBullets = 30;
-    
+
     // add some random holes for the bugs to come out
     int nHoldes = 10;
     for(int i=0; i<nHoldes; i++) {
         ofVec2f p(ofRandomWidth(), ofRandomHeight());
         holes.push_back(p);
     }
-    
+
     // listen to any of the events for the game
     ofAddListener(GameEvent::events, this, &ofApp::gameEvent);
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gameEvent(GameEvent &e) {
-    
+
     cout << "Game Event: "+e.message << endl;
     e.bug->timeBugKilled = ofGetElapsedTimef();
     e.bug->bSquashed = true;
-    
+
     e.bullet->bRemove = true;
-    
+
     bugsKilled ++;
 }
 
 //--------------------------------------------------------------
 void ofApp::update() {
-    
+
     if((int)ofRandom(0, 20)==10) {
-        
+
         int randomHole = ofRandom(holes.size());
-        
+
         Bug newBug;
         newBug.pos = holes[randomHole];
         newBug.vel.set(ofRandom(-1, 1), ofRandom(-1, 1));
         bugs.push_back(newBug);
     }
-    
+
     for(unsigned int i=0; i<bugs.size(); i++) {
-        
+
         bugs[i].update();
-        
+
         // bug pos and size
         float   size = bugs[i].size;
         ofVec2f pos  = bugs[i].pos;
-        
+
         // wrap the bugs around the screen
         if(pos.x > ofGetWidth()-size)  bugs[i].pos.x = -size;
         if(pos.x < -size)              bugs[i].pos.x = ofGetWidth()-size;
         if(pos.y > ofGetHeight()+size) bugs[i].pos.y = -size;
         if(pos.y < -size)              bugs[i].pos.y = ofGetHeight()-size;
-        
-    } 
-    
+
+    }
+
     // check if we should remove any bugs
     ofRemove(bugs, shouldRemoveBug);
-    
+
     // update the bullets
     for(unsigned int i=0; i<bullets.size(); i++) {
         bullets[i].update();
-    } 
-    
+    }
+
     // check if we want to remove the bullet
     ofRemove(bullets, shouldRemoveBullet);
-    
-    
+
+
     // did we hit a bug loop we are checking to see if a bullet
     // hits a bug. if so we are going to launch an event for the game
     for(unsigned int i=0; i<bullets.size(); i++) {
         for(unsigned int j=0; j<bugs.size(); j++) {
-            
+
             ofVec2f a       = bullets[i].pos;
             ofVec2f b       = bugs[j].pos;
             float   minSize = bugs[j].size;
-            
+
             if(a.distance(b) < minSize) {
-                
+
                 static GameEvent newEvent;
                 newEvent.message = "BUG HIT";
                 newEvent.bug     = &bugs[j];
                 newEvent.bullet  = &bullets[i];
-                
+
                 ofNotifyEvent(GameEvent::events, newEvent);
             }
-            
+
         }
     }
-    
-    
+
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-    
+
     // draw the bug holes
     for(unsigned int i=0; i<holes.size(); i++) {
         ofSetColor(100);
@@ -154,59 +154,59 @@ void ofApp::draw(){
         ofSetColor(40);
 		ofDrawCircle(holes[i], 7);
     }
-    
+
     for(unsigned int i=0; i<bugs.size(); i++) {
         bugs[i].draw();
     }
-    
+
     // draw the bullets
     for(unsigned int i=0; i<bullets.size(); i++) {
         bullets[i].draw();
     }
-    
-    
-    
+
+
+
     // game stats
     ofSetColor(10);
     ofDrawBitmapString("Bullets "+ofToString(bullets.size())+"\nBugs Killed: "+ofToString(bugsKilled), 20, 20);
-    
-    
+
+
     // gun
     ofVec2f gunPos(ofGetWidth()/2, ofGetHeight()-20);
     ofVec2f mousePos(ofGetMouseX(), ofGetMouseY());
-    
+
     // get the vector from the mouse to gun
     ofVec2f vec = mousePos - gunPos;
     vec.normalize();
     vec *= 100;
-    
+
     // get the angle of the vector for rotating the rect
     float angle = ofRadToDeg(atan2(vec.y, vec.x)) - 90;
-    
+
     ofPushMatrix();
-    ofTranslate(gunPos.x, gunPos.y);    
-    ofRotateZ(angle);
-    
+    ofTranslate(gunPos.x, gunPos.y);
+    ofRotateZDeg(angle);
+
     ofFill();
     ofSetColor(10);
     ofDrawRectangle(-10, 0, 20, 100);
-    
+
     float bulletPct = ofMap(bullets.size(), 0, maxBullets, 0.0, 100.0);
     ofSetColor(100);
     ofDrawRectangle(-10, 0, 20, bulletPct);
-    
+
     ofSetColor(100);
     ofDrawRectangle(-10, 90, 20, 10);
-    
+
     if(bFire) {
         ofSetColor(220, 0, 0);
         ofDrawRectangle(-10, 97, 20, 3);
     }
     ofPopMatrix();
-    
+
     ofSetColor(255);
 	ofDrawCircle(gunPos.x, gunPos.y, 2);
-    
+
 }
 
 //--------------------------------------------------------------
@@ -214,27 +214,27 @@ void ofApp::keyPressed(int key) {
     if(key == ' ') {
         if(bullets.size() < maxBullets) {
             bFire = true;
-            
+
             Bullet b;
-            
+
             // the two points for the mouse and gun
             ofVec2f gunPt(ofGetWidth()/2, ofGetHeight()-20);
             ofVec2f mousePt(ofGetMouseX(), ofGetMouseY());
-            
+
             // the vector between the two
             ofVec2f vec = mousePt - gunPt;
-            
+
             // normalize = 0.0 - 1.0
             vec.normalize();
-            
+
             // bullet position = the start pos of the gun
             // and the vec scaled by 100
             ofVec2f bulletPos = gunPt + (vec * 100);
-            
+
             b.pos     = bulletPos;
-            b.vel     = vec * ofRandom(9, 12); // randomly make it faster        
+            b.vel     = vec * ofRandom(9, 12); // randomly make it faster
             b.bRemove = false;
-            
+
             // add the bullets to the array
             bullets.push_back(b);
         }
@@ -287,6 +287,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/gl/billboardExample/src/ofApp.cpp
+++ b/examples/gl/billboardExample/src/ofApp.cpp
@@ -3,34 +3,34 @@
 //--------------------------------------------------------------
 void ofApp::setup() {
 	ofBackground(0, 0, 0);
-	
+
 	cameraRotation.set(0);
 	zoom = -500;
 	zoomTarget = 200;
-	
+
 	billboards.getVertices().resize(NUM_BILLBOARDS);
 	billboards.getColors().resize(NUM_BILLBOARDS);
 	billboards.getNormals().resize(NUM_BILLBOARDS,ofVec3f(0));
-	
+
 	// ------------------------- billboard particles
 	for (int i=0; i<NUM_BILLBOARDS; i++) {
-		
+
 		billboardVels[i].set(ofRandomf(), -1.0, ofRandomf());
-		billboards.getVertices()[i].set(ofRandom(-500, 500), 
-													ofRandom(-500, 500), 
+		billboards.getVertices()[i].set(ofRandom(-500, 500),
+													ofRandom(-500, 500),
 													ofRandom(-500, 500));
-		
+
 		billboards.getColors()[i].set(ofColor::fromHsb(ofRandom(96, 160), 255, 255));
 	    billboardSizeTarget[i] = ofRandom(4, 64);
-		
+
 	}
-	
-	
+
+
 	billboards.setUsage( GL_DYNAMIC_DRAW );
 	billboards.setMode(OF_PRIMITIVE_POINTS);
 	//billboardVbo.setVertexData(billboardVerts, NUM_BILLBOARDS, GL_DYNAMIC_DRAW);
 	//billboardVbo.setColorData(billboardColor, NUM_BILLBOARDS, GL_DYNAMIC_DRAW);
-	
+
 	// load the billboard shader
 	// this is used to change the
 	// size of the particle
@@ -39,7 +39,7 @@ void ofApp::setup() {
 	}else{
 		billboardShader.load("shadersGL2/Billboard");
 	}
-	
+
 	// we need to disable ARB textures in order to use normalized texcoords
 	ofDisableArbTex();
 	texture.load("dot.png");
@@ -48,68 +48,68 @@ void ofApp::setup() {
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	
+
 	float t = (ofGetElapsedTimef()) * 0.9f;
 	float div = 250.0;
-	
+
 	for (int i=0; i<NUM_BILLBOARDS; i++) {
-		
-		// noise 
+
+		// noise
 		ofVec3f vec(ofSignedNoise(t, billboards.getVertex(i).y/div, billboards.getVertex(i).z/div),
 								ofSignedNoise(billboards.getVertex(i).x/div, t, billboards.getVertex(i).z/div),
 								ofSignedNoise(billboards.getVertex(i).x/div, billboards.getVertex(i).y/div, t));
-		
+
 		vec *= 10 * ofGetLastFrameTime();
 		billboardVels[i] += vec;
-		billboards.getVertices()[i] += billboardVels[i]; 
-		billboardVels[i] *= 0.94f; 
+		billboards.getVertices()[i] += billboardVels[i];
+		billboardVels[i] *= 0.94f;
     	billboards.setNormal(i,ofVec3f(12 + billboardSizeTarget[i] * ofNoise(t+i),0,0));
 	}
-	
-	
+
+
 	// move the camera around
 	float mx = (float)mouseX/(float)ofGetWidth();
 	float my = (float)mouseY/(float)ofGetHeight();
 	ofVec3f des(mx * 360.0, my * 360.0, 0);
 	cameraRotation += (des-cameraRotation) * 0.03;
 	zoom += (zoomTarget - zoom) * 0.03;
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw() {
 	ofBackgroundGradient(ofColor(255), ofColor(230, 240, 255));
-	
+
 	string info = ofToString(ofGetFrameRate(), 2)+"\n";
 	info += "Particle Count: "+ofToString(NUM_BILLBOARDS);
 	ofDrawBitmapStringHighlight(info, 30, 30);
-	
+
 	ofSetColor(255);
-	
+
 	ofPushMatrix();
 	ofTranslate(ofGetWidth()/2, ofGetHeight()/2, zoom);
-	ofRotate(cameraRotation.x, 1, 0, 0);
-	ofRotate(cameraRotation.y, 0, 1, 0);
-	ofRotate(cameraRotation.y, 0, 0, 1);
-	
+	ofRotateDeg(cameraRotation.x, 1, 0, 0);
+	ofRotateDeg(cameraRotation.y, 0, 1, 0);
+	ofRotateDeg(cameraRotation.y, 0, 0, 1);
+
 	// bind the shader so that wee can change the
 	// size of the points via the vert shader
 	billboardShader.begin();
-	
+
 	ofEnablePointSprites(); // not needed for GL3/4
 	texture.getTexture().bind();
 	billboards.draw();
 	texture.getTexture().unbind();
 	ofDisablePointSprites(); // not needed for GL3/4
-	
+
 	billboardShader.end();
-	
+
 	ofPopMatrix();
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	
+
 	if(key == 'f') ofToggleFullscreen();
 	if(key == OF_KEY_UP) zoomTarget +=10;
 	if(key == OF_KEY_DOWN) zoomTarget -=10;
@@ -162,6 +162,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/gl/fboTrailsExample/src/ofApp.cpp
+++ b/examples/gl/fboTrailsExample/src/ofApp.cpp
@@ -4,19 +4,19 @@
 void ofApp::setup(){
 
     ofBackground(0,0,0);
-	ofSetFrameRate(60);   
-	
-	//allocate our fbos. 
+	ofSetFrameRate(60);
+
+	//allocate our fbos.
 	//providing the dimensions and the format for the,
-	rgbaFbo.allocate(400, 400, GL_RGBA); // with alpha, 8 bits red, 8 bits green, 8 bits blue, 8 bits alpha, from 0 to 255 in 256 steps	
+	rgbaFbo.allocate(400, 400, GL_RGBA); // with alpha, 8 bits red, 8 bits green, 8 bits blue, 8 bits alpha, from 0 to 255 in 256 steps
 
 	#ifdef TARGET_OPENGLES
 	rgbaFboFloat.allocate(400, 400, GL_RGBA ); // with alpha, 32 bits red, 32 bits green, 32 bits blue, 32 bits alpha, from 0 to 1 in 'infinite' steps
-        ofLogWarning("ofApp") << "GL_RGBA32F_ARB is not available for OPENGLES.  Using RGBA.";	
+        ofLogWarning("ofApp") << "GL_RGBA32F_ARB is not available for OPENGLES.  Using RGBA.";
 	#else
         rgbaFboFloat.allocate(400, 400, GL_RGBA32F_ARB); // with alpha, 32 bits red, 32 bits green, 32 bits blue, 32 bits alpha, from 0 to 1 in 'infinite' steps
 	#endif
-	
+
 	// we can also define the fbo with ofFbo::Settings.
 	// this allows us so set more advanced options the width (400), the height (200) and the internal format like this
 	/*
@@ -28,46 +28,46 @@ void ofApp::setup(){
 	 // and assigning this values to the fbo like this:
 	 rgbFbo.allocate(s);
 	 */
-	 
-		
+
+
     // we have to clear all the fbos so that we don't see any artefacts
 	// the clearing color does not matter here, as the alpha value is 0, that means the fbo is cleared from all colors
 	// whenever we want to draw/update something inside the fbo, we have to write that inbetween fbo.begin() and fbo.end()
-    
+
     rgbaFbo.begin();
 	ofClear(255,255,255, 0);
     rgbaFbo.end();
-	
+
 	rgbaFboFloat.begin();
 	ofClear(255,255,255, 0);
     rgbaFboFloat.end();
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::update(){
 
     ofEnableAlphaBlending();
-	
+
 	//lets draw some graphics into our two fbos
     rgbaFbo.begin();
 		drawFboTest();
     rgbaFbo.end();
-	  	
+
     rgbaFboFloat.begin();
 		drawFboTest();
 	rgbaFboFloat.end();
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::drawFboTest(){
-	//we clear the fbo if c is pressed. 
+	//we clear the fbo if c is pressed.
 	//this completely clears the buffer so you won't see any trails
 	if( ofGetKeyPressed('c') ){
 		ofClear(255,255,255, 0);
-	}	
-	
+	}
+
 	//some different alpha values for fading the fbo
 	//the lower the number, the longer the trails will take to fade away.
 	fadeAmnt = 40;
@@ -77,34 +77,34 @@ void ofApp::drawFboTest(){
 		fadeAmnt = 5;
 	}else if(ofGetKeyPressed('3')){
 		fadeAmnt = 15;
-	}  
+	}
 
 	//1 - Fade Fbo
-	
+
 	//this is where we fade the fbo
-	//by drawing a rectangle the size of the fbo with a small alpha value, we can slowly fade the current contents of the fbo. 
+	//by drawing a rectangle the size of the fbo with a small alpha value, we can slowly fade the current contents of the fbo.
 	ofFill();
 	ofSetColor(255,255,255, fadeAmnt);
 	ofDrawRectangle(0,0,400,400);
 
 	//2 - Draw graphics
-	
+
 	ofNoFill();
 	ofSetColor(255,255,255);
-	
+
 	//we draw a cube in the center of the fbo and rotate it based on time
 	ofPushMatrix();
 		ofTranslate(200,200,0);
-		ofRotate(ofGetElapsedTimef()*30, 1,0,0.5);
+		ofRotateDeg(ofGetElapsedTimef()*30, 1,0,0.5);
 		ofDrawBox(0,0,0,100);
 	ofPopMatrix();
 
 	//also draw based on our mouse position
-	ofFill();	   
+	ofFill();
 	ofDrawCircle(ofGetMouseX() % 410, ofGetMouseY(), 8);
 
 	//we move a line across the screen based on the time
-	//the %400 makes the number stay in the 0-400 range. 
+	//the %400 makes the number stay in the 0-400 range.
 	int shiftX   = (ofGetElapsedTimeMillis() / 8 ) % 400;
 
 	ofDrawRectangle(shiftX, rgbaFbo.getHeight()-30, 3, 30);
@@ -113,11 +113,11 @@ void ofApp::drawFboTest(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-	
-    ofSetColor(255,255,255);  	
+
+    ofSetColor(255,255,255);
     rgbaFbo.draw(0,0);
     rgbaFboFloat.draw(410,0);
-	  	
+
     ofDrawBitmapString("non floating point FBO", ofPoint(10,20));
     ofDrawBitmapString("floating point FBO", ofPoint(420,20));
 
@@ -126,39 +126,39 @@ void ofApp::draw(){
 	alphaInfo += "\nHold '2' to set alpha fade to 5";
 	alphaInfo += "\nHold '3' to set alpha fade to 15";
 	alphaInfo += "\nHold 'c' to clear the fbo each frame\n\nMove mouse to draw with a circle";
-	
+
     ofDrawBitmapString(alphaInfo, ofPoint(10,430));
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -173,15 +173,15 @@ void ofApp::mouseExited(int x, int y){
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
-	
+void ofApp::dragEvent(ofDragInfo dragInfo){
+
 }

--- a/examples/gl/geometryShaderExample/src/ofApp.cpp
+++ b/examples/gl/geometryShaderExample/src/ofApp.cpp
@@ -7,21 +7,21 @@ void ofApp::setup(){
 	ofBackground(50, 50, 50);
 	ofSetVerticalSync(false);
 	ofEnableAlphaBlending();
-	
+
 	shader.setGeometryInputType(GL_LINES);
 	shader.setGeometryOutputType(GL_TRIANGLE_STRIP);
 	shader.setGeometryOutputCount(4);
-	shader.load("shaders/vert.glsl", "shaders/frag.glsl", "shaders/geom.glsl"); 
-	
+	shader.load("shaders/vert.glsl", "shaders/frag.glsl", "shaders/geom.glsl");
+
 	ofLog() << "Maximum number of output vertices support is: " << shader.getGeometryMaxOutputCount();
-	
+
 	// create a bunch of random points
 	float r = ofGetHeight()/2;
 	for(int i=0; i<100; i++) {
 		points.push_back(ofPoint(ofRandomf() * r, ofRandomf() * r, ofRandomf() * r));
 	}
-	
-	doShader = true;	
+
+	doShader = true;
 	ofEnableDepthTest();
 }
 
@@ -36,56 +36,56 @@ void ofApp::draw(){
 
 	if(doShader) {
 		shader.begin();
-		
+
 		// set thickness of ribbons
 		shader.setUniform1f("thickness", 20);
-		
+
 		// make light direction slowly rotate
 		shader.setUniform3f("lightDir", sin(ofGetElapsedTimef()/10), cos(ofGetElapsedTimef()/10), 0);
 	}
 
 	ofColor(255);
-	
+
 	ofTranslate(ofGetWidth() / 2, ofGetHeight() / 2, 0);
-	ofRotateX(mouseY);
-	ofRotateY(mouseX);
+	ofRotateXDeg(mouseY);
+	ofRotateYDeg(mouseX);
 
 	for(unsigned int i=1; i<points.size(); i++) {
 		ofDrawLine(points[i-1], points[i]);
 	}
-	
+
 	if(doShader) shader.end();
-	
+
 	ofPopMatrix();
-	
+
 	ofDrawBitmapString("fps: " + ofToString((int)ofGetFrameRate()) + "\nPress 's' to toggle shader: " + (doShader ? "ON" : "OFF"), 20, 20);
 }
 
 //--------------------------------------------------------------
-void ofApp::keyPressed  (int key){ 
+void ofApp::keyPressed  (int key){
 	if( key == 's' ){
 		doShader = !doShader;
-	}	
+	}
 }
 
 //--------------------------------------------------------------
-void ofApp::keyReleased(int key){ 
-	
+void ofApp::keyReleased(int key){
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -114,7 +114,7 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }
 

--- a/examples/gl/multiLightExample/src/ofApp.cpp
+++ b/examples/gl/multiLightExample/src/ofApp.cpp
@@ -6,62 +6,62 @@ void ofApp::setup(){
 	ofSetFrameRate(60);
 	ofBackground(10, 10, 10);
 	ofEnableDepthTest();
-    
+
     // turn on smooth lighting //
     bSmoothLighting     = true;
     ofSetSmoothLighting(true);
-    
+
     // lets make a high-res sphere //
     // default is 20 //
     ofSetSphereResolution(128);
-	
+
     // radius of the sphere //
 	radius		= 180.f;
 	center.set(ofGetWidth()*.5, ofGetHeight()*.5, 0);
-    
+
     // Point lights emit light in all directions //
     // set the diffuse color, color reflected from the light source //
     pointLight.setDiffuseColor( ofColor(0.f, 255.f, 0.f));
-    
+
     // specular color, the highlight/shininess color //
 	pointLight.setSpecularColor( ofColor(255.f, 255.f, 0.f));
 	pointLight.setPointLight();
-    
-    
-	
+
+
+
     spotLight.setDiffuseColor( ofColor(255.f, 0.f, 0.f));
 	spotLight.setSpecularColor( ofColor(255.f, 255.f, 255.f));
-    
+
     // turn the light into spotLight, emit a cone of light //
     spotLight.setSpotlight();
-    
+
     // size of the cone of emitted light, angle between light axis and side of cone //
     // angle range between 0 - 90 in degrees //
     spotLight.setSpotlightCutOff( 50 );
-    
+
     // rate of falloff, illumitation decreases as the angle from the cone axis increases //
     // range 0 - 128, zero is even illumination, 128 is max falloff //
     spotLight.setSpotConcentration( 45 );
-    
-	
+
+
     // Directional Lights emit light based on their orientation, regardless of their position //
 	directionalLight.setDiffuseColor(ofColor(0.f, 0.f, 255.f));
 	directionalLight.setSpecularColor(ofColor(255.f, 255.f, 255.f));
 	directionalLight.setDirectional();
-    
+
     // set the direction of the light
     // set it pointing from left to right -> //
 	directionalLight.setOrientation( ofVec3f(0, 90, 0) );
-    
-	
+
+
 	bShiny = true;
     // shininess is a value between 0 - 128, 128 being the most shiny //
 	material.setShininess( 120 );
     // the light highlight of the material //
 	material.setSpecularColor(ofColor(255, 255, 255, 255));
-	
+
 	bPointLight = bSpotLight = bDirLight = true;
-    
+
     // tex coords for 3D objects in OF are from 0 -> 1, not 0 -> image.width
     // so we must disable the arb rectangle call to allow 0 -> 1
     ofDisableArbTex();
@@ -72,10 +72,10 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::update() {
-    pointLight.setPosition(cos(ofGetElapsedTimef()*.6f) * radius * 2 + center.x, 
-						   sin(ofGetElapsedTimef()*.8f) * radius * 2 + center.y, 
+    pointLight.setPosition(cos(ofGetElapsedTimef()*.6f) * radius * 2 + center.x,
+						   sin(ofGetElapsedTimef()*.8f) * radius * 2 + center.y,
 						   -cos(ofGetElapsedTimef()*.8f) * radius * 2 + center.z);
-	
+
     spotLight.setOrientation( ofVec3f( 0, cos(ofGetElapsedTimef()) * RAD_TO_DEG, 0) );
 	spotLight.setPosition( mouseX, mouseY, 200);
 }
@@ -90,48 +90,48 @@ void ofApp::draw(){
 	if (bPointLight) pointLight.enable();
 	if (bSpotLight) spotLight.enable();
 	if (bDirLight) directionalLight.enable();
-    
+
     // grab the texture reference and bind it //
     // this will apply the texture to all drawing (vertex) calls before unbind() //
     if(bUseTexture) ofLogoImage.getTexture().bind();
-    
+
 	ofSetColor(255, 255, 255, 255);
     ofPushMatrix();
     ofTranslate(center.x, center.y, center.z-300);
-    ofRotate(ofGetElapsedTimef() * .8 * RAD_TO_DEG, 0, 1, 0);
+    ofRotateRad(ofGetElapsedTimef() * .8, 0, 1, 0);
 	ofDrawSphere( 0,0,0, radius);
     ofPopMatrix();
-	
+
 	ofPushMatrix();
 	ofTranslate(300, 300, cos(ofGetElapsedTimef()*1.4) * 300.f);
-	ofRotate(ofGetElapsedTimef()*.6 * RAD_TO_DEG, 1, 0, 0);
-	ofRotate(ofGetElapsedTimef()*.8 * RAD_TO_DEG, 0, 1, 0);
+	ofRotateRad(ofGetElapsedTimef()*.6, 1, 0, 0);
+	ofRotateRad(ofGetElapsedTimef()*.8, 0, 1, 0);
 	ofDrawBox(0, 0, 0, 60);
 	ofPopMatrix();
-	
+
 	ofPushMatrix();
 	ofTranslate(center.x, center.y, -900);
-	ofRotate(ofGetElapsedTimef() * .2 * RAD_TO_DEG, 0, 1, 0);
+	ofRotateRad(ofGetElapsedTimef() * .2, 0, 1, 0);
 	ofDrawBox( 0, 0, 0, 850);
 	ofPopMatrix();
-    
+
     if(bUseTexture) ofLogoImage.getTexture().unbind();
-	
+
 	if (!bPointLight) pointLight.disable();
 	if (!bSpotLight) spotLight.disable();
 	if (!bDirLight) directionalLight.disable();
-	
+
     material.end();
 	// turn off lighting //
     ofDisableLighting();
-    
+
 	ofSetColor( pointLight.getDiffuseColor() );
 	if(bPointLight) pointLight.draw();
-    
+
     ofSetColor(255, 255, 255);
 	ofSetColor( spotLight.getDiffuseColor() );
 	if(bSpotLight) spotLight.draw();
-	
+
 	ofSetColor(255, 255, 255);
 	ofDrawBitmapString("Point Light On (1) : "+ofToString(bPointLight) +"\n"+
 					   "Spot Light On (2) : "+ofToString(bSpotLight) +"\n"+
@@ -235,6 +235,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/gl/singleLightExample/src/ofApp.cpp
+++ b/examples/gl/singleLightExample/src/ofApp.cpp
@@ -6,39 +6,39 @@ void ofApp::setup(){
 	ofSetFrameRate(60);
 	ofBackground(10, 10, 10);
 	ofEnableDepthTest();
-    
+
     // turn on smooth lighting //
     ofSetSmoothLighting(true);
-    
+
     // lets make a sphere with more resolution than the default //
     // default is 20 //
     ofSetSphereResolution(32);
-	
+
 	radius		= 300.f;
 	center.set(ofGetWidth()*.5, ofGetHeight()*.5, 0);
-    
+
     // Point lights emit light in all directions //
     // set the diffuse color, color reflected from the light source //
     pointLight.setDiffuseColor( ofColor(0.f, 255.f, 0.f));
-    
+
     // specular color, the highlight/shininess color //
 	pointLight.setSpecularColor( ofColor(255.f, 255.f, 255.f));
     pointLight.setPosition(center.x, center.y, 0);
-    
+
     // shininess is a value between 0 - 128, 128 being the most shiny //
 	material.setShininess( 64 );
-    
-    
+
+
     sphereRadius    = 140;
     numSpheres      = 8;
     rotation        = 0.f;
     bDrawWireframe  = false;
-    
+
     colorHue = ofRandom(0, 250);
-    
+
     lightColor.setBrightness( 180.f );
     lightColor.setSaturation( 150.f );
-    
+
     materialColor.setBrightness(250.f);
     materialColor.setSaturation(200);
 }
@@ -48,15 +48,15 @@ void ofApp::update() {
 	colorHue += .1f;
     if(colorHue >= 255) colorHue = 0.f;
     lightColor.setHue(colorHue);
-    
+
     rotation += 1;
     if(rotation >=360) rotation = 0;
-    
+
     radius = cos(ofGetElapsedTimef()) * 200.f + 200.f;
-    
+
     pointLight.setDiffuseColor(lightColor);
-    
-    
+
+
     materialColor.setHue(colorHue);
     // the light highlight of the material //
 	material.setSpecularColor(materialColor);
@@ -64,23 +64,23 @@ void ofApp::update() {
 
 //--------------------------------------------------------------
 void ofApp::draw() {
-    
+
     ofSetColor(pointLight.getDiffuseColor());
     ofDrawSphere(pointLight.getPosition(), 20.f);
-    
+
     // enable lighting //
     ofEnableLighting();
-    // the position of the light must be updated every frame, 
+    // the position of the light must be updated every frame,
     // call enable() so that it can update itself //
     pointLight.enable();
     material.begin();
-    
+
     if(bDrawWireframe) ofNoFill();
     else ofFill();
-    
+
     ofPushMatrix();
     ofTranslate(center.x, center.y, 0);
-    ofRotate(rotation, 0, 0, 1);
+    ofRotateDeg(rotation, 0, 0, 1);
 	for(int i = 0; i < numSpheres; i++) {
         float angle = TWO_PI / (float)numSpheres * i;
         float x = cos(angle) * radius;
@@ -91,10 +91,10 @@ void ofApp::draw() {
 	material.end();
 	// turn off lighting //
     ofDisableLighting();
-    
+
     ofSetColor(255, 255, 255);
     ofDrawBitmapString("Draw Wireframe (w) : "+ofToString(bDrawWireframe, 0), 20, 20);
-    
+
 }
 
 //--------------------------------------------------------------
@@ -154,6 +154,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/gl/textureScreengrabExample/src/ofApp.cpp
+++ b/examples/gl/textureScreengrabExample/src/ofApp.cpp
@@ -1,14 +1,14 @@
 #include "ofApp.h"
 
 //--------------------------------------------------------------
-void ofApp::setup(){	
+void ofApp::setup(){
 	counter = 0;
 	ofSetCircleResolution(100);
 	texScreen.allocate(300,300,GL_RGB);
 	ofBackground(230,230,240);
-	
+
 }
- 
+
 
 //--------------------------------------------------------------
 void ofApp::update(){
@@ -20,22 +20,22 @@ void ofApp::update(){
 void ofApp::draw(){
 
 	// 1st, draw on screen:
-	ofSetHexColor(0x66CC33);	
+	ofSetHexColor(0x66CC33);
 	ofDrawRectangle(100,100,300,300);
-	
+
 	ofSetHexColor(0xffffff);
 	ofPushMatrix();
 		ofTranslate(200,200,0);
-		ofRotate(counter,0,0,1);
+		ofRotateDeg(counter,0,0,1);
 		ofDrawCircle(0,0,80);
 		ofDrawCircle(100,0,10);	// a small one
 	ofPopMatrix();
 	ofSetHexColor(0x333333);
 	ofDrawBitmapString("(a) on screen", 150,200);
 
-	ofSetHexColor(0xFFCC33);	
+	ofSetHexColor(0xFFCC33);
 	ofDrawCircle(mouseX, mouseY,20);
-	
+
 
 	// 2nd, grab a portion of the screen into a texture
 	// this is quicker then grabbing into an ofImage
@@ -43,11 +43,11 @@ void ofApp::draw(){
 	// as opposed to bringing pixels back to memory
 	// note: you need to allocate the texture to the right size
 	texScreen.loadScreenData(100,100,300,300);
-	
-	
+
+
 
 	// finally, draw that texture on screen, how ever you want
-	// (note: you can even draw the texture before you call loadScreenData, 
+	// (note: you can even draw the texture before you call loadScreenData,
 	// in order to make some trails or feedback type effects)
 	ofPushMatrix();
 		ofSetHexColor(0xffffff);
@@ -61,7 +61,7 @@ void ofApp::draw(){
 	ofPushMatrix();
 		ofSetHexColor(0xffffff);
 		ofTranslate(700,210,0);
-		ofRotate(counter, 0.1f, 0.03f, 0);
+		ofRotateDeg(counter, 0.1f, 0.03f, 0);
 		texScreen.draw(-50,-50,100,100);
 	ofPopMatrix();
 
@@ -70,28 +70,28 @@ void ofApp::draw(){
 }
 
 //--------------------------------------------------------------
-void ofApp::keyPressed  (int key){ 
-	
+void ofApp::keyPressed  (int key){
+
 }
 
 //--------------------------------------------------------------
-void ofApp::keyReleased(int key){ 
-	
+void ofApp::keyReleased(int key){
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -120,6 +120,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/gl/vboExample/src/ofApp.cpp
+++ b/examples/gl/vboExample/src/ofApp.cpp
@@ -56,19 +56,19 @@ ofVec3f ofApp::getVertexFromImg(ofImage& img, int x, int y) {
 void ofApp::setup() {
 
     #ifdef TARGET_OPENGLES
-    // While this will will work on normal OpenGL as well, it is 
+    // While this will will work on normal OpenGL as well, it is
     // required for OpenGL ES because ARB textures are not supported.
-    // If this IS set, then we conditionally normalize our 
+    // If this IS set, then we conditionally normalize our
     // texture coordinates below.
     ofEnableNormalizedTexCoords();
     #endif
 
 	img.load("linzer.png");
-	
+
 	// OF_PRIMITIVE_TRIANGLES means every three vertices create a triangle
 	mesh.setMode(OF_PRIMITIVE_TRIANGLES);
 	int skip = 10;	// this controls the resolution of the mesh
-	
+
 	int width = img.getWidth();
 	int height = img.getHeight();
 
@@ -91,12 +91,12 @@ void ofApp::setup() {
 			ofVec2f nei(x + skip, y);
 			ofVec2f swi(x, y + skip);
 			ofVec2f sei(x + skip, y + skip);
-			
+
 			// ignore any zero-data (where there is no depth info)
 			if(nw != zero && ne != zero && sw != zero && se != zero) {
 				addFace(mesh, nw, ne, se, sw);
 
-				// Normalize our texture coordinates if normalized 
+				// Normalize our texture coordinates if normalized
 				// texture coordinates are currently enabled.
 				if(ofGetUsingNormalizedTexCoords()) {
 					nwi /= imageSize;
@@ -109,13 +109,13 @@ void ofApp::setup() {
 			}
 		}
 	}
-	
+
 	vboMesh = mesh;
 }
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	
+
 }
 
 //--------------------------------------------------------------
@@ -123,12 +123,12 @@ void ofApp::draw() {
 	ofBackgroundGradient(ofColor(64), ofColor(0));
 	cam.begin();
 	ofEnableDepthTest();
-	
-	ofRotateY(ofGetElapsedTimef() * 30); // slowly rotate the model
-	
+
+	ofRotateYDeg(ofGetElapsedTimef() * 30); // slowly rotate the model
+
 	ofScale(1, -1, 1); // make y point down
 	ofScale(.5, .5, .5); // make everything a bit smaller
-	
+
 	img.bind(); // bind the image to begin texture mapping
 	int n = 5; // make a 5x5 grid
 	ofVec2f spacing(img.getWidth(), img.getHeight()); // spacing between meshes
@@ -147,10 +147,10 @@ void ofApp::draw() {
 		}
 	}
 	img.unbind();
-	
+
 	ofDisableDepthTest();
 	cam.end();
-	
+
 	// draw the framerate in the top left corner
 	ofDrawBitmapString(ofToString((int) ofGetFrameRate()) + " fps", 10, 20);
 	ofDrawBitmapString("Hold any key for ofVboMesh mode.", 10, 40);
@@ -167,27 +167,27 @@ void ofApp::keyPressed(int key){
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -202,15 +202,15 @@ void ofApp::mouseExited(int x, int y){
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
-	
+void ofApp::dragEvent(ofDragInfo dragInfo){
+
 }

--- a/examples/gles/customEGLWindowSettingsExample/src/ofApp.cpp
+++ b/examples/gles/customEGLWindowSettingsExample/src/ofApp.cpp
@@ -1,6 +1,6 @@
 #include "ofApp.h"
 
-	
+
 //--------------------------------------------------------------
 void ofApp::setup(){
     ofSetLogLevel(OF_LOG_VERBOSE);
@@ -29,7 +29,7 @@ void ofApp::draw() {
     ofSetColor(255);
     ofPushMatrix();
     ofTranslate(ofGetWidth()/2.0f,ofGetHeight()/2.0f);
-    ofRotateZ(angle);
+    ofRotateZDeg(angle);
     ofEnableAlphaBlending();
     rpiLogo.draw(-rpiLogo.getWidth()/2.0f,-rpiLogo.getHeight()/2.0f);
     ofDisableAlphaBlending();

--- a/examples/graphics/floatingPointImageExample/src/ofApp.cpp
+++ b/examples/graphics/floatingPointImageExample/src/ofApp.cpp
@@ -26,14 +26,14 @@ ofVec3f ofApp::getVertexFromImg(ofFloatImage& img, int x, int y) {
 //--------------------------------------------------------------
 void ofApp::setup(){
 
-	//note: you can get nicer anti-aliased rendering ( with slower fps ) 
+	//note: you can get nicer anti-aliased rendering ( with slower fps )
 	//if you uncomment the appropriate line in main.cpp
 
 	img.load("nyc-small.exr");
-	
+
 	light.enable();
 	light.setPosition(+500, 0, 0);
-	
+
 	mesh.setMode(OF_PRIMITIVE_TRIANGLES);
 	int skip = 1;
 	int width = img.getWidth();
@@ -44,7 +44,7 @@ void ofApp::setup(){
 			ofVec3f ne = getVertexFromImg(img, x + skip, y);
 			ofVec3f sw = getVertexFromImg(img, x, y + skip);
 			ofVec3f se = getVertexFromImg(img, x + skip, y + skip);
-			
+
 			addFace(mesh, nw, ne, se, sw);
 		}
 	}
@@ -58,10 +58,10 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofBackground(0);
-	
+
 	easyCam.begin();
 		ofScale(1, -1, 1);
-		ofRotateX(60);
+		ofRotateXDeg(60);
 		ofTranslate(-img.getWidth() / 2, -img.getHeight() / 2, 0);
 		ofSetColor(255);
 		ofEnableDepthTest();
@@ -121,6 +121,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/graphics/fontsExample/src/ofApp.cpp
+++ b/examples/graphics/fontsExample/src/ofApp.cpp
@@ -1,10 +1,10 @@
 #include "ofApp.h"
 
 //--------------------------------------------------------------
-void ofApp::setup(){	 
+void ofApp::setup(){
 	ofBackground(54, 54, 54, 255);
-	
-	//old OF default is 96 - but this results in fonts looking larger than in other programs. 
+
+	//old OF default is 96 - but this results in fonts looking larger than in other programs.
 	ofTrueTypeFont::setGlobalDpi(72);
 
 	verdana14.load("verdana.ttf", 14, true, true);
@@ -14,7 +14,7 @@ void ofApp::setup(){
 	verdana30.load("verdana.ttf", 30, true, true);
 	verdana30.setLineHeight(34.0f);
 	verdana30.setLetterSpacing(1.035);
-	
+
 	verdana14A.load("verdana.ttf", 14, false);
 	verdana14A.setLineHeight(18.0f);
 	verdana14A.setLetterSpacing(1.037);
@@ -46,16 +46,16 @@ void ofApp::draw(){
 	verdana14.drawString("anti aliased", 155, 92);
 	verdana14.drawString("anti aliased", 155, 195);
 	verdana14A.drawString("aliased", 545, 92);
-	
+
 	ofSetColor(225);
 	verdana14.drawString("verdana 14pt - ", 30, 92);
 	verdana14.drawString(typeStr, 30, 111);
 
 	verdana14A.drawString("verdana 14pt - ", 422, 92);
 	ofDrawRectangle(420, 97, 292, 62);
-	ofSetColor(54, 54, 54);	
+	ofSetColor(54, 54, 54);
 	verdana14A.drawString(typeStr, 422, 111);
-	
+
 
 	ofSetColor(29,29,29);
 	ofDrawLine(30, 169, ofGetWidth()-4, 169);
@@ -70,58 +70,58 @@ void ofApp::draw(){
 	ofSetColor(245, 58, 135);
 	franklinBook14.drawString("anti aliased", 169, 338);
 	franklinBook14A.drawString("aliased", 560, 338);
-	
+
 	ofSetColor(225);
 	franklinBook14.drawString("franklin book 14pt - ", 30, 338);
 	franklinBook14.drawString(typeStr, 30, 358);
 
 	franklinBook14A.drawString("franklin book 14pt - ", 422, 338);
 	ofDrawRectangle(420, 345, 292, 62);
-	ofSetColor(54, 54, 54);	
+	ofSetColor(54, 54, 54);
 	franklinBook14A.drawString(typeStr, 422, 358);
 
 	ofSetColor(29,29,29);
 	ofDrawLine(30, 418, ofGetWidth()-4, 418);
 
-	ofSetColor(225);	
+	ofSetColor(225);
 	verdana14.drawString("ROTATION", 30, 445);
 	verdana14.drawString("SCALE", 422, 445);
-	
+
 	ofPushMatrix();
 		string rotZ = "Rotate Z";
 		ofRectangle bounds = verdana30.getStringBoundingBox(rotZ, 0, 0);
-		
+
 		ofTranslate(110 + bounds.width/2, 500 + bounds.height / 2, 0);
-		ofRotateZ(ofGetElapsedTimef() * -30.0);
-				
+		ofRotateZDeg(ofGetElapsedTimef() * -30.0);
+
 		verdana30.drawString(rotZ, -bounds.width/2, bounds.height/2 );
 	ofPopMatrix();
 
 	ofPushMatrix();
 		string scaleAA = "SCALE AA";
 		bounds = verdana14.getStringBoundingBox(scaleAA, 0, 0);
-		
+
 		ofTranslate(500 + bounds.width/2, 480 + bounds.height / 2, 0);
 		ofScale(2.0 + sin(ofGetElapsedTimef()), 2.0 + sin(ofGetElapsedTimef()), 1.0);
-				
+
 		verdana14.drawString(scaleAA, -bounds.width/2, bounds.height/2 );
-	ofPopMatrix();	
+	ofPopMatrix();
 
 	ofPushMatrix();
 		string scaleA = "SCALE ALIASED";
 		bounds = verdana14A.getStringBoundingBox(scaleA, 0, 0);
-		
+
 		ofTranslate(500 + bounds.width/2, 530 + bounds.height / 2, 0);
 		ofScale(2.0 + cos(ofGetElapsedTimef()), 2.0 + cos(ofGetElapsedTimef()), 1.0);
-				
+
 		verdana14A.drawString(scaleA, -bounds.width/2, bounds.height/2 );
-	ofPopMatrix();	
-	
+	ofPopMatrix();
+
 }
 
 
 //--------------------------------------------------------------
-void ofApp::keyPressed(int key){ 
+void ofApp::keyPressed(int key){
 
 	if(key == OF_KEY_DEL || key == OF_KEY_BACKSPACE){
 		typeStr = typeStr.substr(0, typeStr.length()-1);
@@ -138,23 +138,23 @@ void ofApp::keyPressed(int key){
 }
 
 //--------------------------------------------------------------
-void ofApp::keyReleased(int key){ 
-	
+void ofApp::keyReleased(int key){
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -183,6 +183,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/graphics/polylineBlobsExample/src/ofApp.cpp
+++ b/examples/graphics/polylineBlobsExample/src/ofApp.cpp
@@ -3,14 +3,14 @@
 //--------------------------------------------------------------
 void ofApp::setup() {
 	threshold = 32;
-	
+
 	camWidth = 640;
 	camHeight = 480;
-	
+
 	cam.setup(640, 480);
 	cvImgColor.allocate(camWidth, camHeight);
 	cvImgGrayscale.allocate(camWidth, camHeight);
-	
+
 	ofEnableBlendMode(OF_BLENDMODE_ALPHA);
 }
 
@@ -25,30 +25,30 @@ void ofApp::update() {
 		cvImgGrayscale.setFromColorImage(cvImgColor);
 		cvImgGrayscale.threshold(threshold, ofGetKeyPressed());
 		contourFinder.findContours(cvImgGrayscale, 64 * 64, camWidth * camHeight, 5, false, true);
-		
-		polylines.clear(); 
+
+		polylines.clear();
 		smoothed.clear();
 		resampled.clear();
 		boundingBoxes.clear();
 		closestPoints.clear();
 		closestIndices.clear();
-		
+
 		ofPoint target;
 		target.set(mouseX, mouseY);
-			
+
 		for(unsigned int i = 0; i < contourFinder.blobs.size(); i++) {
 			ofPolyline cur;
 			// add all the current vertices to cur polyline
 			cur.addVertices(contourFinder.blobs[i].pts);
 			cur.setClosed(true);
-			
+
 			// add the cur polyline to all these vector<ofPolyline>
 			polylines.push_back(cur);
 			smoothed.push_back(cur.getSmoothed(8));
 			resampled.push_back(cur.getResampledByCount(100).getSmoothed(8));
-			
+
 			boundingBoxes.push_back(cur.getBoundingBox());
-			
+
 			unsigned int index;
 			closestPoints.push_back(resampled.back().getClosestPoint(target, &index));
 			closestIndices.push_back(index);
@@ -60,19 +60,19 @@ void ofApp::update() {
 void drawWithNormals(const ofPolyline& polyline) {
 	for(int i=0; i< (int) polyline.size(); i++ ) {
 		bool repeatNext = i == (int)polyline.size() - 1;
-	
+
 		const ofPoint& cur = polyline[i];
 		const ofPoint& next = repeatNext ? polyline[0] : polyline[i + 1];
-		
+
 		float angle = atan2f(next.y - cur.y, next.x - cur.x) * RAD_TO_DEG;
 		float distance = cur.distance(next);
-	
+
 		if(repeatNext) {
 			ofSetColor(255, 0, 255);
 		}
 		glPushMatrix();
 		glTranslatef(cur.x, cur.y, 0);
-		ofRotate(angle);
+		ofRotateDeg(angle);
 		ofDrawLine(0, 0, 0, distance);
 		ofDrawLine(0, 0, distance, 0);
 		glPopMatrix();
@@ -82,32 +82,32 @@ void drawWithNormals(const ofPolyline& polyline) {
 //--------------------------------------------------------------
 void ofApp::draw() {
 	ofBackground(0);
-	
+
 	ofSetColor(255);
 	cvImgGrayscale.draw(0, 0);
-	
+
 	for(unsigned int i = 0; i < polylines.size(); i++) {
 		ofNoFill();
-	
+
 		ofSetColor(255, 0, 0);
 		drawWithNormals(polylines[i]);
-		
+
 		ofSetColor(0, 255, 0);
 		drawWithNormals(smoothed[i]);
-		
+
 		ofSetColor(0, 0, 255);
 		drawWithNormals(resampled[i]);
-		
+
 		ofSetColor(0, 255, 255);
 		ofDrawRectangle(boundingBoxes[i]);
-		
+
 		ofSetColor(255, 0, 0);
 		ofDrawLine(closestPoints[i], ofPoint(mouseX, mouseY));
 		ofSetColor(0, 0, 255);
 		ofDrawLine(resampled[i][closestIndices[i]], ofPoint(mouseX, mouseY));
 	}
-	
-	ofSetColor(255, 0, 0);	
+
+	ofSetColor(255, 0, 0);
 	ofDrawBitmapString(ofToString((int) ofGetFrameRate()) + " fps", 10, 20);
 	ofDrawBitmapString("Click and drag to set a new threshold.", 10, 40);
 	ofDrawBitmapString("Hold down any key to invert the thresholding.", 10, 60);
@@ -164,6 +164,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/input_output/pdfExample/src/ofApp.cpp
+++ b/examples/input_output/pdfExample/src/ofApp.cpp
@@ -9,14 +9,14 @@ void ofApp::setup(){
 
 	ofBackground(225,225,225);
 	ofSetVerticalSync(true);
-	
+
 	font.load("frabk.ttf", 24, true, false, true);
-	
+
 	dropZoneRects.assign(3, ofRectangle());
 
 	images.assign(3, ofImage());
 	images[0].load("DSC09316.jpeg");
-	
+
 	for(unsigned int k = 0; k < dropZoneRects.size(); k++){
 		dropZoneRects[k] = ofRectangle(32 + k * 310, 200, 300, 200);
 	}
@@ -32,66 +32,66 @@ void ofApp::draw(){
 	if( oneShot ){
 		ofBeginSaveScreenAsPDF("screenshot-"+ofGetTimestampString()+".pdf", false);
 	}
-	
+
 	ofSetColor(54);
 	ofDrawBitmapString("PDF OUTPUT EXAMPLE", 32, 32);
 	if( pdfRendering ){
 		ofDrawBitmapString("press r to stop pdf multipage rendering", 32, 92);
-	}else{	
+	}else{
 		ofDrawBitmapString("press r to start pdf multipage rendering\npress s to save a single screenshot as pdf to disk", 32, 92);
 	}
-		
-		
-	ofFill();		
+
+
+	ofFill();
 	ofSetColor(54,54,54);
 	ofDrawBitmapString("TTF Font embdedded into pdf as vector shapes", 32, 460);
-	
+
 	if( oneShot || pdfRendering ){
 		font.drawStringAsShapes("Current Frame: ",  32, 500);
 		ofSetColor(245, 58, 135);
 		font.drawStringAsShapes( ofToString(ofGetFrameNum()), 32 + font.getStringBoundingBox("Current Frame: ", 0, 0).width + 9, 500);
 	}else{
-		font.drawString("Current Frame: ",  32, 500);	
-		ofSetColor(245, 58, 135);		
-		font.drawString( ofToString(ofGetFrameNum()), 32 + font.getStringBoundingBox("Current Frame: ", 0, 0).width + 9, 500);		
+		font.drawString("Current Frame: ",  32, 500);
+		ofSetColor(245, 58, 135);
+		font.drawString( ofToString(ofGetFrameNum()), 32 + font.getStringBoundingBox("Current Frame: ", 0, 0).width + 9, 500);
 	}
-	
-	
+
+
 	ofSetColor(54,54,54);
 	ofDrawBitmapString("Images can also be embedded into pdf", 32, dropZoneRects[0].y - 18);
-	
+
 	ofSetRectMode(OF_RECTMODE_CORNER);
 	ofNoFill();
 	for(unsigned int k = 0; k < dropZoneRects.size(); k++){
 		ofSetColor(54,54,54);
 		ofDrawRectangle(dropZoneRects[k]);
-		ofSetColor(245, 58, 135);		
+		ofSetColor(245, 58, 135);
 		ofDrawBitmapString("drop images here", dropZoneRects[k].getCenter().x - 70, dropZoneRects[k].getCenter().y);
 	}
 
 	ofSetColor(255);
 	for(unsigned int j = 0; j < images.size(); j ++){
 		if( images[j].getWidth() > 0 ){
-			
+
 			float tw = 300;
 			float th = 200;
-			
+
 			if( images[j].getWidth() / images[j].getHeight() < tw / th ){
 				tw = th * ( images[j].getWidth() / images[j].getHeight() );
 			}else{
-				th = tw * ( images[j].getHeight() / images[j].getWidth() );			
+				th = tw * ( images[j].getHeight() / images[j].getWidth() );
 			}
-			
+
 			images[j].draw(dropZoneRects[j].x, dropZoneRects[j].y, tw, th);
-			
+
 		}
 	}
-	
+
 	//lets draw a box with a trail
 	ofSetColor(245, 58, 135);
-	
+
 	ofRectangle boxBounds(32, 500, ofGetWidth()-32, 250);
-	
+
 	//lets get a noise value based on the current frame
 	float noiseX = ofNoise(float(ofGetFrameNum())/600.f, 200.0f);
 	float noiseY = ofNoise(float(ofGetFrameNum())/800.f, -900.0f);
@@ -100,7 +100,7 @@ void ofApp::draw(){
 	ofBeginShape();
 	ofVertices(boxTrail);
 	ofEndShape(false);
-	
+
 	ofFill();
 	ofSetRectMode(OF_RECTMODE_CENTER);
 
@@ -109,38 +109,38 @@ void ofApp::draw(){
 		float y = ofMap( noiseY, 0, 1, boxBounds.y, boxBounds.y + boxBounds.height, true);
 
 		ofTranslate(x, y, 0);
-		ofRotate(angle);
+		ofRotateDeg(angle);
 		ofDrawRectangle(0, 0, 30, 30);
-	ofPopMatrix();	
-	
+	ofPopMatrix();
+
 	if( boxTrail.size() == 0 || ( boxTrail.back() - ofPoint(x, y) ).length() > 1.5 ){
 		boxTrail.push_back(ofPoint(x, y));
 	}
-	
+
 	if(boxTrail.size() > 800 ){
 		boxTrail.erase(boxTrail.begin(), boxTrail.begin()+1);
 	}
-	
+
 	if( oneShot ){
 		ofEndSaveScreenAsPDF();
 		oneShot = false;
-	}	
+	}
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	
+
 	if( key=='r'){
-		pdfRendering = !pdfRendering;	
+		pdfRendering = !pdfRendering;
 		if( pdfRendering ){
 			ofSetFrameRate(12);  // so it doesn't generate tons of pages
 			ofBeginSaveScreenAsPDF("recording-"+ofGetTimestampString()+".pdf", true);
 		}else{
 			ofSetFrameRate(60);
-			ofEndSaveScreenAsPDF();		
+			ofEndSaveScreenAsPDF();
 		}
 	}
-	
+
 	if( !pdfRendering && key == 's' ){
 		oneShot = true;
 	}
@@ -192,7 +192,7 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 	for(unsigned int j = 0; j < dropZoneRects.size(); j++){
 		if( dropZoneRects[j].inside( dragInfo.position ) ){
 			images[j].load( dragInfo.files[0] );

--- a/examples/input_output/svgExample/src/ofApp.cpp
+++ b/examples/input_output/svgExample/src/ofApp.cpp
@@ -3,10 +3,10 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofSetVerticalSync(true);
-	
+
 	ofBackground(0);
 	ofSetColor(255);
-	
+
 	svg.load("tiger.svg");
 	for (int i = 0; i < svg.getNumPath(); i++){
 		ofPath p = svg.getPathAt(i);
@@ -33,7 +33,7 @@ void ofApp::draw(){
 	ofDrawBitmapString(ofToString(ofGetFrameRate()),20,20);
 	ofPushMatrix();
 	ofTranslate(ofGetWidth() / 2, ofGetHeight() / 2);
-	ofRotate(mouseX);
+	ofRotateDeg(mouseX);
 	float scale = ofMap(mouseY, 0, ofGetHeight(), .5, 10);
 	ofScale(scale, scale, scale);
 	ofTranslate(-250, -250);
@@ -53,38 +53,38 @@ void ofApp::draw(){
 	} else {
 		svg.draw();
 	}
-	
+
 	ofPopMatrix();
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyReleased(int key){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -99,15 +99,15 @@ void ofApp::mouseExited(int x, int y){
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::dragEvent(ofDragInfo dragInfo){
-	
+
 }

--- a/examples/math/noise1dExample/src/ofApp.cpp
+++ b/examples/math/noise1dExample/src/ofApp.cpp
@@ -4,37 +4,37 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	
+
 	ofSetWindowTitle("Noise 1D Example");
 	ofBackground(215,215,215);
 	ofSetVerticalSync(true);
 	ofSetCircleResolution(256);
-	
+
 	setupSignedNoiseDemo();
 }
 
 //--------------------------------------------------------------
 void ofApp::setupSignedNoiseDemo(){
 	// Setup and allocate resources used in the signed noise demo.
-	
+
 	nSignedNoiseData = 400; // we'll store a history of 400 numbers
 	signedNoiseData = new float[nSignedNoiseData];
 	for (int i=0; i<nSignedNoiseData; i++){
-		signedNoiseData[i] = 0; 
+		signedNoiseData[i] = 0;
 	}
-	
+
 	// Some coordinates...
-	radialNoiseDemoY = 200; 
+	radialNoiseDemoY = 200;
 	radialNoiseDemoR = 100;
-	radialNoiseDemoX = ofGetWidth()/2 - radialNoiseDemoR; 
-	
-	// These 2 sliders control the noise waveform at the top. 
+	radialNoiseDemoX = ofGetWidth()/2 - radialNoiseDemoR;
+
+	// These 2 sliders control the noise waveform at the top.
 	radialNoiseStepSlider.setup(radialNoiseDemoX,   radialNoiseDemoY+150, 200,16, 0.010, 0.150, 0.05, false,true);
 	radialNoiseAmountSlider.setup(radialNoiseDemoX, radialNoiseDemoY+170, 200,16, 0.000, 1.000, 0.40, false,true);
-	
-	radialNoiseStepSlider.setLabelString(  "Noise Step"); 
-	radialNoiseAmountSlider.setLabelString("Noise Amount"); 
-	radialNoiseStepSlider.setNumberDisplayPrecision(3); 
+
+	radialNoiseStepSlider.setLabelString(  "Noise Step");
+	radialNoiseAmountSlider.setLabelString("Noise Amount");
+	radialNoiseStepSlider.setNumberDisplayPrecision(3);
 	radialNoiseCursor = 0.0;
 }
 
@@ -54,84 +54,84 @@ void ofApp::draw(){
 
 //--------------------------------------------------------------
 void ofApp::updateSignedNoiseDemo (){
-	
+
 	// Shift all of the old data forward through the array
 	for (int i=(nSignedNoiseData-1); i>0; i--){
 		signedNoiseData[i] = signedNoiseData[i-1];
 	}
-	
+
 	// Compute the latest data, and insert it at the head of the array.
 	// Here is where ofSignedNoise is requested.
 	float noiseStep    = radialNoiseStepSlider.getValue();
 	float noiseAmount  = radialNoiseAmountSlider.getValue();
-	
-	signedNoiseData[0] = noiseAmount * ofSignedNoise( radialNoiseCursor ); 
+
+	signedNoiseData[0] = noiseAmount * ofSignedNoise( radialNoiseCursor );
 	radialNoiseCursor += noiseStep;
 }
 
 
 //--------------------------------------------------------------
 void ofApp::renderNoisyRobotArmDemo(){
-	
-	float t = ofGetElapsedTimef(); 
-	float shoulderNoiseAngleDegrees = 90 + 70.0 * ofSignedNoise(t * 1.00); 
-	float elbowNoiseAngleDegrees    = 60 + 80.0 * ofSignedNoise(t * 0.87); 
-	float wristNoiseAngleDegrees	= (2.5 * 72) + 45.0 * ofSignedNoise(t * 1.13); 
-	
-	float noisyR = ofNoise(t * 0.66); // different multiplicative step-factors 
-	float noisyG = ofNoise(t * 0.73); // guarantee that our color channels are 
+
+	float t = ofGetElapsedTimef();
+	float shoulderNoiseAngleDegrees = 90 + 70.0 * ofSignedNoise(t * 1.00);
+	float elbowNoiseAngleDegrees    = 60 + 80.0 * ofSignedNoise(t * 0.87);
+	float wristNoiseAngleDegrees	= (2.5 * 72) + 45.0 * ofSignedNoise(t * 1.13);
+
+	float noisyR = ofNoise(t * 0.66); // different multiplicative step-factors
+	float noisyG = ofNoise(t * 0.73); // guarantee that our color channels are
 	float noisyB = ofNoise(t * 0.81); // not all (apparently) synchronized.
-	
+
 	ofEnableSmoothing();
 	ofEnableAlphaBlending();
 	ofSetCircleResolution(12);
 	ofSetLineWidth(1.0);
-	
+
 	ofPushMatrix();
-	
+
 	// Translate over to the shoulder location; draw it
 	ofTranslate(ofGetWidth()/2, 540, 0);
-	ofRotate(shoulderNoiseAngleDegrees, 0, 0, 1);
-	drawNoisyArmRect(100,24); 
-	
+	ofRotateDeg(shoulderNoiseAngleDegrees, 0, 0, 1);
+	drawNoisyArmRect(100,24);
+
 	// Translate over to the forearm location; draw it
 	ofTranslate(76, 0, 0);
-	ofRotate(elbowNoiseAngleDegrees, 0, 0, 1);
-	drawNoisyArmRect(90,16); 
-	
-	// Translate over to the hand location; draw it. 
-	// Note that the color of the 'hand' is controlled by noise. 
+	ofRotateDeg(elbowNoiseAngleDegrees, 0, 0, 1);
+	drawNoisyArmRect(90,16);
+
+	// Translate over to the hand location; draw it.
+	// Note that the color of the 'hand' is controlled by noise.
 	ofTranslate(74, 0, 0);
-	ofRotate(wristNoiseAngleDegrees, 0, 0, 1);
+	ofRotateDeg(wristNoiseAngleDegrees, 0, 0, 1);
 	ofSetCircleResolution(5); // a kludgy "pentagon"
 	ofFill();
-	ofSetColor (ofFloatColor(noisyR, noisyG, noisyB, 0.75)); 
-	ofDrawEllipse(-10,0, 60,60); 
+	ofSetColor (ofFloatColor(noisyR, noisyG, noisyB, 0.75));
+	ofDrawEllipse(-10,0, 60,60);
 	ofNoFill();
 	ofSetColor(0);
-	ofDrawEllipse(-10,0, 60,60); 
+	ofDrawEllipse(-10,0, 60,60);
 	ofSetCircleResolution(12);
-	ofSetColor(0); 
+	ofSetColor(0);
 	ofFill();
 	ofDrawEllipse(0,0, 7,7);
-	
+
 	ofPopMatrix();
 }
 
 
 //--------------------------------------------------------------
 void ofApp::drawNoisyArmRect (float w, float h){
-	// A little helper function to simplify the code above. 
-	
+	// A little helper function to simplify the code above.
+
 	ofFill();
 	ofSetColor(255,255,255, 128);
 	ofDrawRectangle(-h/2,-h/2, w,h);
-	
+
 	ofNoFill();
 	ofSetColor(0);
-	ofDrawRectangle(-h/2,-h/2, w,h); 
-	
-	ofSetColor(0); 
+	ofDrawRectangle(-h/2,-h/2, w,h);
+
+	ofSetColor(0);
 	ofFill();
 	ofDrawEllipse(0,0, 7,7);
 }
@@ -140,22 +140,22 @@ void ofApp::drawNoisyArmRect (float w, float h){
 
 //--------------------------------------------------------------
 void ofApp::renderSignedNoiseDemo(){
-	
-	// Draw the explanatory text. 
+
+	// Draw the explanatory text.
 	string signedNoiseText = "ofSignedNoise() generates values between -1 and 1.\n";
 	signedNoiseText       += "It can be used to generate a terrain - whether as\n";
 	signedNoiseText       += "displacements to a line, or to some other shape.\n\n";
 	signedNoiseText       += "1D Noise can also be used to control other visual\n";
 	signedNoiseText       += "properties, such as rotation angles or color values.\n";
 	signedNoiseText       += "Noise is mapped to rotation -- there's no physics here!\n";
-	
-	ofSetColor(0,0,0); 
+
+	ofSetColor(0,0,0);
 	float signedNoiseTextX = radialNoiseDemoX - radialNoiseDemoR;
 	float signedNoiseTextY = radialNoiseDemoY + radialNoiseDemoR * 2.0 + 16;
 	ofDrawBitmapString(signedNoiseText, signedNoiseTextX, signedNoiseTextY);
 	ofDrawBitmapString("ofSignedNoise()", signedNoiseTextX+1, signedNoiseTextY); // 'bold' it
-	
-	// Now draw the linear and circle-wrapped waveforms. 
+
+	// Now draw the linear and circle-wrapped waveforms.
 	renderRadialSignedNoiseDemo();
 	renderLinearSignedNoiseDemo();
 }
@@ -164,93 +164,93 @@ void ofApp::renderSignedNoiseDemo(){
 
 //--------------------------------------------------------------
 void ofApp::renderRadialSignedNoiseDemo (){
-	
-	float centerX = radialNoiseDemoX; 
-	float centerY = radialNoiseDemoY; 
-	
-	// Render the Signed Noise demo, using 
-	// the noise as radial displacements to a circle. 
+
+	float centerX = radialNoiseDemoX;
+	float centerY = radialNoiseDemoY;
+
+	// Render the Signed Noise demo, using
+	// the noise as radial displacements to a circle.
 	ofPushMatrix();
 	ofTranslate(centerX + radialNoiseDemoR,centerY,0);
 	ofEnableAlphaBlending();
 	ofEnableSmoothing();
 	ofNoFill();
-	
-	// Draw a faint plain circle, so that we can better understand  
-	// the radial displacements caused by the signed noise later on. 
-	ofSetColor(0,0,0, 64); 
+
+	// Draw a faint plain circle, so that we can better understand
+	// the radial displacements caused by the signed noise later on.
+	ofSetColor(0,0,0, 64);
 	ofSetCircleResolution(256);
 	ofDrawEllipse(0,0, radialNoiseDemoR*2,radialNoiseDemoR*2);
-	
-	// Let's use the signed noise as a radial displacement to a circle. 
-	// We render out the points stored in the X and Y arrays. 
+
+	// Let's use the signed noise as a radial displacement to a circle.
+	// We render out the points stored in the X and Y arrays.
 	ofMesh wigglyMeshLine; // yes, technically, it's a "mesh"
 	wigglyMeshLine.setMode(OF_PRIMITIVE_LINE_STRIP);
 	float px = 0, py = 0;
 	for (int i=(nSignedNoiseData-1); i>=0; i--){
-		
-		// From the 'i' iterator, use ofMap to compute both 
-		// an angle (around a circle) and an alpha value. 
+
+		// From the 'i' iterator, use ofMap to compute both
+		// an angle (around a circle) and an alpha value.
 		float angle   = ofMap(i, 0,nSignedNoiseData-1, 0,-TWO_PI) - HALF_PI;
 		float alph    = ofMap(i, 0,nSignedNoiseData-1, 1,0     );
-		wigglyMeshLine.addColor(ofFloatColor(0,0,255, alph)); 
-		
+		wigglyMeshLine.addColor(ofFloatColor(0,0,255, alph));
+
 		// Cpmpute the displaced radius
 		float wigglyRadius = radialNoiseDemoR;
 		wigglyRadius +=  radialNoiseDemoR * signedNoiseData[i];
-		
+
 		// Good old-fashioned trigonometry: y = cos(t), x = sin(t)
 		px = wigglyRadius * cos( angle );
 		py = wigglyRadius * sin( angle );
 		wigglyMeshLine.addVertex(ofVec2f(px,py));
 	}
-	
+
 	// draw the "mesh" (line)
 	ofEnableSmoothing();
 	wigglyMeshLine.draw();
-	
+
 	// draw a little ball at the end
 	ofFill();
 	ofSetColor(0,0,0, 160);
-	ofDrawEllipse(px,py, 7,7); 
-	
+	ofDrawEllipse(px,py, 7,7);
+
 	ofPopMatrix();
 }
 
 //--------------------------------------------------------------
 void ofApp::renderLinearSignedNoiseDemo(){
-	
-	// Draw the stored noise history as a straightforward timeline. 
+
+	// Draw the stored noise history as a straightforward timeline.
 	ofPushMatrix();
-	
+
 	float drawWiggleWidth = radialNoiseDemoR*TWO_PI;
 	ofTranslate (radialNoiseDemoX + radialNoiseDemoR - drawWiggleWidth, radialNoiseDemoY-radialNoiseDemoR,0);
 	ofEnableAlphaBlending();
 	ofEnableSmoothing();
 	ofNoFill();
-	
+
 	// draw a "baseline"
-	ofSetColor(0,0,0, 64); 
-	ofDrawLine(0,0, drawWiggleWidth,0); 
-	
+	ofSetColor(0,0,0, 64);
+	ofDrawLine(0,0, drawWiggleWidth,0);
+
 	// draw a wiggly line
-	ofSetColor(255,0,0, 192); 
-	ofPolyline wigglyPolyLine; 
+	ofSetColor(255,0,0, 192);
+	ofPolyline wigglyPolyLine;
 	for (int i=0; i<nSignedNoiseData; i++){
-		
-		// From the 'i' iterator, use ofMap to compute both 
-		// an angle (around a circle) and an alpha value. 
-		float px = ofMap(i, 0,nSignedNoiseData-1, drawWiggleWidth,0); 
+
+		// From the 'i' iterator, use ofMap to compute both
+		// an angle (around a circle) and an alpha value.
+		float px = ofMap(i, 0,nSignedNoiseData-1, drawWiggleWidth,0);
 		float py = 0 - radialNoiseDemoR * signedNoiseData[i];
 		wigglyPolyLine.addVertex(ofVec2f(px,py));
 	}
-	
-	// draw the line 
+
+	// draw the line
 	wigglyPolyLine.draw();
 	ofPopMatrix();
 }
 
-// In case you're wondering, the simpleSliders get their mouse info through event handlers. 
+// In case you're wondering, the simpleSliders get their mouse info through event handlers.
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
 
@@ -302,6 +302,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/math/trigonometricMotionExample/src/ofApp.cpp
+++ b/examples/math/trigonometricMotionExample/src/ofApp.cpp
@@ -2,9 +2,9 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	
+
 	ofSetCircleResolution(40);
-	
+
 	//our history arrays are initialized with a value of zero for all of it's elements.
 	for (int i=1; i<TAIL_LENGTH; i++) {
 		waveHistory[i] = ofVec3f(0, 0, 0);
@@ -13,23 +13,23 @@ void ofApp::setup(){
 		horWaveHistory[i] = 0;
 		vertWaveHistory[i] = 0;
 	}
-	
+
 	//our center point is defined here.
-	center= ofPoint((ofGetWidth()-LEFT_MARGIN)*0.5f +LEFT_MARGIN, 
+	center= ofPoint((ofGetWidth()-LEFT_MARGIN)*0.5f +LEFT_MARGIN,
 									(ofGetHeight()-TOP_MARGIN)*0.5f + TOP_MARGIN);
-	
+
 	bScaleMouse=false;
-	
+
 	scale=1;
-	
+
 	//this are the multipliers for scaling the horizontal and vertical waveforms so this fit into the screen.
 	hWaveMult=(ofGetWidth()-LEFT_MARGIN)/float(WAVEFORM_HISTORY);
 	vWaveMult=(ofGetHeight()-TOP_MARGIN)/float(WAVEFORM_HISTORY);
-	
+
 	selectedOscilator=-1;
 	bSelectedOscHor = false;
 	bSelectedOscVert = false;
-	
+
 	ofEnableSmoothing();
 	ofEnableAlphaBlending();
 	ofSetVerticalSync(true);
@@ -37,55 +37,55 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::update(){
-	
+
 	for (unsigned int i=0; i<horizontalOscilators.size(); i++) {
 		horizontalOscilators[i].update();
 	}
 	for (unsigned int i=0; i<verticalOscilators.size(); i++) {
 		verticalOscilators[i].update();
 	}
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofBackgroundGradient(ofColor(245), ofColor(200));
 	//ofSetLineWidth(1);
-	
+
 	//The following is just to print the instructions to the screen.
 	ofSetColor(80);
 	ofDrawBitmapString("Click here to add horizontal oscillators.", LEFT_MARGIN +100, TOP_MARGIN-5 );
-	
+
 	ofDrawBitmapString("Click and drag\nover an\noscillator to\nmodify it's\nspeed and\namplitude", 15,25);
 	ofDrawBitmapString("Click in this area and drag upwards/downwards to scale up/down.\nPress spacebar to delete all the oscillators.", LEFT_MARGIN + 200, ofGetHeight()-40);
-	
+
 	//All this bunch is to print the vertical text
 	ofPushMatrix();
 	ofTranslate(LEFT_MARGIN -5,  ofGetHeight() - 100, 0);
-	ofRotate(-90, 0, 0, 1);
+	ofRotateDeg(-90, 0, 0, 1);
 	ofDrawBitmapString("Click here to add vertical oscillators.",  0, 0 );
 	ofPopMatrix();
-	
-	
-	
-	
+
+
+
+
 	ofEnableSmoothing();
-	
+
 	//This are just the reference lines draw in the screen.
 	ofSetColor(0, 0, 0, 150);
 	ofDrawLine(LEFT_MARGIN, 0, LEFT_MARGIN, ofGetHeight());
 	ofDrawLine(0, TOP_MARGIN, ofGetWidth(), TOP_MARGIN);
-	
+
 	ofSetColor(0, 0, 0, 80);
 	ofDrawLine(LEFT_MARGIN, center.y, ofGetWidth(), center.y);
 	ofDrawLine(center.x, TOP_MARGIN, center.x, ofGetHeight());
-	
+
 	//ofSetLineWidth(2);
-	
-	
+
+
 	float horWave = 0;
 	float vertWave = 0;
-	
+
 	//here we go through all the horizontal oscillators
 	for (unsigned int i=0; i<horizontalOscilators.size(); i++) {
 		ofSetColor(255, 127+i, 0,150);
@@ -103,7 +103,7 @@ void ofApp::draw(){
 	//here we move all the elements of the array one position forward so to make space for a new value.
 	for (int i=1; i<TAIL_LENGTH; i++) {
 		waveHistory[i-1] = waveHistory[i];
-	} 
+	}
 	for (int i=1; i<WAVEFORM_HISTORY; i++) {
 		horWaveHistory[i-1] = horWaveHistory[i];
 		vertWaveHistory[i-1]= vertWaveHistory[i];
@@ -112,16 +112,16 @@ void ofApp::draw(){
 	horWaveHistory[WAVEFORM_HISTORY-1] = horWave;
 	vertWaveHistory[WAVEFORM_HISTORY-1] = vertWave;
 	waveHistory[TAIL_LENGTH-1] = ofVec3f(horWave, vertWave,0);
-	
-	
-	
+
+
+
 	ofMesh wave; // declaring a new ofMesh object with which we're drawing the motion path created by summing the vertical and horizontal oscillators
 	wave.setMode(OF_PRIMITIVE_LINE_STRIP);
 	for (int i=0; i<TAIL_LENGTH; i++) {
 		wave.addColor(ofFloatColor(0.1f,0.1f,0.1f, 0.5f + 0.5f * i/float(TAIL_LENGTH) ));
 		wave.addVertex(waveHistory[i]);
 	}
-	
+
 	//all the following is to create and populate the horizontal and vertical waveforms.
 	ofMesh hWave;
 	hWave.setMode(OF_PRIMITIVE_LINE_STRIP);
@@ -133,14 +133,14 @@ void ofApp::draw(){
 		vWave.addColor(ofFloatColor(255, 240,10, 255));
 		vWave.addVertex(ofVec3f(vertWaveHistory[i]*0.1f*scale, i*vWaveMult, 0));
 	}
-	
+
 	//draw the vertical and horizontal wave.
 	ofPushMatrix();
 	ofTranslate(LEFT_MARGIN, TOP_MARGIN, 0);
 	hWave.draw();
 	vWave.draw();
 	ofPopMatrix();
-	
+
 	//draw the composite wave.
 	ofPushMatrix();
 	ofTranslate(center.x, center.y, 0);
@@ -149,13 +149,13 @@ void ofApp::draw(){
 	ofSetColor(0,10, 255),
 	ofDrawCircle(horWave, vertWave, 10);
 	ofPopMatrix();
-	
+
 }
 
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -168,7 +168,7 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	
+
 }
 
 //--------------------------------------------------------------
@@ -177,10 +177,10 @@ void ofApp::mouseDragged(int x, int y, int button){
 		//the following lines do so.
 		if(bSelectedOscHor==true){
 			horizontalOscilators[selectedOscilator].freq += 0.1f * (ofGetPreviousMouseX() - ofGetMouseX())/ float(ofGetWidth());
-			horizontalOscilators[selectedOscilator].amplitude += ofGetMouseY() - ofGetPreviousMouseY();	
+			horizontalOscilators[selectedOscilator].amplitude += ofGetMouseY() - ofGetPreviousMouseY();
 		}else if (bSelectedOscVert==true) {
 			verticalOscilators[selectedOscilator].freq += 0.1f * (ofGetPreviousMouseY() - ofGetMouseY())/ float(ofGetHeight());
-			verticalOscilators[selectedOscilator].amplitude += ofGetMouseX() - ofGetPreviousMouseX(); 
+			verticalOscilators[selectedOscilator].amplitude += ofGetMouseX() - ofGetPreviousMouseX();
 		}
 	}else if (bScaleMouse) {
 		scale += float(ofGetMouseY()-ofGetPreviousMouseY())/ofGetHeight();
@@ -189,7 +189,7 @@ void ofApp::mouseDragged(int x, int y, int button){
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 	if (y< TOP_MARGIN && x>LEFT_MARGIN) {
 		for (unsigned int i = 0; i < horizontalOscilators.size(); i++) {//this goes through the horizontal oscillators checking if anyone has been clicked over.
 			if(horizontalOscilators[i].checkOver(x, y)){
@@ -204,7 +204,7 @@ void ofApp::mousePressed(int x, int y, int button){
 	}else if(y>TOP_MARGIN && x<LEFT_MARGIN){
 		for (unsigned int i = 0; i < verticalOscilators.size(); i++) {
 			if(verticalOscilators[i].checkOver(x, y)){
-				setPressedOscilator(i, false);	
+				setPressedOscilator(i, false);
 				break;
 			}
 		}
@@ -242,15 +242,15 @@ void ofApp::mouseExited(int x, int y){
 
 //--------------------------------------------------------------
 void ofApp::windowResized(int w, int h){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::gotMessage(ofMessage msg){
-	
+
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
-	
+void ofApp::dragEvent(ofDragInfo dragInfo){
+
 }

--- a/examples/shader/02_simpleVertexDisplacement/src/ofApp.cpp
+++ b/examples/shader/02_simpleVertexDisplacement/src/ofApp.cpp
@@ -2,7 +2,7 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-    
+
 #ifdef TARGET_OPENGLES
 	shader.load("shadersES2/shader");
 #else
@@ -19,7 +19,7 @@ void ofApp::setup(){
     int planeGridSize = 20;
     int planeColums = planeWidth / planeGridSize;
     int planeRows = planeHeight / planeGridSize;
-    
+
     plane.set(planeWidth, planeHeight, planeColums, planeRows, OF_PRIMITIVE_TRIANGLES);
 }
 
@@ -30,7 +30,7 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-    
+
     float percentX = mouseX / (float)ofGetWidth();
     percentX = ofClamp(percentX, 0, 1);
 
@@ -41,13 +41,13 @@ void ofApp::draw(){
     ofColor colorRight = ofColor::cyan;
     ofColor colorMix = colorLeft.getLerped(colorRight, percentX);
     ofSetColor(colorMix);
-    
+
     shader.begin();
 
     // a lot of the time you have to pass in variables into the shader.
     // in this case we need to pass it the elapsed time for the sine wave animation.
     shader.setUniform1f("time", ofGetElapsedTimef());
-    
+
     // translate plane into center screen.
     float tx = ofGetWidth() / 2;
     float ty = ofGetHeight() / 2;
@@ -56,16 +56,16 @@ void ofApp::draw(){
     // the mouse/touch Y position changes the rotation of the plane.
     float percentY = mouseY / (float)ofGetHeight();
     float rotation = ofMap(percentY, 0, 1, -60, 60, true) + 60;
-    ofRotate(rotation, 1, 0, 0);
+    ofRotateDeg(rotation, 1, 0, 0);
 
     plane.drawWireframe();
-    
+
     shader.end();
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-    
+
 }
 
 //--------------------------------------------------------------
@@ -75,7 +75,7 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-    
+
 }
 
 //--------------------------------------------------------------
@@ -104,6 +104,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/shader/08_displacementMap/src/ofApp.cpp
+++ b/examples/shader/08_displacementMap/src/ofApp.cpp
@@ -2,7 +2,7 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-    
+
 #ifdef TARGET_OPENGLES
 	shader.load("shadersES2/shader");
 #else
@@ -23,7 +23,7 @@ void ofApp::setup(){
 void ofApp::update(){
     float noiseScale = ofMap(mouseX, 0, ofGetWidth(), 0, 0.1);
     float noiseVel = ofGetElapsedTimef();
-    
+
     unsigned char * pixels = img.getPixels();
     int w = img.getWidth();
     int h = img.getHeight();
@@ -39,15 +39,15 @@ void ofApp::update(){
 
 //--------------------------------------------------------------
 void ofApp::draw(){
-    
+
     // bind our texture. in our shader this will now be tex0 by default
     // so we can just go ahead and access it there.
     img.getTextureReference().bind();
-    
+
     shader.begin();
 
     ofPushMatrix();
-    
+
     // translate plane into center screen.
     float tx = ofGetWidth() / 2;
     float ty = ofGetHeight() / 2;
@@ -56,12 +56,12 @@ void ofApp::draw(){
     // the mouse/touch Y position changes the rotation of the plane.
     float percentY = mouseY / (float)ofGetHeight();
     float rotation = ofMap(percentY, 0, 1, -60, 60, true) + 60;
-    ofRotate(rotation, 1, 0, 0);
+    ofRotateDeg(rotation, 1, 0, 0);
 
     plane.drawWireframe();
-    
+
     ofPopMatrix();
-    
+
     shader.end();
 
     ofSetColor(ofColor::white);
@@ -70,7 +70,7 @@ void ofApp::draw(){
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
-    
+
 }
 
 //--------------------------------------------------------------
@@ -80,7 +80,7 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y){
-    
+
 }
 
 //--------------------------------------------------------------
@@ -109,6 +109,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/examples/strings/sortingExample/src/ofApp.cpp
+++ b/examples/strings/sortingExample/src/ofApp.cpp
@@ -23,13 +23,13 @@ bool ofApp::sortOnOccurrences(const LyricWord &a, const LyricWord &b) {
 // remove runction
 //--------------------------------------------------------------
 bool ofApp::removeWordIf(LyricWord &wrd) {
-    
+
     bool bRemove = false;
     static string ignoreWords[11] = {"the", "to", "of", "a", "and", "i", "it", "if", "is", "in", "be"};
-    
+
     // if this word empty
     if(wrd.word.empty()) bRemove = true;
-    
+
     // are we a word that we do now want
     for (int j=0; j<11; j++) {
         if(wrd.word == ignoreWords[j]) {
@@ -37,32 +37,32 @@ bool ofApp::removeWordIf(LyricWord &wrd) {
             break;
         }
     }
-    
+
     return bRemove;
 }
 
 //--------------------------------------------------------------
 void ofApp::setup() {
-    
+
     ofTrueTypeFont::setGlobalDpi(96);
 
     // load the font
 	font.load("sans-serif", 11);
     sortTypeInfo = "no sort";
     words.clear();
-    
-    // load the txt document into a ofBuffer 
+
+    // load the txt document into a ofBuffer
     ofBuffer buffer = ofBufferFromFile("freshprince.txt");
     string   content = buffer.getText();
-    
-    
+
+
     // take the content and split it up by spaces
-    // we need to also turn new lines into spaces so we can seperate words on new lines as well 
+    // we need to also turn new lines into spaces so we can seperate words on new lines as well
     ofStringReplace(content, "\r", " ");
     ofStringReplace(content, "\n", " ");
 
     vector <string> splitString = ofSplitString(content, " ", true, true);
-    
+
     // copy over the words to our object
     for (unsigned int i=0; i<splitString.size(); i++) {
         LyricWord wrd;
@@ -70,25 +70,25 @@ void ofApp::setup() {
         wrd.word = ofToLower( splitString[i] );
         words.push_back(wrd);
     }
-    
-    // clean up the words removing any 
+
+    // clean up the words removing any
     // characters that we do not want
     for (unsigned int i=0; i<words.size(); i++) {
         // run throught this ignore list and replace
         // that char with nothing
         char ignoreList[12] = {',', '.', '(', ')', '?', '!', '-', ':', '"', '\'', '\n', '\t'};
         for(int j=0; j<12; j++) {
-      
+
             // make string from char
             string removeStr;
             removeStr += ignoreList[j];
-            
+
             // remove and of the chars found
-            ofStringReplace(words[i].word, removeStr, "");    
+            ofStringReplace(words[i].word, removeStr, "");
         }
     }
-    
- 
+
+
     // count the amount of times that we see a word
     for (unsigned int i=0; i<words.size(); i++) {
         int c = 1;
@@ -97,7 +97,7 @@ void ofApp::setup() {
         }
         words[i].occurrences = c;
     }
-    
+
     // remove duplicates of the words
     vector<LyricWord>tempWord;
     for (unsigned int i=0; i<words.size(); i++) {
@@ -105,14 +105,14 @@ void ofApp::setup() {
         for(unsigned int j=0; j<tempWord.size(); j++) {
             if(words[i].word == tempWord[j].word) bAdd = false;
         }
-        
+
         if(bAdd) {
             tempWord.push_back(words[i]);
         }
     }
-    
+
     words = tempWord;
-    
+
     // remove word we do not want
     ofRemove(words, ofApp::removeWordIf);
 
@@ -121,19 +121,19 @@ void ofApp::setup() {
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::draw() {
 
     ofSetColor(50);
-    
+
     ofPushMatrix();
     ofTranslate(ofGetWidth()/2, ofGetHeight()/2);
-    
+
     float radius = 350;
-    
+
     for(unsigned int i=0; i<words.size()/2; i++) {
         float t = -HALF_PI + ofMap(i, 0, (words.size()/2), 0, TWO_PI);
         float x = cos( t ) * radius;
@@ -142,79 +142,79 @@ void ofApp::draw() {
         ofSetColor(0);
         ofPushMatrix();
         ofTranslate(x, y);
-        ofRotateZ(a);
+        ofRotateZDeg(a);
         float scl = 1;
         glScalef(scl, scl, scl);
         font.drawString(words[i].word, 0, 20);
         ofPopMatrix();
-        
-    }    
-    
+
+    }
+
     ofSetColor(100);
     font.drawString(sortTypeInfo, -(font.stringWidth(sortTypeInfo)/2), 0);
     ofPopMatrix();
-    
-    
+
+
     // instruction
     ofSetColor(10);
     ofDrawBitmapString("\nPress 1 for no sort\nPress 2 for alphabetical\nPress 3 for word length\nPress 4 for word occurrence", 20, 20);
-    
 
-  
+
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyPressed  (int key){
- 
-    // sort raw 
+
+    // sort raw
     if(key == '1')     {
         sortTypeInfo = "no sort";
         setup();
     }
-    
+
     // sort alphabetically
     if(key == '2') {
         sortTypeInfo = "sorting alphabetically";
         ofSort(words, ofApp::sortOnABC);
     }
-    
+
     // sort by length of word
     if(key == '3')     {
         sortTypeInfo = "sorting on word length";
         ofSort(words, ofApp::sortOnLength);
     }
-    
+
     // sort by length of word
     if(key == '4')     {
         sortTypeInfo = "sorting on word occurrences";
         ofSort(words, ofApp::sortOnOccurrences);
     }
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::keyReleased  (int key){
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-    
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	
+
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-    
+
 }
 
 //--------------------------------------------------------------
@@ -238,6 +238,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }


### PR DESCRIPTION
…tateDeg/Rad() functions in examples.

Ignoring whitespace makes this a little easier to comprehend ...

https://github.com/openframeworks/openFrameworks/compare/master...bakercp:update-examples-for-ofRotate?expand=1&w=1