### PR TITLE
Avoid crash of doesDirectoryExists function

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1423,10 +1423,16 @@ bool ofDirectory::createDirectory(const std::string& _dirPath, bool bRelativeToD
 //------------------------------------------------------------------------------------------------------------
 bool ofDirectory::doesDirectoryExist(const std::string& _dirPath, bool bRelativeToData){
 	std::string dirPath = _dirPath;
-	if(bRelativeToData){
-		dirPath = ofToDataPath(dirPath);
+	try {
+		if (bRelativeToData) {
+			dirPath = ofToDataPath(dirPath);
+		}
+		return std::filesystem::exists(dirPath) && std::filesystem::is_directory(dirPath);
 	}
-	return std::filesystem::exists(dirPath) && std::filesystem::is_directory(dirPath);
+	catch (std::exception & except) {
+		ofLogError("ofDirectory") << "doesDirectoryExist(): couldn't find directory \"" << dirPath << "\": " << except.what() << endl;
+		return false;
+	}
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1337,30 +1337,9 @@ static bool natural(const ofFile& a, const ofFile& b) {
 
 //------------------------------------------------------------------------------------------------------------
 static bool byDate(const ofFile& a, const ofFile& b) {
-	struct stat st1;
-	struct stat st2;
-	int date1, date2;
-
-	int err1 = stat(a.getAbsolutePath().c_str(), &st1);
-	int err2 = stat(b.getAbsolutePath().c_str(), &st2);
-
-	if (err1 == 0) {
-		date1 = st1.st_mtime;
-	}
-	else {
-		ofLogError("ofDirectory") << "sortByDate(): stat() failed for file 'a' while sorting by date.";
-		return false;
-	}
-
-	if (err2 == 0) {
-		date2 = st2.st_mtime;
-	}
-	else {
-		ofLogError("ofDirectory") << "sortByDate(): stat() failed for file 'b' while sorting by date.";
-		return false;
-	}
-
-	return date1 < date2;
+	auto ta = std::filesystem::last_write_time(a);
+	auto tb = std::filesystem::last_write_time(b);
+	return ta < tb;
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1336,6 +1336,39 @@ static bool natural(const ofFile& a, const ofFile& b) {
 }
 
 //------------------------------------------------------------------------------------------------------------
+static bool byDate(const ofFile& a, const ofFile& b) {
+	struct stat st1;
+	struct stat st2;
+	int date1, date2;
+
+	int err1 = stat(a.getAbsolutePath().c_str(), &st1);
+	int err2 = stat(b.getAbsolutePath().c_str(), &st2);
+
+	if (err1 == 0) {
+		date1 = st1.st_mtime;
+	}
+	else {
+		ofLogError("ofDirectory") << "sortByDate(): stat() failed for file 'a' while sorting by date.";
+		return false;
+	}
+
+	if (err2 == 0) {
+		date2 = st2.st_mtime;
+	}
+	else {
+		ofLogError("ofDirectory") << "sortByDate(): stat() failed for file 'b' while sorting by date.";
+		return false;
+	}
+
+	return date1 < date2;
+}
+
+//------------------------------------------------------------------------------------------------------------
+void ofDirectory::sortByDate() {
+	ofSort(files, byDate);
+}
+
+//------------------------------------------------------------------------------------------------------------
 void ofDirectory::sort(){
 	if(files.empty() && !myDir.empty()){
 		listDir();

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1344,6 +1344,9 @@ static bool byDate(const ofFile& a, const ofFile& b) {
 
 //------------------------------------------------------------------------------------------------------------
 void ofDirectory::sortByDate() {
+	if (files.empty() && !myDir.empty()) {
+		listDir();
+	}
 	ofSort(files, byDate);
 }
 

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1072,6 +1072,12 @@ public:
 	/// nothing to sort.
 	void sort();
 	
+	/// Sort the directory contents list alphabetically.
+	///
+	/// \warning Call listDir() before using this function or there will be
+	/// nothing to sort.
+	void sortByDate();
+
 	/// Get a sorted ofDirectory instance using the current path.
 	///
 	/// \returns sorted ofDirectory instance


### PR DESCRIPTION
This function makes the app crash on win7. I put a try catch to avoid
the crash.
issue #5315