### PR TITLE
Fix for #5262 - Short lived threads can cause exceptions

### DIFF
--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -172,11 +172,7 @@ void ofThread::run(){
 	if(thread.joinable()){
 		try{
 			thread.detach();
-		}catch(const std::exception& exc){
-			ofLogFatalError("ofThreadErrorLogger::exception") << exc.what();
-		}catch(...){
-			ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
-		}
+		}catch(...){}
 	}
 #ifdef TARGET_ANDROID
 	attachResult = ofGetJavaVMPtr()->DetachCurrentThread();

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -169,11 +169,9 @@ void ofThread::run(){
 	}catch(...){
 		ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
 	}
-	if(thread.joinable()){
-		try{
-			thread.detach();
-		}catch(...){}
-	}
+	try{
+		thread.detach();
+	}catch(...){}
 #ifdef TARGET_ANDROID
 	attachResult = ofGetJavaVMPtr()->DetachCurrentThread();
 #endif

--- a/libs/openFrameworks/utils/ofThread.cpp
+++ b/libs/openFrameworks/utils/ofThread.cpp
@@ -169,7 +169,15 @@ void ofThread::run(){
 	}catch(...){
 		ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
 	}
-	thread.detach();
+	if(thread.joinable()){
+		try{
+			thread.detach();
+		}catch(const std::exception& exc){
+			ofLogFatalError("ofThreadErrorLogger::exception") << exc.what();
+		}catch(...){
+			ofLogFatalError("ofThreadErrorLogger::exception") << "Unknown exception.";
+		}
+	}
 #ifdef TARGET_ANDROID
 	attachResult = ofGetJavaVMPtr()->DetachCurrentThread();
 #endif


### PR DESCRIPTION
Try-catch around ofThread deteach(), and only detach if not joinable