### PR TITLE
fix ofPolyline::bezierTo

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -278,9 +278,9 @@ void ofPolyline_<T>::curveTo( const T & to, int curveResolution ){
 		float t,t2,t3;
 		float x,y,z;
         
-		for (int i = 0; i < curveResolution; i++){
+		for (int i = 1; i <= curveResolution; i++){
             
-			t 	=  (float)i / (float)(curveResolution-1);
+			t 	=  (float)i / (float)(curveResolution);
 			t2 	= t * t;
 			t3 	= t2 * t;
             

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -224,8 +224,8 @@ void ofPolyline_<T>::bezierTo( const T & cp1, const T & cp2, const T & to, int c
 		bz = 3.0f * (cp2.z - cp1.z) - cz;
 		az = to.z - z0 - cz - bz;
         
-		for (int i = 0; i < curveResolution; i++){
-			t 	=  (float)i / (float)(curveResolution-1);
+		for (int i = 1; i <= curveResolution; i++){
+			t 	=  (float)i / (float)(curveResolution);
 			t2 = t * t;
 			t3 = t2 * t;
 			x = (ax * t3) + (bx * t2) + (cx * t) + x0;


### PR DESCRIPTION
fixes an issue where the starting point of a cubic bezier
would be doubled, while the target point would never be
fully reached.

BezierTo draws a cubic bezier to the target point using
two control points. Bezier curves are defined through four
points: p0, control0, control1, and p1.

In our implementation, p0 is taken from the last point in
the current polyline, and is therefore already a point on
the polyline.

Then the bezier curve is sampled curveResolution times.
When sampling, we want to make sure that the interpolation parameter
t goes from 0 to 1, **1 inclusive**. 1 inclusive, so that at the
end of interpolation we fully reach the target point p1.

As the bezier curve is attached to the current polyline, the
first step, where the interpolation parameter would be 0, is
already part of the vertices in the polyline, and must be
ommitted.