### PR TITLE
ofSerial: fix port name vs. path parsing on Windows

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -194,7 +194,7 @@ void ofSerial::buildDeviceList(){
 		ofLogNotice("ofSerial") << "found " << nPorts << " devices";
 		for(int i = 0; i < nPorts; i++){
 			//NOTE: we give the short port name for both as that is what the user should pass and the short name is more friendly
-			devices.push_back(ofSerialDeviceInfo(string(portNamesShort[i]), string(portNamesShort[i]), i));
+			devices.push_back(ofSerialDeviceInfo(string(portNamesShort[i]), string(portNamesFriendly[i]), i));
 		}
 
 	#endif


### PR DESCRIPTION
Closes openframeworks/openFrameworks#5465