### PR TITLE
Change sphere winding order from CCW to CW

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1933,9 +1933,9 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::sphere( float radius, int res, ofPrimitiveMod
 					index2 = (iy+0) * (nr) + (ix+1);
 					index3 = (iy+1) * (nr) + (ix+0);
 
-					mesh.addIndex(index1);
-					mesh.addIndex(index3);
 					mesh.addIndex(index2);
+					mesh.addIndex(index3);
+					mesh.addIndex(index1);
 				}
 
 				if(iy < res-1 ) {
@@ -1944,9 +1944,9 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::sphere( float radius, int res, ofPrimitiveMod
 					index2 = (iy+1) * (nr) + (ix+1);
 					index3 = (iy+1) * (nr) + (ix+0);
 
-					mesh.addIndex(index1);
-					mesh.addIndex(index3);
 					mesh.addIndex(index2);
+					mesh.addIndex(index3);
+					mesh.addIndex(index1);
 
 				}
 			}


### PR DESCRIPTION
Sphere has an opposite winding order to other 3d primitives.
This commit changes sphere winding order from CCW to CW.

https://forum.openframeworks.cc/t/ofsphereprimitive-has-an-opposite-winding-order/25502