### PR TITLE
don't perform "hierarchy-management" in ofParameter::getFirstParent()

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -516,9 +516,6 @@ public:
 	void setParent(ofParameterGroup & _parent);
 
 	const ofParameterGroup getFirstParent() const{
-		obj->parents.erase(std::remove_if(obj->parents.begin(),obj->parents.end(),
-						   [](weak_ptr<ofParameterGroup::Value> p){return p.lock()==nullptr;}),
-						obj->parents.end());
 		if(!obj->parents.empty()){
 			return obj->parents.front().lock();
 		}else{


### PR DESCRIPTION
Relates to issue #5248 

Note that I simply removed the code that seems to check the ParameterGroup hierarchy integrity from the getFirstParent function, which might be problematic? I'm unclear about why this happens here. Similar functionality can be found in the ofParameter::eventsSetValue function that is called every time a parameter's value is changed, which seems wildly inefficient.

Note that I know very little about all this weak_ptr/shared_ptr style coding, so it's not unlikely that I don't know what I'm talking bout.