### PR TITLE
fix to get the mesh verticies

### DIFF
--- a/examples/3d/modelNoiseExample/src/ofApp.cpp
+++ b/examples/3d/modelNoiseExample/src/ofApp.cpp
@@ -105,12 +105,8 @@ void ofApp::drawWithMesh(){
 	float liquidness = 5;
 	float amplitude = mouseY/100.0;
 	float speedDampen = 5;
-    auto t_vect = mesh.getVertices();
-    vector<ofVec3f> verts;
-    for(unsigned int i = 0;i < t_vect.size(); i++){
-        ofVec3f t(t_vect[i]);
-        verts.push_back(t);
-    }
+    auto &verts = mesh.getVertices();
+
 	for(unsigned int i = 0; i < verts.size(); i++){
 		verts[i].x += ofSignedNoise(verts[i].x/liquidness, verts[i].y/liquidness,verts[i].z/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 		verts[i].y += ofSignedNoise(verts[i].z/liquidness, verts[i].x/liquidness,verts[i].y/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;

--- a/examples/3d/modelNoiseExample/src/ofApp.cpp
+++ b/examples/3d/modelNoiseExample/src/ofApp.cpp
@@ -105,7 +105,12 @@ void ofApp::drawWithMesh(){
 	float liquidness = 5;
 	float amplitude = mouseY/100.0;
 	float speedDampen = 5;
-	vector<ofVec3f>& verts = mesh.getVertices();
+    auto t_vect = mesh.getVertices();
+    vector<ofVec3f> verts;
+    for(unsigned int i = 0;i < t_vect.size(); i++){
+        ofVec3f t(t_vect[i]);
+        verts.push_back(t);
+    }
 	for(unsigned int i = 0; i < verts.size(); i++){
 		verts[i].x += ofSignedNoise(verts[i].x/liquidness, verts[i].y/liquidness,verts[i].z/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;
 		verts[i].y += ofSignedNoise(verts[i].z/liquidness, verts[i].x/liquidness,verts[i].y/liquidness, ofGetElapsedTimef()/speedDampen)*amplitude;


### PR DESCRIPTION
mesh.getVerticies() doesn't return the correct vector type. This fix takes the resulting vector and creates the correct type for the remainder of the code.