### PR TITLE
Handle return and enter key presses properly

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -1630,6 +1630,11 @@ void ofAppEGLWindow::readNativeKeyboardEvents() {
 				pushKeyEvent = true;
 				keyEvent.key = OF_KEY_INSERT;
 				break;
+			case KEY_ENTER:
+			case KEY_KPENTER:
+				pushKeyEvent = true;
+				keyEvent.key = OF_KEY_RETURN;
+				break;
 
 			default:
 				// VERY RUDIMENTARY KEY MAPPING WITH MAPS ABOVE


### PR DESCRIPTION
This PR translates keypresses from `KEY_ENTER` and `KEY_KPENTER` properly to the right OF value.

See: https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/app/ofAppGLFWWindow.cpp#L1287-L1292

And: https://forum.openframeworks.cc/t/keyboard-layout-problem/25248