### PR TITLE
rename check to check_op in ofParameter SFINAE.

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -363,22 +363,22 @@ namespace priv{
 	no operator << (const anyx &, const anyx &);
 	no operator >> (const anyx &, const anyx &);
 
-
-	template <class T> yes check(T const&);
-	no check(no);
+	
+	template <class T> yes check_op(T const&);
+	no check_op(no);
 
 	template <typename T>
 	struct has_loading_support {
 		static istream & stream;
 		static T & x;
-		static const bool value = sizeof(check(stream >> x)) == sizeof(yes);
+		static const bool value = sizeof(check_op(stream >> x)) == sizeof(yes);
 	};
 
 	template <typename T>
 	struct has_saving_support {
 		static ostream & stream;
 		static T & x;
-		static const bool value = sizeof(check(stream << x)) == sizeof(yes);
+		static const bool value = sizeof(check_op(stream << x)) == sizeof(yes);
 	};
 
 	template <typename T>

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -371,21 +371,21 @@ namespace priv{
 	struct has_loading_support {
 		static istream & stream;
 		static T & x;
-		static const bool value = sizeof(check_op(stream >> x)) == sizeof(yes);
+		static constexpr bool value = sizeof(check_op(stream >> x)) == sizeof(yes);
 	};
 
 	template <typename T>
 	struct has_saving_support {
 		static ostream & stream;
 		static T & x;
-		static const bool value = sizeof(check_op(stream << x)) == sizeof(yes);
+		static constexpr bool value = sizeof(check_op(stream << x)) == sizeof(yes);
 	};
 
 	template <typename T>
 	struct has_stream_operators {
-		static const bool can_load = has_loading_support<T>::value;
-		static const bool can_save = has_saving_support<T>::value;
-		static const bool value = can_load && can_save;
+		static constexpr bool can_load = has_loading_support<T>::value;
+		static constexpr bool can_save = has_saving_support<T>::value;
+		static constexpr bool value = can_load && can_save;
 	};
 
 	template<typename ParameterType>


### PR DESCRIPTION
Xcode has terrible macro `check` in "AssertMacros.h".
if we include AssertMacros.h, then ofParameter got error.
and, AssertMacros.h is include too deep layer.

other way,
`#undef check`
or,
```
#define MACRO_DISABLER
	template <class T> yes check MACRO_DISABLER (T const&);
	no check MACRO_DISABLER (no);
...
	static const bool value = sizeof(check MACRO_DISABLER (stream >> x)) == sizeof(yes);
...
	static const bool value = sizeof(check MACRO_DISABLER (stream << x)) == sizeof(yes);
...
```

i think, rename is simple most better way.