### PR TITLE
fboAlphaMask example fix.

### DIFF
--- a/examples/shader/07_fboAlphaMask/bin/data/shadersES2/shader.frag
+++ b/examples/shader/07_fboAlphaMask/bin/data/shadersES2/shader.frag
@@ -1,14 +1,22 @@
-
 precision highp float;
 
-uniform sampler2D tex0;
+// these are our textures
+uniform sampler2D tex0;//this is the background texture
 uniform sampler2D maskTex;
+uniform sampler2D foregroundTex;
 
+// this comes from the vertex shader
 varying vec2 texCoordVarying;
 
 void main()
 {
-    vec3 src = texture2D(tex0, texCoordVarying).rgb;
-    float mask = texture2D(maskTex, texCoordVarying).r;
-    gl_FragColor = vec4(src , mask);
+	// Get color values from the background and foreground
+	vec4 back = texture2D(tex0, texCoordVarying);
+	vec4 fore = texture2D(foregroundTex, texCoordVarying);
+
+	// get alpha from mask
+	float mask = texture2D(maskTex, texCoordVarying).r;
+	
+	//mix colors from background and foreground based on the mask value
+	gl_FragColor = mix(fore , back, mask);
 }

--- a/examples/shader/07_fboAlphaMask/bin/data/shadersGL2/shader.frag
+++ b/examples/shader/07_fboAlphaMask/bin/data/shadersGL2/shader.frag
@@ -1,18 +1,22 @@
 #version 120
 
-uniform sampler2DRect tex0;
+// these are our textures
+uniform sampler2DRect tex0;//this is the background texture
 uniform sampler2DRect maskTex;
+uniform sampler2DRect foregroundTex;
 
+// this comes from the vertex shader
 varying vec2 texCoordVarying;
 
 void main()
 {
-    // Get color value from
-    vec3 src = texture2DRect(tex0, texCoordVarying).rgb;
+    // Get color values from the background and foreground
+    vec4 back = texture2DRect(tex0, texCoordVarying);
+    vec4 fore = texture2DRect(foregroundTex, texCoordVarying);
 
-    // Get alpha value
+	// get alpha from mask
     float mask = texture2DRect(maskTex, texCoordVarying).r;
 
-    // Set
-    gl_FragColor = vec4(src , mask);
+	//mix colors from background and foreground based on the mask value
+    gl_FragColor = mix(fore , back, mask);
 }

--- a/examples/shader/07_fboAlphaMask/bin/data/shadersGL3/shader.frag
+++ b/examples/shader/07_fboAlphaMask/bin/data/shadersGL3/shader.frag
@@ -1,8 +1,9 @@
 #version 150
 
 // these are our textures
-uniform sampler2DRect tex0;
+uniform sampler2DRect tex0;//this is the background texture
 uniform sampler2DRect maskTex;
+uniform sampler2DRect foregroundTex;
 
 // this comes from the vertex shader
 in vec2 texCoordVarying;
@@ -12,12 +13,13 @@ out vec4 outputColor;
 
 void main()
 {
-    // get rgb from tex0
-    vec3 src = texture(tex0, texCoordVarying).rgb;
+	// Get color values from the background and foreground
+	vec4 back = texture(tex0, texCoordVarying);
+	vec4 fore = texture(foregroundTex, texCoordVarying);
 
     // get alpha from mask
     float mask = texture(maskTex, texCoordVarying).r;
-    
-    //mix the rgb from tex0 with the alpha of the mask
-    outputColor = vec4(src , mask);
+	
+	//mix colors from background and foreground based on the mask value
+    outputColor = mix(fore , back, mask);
 }

--- a/examples/shader/07_fboAlphaMask/src/ofApp.cpp
+++ b/examples/shader/07_fboAlphaMask/src/ofApp.cpp
@@ -13,26 +13,21 @@ void ofApp::setup(){
 	}
 #endif
 
-    backgroundImage.loadImage("A.jpg");
-    foregroundImage.loadImage("B.jpg");
-    brushImage.loadImage("brush.png");
+    backgroundImage.load("A.jpg");
+    foregroundImage.load("B.jpg");
+    brushImage.load("brush.png");
     
     int width = backgroundImage.getWidth();
     int height = backgroundImage.getHeight();
     
     maskFbo.allocate(width, height);
-    fbo.allocate(width, height);
     
     // Clear the FBO's
     // otherwise it will bring some junk with it from the memory
     maskFbo.begin();
     ofClear(0,0,0,255);
     maskFbo.end();
-    
-    fbo.begin();
-    ofClear(0,0,0,255);
-    fbo.end();
-    
+	
     bBrushDown = false;
 }
 
@@ -61,26 +56,17 @@ void ofApp::draw(){
     
     //----------------------------------------------------------
     // HERE the shader-masking happends
-    fbo.begin();
-    // Cleaning everthing with alpha mask on 0 in order to make it transparent by default
-    ofClear(0, 0, 0, 0);
-    
+	
     shader.begin();
     // here is where the fbo is passed to the shader
-    shader.setUniformTexture("maskTex", maskFbo.getTextureReference(), 1 );
-    
-    backgroundImage.draw(0, 0);
+    shader.setUniformTexture("maskTex", maskFbo.getTexture(), 1 );
+    shader.setUniformTexture("foregroundTex", foregroundImage.getTexture(), 2 );
+
+	backgroundImage.draw(0, 0);
     
     shader.end();
-    fbo.end();
-    
-    //----------------------------------------------------------
-    // FIRST draw the background image
-    foregroundImage.draw(0,0);
-    
-    // THEN draw the masked fbo on top
-    fbo.draw(0,0);
-    
+	
+	
     //----------------------------------------------------------
     ofDrawBitmapString("Drag the Mouse to draw", 15,15);
     ofDrawBitmapString("Press spacebar to clear", 15, 30);

--- a/examples/shader/07_fboAlphaMask/src/ofApp.h
+++ b/examples/shader/07_fboAlphaMask/src/ofApp.h
@@ -26,7 +26,6 @@ class ofApp : public ofBaseApp{
     ofImage brushImage;
     
     ofFbo maskFbo;
-    ofFbo fbo;
     
     bool bBrushDown;
 };


### PR DESCRIPTION
-Fixed issue where blending gave darker edges.
-Moved all the masking into the shader.
-Removed one fbo so it is easier to understand.

fixes issue
https://github.com/openframeworks/openFrameworks/issues/5460