### PR TITLE
register for correct notification on screen change

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
+++ b/addons/ofxiOS/src/core/ofxiOSAppDelegate.mm
@@ -88,7 +88,7 @@
     
     [center addObserver:self
                selector:@selector(handleScreenModeDidChangeNotification:)
-                   name:UIScreenDidDisconnectNotification object:nil];
+                   name:UIScreenModeDidChangeNotification object:nil];
     
     
     bool bDoesHWOrientation = ofxiOSGetOFWindow()->doesHWOrientation();


### PR DESCRIPTION
iOSAppDelegate is currently registering for the wrong enum for screen changes