### PR TITLE
ofImage: encode path to URI before parsing

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -186,25 +186,23 @@ static bool loadImage(ofPixels_<PixelType> & pix, const std::filesystem::path& _
 
 	auto uriStr = _fileName.string();
 	const int bytesNeeded = 8 + 3 * strlen(uriStr.c_str()) + 1;
-	char* absUri = (char*) malloc(bytesNeeded * sizeof(char));
+	std::vector<char> absUri(bytesNeeded);
 
 #ifdef TARGET_WIN32
-	uriWindowsFilenameToUriStringA(uriStr.c_str(), absUri);
+	uriWindowsFilenameToUriStringA(uriStr.c_str(), absUri.data());
 #else
-	uriUnixFilenameToUriStringA(uriStr.c_str(), absUri);
+	uriUnixFilenameToUriStringA(uriStr.c_str(), absUri.data());
 #endif
 
 	UriUriA uri;
 	UriParserStateA state;
 	state.uri = &uri;
-	if(uriParseUriA(&state, absUri)!=URI_SUCCESS){
+	if(uriParseUriA(&state, absUri.data())!=URI_SUCCESS){
 		ofLogError("ofImage") << "loadImage(): malformed uri when loading image from uri " << _fileName;
-		free(absUri);
 		uriFreeUriMembersA(&uri);
 		return false;
 	}
 	std::string scheme(uri.scheme.first, uri.scheme.afterLast);
-	free(absUri);
 	uriFreeUriMembersA(&uri);
 
 	if(scheme == "http" || scheme == "https"){


### PR DESCRIPTION
As per discussion in https://github.com/openframeworks/openFrameworks/issues/5455, `ofImage` was failing to load when the file path has spaces. According to [the discussion here](http://stackoverflow.com/questions/497908/is-a-url-allowed-to-contain-a-space), and probably elaborated in [RFC 3986](https://tools.ietf.org/html/rfc3986) which I haven't read in detail, spaces are not allowed and *must* be encoded to `%20` first.

This PR uses the `uriparser` library to first encode the path string, and then use that when trying to parse with `uriParseUriA` as previously implemented. The code was taken directly from the [example related to converting filenames to URIs](http://uriparser.sourceforge.net/doc/html/#filenames), and uses an `#ifdef` to check on using the platform-appropriate calls to either `uriUnixFilenameToUriStringA()` or `uriUriStringToWindowsFilenameA()`