### PR TITLE
fix ofPolyLine::calcData returning invalid values

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -501,10 +501,10 @@ private:
     
     // cache
     mutable vector<float> lengths;    // cumulative lengths, stored per point (lengths[n] is the distance to the n'th point, zero based)
-	mutable vector<T> tangents;   // tangent at vertex, stored per point
-	mutable vector<T> normals;    //
-	mutable vector<T> rotations;   // rotation between adjacent segments, stored per point (cross product)
-    mutable vector<float> angles;    // angle (degrees) between adjacent segments, stored per point (asin(cross product))
+	mutable vector<T> tangents;       // tangent at vertex, stored per point
+	mutable vector<T> normals;        //
+	mutable vector<T> rotations;      // rotation axes between adjacent segments, stored per point (cross product)
+    mutable vector<float> angles;     // angle (rad) between adjacent segments, stored per point (asin(cross product))
 	mutable T centroid2D;
     mutable float area;
     

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -997,27 +997,35 @@ T ofPolyline_<T>::getNormalAtIndexInterpolated(float findex) const {
 //--------------------------------------------------
 template<class T>
 void ofPolyline_<T>::calcData(int index, T &tangent, float &angle, T &rotation, T &normal) const {
-    int i1 = getWrappedIndex(index - 1);
-    int i2 = getWrappedIndex(index);
-    int i3 = getWrappedIndex(index + 1);
-    
-	T p1(points[i1]);
-	T p2(points[i2]);
-	T p3(points[i3]);
-    
-	T v1(p1 - p2); // vector to previous point
-	T v2(p3 - p2); // vector to next point
-	glm::normalize(toGlm(v1));
-	glm::normalize(toGlm(v2));
-    
-    tangent = (v2 - v1);
-	glm::normalize(toGlm(tangent));
-    
-	rotation = glm::cross(toGlm(v1), toGlm(v2));
-	angle = glm::pi<float>() - acos(ofClamp(v1.x * v2.x + v1.y * v2.y + v1.z * v2.z, -1, 1));
+	int i1 = getWrappedIndex( index - 1 );
+	int i2 = getWrappedIndex( index     );
+	int i3 = getWrappedIndex( index + 1 );
 
-	normal = glm::cross(toGlm(rightVector), toGlm(tangent));
-	glm::normalize(toGlm(normal));
+	const auto &p1 = toGlm(points[i1]);
+	const auto &p2 = toGlm(points[i2]);
+	const auto &p3 = toGlm(points[i3]);
+
+	auto v1(p1 - p2); // vector to previous point
+	auto v2(p3 - p2); // vector to next point
+	
+	v1 = glm::normalize(v1);
+	v2 = glm::normalize(v2);
+
+	// If just one of p1, p2, or p3 was identical, further calculations 
+	// are (almost literally) pointless, as v1 or v2 will then contain 
+	// NaN values instead of floats.
+
+	bool noSegmentHasZeroLength = (v1 == v1 && v2 == v2);
+
+	if ( noSegmentHasZeroLength ){
+		tangent  = toOf( glm::length2(v2 - v1) > 0 ? glm::normalize(v2 - v1) : -v1 );
+		normal   = toOf( glm::normalize( glm::cross( toGlm( rightVector ), toGlm( tangent ) ) ) );
+		rotation = toOf( glm::cross( v1, v2 ) );
+		angle    = glm::pi<float>() - acosf( ofClamp( glm::dot( v1, v2 ), -1.f, 1.f ) );
+	} else{
+		rotation = tangent = normal = T( 0.f );
+		angle    = 0.f;
+	}
 }
 
 


### PR DESCRIPTION
This fixes a regression where ofPolyline would return unnormalized values for tangent, rotation and normal.

The issue existed, because the glm:: implementation of glm::normalize don't operate in-place, but their return value must be used.

Addresses issue #5288

+ fixes an issue where pathological polylines would return nan vectors

Whenever a calculation is done which involves normalisation we should check for the length of the vector being normalised, or the normalization result not being NaN (which is the result of normalizing a `{0,0,0}`-vector in glm). 

oF used to return a zero vector in this case, and this implementation tries to match the output you would have received if using code from the pre-inline revision: 0361224e.

+ Address edge case: segments point against each other

When two segments are congruent i.e. they point exactly against each other, this implementation will use the direction of one segment as tangent, so that a meaningful normal can be calculated. This is an edge case, and it should probably discussed how best to implement this.

+ also updates comments in .h file

I'm attaching a minimal test app (main.cpp only): https://gist.github.com/tgfrerer/ae38a263a881526415d38fe3723b3463
![testpolyline_debug 2016-09-29 21-18-50-141](https://cloud.githubusercontent.com/assets/423509/18970974/467ddd28-868b-11e6-9803-c9d0974340e9.png)
![testpolyline_debug 2016-09-29 21-22-38-216](https://cloud.githubusercontent.com/assets/423509/18970975/46837346-868b-11e6-8af1-5114b7f14333.png)
![testpolyline_debug 2016-09-29 21-22-57-829](https://cloud.githubusercontent.com/assets/423509/18970976/46888228-868b-11e6-841e-e7aa6683b133.png)
Test app screenshots show polyline in blue, normals in red, tangents in green.