### PR TITLE
cleanup ofParameter's parents before starting the notification iteration

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -680,35 +680,19 @@ inline void ofParameter<ParameterType>::eventsSetValue(const ParameterType & v){
         // Notify all parents, if there are any.
         if(!obj->parents.empty())
         {
-
-            // This lambda will conditionally notify a parent if its child
-            // value has changed.
-            //
-            // If it was successful (i.e. the parent pointer is valid) the
-            // lambda will return false.  If it was unsuccessful (i.e. the
-            // parent pointer is invalid) the lambda will return true.
-            //
-            // This return value is used by the std::remove_if algorithm
-            // to erase invalid parents from this object's parent list.
-			auto notifyParents = [this](const weak_ptr<ofParameterGroup::Value> & p){
-                // Try to get a valid shared pointer ot the parent.
-                auto parent = p.lock();
-
-                // If the parent's shared pointer is not nullptr, notify it.
-                if(parent != nullptr) {
-                    parent->notifyParameterChanged(*this);
-                    return false;
-                } else {
-                    return true;
-                }
-            };
-
-            // Erase each invalid parent and notify all valid parents of this
-            // object's changed value.
+            // Erase each invalid parent
             obj->parents.erase(std::remove_if(obj->parents.begin(),
                                               obj->parents.end(),
-                                              notifyParents),
+											  [this](const weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
                                obj->parents.end());
+
+			// notify all leftover (valid) parents of this object's changed value.
+			// this can't happen in the same iterator as above, because a notified listener
+			// might perform similar cleanups that would corrupt our iterator
+			// (which appens for example if the listener calls getFirstParent on us)
+			for(auto parent = obj->parents.begin(); parent != obj->parents.end(); parent++){
+				parent->lock()->notifyParameterChanged(*this);
+			}
         }
         obj->bInNotify = false;
     }

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -690,8 +690,11 @@ inline void ofParameter<ParameterType>::eventsSetValue(const ParameterType & v){
 			// this can't happen in the same iterator as above, because a notified listener
 			// might perform similar cleanups that would corrupt our iterator
 			// (which appens for example if the listener calls getFirstParent on us)
-			for(auto parent = obj->parents.begin(); parent != obj->parents.end(); parent++){
-				parent->lock()->notifyParameterChanged(*this);
+			for(auto & parent: obj->parents){
+				auto p = parent.lock();
+				if(p){
+					p->notifyParameterChanged(*this);
+				}
 			}
         }
         obj->bInNotify = false;

--- a/tests/addons/ofxGui/addons.make
+++ b/tests/addons/ofxGui/addons.make
@@ -1,0 +1,2 @@
+ofxUnitTests
+ofxGui

--- a/tests/addons/ofxGui/src/main.cpp
+++ b/tests/addons/ofxGui/src/main.cpp
@@ -1,0 +1,28 @@
+#include "ofMain.h"
+#include "ofxUnitTests.h"
+#include "ofxGui.h"
+
+class ofApp : public ofxUnitTestsApp{
+    void parameterChanged(ofAbstractParameter & parameter){
+        param.getFirstParent();
+    }
+    
+    ofxPanel gui;
+    ofParameterGroup group;
+    ofParameter<int> param;
+    
+    void run(){
+        group.setName("myGroup");
+        group.add(param.set("myParam", 1));
+        gui.setup(group);
+        ofAddListener(group.parameterChangedE(),this,&ofApp::parameterChanged);
+        param.set(2); // if this don't crash, test succeeds
+        test_eq(param.get(), 2, "callback listener corrupted param.obj->parents");
+    }
+};
+
+//========================================================================
+int main( ){
+    ofSetupOpenGL(1024,768, OF_WINDOW);
+    ofRunApp( new ofApp());
+}


### PR DESCRIPTION
Another shot at resolving #5248. See also #5250.

While writing the unittest I noticed that the issue doesn't occur if ofxGui isn't getting involved with the ofParameterGroup, so I guess the issue (#5248) might be inside ofxGui (I haven't been able to find the culprit yet). On the other hand, if ofParameter does all these weak_ptr validity checks, it should probably be resistant against situations where there is actually an invalid weak_ptr among the obj->parents. Hence, still the patch to ofParameter.h