### PR TITLE
Fix for unreleased synthesized properties

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -127,6 +127,13 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		deallocCond = nil;
 	}
 	
+    [_asset release];
+    [_assetReader release];
+    [_player release];
+    [_playerItem release];
+    [_assetReaderVideoTrackOutput release];
+    [_assetReaderVideoTrackOutput release];
+    [_videoOutput release];
 	
 	[super dealloc];
 }


### PR DESCRIPTION
Fix for synthesized properties that are not released before ‘[super dealloc]’