### PR TITLE
include Xinerama in linux of.qbs

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -152,6 +152,7 @@ Module{
                 "Xxf86vm",
                 "Xi",
                 "Xcursor",
+                "Xinerama",
                 "dl",
                 "pthread",
                 "freeimage",


### PR DESCRIPTION
qt composer project file was missing Xinerama for linux compiles. Xinerama is already included in makefiles. This only affects builds through the Qt gui, which may otherwise fail linking.