### PR TITLE
fix for qtcreator 4.1

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
@@ -1,3 +1,6 @@
+var Process = loadExtension("qbs.Process");
+var File = loadExtension("qbs.File");
+
 function listDir(dir){
     var ls = new Process();
     ls.exec("ls", [dir]);


### PR DESCRIPTION
Quick fix for qtcreator 4.1. I had to import missing modules into the  javascript helpers.

Note that I also get these deprecation warnings:

```
The item 'Transformer' is deprecated and will be removed in qbs 1.7.0.
Use the 'Rule' item instead.
```