### PR TITLE
MacOS: restore window title when restoring window

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -449,7 +449,8 @@ void ofAppGLFWWindow::setWindowShouldClose(){
 
 //------------------------------------------------------------
 void ofAppGLFWWindow::setWindowTitle(string title){
-	glfwSetWindowTitle(windowP,title.c_str());
+	settings.title = title;
+	glfwSetWindowTitle(windowP,settings.title.c_str());
 }
 
 //------------------------------------------------------------
@@ -814,7 +815,8 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 		[cocoaWindow setStyleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask];
  
 		setWindowShape(windowRect.width, windowRect.height);
- 
+		setWindowTitle(settings.title);
+		
 		//----------------------------------------------------
 		// if we have recorded the screen posion, put it there
 		// if not, better to let the system do it (and put it where it wants)


### PR DESCRIPTION
+ fixes an issue where when restoring a window from
  fullscreen on MacOS the window title would be lost. The
  restore appears only to affect MacOS.

+ keeps glfw window title in sync with window
  `settings.title`

Closes issue #5463 