### PR TITLE
ofSerial: only check filenames, not full paths, in buildDeviceList()

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -170,7 +170,7 @@ void ofSerial::buildDeviceList(){
 		ofDirectory dir("/dev");
 		int deviceCount = 0;
 		for(auto & entry: dir){
-			std::string deviceName = entry.path();
+			std::string deviceName = entry.getFileName();
 
 			//we go through the prefixes
 			for(auto & prefix: prefixMatch){


### PR DESCRIPTION
Fix ofSerial not listing any devices on OSX (and possibly Linux) as per issue/discussion https://github.com/openframeworks/openFrameworks/issues/5221