### PR TITLE
AVFoundationGrabber: Avoid integer and floating point comparison

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationGrabber.mm
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.mm
@@ -65,8 +65,8 @@
 				CMFormatDescriptionRef desc = format.formatDescription;
 				CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(desc);
 				
-				float tw = dimensions.width;
-				float th = dimensions.height;
+				int tw = dimensions.width;
+				int th = dimensions.height;
 				ofVec2f formatDimension(tw, th);
 				
 				if( tw == width && th == height ){


### PR DESCRIPTION
`dimentions.width` and `dimentions.height` are `int32_t`-valued, so it doesn't need to be floating point values.