### PR TITLE
ofFbo: add methods to clear the different buffers + allow no color

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -451,6 +451,33 @@ void ofFbo::clear() {
 #endif
 }
 
+
+//--------------------------------------------------------------
+void ofFbo::clearColorBuffer(const ofFloatColor & color){
+	glClearBufferfv(GL_COLOR, 0, &color.r);
+}
+
+
+//--------------------------------------------------------------
+void ofFbo::clearColorBuffer(size_t buffer_idx, const ofFloatColor & color){
+	glClearBufferfv(GL_COLOR, buffer_idx, &color.r);
+}
+
+//--------------------------------------------------------------
+void ofFbo::clearDepthBuffer(float value){
+	glClearBufferfv(GL_DEPTH, 0, &value);
+}
+
+//--------------------------------------------------------------
+void ofFbo::clearStencilBuffer(float value){
+	glClearBufferfv(GL_STENCIL, 0, &value);
+}
+
+//--------------------------------------------------------------
+void ofFbo::clearDepthStencilBuffer(float depth, float stencil){
+	glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
+}
+
 //--------------------------------------------------------------
 void ofFbo::destroy() {
 	clear();
@@ -504,7 +531,7 @@ void ofFbo::allocate(int width, int height, int internalformat, int numSamples) 
 	settings.useStencil		= false;
 	//we do this as the fbo and the settings object it contains could be created before the user had the chance to disable or enable arb rect.
     settings.textureTarget	= GL_TEXTURE_2D;
-#else    
+#else
 	settings.useDepth		= true;
 	settings.useStencil		= true;
 	//we do this as the fbo and the settings object it contains could be created before the user had the chance to disable or enable arb rect. 	
@@ -652,7 +679,8 @@ void ofFbo::allocate(Settings _settings) {
 		for(int i=0; i<_settings.numColorbuffers; i++) createAndAttachTexture(_settings.internalformat, i);
 		_settings.colorFormats = settings.colorFormats;
 	} else {
-		ofLogWarning("ofFbo") << "allocate(): no color buffers specified for frame buffer object " << fbo;
+		//ofLogWarning("ofFbo") << "allocate(): no color buffers specified for frame buffer object " << fbo;
+		glDrawBuffer(GL_NONE);
 	}
 	settings.internalformat = _settings.internalformat;
 	
@@ -1105,7 +1133,7 @@ void ofFbo::draw(float x, float y) const{
 
 //----------------------------------------------------------
 void ofFbo::draw(float x, float y, float width, float height) const{
-	if(!bIsAllocated) return;
+	if(!bIsAllocated || settings.numColorbuffers==0) return;
     getTexture().draw(x, y, width, height);
 }
 

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -680,8 +680,11 @@ void ofFbo::allocate(Settings _settings) {
 		for(int i=0; i<_settings.numColorbuffers; i++) createAndAttachTexture(_settings.internalformat, i);
 		_settings.colorFormats = settings.colorFormats;
 	} else {
-		//ofLogWarning("ofFbo") << "allocate(): no color buffers specified for frame buffer object " << fbo;
+#ifndef TARGET_OPENGLES
 		glDrawBuffer(GL_NONE);
+#else
+		ofLogWarning("ofFbo") << "allocate(): no color buffers specified for frame buffer object " << fbo;
+#endif
 	}
 	settings.internalformat = _settings.internalformat;
 	

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -452,11 +452,11 @@ void ofFbo::clear() {
 }
 
 
+#ifndef TARGET_OPENGLES
 //--------------------------------------------------------------
 void ofFbo::clearColorBuffer(const ofFloatColor & color){
 	glClearBufferfv(GL_COLOR, 0, &color.r);
 }
-
 
 //--------------------------------------------------------------
 void ofFbo::clearColorBuffer(size_t buffer_idx, const ofFloatColor & color){
@@ -477,6 +477,7 @@ void ofFbo::clearStencilBuffer(int value){
 void ofFbo::clearDepthStencilBuffer(float depth, int stencil){
 	glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
 }
+#endif
 
 //--------------------------------------------------------------
 void ofFbo::destroy() {

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -469,12 +469,12 @@ void ofFbo::clearDepthBuffer(float value){
 }
 
 //--------------------------------------------------------------
-void ofFbo::clearStencilBuffer(float value){
-	glClearBufferfv(GL_STENCIL, 0, &value);
+void ofFbo::clearStencilBuffer(int value){
+	glClearBufferiv(GL_STENCIL, 0, &value);
 }
 
 //--------------------------------------------------------------
-void ofFbo::clearDepthStencilBuffer(float depth, float stencil){
+void ofFbo::clearDepthStencilBuffer(float depth, int stencil){
 	glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
 }
 

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -37,6 +37,7 @@ public:
 	OF_DEPRECATED_MSG("Use clear instead",void destroy());
 	void clear();
 
+#ifndef TARGET_OPENGLES
 	/// glClearBufferfv(GL_COLOR, 0...)
 	///
 	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
@@ -61,6 +62,7 @@ public:
 	///
 	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
 	void clearDepthStencilBuffer(float depth, int stencil);
+#endif
 
 	using ofBaseDraws::draw;
 	void draw(float x, float y) const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -37,6 +37,31 @@ public:
 	OF_DEPRECATED_MSG("Use clear instead",void destroy());
 	void clear();
 
+	/// glClearBufferfv(GL_COLOR, 0...)
+	///
+	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
+	void clearColorBuffer(const ofFloatColor & color);
+
+	/// glClearBufferfv(GL_COLOR, buffer_idx...)
+	///
+	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
+	void clearColorBuffer(size_t buffer_idx, const ofFloatColor & color);
+
+	/// glClearBufferfv(GL_DEPTH...)
+	///
+	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
+	void clearDepthBuffer(float value);
+
+	/// glClearBufferfv(GL_STENCIL...)
+	///
+	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
+	void clearStencilBuffer(float value);
+
+	/// glClearBufferfi(GL_DEPTH_STENCIL...)
+	///
+	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
+	void clearDepthStencilBuffer(float depth, float stencil);
+
 	using ofBaseDraws::draw;
 	void draw(float x, float y) const;
 	void draw(float x, float y, float width, float height) const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -52,15 +52,15 @@ public:
 	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
 	void clearDepthBuffer(float value);
 
-	/// glClearBufferfv(GL_STENCIL...)
+	/// glClearBufferiv(GL_STENCIL...)
 	///
 	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
-	void clearStencilBuffer(float value);
+	void clearStencilBuffer(int value);
 
 	/// glClearBufferfi(GL_DEPTH_STENCIL...)
 	///
 	/// @see: https://www.opengl.org/wiki/GLAPI/glClearBuffer
-	void clearDepthStencilBuffer(float depth, float stencil);
+	void clearDepthStencilBuffer(float depth, int stencil);
 
 	using ofBaseDraws::draw;
 	void draw(float x, float y) const;

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -292,7 +292,7 @@ bool ofShader::setupShaderFromFile(GLenum type, std::filesystem::path filename) 
 	if(buffer.size()) {
 		return setupShaderFromSource(type, buffer.getText(), sourceDirectoryPath);
 	} else {
-		ofLogError("ofShader") << "setupShaderFromFile(): couldn't load " << nameForType(type) << " shader " << " from \"" << filename << "\"";
+		ofLogError("ofShader") << "setupShaderFromFile(): couldn't load " << nameForType(type) << " shader " << " from \"" << absoluteFilePath << "\"";
 		return false;
 	}
 }
@@ -307,7 +307,7 @@ ofShader::Source ofShader::sourceFromFile(GLenum type, std::filesystem::path fil
 	if(buffer.size()) {
 		return std::move(Source{type, buffer.getText(), sourceDirectoryPath});
 	} else {
-		ofLogError("ofShader") << "setupShaderFromFile(): couldn't load " << nameForType(type) << " shader " << " from \"" << filename << "\"";
+		ofLogError("ofShader") << "setupShaderFromFile(): couldn't load " << nameForType(type) << " shader " << " from \"" << absoluteFilePath << "\"";
 		return Source{};
 	}
 }


### PR DESCRIPTION
useful when using MRT and need to clear each buffer with different colors.

also allow no color buffer without warning since it's perfectly valid to have an fbo with depth only