### PR TITLE
assimp: add missing .dll copy step to vs

### DIFF
--- a/addons/ofxAssimpModelLoader/addon_config.mk
+++ b/addons/ofxAssimpModelLoader/addon_config.mk
@@ -85,4 +85,6 @@ msys2:
 	ADDON_LIBS_EXCLUDE = libs/assimp
 	ADDON_INCLUDES_EXCLUDE = libs/assimp/%
 	
-	
+vs:
+	ADDON_DLLS_TO_COPY = libs/assimp/lib/vs/Win32/assimp32.dll
+	ADDON_DLLS_TO_COPY += libs/assimp/lib/vs/Win32/assimp64.dll	


### PR DESCRIPTION
Adds a missing step to the vs addon_config for assimp so that the project generator knows to copy the assimp dlls into the app's bin directory when generating or updating a project which uses the `ofxAssimpModelLoader` addon. This depends on a [fix in apothecary ](https://github.com/openframeworks/apothecary/pull/64)which assures that the 32 and 64 bit libs for assimp have different names.