### PR TITLE
s/face/vertex in a comment about normals

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -293,7 +293,7 @@ public:
 	/// brighter the surface will look. See the normalsExample for advice on
 	/// computing the normals.
 	/// addNormal adds the 3D vector to the end of the list, so you need to
-	/// make sure you add normals at the same index of the matching face.
+	/// make sure you add normals at the same index of the matching vertex.
 	void addNormal(const N& n);
 
 	/// \brief Add a vector of normals to a mesh,


### PR DESCRIPTION
This comment could imply that normals are per-face instead of per-vertex, and it ends up in the documentation.