### PR TITLE
fixing cameraLensOffsetExample call to inverse()

### DIFF
--- a/examples/3d/cameraLensOffsetExample/src/ofApp.cpp
+++ b/examples/3d/cameraLensOffsetExample/src/ofApp.cpp
@@ -99,7 +99,7 @@ void ofApp::drawScene(bool isPreview){
 		ofNode().draw();
 		ofPopMatrix();
 		
-		ofMultMatrix(headTrackedCamera.getProjectionMatrix().getInverse());
+		ofMultMatrix(inverse(headTrackedCamera.getProjectionMatrix()));
 		
 		ofNoFill();
 		ofDrawBox(2.0f);

--- a/examples/3d/modelNoiseExample/src/ofApp.cpp
+++ b/examples/3d/modelNoiseExample/src/ofApp.cpp
@@ -105,7 +105,12 @@ void ofApp::drawWithMesh(){
 	float liquidness = 5;
 	float amplitude = mouseY/100.0;
 	float speedDampen = 5;
-	vector<ofVec3f>& verts = mesh.getVertices();
+    auto t_vect = mesh.getVertices();
+    vector<ofVec3f> verts;
+    for(unsigned int i = 0;i < t_vect.size(); i++){
+        ofVec3f t(t_vect[i]);
+        verts.push_back(t);
+    }
 	for(unsigned int i = 0; i < verts.size(); i++){
 		verts[i].x += ofSignedNoise(verts[i].x/liquidness, verts[i].y/liquidness,verts[i].z/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 		verts[i].y += ofSignedNoise(verts[i].z/liquidness, verts[i].x/liquidness,verts[i].y/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;


### PR DESCRIPTION
There are a bunch of small errors that keep some of the examples from building cleanly. This is the first of a series of PRs to fix these problems.