### PR TITLE
iOS EAGLView - prevent flicker by synchronously drawing the first frame when starting animation

### DIFF
--- a/addons/ofxiOS/src/gl/EAGLView.m
+++ b/addons/ofxiOS/src/gl/EAGLView.m
@@ -283,6 +283,8 @@ andPreferedRenderer:(ESRendererVersion)version
         
         [self notifyAnimationStarted];
 	}
+	
+	[self drawView:self];
 }
 
 - (void)stopAnimation {


### PR DESCRIPTION
A small bug, mostly affecting rare scenarios (like mine) with multiple view controllers drawing OF content. This one line fix draws the first frame right away, so that the previous content is not shown. 