### PR TITLE
Updates compileOF.sh for Linux to solve `chown` error

### DIFF
--- a/scripts/linux/compileOF.sh
+++ b/scripts/linux/compileOF.sh
@@ -9,9 +9,6 @@ else
         LIBSPATH=linux
 fi
 
-ID=`whoami`
-GROUP_ID=`id --group -n ${ID}`
-
 pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
@@ -33,7 +30,6 @@ exit_code=$?
 if [ $exit_code != 0 ]; then
   echo "there has been a problem compiling Debug OF library"
   echo "please report this problem in the forums"
-  chown -R $ID:$GROUP_ID ../lib/*
   exit $exit_code
 fi
 
@@ -43,9 +39,6 @@ if [ "$BUILD" == "install" ]; then
     if [ $exit_code != 0 ]; then
       echo "there has been a problem compiling Release OF library"
       echo "please report this problem in the forums"
-      chown -R $ID:$GROUP_ID ../lib/*
       exit $exit_code
     fi
 fi
-
-chown -R $ID:$GROUP_ID ../lib/*

--- a/scripts/linux/compileOF.sh
+++ b/scripts/linux/compileOF.sh
@@ -9,7 +9,7 @@ else
         LIBSPATH=linux
 fi
 
-ID=`logname`
+ID=`whoami`
 GROUP_ID=`id --group -n ${ID}`
 
 pushd `dirname $0` > /dev/null


### PR DESCRIPTION
Very small fix. Solving errors when compiling using a different user than the one logged in.

Example, compilation would produce error in this case:
 1. log into a machine using a certain user `user1`
 2. use sudo powers from user1 to switch to `user2`
 3. launch `./compileOF.sh` as user2
 4. breaks when reaching the line `chown -R $ID:$GROUP_ID ../lib/*` because the `$ID` returned by `logname` earlier in the script is `user1` and not `user2` who is calling the script. 

Using `whoami` instead of `logname` fixes this error without breaking the script for other common cases.