### PR TITLE
changed ofToFloat to ofToDouble in ofxXmlSettings

### DIFF
--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -165,7 +165,7 @@ int ofxXmlSettings::getValue(const string& tag, int defaultValue, int which) con
 double ofxXmlSettings::getValue(const string& tag, double defaultValue, int which) const{
     TiXmlHandle valHandle(NULL);
 	if (readTag(tag, valHandle, which)){
-		return ofToFloat(valHandle.ToText()->Value());
+		return ofToDouble(valHandle.ToText()->Value());
 	}
 	return defaultValue;
 }


### PR DESCRIPTION
It is parsing a double, it should convert to double, or we will lose precision