### PR TITLE
debug specific defines (preprocessor macros)

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
@@ -330,6 +330,10 @@ OF_PROJECT_LIBS += $(PROJECT_ADDONS_LIBS)
 OF_PROJECT_DEFINES := $(PROJECT_DEFINES)
 OF_PROJECT_DEFINES += $(PROJECT_ADDONS_DEFINES)
 
+ifeq ($(findstring Debug,$(MAKECMDGOALS)),Debug)
+	OF_PROJECT_DEFINES += $(PROJECT_DEFINES_DEBUG)
+endif
+
 OF_PROJECT_DEFINES_CFLAGS = $(addprefix -D,$(OF_PROJECT_DEFINES))
 
 ################################################################################

--- a/scripts/templates/android/config.make
+++ b/scripts/templates/android/config.make
@@ -88,6 +88,7 @@
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
 # PROJECT_DEFINES = 
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/linux/config.make
+++ b/scripts/templates/linux/config.make
@@ -87,7 +87,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/linux64/config.make
+++ b/scripts/templates/linux64/config.make
@@ -87,7 +87,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/linuxarmv6l/config.make
+++ b/scripts/templates/linuxarmv6l/config.make
@@ -88,7 +88,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/linuxarmv7l/config.make
+++ b/scripts/templates/linuxarmv7l/config.make
@@ -88,7 +88,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/msys2/config.make
+++ b/scripts/templates/msys2/config.make
@@ -87,7 +87,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS

--- a/scripts/templates/osx/config.make
+++ b/scripts/templates/osx/config.make
@@ -88,7 +88,8 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_DEFINES = 
+# PROJECT_DEFINES =
+# PROJECT_DEFINES_DEBUG = DEBUG
 
 ################################################################################
 # PROJECT CFLAGS


### PR DESCRIPTION
This implement the PROJECT_DEFINES_DEBUG variable in the config.project.mk so you can specify PROJECT_DEFINES (preprocessor definitions) in your project's config.mk to distinguish in-code between Debug and Release builds, like so;

> PROJECT_DEFINES_DEBUG=DEBUG

In the code you would then perform #ifdef to enable/disable Debug-specific code like so;

> #ifdef DEBUG
>    performSomeKindOfDebugOperationLikeGatheringPerformanceStatistics();
> #endif

Relates to forum topic;
https://forum.openframeworks.cc/t/determing-whether-debug-or-release-is-active/7249/12