### PR TITLE
Add GLM_META_PROG_HELPERS to mimic previous ofVec2f/3f/4f DIM functio…

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -67,6 +67,7 @@ enum ofTargetPlatform{
 #include <unordered_map>
 #include <memory>
 
+#define GLM_META_PROG_HELPERS
 #define GLM_SWIZZLE
 #define GLM_FORCE_SIZE_FUNC
 #include "glm/glm.hpp"


### PR DESCRIPTION
…nality.

Allows us to call:

```
glm::vec2::components // etc
```
to get a get the number of components.  Works the same as `ofVec2f::DIM`, etc.