### PR TITLE
ofxOsc updates

### DIFF
--- a/addons/ofxOsc/src/ofxOsc.h
+++ b/addons/ofxOsc/src/ofxOsc.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "ofxOscArg.h"

--- a/addons/ofxOsc/src/ofxOsc.h
+++ b/addons/ofxOsc/src/ofxOsc.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "ofxOscArg.h"

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "ofConstants.h"
@@ -17,7 +17,7 @@
 ///   T - TRUE (no value required)
 ///   F - FALSE (no value required)
 ///   N - NIL (no value required)
-///   I - impulse TRIGGER, act as an trigger (no value required), aka IMPULSE &  INFINITUM
+///   I - impulse TRIGGER (no value required), aka IMPULSE & INFINITUM
 ///   t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
 /// See: http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
 typedef enum _ofxOscArgType{
@@ -37,7 +37,7 @@ typedef enum _ofxOscArgType{
 	OFXOSC_TYPE_BLOB             = 'b',
 	OFXOSC_TYPE_BUNDLE           = 'B',
 	OFXOSC_TYPE_RGBA_COLOR       = 'r',
-	OFXOSC_TYPE_INDEXOUTOFBOUNDS = 0    //< bad index value
+	OFXOSC_TYPE_INDEXOUTOFBOUNDS = 0 //< bad index value
 } ofxOscArgType;
 
 /// \class ofxOscArg
@@ -237,7 +237,7 @@ private:
 };
 
 /// \class ofxOscArgNone
-/// \brief a none/nil (has no value), type name "I"
+/// \brief a none/nil (has no value), type name "N"
 class ofxOscArgNone : public ofxOscArgBool{
 public:
 	ofxOscArgNone() : ofxOscArgBool(true) {};

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -176,7 +176,7 @@ public:
 /// \brief a null-terminated char argument, type name "c"
 class ofxOscArgChar : public ofxOscArg{
 public:
-	ofxOscArgChar(char _value) : value(value) {};
+	ofxOscArgChar(char value) : value(value) {};
 	~ofxOscArgChar() {};
 
 	/// return the type of this argument
@@ -194,14 +194,22 @@ private:
 
 /// \class ofxOscArgMidiMessage
 /// \brief a 4-byte MIDI message argument, type name "m"
-class ofxOscArgMidiMessage : public ofxOscArgInt32{
+class ofxOscArgMidiMessage : public ofxOscArg{
 public:
-	ofxOscArgMidiMessage(int32_t value) : ofxOscArgInt32(value) {};
+	ofxOscArgMidiMessage(uint32_t value) : value(value) {};
 	~ofxOscArgMidiMessage() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_MIDI_MESSAGE;}
 	string getTypeName() {return "m";}
+	
+	/// return value
+	uint32_t get() const {return value;}
+	/// set value
+	void set(uint32_t value) {this->value = value;}
+
+private:
+	uint32_t value;
 };
 
 /// \class ofxOscArgBool
@@ -254,14 +262,22 @@ public:
 
 /// \class ofxOscArgTimetag
 /// \brief a 64-bit NTP time tag argument, type name "t"
-class ofxOscArgTimetag : public ofxOscArgInt64{
+class ofxOscArgTimetag : public ofxOscArg{
 public:
-	ofxOscArgTimetag(int64_t value) : ofxOscArgInt64(value) {};
+	ofxOscArgTimetag(uint64_t value) : value(value) {};
 	~ofxOscArgTimetag() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_TIMETAG;}
 	string getTypeName() {return "t";}
+	
+	/// return value
+	uint64_t get() const {return value;}
+	/// set value
+	void set(uint64_t value) {this->value = value;}
+
+private:
+	uint64_t value;
 };
 
 /// \class ofxOscArgBlob
@@ -288,20 +304,12 @@ private:
 
 /// \class ofxOscArgRgbaColor
 /// \brief a 32-bit RGBA color argument, type name "r"
-class ofxOscArgRgbaColor : public ofxOscArg{
+class ofxOscArgRgbaColor : public ofxOscArgMidiMessage{
 public:
-	ofxOscArgRgbaColor(int32_t value) : value(value) {};
+	ofxOscArgRgbaColor(uint32_t value) : ofxOscArgMidiMessage(value) {};
 	~ofxOscArgRgbaColor() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_RGBA_COLOR;}
 	string getTypeName() {return "r";}
-
-	/// return value
-	int32_t get() const {return value;}
-	/// set value
-	void set(int32_t value) {this->value = value;}
-
-private:
-	int32_t value;
 };

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -228,8 +228,20 @@ private:
 	bool value;
 };
 
+/// \class ofxOscArgNone
+/// \brief a none/nil (has no value), type name "I"
+class ofxOscArgNone : public ofxOscArgBool{
+public:
+	ofxOscArgNone() : ofxOscArgBool(true) {};
+	~ofxOscArgNone() {};
+
+	/// return the type of this argument
+	ofxOscArgType getType() {return OFXOSC_TYPE_NONE;}
+	string getTypeName() {return "N";}
+};
+
 /// \class ofxOscArgTrigger
-/// \brief a trigger impulse, type name "I"
+/// \brief a trigger impulse (has no value), type name "I"
 class ofxOscArgTrigger : public ofxOscArgBool{
 public:
 	ofxOscArgTrigger() : ofxOscArgBool(true) {};

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -28,8 +28,8 @@
 
 #pragma once
 
-#include <string>
-#include "ofMain.h"
+#include "ofConstants.h"
+#include "ofFileUtils.h"
 
 /*
 OSC 1.1 specifications types:
@@ -86,7 +86,7 @@ public:
 	virtual ~ofxOscArg() {};
 
 	virtual ofxOscArgType getType() { return OFXOSC_TYPE_NONE; };
-	virtual std::string getTypeName() { return "N"; };
+	virtual string getTypeName() { return "N"; };
 
 private:
 };
@@ -101,46 +101,46 @@ subclasses for each possible argument type
 class ofxOscArgInt32 : public ofxOscArg
 {
 public:
-	ofxOscArgInt32( std::int32_t _value ) { value = _value; };
+	ofxOscArgInt32( int32_t _value ) { value = _value; };
 	~ofxOscArgInt32() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_INT32; };
-	std::string getTypeName() { return "i"; };
+	string getTypeName() { return "i"; };
 
 	/// return value
-	std::int32_t get() const { return value; };
+	int32_t get() const { return value; };
 	/// set value
-	void set( std::int32_t _value ) { value = _value; };
+	void set( int32_t _value ) { value = _value; };
 
 private:
-	std::int32_t value;
+	int32_t value;
 };
 
 class ofxOscArgInt : public ofxOscArgInt32
 {
 public:
-	ofxOscArgInt( std::int32_t _value ) : ofxOscArgInt32(_value) {};
+	ofxOscArgInt( int32_t _value ) : ofxOscArgInt32(_value) {};
 	~ofxOscArgInt(){};
 };
 
 class ofxOscArgInt64 : public ofxOscArg
 {
 public:
-	ofxOscArgInt64( std::int64_t _value ) { value = _value; };
+	ofxOscArgInt64( int64_t _value ) { value = _value; };
 	~ofxOscArgInt64() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_INT64; };
-	std::string getTypeName() { return "h"; };
+	string getTypeName() { return "h"; };
 
 	/// return value
-	std::int64_t get() const { return value; };
+	int64_t get() const { return value; };
 	/// set value
-	void set( std::int64_t _value ) { value = _value; };
+	void set( int64_t _value ) { value = _value; };
 
 private:
-    std::int64_t value;
+    int64_t value;
 };
 
 class ofxOscArgFloat : public ofxOscArg
@@ -151,7 +151,7 @@ public:
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_FLOAT; };
-    std::string getTypeName() { return "f"; };
+    string getTypeName() { return "f"; };
 
 	/// return value
 	float get() const { return value; };
@@ -170,7 +170,7 @@ public:
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_DOUBLE;};
-	std::string getTypeName() {return "d";};
+	string getTypeName() {return "d";};
 
 	/// return value
 	double get() const { return value; };
@@ -184,32 +184,32 @@ private:
 class ofxOscArgString : public ofxOscArg
 {
 public:
-	ofxOscArgString( const std::string &_value ) { value = _value; };
+	ofxOscArgString( const string &_value ) { value = _value; };
 	~ofxOscArgString() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_STRING; };
-	std::string getTypeName() { return "s"; };
+	string getTypeName() { return "s"; };
 
 	/// return value
-	const std::string &get() const { return value; }
+	const string &get() const { return value; }
 	/// set value
 	void set( const char* _value ) { value = _value; };
-	void set( const std::string &_value ) {value = _value; };
+	void set( const string &_value ) {value = _value; };
 
 private:
-	std::string value;
+	string value;
 };
 
 class ofxOscArgSymbol : public ofxOscArgString
 {
 public:
-	ofxOscArgSymbol( const std::string &_value ) : ofxOscArgString(_value){};
+	ofxOscArgSymbol( const string &_value ) : ofxOscArgString(_value){};
 	~ofxOscArgSymbol() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_SYMBOL; };
-	std::string getTypeName() { return "S"; };
+	string getTypeName() { return "S"; };
 };
 
 class ofxOscArgChar : public ofxOscArg
@@ -220,7 +220,7 @@ public:
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_CHAR; };
-	std::string getTypeName() { return "c"; };
+	string getTypeName() { return "c"; };
 
 	/// return value
 	char get() const { return value; };
@@ -234,12 +234,12 @@ private:
 class ofxOscArgMidiMessage : public ofxOscArgInt32
 {
 public:
-    ofxOscArgMidiMessage( std::int32_t _value ) : ofxOscArgInt32(_value) {};
+    ofxOscArgMidiMessage( int32_t _value ) : ofxOscArgInt32(_value) {};
 	~ofxOscArgMidiMessage() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_MIDI_MESSAGE; };
-	std::string getTypeName() { return "m"; };
+	string getTypeName() { return "m"; };
 };
 
 class ofxOscArgBool : public ofxOscArg
@@ -255,7 +255,7 @@ public:
 		else
 			return OFXOSC_TYPE_FALSE;
 	};
-	std::string getTypeName() {
+	string getTypeName() {
 		if(value)
 			return "T";
 		else
@@ -279,18 +279,18 @@ public:
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_TRIGGER; };
-	std::string getTypeName() { return "I"; };
+	string getTypeName() { return "I"; };
 };
 
 class ofxOscArgTimetag : public ofxOscArgInt64
 {
 public:
-    ofxOscArgTimetag( std::int64_t _value ) : ofxOscArgInt64(_value) {};
+    ofxOscArgTimetag( int64_t _value ) : ofxOscArgInt64(_value) {};
 	~ofxOscArgTimetag() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_TIMETAG; };
-	std::string getTypeName() { return "t"; };
+	string getTypeName() { return "t"; };
 };
 
 class ofxOscArgBlob : public ofxOscArg
@@ -303,7 +303,7 @@ public:
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_BLOB; };
-	std::string getTypeName() { return "b"; };
+	string getTypeName() { return "b"; };
 
 	/// return value
 	const ofBuffer &get() const { return value; };
@@ -317,19 +317,19 @@ private:
 class ofxOscArgRgbaColor : public ofxOscArg
 {
 public:
-    ofxOscArgRgbaColor( std::int32_t _value ) { value = _value; };
+    ofxOscArgRgbaColor( int32_t _value ) { value = _value; };
 	~ofxOscArgRgbaColor() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() { return OFXOSC_TYPE_RGBA_COLOR; };
-	std::string getTypeName() { return "r"; };
+	string getTypeName() { return "r"; };
 
 	/// return value
-    std::int32_t get() const { return value; };
+    int32_t get() const { return value; };
 	/// set value
-    void set( std::int32_t _value ) { value = _value; };
+    void set( int32_t _value ) { value = _value; };
 
 private:
-    std::int32_t value;
+    int32_t value;
 };
 

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -33,25 +33,24 @@
 
 /*
 OSC 1.1 specifications types:
-          i - 32bit integer
-          h - 64bit integer
-          f - 32bit floating point number
-          d - 64bit (double) floating point number
-          s - string
-          S - symbol
-          c - char
-          m - 4 byte midi packet (8 digits hexadecimal)
-          T - TRUE (no value required)
-          F - FALSE (no value required)
-          N - NIL (no value required)
-          I - IMPULSE, act as a trigger (no value required), previously named INFINITUM
-          t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
+		  i - 32bit integer
+		  h - 64bit integer
+		  f - 32bit floating point number
+		  d - 64bit (double) floating point number
+		  s - string
+		  S - symbol
+		  c - char
+		  m - 4 byte midi packet (8 digits hexadecimal)
+		  T - TRUE (no value required)
+		  F - FALSE (no value required)
+		  N - NIL (no value required)
+		  I - IMPULSE, act as a trigger (no value required), previously named INFINITUM
+		  t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
 
 See: http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
 See also: https://code.google.com/p/oscpack/source/browse/trunk/osc/OscTypes.h#113
 */
-typedef enum _ofxOscArgType
-{
+typedef enum _ofxOscArgType{
 	OFXOSC_TYPE_INT32 = 'i',
 	OFXOSC_TYPE_INT64 = 'h',
 	OFXOSC_TYPE_FLOAT = 'f',
@@ -79,16 +78,13 @@ base class for arguments
 
 */
 
-class ofxOscArg
-{
+class ofxOscArg{
 public:
 	ofxOscArg() {};
 	virtual ~ofxOscArg() {};
 
-	virtual ofxOscArgType getType() { return OFXOSC_TYPE_NONE; };
-	virtual string getTypeName() { return "N"; };
-
-private:
+	virtual ofxOscArgType getType() {return OFXOSC_TYPE_NONE;}
+	virtual string getTypeName() {return "N";}
 };
 
 
@@ -98,238 +94,217 @@ subclasses for each possible argument type
 
 */
 
-class ofxOscArgInt32 : public ofxOscArg
-{
+class ofxOscArgInt32 : public ofxOscArg{
 public:
-	ofxOscArgInt32( int32_t _value ) { value = _value; };
+	ofxOscArgInt32(int32_t value) : value(value) {};
 	~ofxOscArgInt32() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_INT32; };
-	string getTypeName() { return "i"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_INT32;}
+	string getTypeName() {return "i";}
 
 	/// return value
-	int32_t get() const { return value; };
+	int32_t get() const {return value;}
 	/// set value
-	void set( int32_t _value ) { value = _value; };
+	void set(int32_t value) {this->value = value;};
 
 private:
 	int32_t value;
 };
 
-class ofxOscArgInt : public ofxOscArgInt32
-{
+class ofxOscArgInt : public ofxOscArgInt32{
 public:
-	ofxOscArgInt( int32_t _value ) : ofxOscArgInt32(_value) {};
-	~ofxOscArgInt(){};
+	ofxOscArgInt(int32_t value) : ofxOscArgInt32(value) {};
+	~ofxOscArgInt() {};
 };
 
-class ofxOscArgInt64 : public ofxOscArg
-{
+class ofxOscArgInt64 : public ofxOscArg{
 public:
-	ofxOscArgInt64( int64_t _value ) { value = _value; };
+	ofxOscArgInt64(int64_t value) : value(value) {};
 	~ofxOscArgInt64() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_INT64; };
-	string getTypeName() { return "h"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_INT64;}
+	string getTypeName() {return "h";}
 
 	/// return value
-	int64_t get() const { return value; };
+	int64_t get() const {return value;}
 	/// set value
-	void set( int64_t _value ) { value = _value; };
+	void set(int64_t value) {this->value = value;}
 
 private:
-    int64_t value;
+	int64_t value;
 };
 
-class ofxOscArgFloat : public ofxOscArg
-{
+class ofxOscArgFloat : public ofxOscArg{
 public:
-	ofxOscArgFloat( float _value ) { value = _value; };
+	ofxOscArgFloat(float value) : value(value) {};
 	~ofxOscArgFloat() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_FLOAT; };
-    string getTypeName() { return "f"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_FLOAT;}
+	string getTypeName() {return "f";}
 
 	/// return value
-	float get() const { return value; };
+	float get() const {return value;}
 	/// set value
-	void set( float _value ) { value = _value; };
+	void set(float value) {this->value = value;}
 
 private:
 	float value;
 };
 
-class ofxOscArgDouble : public ofxOscArg
-{
+class ofxOscArgDouble : public ofxOscArg{
 public:
-	ofxOscArgDouble( double _value ) { value = _value; };
+	ofxOscArgDouble(double value) : value(value) {};
 	~ofxOscArgDouble() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() {return OFXOSC_TYPE_DOUBLE;};
-	string getTypeName() {return "d";};
+	ofxOscArgType getType() {return OFXOSC_TYPE_DOUBLE;}
+	string getTypeName() {return "d";}
 
 	/// return value
-	double get() const { return value; };
+	double get() const {return value;}
 	/// set value
-	void set( double _value ) { value = _value; };
+	void set(double value) {this->value = value;}
 
 private:
 	double value;
 };
 
-class ofxOscArgString : public ofxOscArg
-{
+class ofxOscArgString : public ofxOscArg{
 public:
-	ofxOscArgString( const string &_value ) { value = _value; };
+	ofxOscArgString(const string &value ) : value(value) {};
 	~ofxOscArgString() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_STRING; };
-	string getTypeName() { return "s"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_STRING;}
+	string getTypeName() {return "s";}
 
 	/// return value
-	const string &get() const { return value; }
+	const string &get() const {return value;}
 	/// set value
-	void set( const char* _value ) { value = _value; };
-	void set( const string &_value ) {value = _value; };
+	void set(const char* value) {this->value = value;}
+	void set(const string &value) {this->value = value;}
 
 private:
 	string value;
 };
 
-class ofxOscArgSymbol : public ofxOscArgString
-{
+class ofxOscArgSymbol : public ofxOscArgString{
 public:
-	ofxOscArgSymbol( const string &_value ) : ofxOscArgString(_value){};
+	ofxOscArgSymbol(const string &value) : ofxOscArgString(value) {};
 	~ofxOscArgSymbol() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_SYMBOL; };
-	string getTypeName() { return "S"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_SYMBOL;}
+	string getTypeName() {return "S";}
 };
 
-class ofxOscArgChar : public ofxOscArg
-{
+class ofxOscArgChar : public ofxOscArg{
 public:
-	ofxOscArgChar( char _value ) { value = _value; };
+	ofxOscArgChar(char _value) : value(value) {};
 	~ofxOscArgChar() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_CHAR; };
-	string getTypeName() { return "c"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_CHAR;}
+	string getTypeName() {return "c";}
 
 	/// return value
-	char get() const { return value; };
+	char get() const {return value;}
 	/// set value
-	void set( char _value ) { value = _value; };
+	void set(char value) {this->value = value;}
 
 private:
 	char value;
 };
 
-class ofxOscArgMidiMessage : public ofxOscArgInt32
-{
+class ofxOscArgMidiMessage : public ofxOscArgInt32{
 public:
-    ofxOscArgMidiMessage( int32_t _value ) : ofxOscArgInt32(_value) {};
+	ofxOscArgMidiMessage(int32_t value) : ofxOscArgInt32(value) {};
 	~ofxOscArgMidiMessage() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_MIDI_MESSAGE; };
-	string getTypeName() { return "m"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_MIDI_MESSAGE;}
+	string getTypeName() {return "m";}
 };
 
-class ofxOscArgBool : public ofxOscArg
-{
+class ofxOscArgBool : public ofxOscArg{
 public:
-	ofxOscArgBool( bool _value ) { value = _value; };
+	ofxOscArgBool(bool value) : value(value) {};
 	~ofxOscArgBool() {};
 
 	/// return the type of this argument
 	ofxOscArgType getType() {
-		if(value)
-			return OFXOSC_TYPE_TRUE;
-		else
-			return OFXOSC_TYPE_FALSE;
-	};
+		return value ? OFXOSC_TYPE_TRUE : OFXOSC_TYPE_FALSE;
+	}
 	string getTypeName() {
-		if(value)
-			return "T";
-		else
-			return "F";
-	};
+		return value ? "T" : "F";
+	}
 
 	/// return value
-	bool get() const { return value; };
+	bool get() const {return value;}
 	/// set value
-	void set( bool _value ) { value = _value; };
+	void set(bool value) {this->value = value;}
 
 private:
 	bool value;
 };
 
-class ofxOscArgTrigger : public ofxOscArgBool
-{
+class ofxOscArgTrigger : public ofxOscArgBool{
 public:
 	ofxOscArgTrigger() : ofxOscArgBool(true) {};
-    ~ofxOscArgTrigger(){};
+	~ofxOscArgTrigger() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_TRIGGER; };
-	string getTypeName() { return "I"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_TRIGGER;}
+	string getTypeName() {return "I";}
 };
 
-class ofxOscArgTimetag : public ofxOscArgInt64
-{
+class ofxOscArgTimetag : public ofxOscArgInt64{
 public:
-    ofxOscArgTimetag( int64_t _value ) : ofxOscArgInt64(_value) {};
+	ofxOscArgTimetag(int64_t value) : ofxOscArgInt64(value) {};
 	~ofxOscArgTimetag() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_TIMETAG; };
-	string getTypeName() { return "t"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_TIMETAG;}
+	string getTypeName() {return "t";}
 };
 
-class ofxOscArgBlob : public ofxOscArg
-{
+class ofxOscArgBlob : public ofxOscArg{
 public:
-	ofxOscArgBlob( const ofBuffer &_value ){
-        value = _value;
-    }
-    ~ofxOscArgBlob(){};
+	ofxOscArgBlob(const ofBuffer &value) : value(value){}
+	~ofxOscArgBlob() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_BLOB; };
-	string getTypeName() { return "b"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_BLOB;}
+	string getTypeName() {return "b";}
 
 	/// return value
-	const ofBuffer &get() const { return value; };
+	const ofBuffer &get() const {return value;}
 	/// set value
-	void set( const char * _value, unsigned int length ) { value.set(_value, length); };
+	void set(const char * value, unsigned int length) {
+		this->value.set(value, length);
+	}
 
 private:
 	ofBuffer value;
 };
 
-class ofxOscArgRgbaColor : public ofxOscArg
-{
+class ofxOscArgRgbaColor : public ofxOscArg{
 public:
-    ofxOscArgRgbaColor( int32_t _value ) { value = _value; };
+	ofxOscArgRgbaColor(int32_t value) : value(value) {};
 	~ofxOscArgRgbaColor() {};
 
 	/// return the type of this argument
-	ofxOscArgType getType() { return OFXOSC_TYPE_RGBA_COLOR; };
-	string getTypeName() { return "r"; };
+	ofxOscArgType getType() {return OFXOSC_TYPE_RGBA_COLOR;}
+	string getTypeName() {return "r";}
 
 	/// return value
-    int32_t get() const { return value; };
+	int32_t get() const {return value;}
 	/// set value
-    void set( int32_t _value ) { value = _value; };
+	void set(int32_t value) {this->value = value;}
 
 private:
-    int32_t value;
+	int32_t value;
 };
-

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "ofConstants.h"

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -44,71 +44,65 @@ typedef enum _ofxOscArgType{
 /// \brief base class for arguments
 class ofxOscArg{
 public:
-	ofxOscArg() {};
-	virtual ~ofxOscArg() {};
-
+	virtual ~ofxOscArg() {}
 	virtual ofxOscArgType getType() {return OFXOSC_TYPE_NONE;}
-	virtual string getTypeName() {return "N";}
+	virtual std::string getTypeName() {return "N";}
 };
 
 /// \class ofxOscArgInt32
 /// \brief a 32-bit integer argument, type name "i"
 class ofxOscArgInt32 : public ofxOscArg{
 public:
-	ofxOscArgInt32(int32_t value) : value(value) {};
-	~ofxOscArgInt32() {};
+	ofxOscArgInt32(std::int32_t value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_INT32;}
-	string getTypeName() {return "i";}
+	std::string getTypeName() {return "i";}
 
 	/// return value
-	int32_t get() const {return value;}
+	std::int32_t get() const {return value;}
 	/// set value
-	void set(int32_t value) {this->value = value;};
+	void set(std::int32_t value) {this->value = value;}
 
 private:
-	int32_t value;
+	std::int32_t value;
 };
 
 /// \class ofxOscArgInt
 /// \brief a 32-bit integer argument, type name "i"
 class ofxOscArgInt : public ofxOscArgInt32{
 public:
-	ofxOscArgInt(int32_t value) : ofxOscArgInt32(value) {};
-	~ofxOscArgInt() {};
+	ofxOscArgInt(std::int32_t value) : ofxOscArgInt32(value) {}
 };
 
 /// \class ofxOscArgInt64
 /// \brief a 64-bit integer argument, type name "h"
 class ofxOscArgInt64 : public ofxOscArg{
 public:
-	ofxOscArgInt64(int64_t value) : value(value) {};
-	~ofxOscArgInt64() {};
+	ofxOscArgInt64(std::int64_t value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_INT64;}
-	string getTypeName() {return "h";}
+	std::string getTypeName() {return "h";}
 
 	/// return value
-	int64_t get() const {return value;}
+	std::int64_t get() const {return value;}
 	/// set value
-	void set(int64_t value) {this->value = value;}
+	void set(std::int64_t value) {this->value = value;}
 
 private:
-	int64_t value;
+	std::int64_t value;
 };
 
 /// \class ofxOscArgFloat
 /// \brief a 32-bit float argument, type name "f"
 class ofxOscArgFloat : public ofxOscArg{
 public:
-	ofxOscArgFloat(float value) : value(value) {};
-	~ofxOscArgFloat() {};
+	ofxOscArgFloat(float value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_FLOAT;}
-	string getTypeName() {return "f";}
+	std::string getTypeName() {return "f";}
 
 	/// return value
 	float get() const {return value;}
@@ -123,12 +117,11 @@ private:
 /// \brief a 64-bit double argument, type name "d"
 class ofxOscArgDouble : public ofxOscArg{
 public:
-	ofxOscArgDouble(double value) : value(value) {};
-	~ofxOscArgDouble() {};
+	ofxOscArgDouble(double value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_DOUBLE;}
-	string getTypeName() {return "d";}
+	std::string getTypeName() {return "d";}
 
 	/// return value
 	double get() const {return value;}
@@ -143,45 +136,42 @@ private:
 /// \brief a null-terminated string argument, type name "s"
 class ofxOscArgString : public ofxOscArg{
 public:
-	ofxOscArgString(const string &value ) : value(value) {};
-	~ofxOscArgString() {};
+	ofxOscArgString(const std::string &value ) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_STRING;}
-	string getTypeName() {return "s";}
+	std::string getTypeName() {return "s";}
 
 	/// return value
-	const string &get() const {return value;}
+	const std::string &get() const {return value;}
 	/// set value
-	void set(const char* value) {this->value = value;}
-	void set(const string &value) {this->value = value;}
+	void set(const char *value) {this->value = value;}
+	void set(const std::string &value) {this->value = value;}
 
 private:
-	string value;
+	std::string value;
 };
 
 /// \class ofxOscArgSymbol
 /// \brief a null-terminated symbol (string) argument, type name "S"
 class ofxOscArgSymbol : public ofxOscArgString{
 public:
-	ofxOscArgSymbol(const string &value) : ofxOscArgString(value) {};
-	~ofxOscArgSymbol() {};
+	ofxOscArgSymbol(const std::string &value) : ofxOscArgString(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_SYMBOL;}
-	string getTypeName() {return "S";}
+	std::string getTypeName() {return "S";}
 };
 
 /// \class ofxOscArgChar
 /// \brief a null-terminated char argument, type name "c"
 class ofxOscArgChar : public ofxOscArg{
 public:
-	ofxOscArgChar(char value) : value(value) {};
-	~ofxOscArgChar() {};
+	ofxOscArgChar(char value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_CHAR;}
-	string getTypeName() {return "c";}
+	std::string getTypeName() {return "c";}
 
 	/// return value
 	char get() const {return value;}
@@ -196,34 +186,32 @@ private:
 /// \brief a 4-byte MIDI message argument, type name "m"
 class ofxOscArgMidiMessage : public ofxOscArg{
 public:
-	ofxOscArgMidiMessage(uint32_t value) : value(value) {};
-	~ofxOscArgMidiMessage() {};
+	ofxOscArgMidiMessage(std::uint32_t value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_MIDI_MESSAGE;}
-	string getTypeName() {return "m";}
+	std::string getTypeName() {return "m";}
 	
 	/// return value
-	uint32_t get() const {return value;}
+	std::uint32_t get() const {return value;}
 	/// set value
-	void set(uint32_t value) {this->value = value;}
+	void set(std::uint32_t value) {this->value = value;}
 
 private:
-	uint32_t value;
+	std::uint32_t value;
 };
 
 /// \class ofxOscArgBool
 /// \brief a boolean argument, either type name "T" or "F" based on value
 class ofxOscArgBool : public ofxOscArg{
 public:
-	ofxOscArgBool(bool value) : value(value) {};
-	~ofxOscArgBool() {};
+	ofxOscArgBool(bool value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {
 		return value ? OFXOSC_TYPE_TRUE : OFXOSC_TYPE_FALSE;
 	}
-	string getTypeName() {
+	std::string getTypeName() {
 		return value ? "T" : "F";
 	}
 
@@ -240,61 +228,57 @@ private:
 /// \brief a none/nil (has no value), type name "N"
 class ofxOscArgNone : public ofxOscArgBool{
 public:
-	ofxOscArgNone() : ofxOscArgBool(true) {};
-	~ofxOscArgNone() {};
+	ofxOscArgNone() : ofxOscArgBool(true) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_NONE;}
-	string getTypeName() {return "N";}
+	std::string getTypeName() {return "N";}
 };
 
 /// \class ofxOscArgTrigger
 /// \brief a trigger impulse (has no value), type name "I"
 class ofxOscArgTrigger : public ofxOscArgBool{
 public:
-	ofxOscArgTrigger() : ofxOscArgBool(true) {};
-	~ofxOscArgTrigger() {};
+	ofxOscArgTrigger() : ofxOscArgBool(true) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_TRIGGER;}
-	string getTypeName() {return "I";}
+	std::string getTypeName() {return "I";}
 };
 
 /// \class ofxOscArgTimetag
 /// \brief a 64-bit NTP time tag argument, type name "t"
 class ofxOscArgTimetag : public ofxOscArg{
 public:
-	ofxOscArgTimetag(uint64_t value) : value(value) {};
-	~ofxOscArgTimetag() {};
+	ofxOscArgTimetag(std::uint64_t value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_TIMETAG;}
-	string getTypeName() {return "t";}
+	std::string getTypeName() {return "t";}
 	
 	/// return value
-	uint64_t get() const {return value;}
+	std::uint64_t get() const {return value;}
 	/// set value
-	void set(uint64_t value) {this->value = value;}
+	void set(std::uint64_t value) {this->value = value;}
 
 private:
-	uint64_t value;
+	std::uint64_t value;
 };
 
 /// \class ofxOscArgBlob
 /// \brief a binary blob argument, type name "b"
 class ofxOscArgBlob : public ofxOscArg{
 public:
-	ofxOscArgBlob(const ofBuffer &value) : value(value){}
-	~ofxOscArgBlob() {};
+	ofxOscArgBlob(const ofBuffer &value) : value(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_BLOB;}
-	string getTypeName() {return "b";}
+	std::string getTypeName() {return "b";}
 
 	/// return value
 	const ofBuffer &get() const {return value;}
 	/// set value
-	void set(const char * value, unsigned int length) {
+	void set(const char *value, unsigned int length) {
 		this->value.set(value, length);
 	}
 
@@ -306,10 +290,9 @@ private:
 /// \brief a 32-bit RGBA color argument, type name "r"
 class ofxOscArgRgbaColor : public ofxOscArgMidiMessage{
 public:
-	ofxOscArgRgbaColor(uint32_t value) : ofxOscArgMidiMessage(value) {};
-	~ofxOscArgRgbaColor() {};
+	ofxOscArgRgbaColor(std::uint32_t value) : ofxOscArgMidiMessage(value) {}
 
 	/// return the type of this argument
 	ofxOscArgType getType() {return OFXOSC_TYPE_RGBA_COLOR;}
-	string getTypeName() {return "r";}
+	std::string getTypeName() {return "r";}
 };

--- a/addons/ofxOsc/src/ofxOscArg.h
+++ b/addons/ofxOsc/src/ofxOscArg.h
@@ -31,53 +31,43 @@
 #include "ofConstants.h"
 #include "ofFileUtils.h"
 
-/*
-OSC 1.1 specifications types:
-		  i - 32bit integer
-		  h - 64bit integer
-		  f - 32bit floating point number
-		  d - 64bit (double) floating point number
-		  s - string
-		  S - symbol
-		  c - char
-		  m - 4 byte midi packet (8 digits hexadecimal)
-		  T - TRUE (no value required)
-		  F - FALSE (no value required)
-		  N - NIL (no value required)
-		  I - IMPULSE, act as a trigger (no value required), previously named INFINITUM
-		  t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
-
-See: http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
-See also: https://code.google.com/p/oscpack/source/browse/trunk/osc/OscTypes.h#113
-*/
+/// OSC 1.1 specification argument type enum values:
+///   i - 32bit integer
+///   h - 64bit integer
+///   f - 32bit floating point number
+///   d - 64bit (double) floating point number
+///   s - string
+///   S - symbol
+///   c - char
+///   m - 4 byte midi packet (8 digits hexadecimal)
+///   T - TRUE (no value required)
+///   F - FALSE (no value required)
+///   N - NIL (no value required)
+///   I - impulse TRIGGER, act as an trigger (no value required), aka IMPULSE &  INFINITUM
+///   t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
+/// See: http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
 typedef enum _ofxOscArgType{
-	OFXOSC_TYPE_INT32 = 'i',
-	OFXOSC_TYPE_INT64 = 'h',
-	OFXOSC_TYPE_FLOAT = 'f',
-	OFXOSC_TYPE_DOUBLE = 'd',
-	OFXOSC_TYPE_STRING = 's',
-	OFXOSC_TYPE_SYMBOL = 'S',
-	OFXOSC_TYPE_CHAR = 'c',
-	OFXOSC_TYPE_MIDI_MESSAGE = 'm',
-	OFXOSC_TYPE_TRUE = 'T',
-	OFXOSC_TYPE_FALSE = 'F',
-	OFXOSC_TYPE_NONE = 'N',
-	OFXOSC_TYPE_TRIGGER = 'I',
-	OFXOSC_TYPE_TIMETAG = 't',
-	OFXOSC_TYPE_BLOB = 'b',
-	OFXOSC_TYPE_BUNDLE = 'B',
-	OFXOSC_TYPE_RGBA_COLOR = 'r',
-	OFXOSC_TYPE_INDEXOUTOFBOUNDS = 0
+	OFXOSC_TYPE_INT32            = 'i',
+	OFXOSC_TYPE_INT64            = 'h',
+	OFXOSC_TYPE_FLOAT            = 'f',
+	OFXOSC_TYPE_DOUBLE           = 'd',
+	OFXOSC_TYPE_STRING           = 's',
+	OFXOSC_TYPE_SYMBOL           = 'S',
+	OFXOSC_TYPE_CHAR             = 'c',
+	OFXOSC_TYPE_MIDI_MESSAGE     = 'm',
+	OFXOSC_TYPE_TRUE             = 'T',
+	OFXOSC_TYPE_FALSE            = 'F',
+	OFXOSC_TYPE_NONE             = 'N',
+	OFXOSC_TYPE_TRIGGER          = 'I',
+	OFXOSC_TYPE_TIMETAG          = 't',
+	OFXOSC_TYPE_BLOB             = 'b',
+	OFXOSC_TYPE_BUNDLE           = 'B',
+	OFXOSC_TYPE_RGBA_COLOR       = 'r',
+	OFXOSC_TYPE_INDEXOUTOFBOUNDS = 0    //< bad index value
 } ofxOscArgType;
 
-/*
-
-ofxOscArg
-
-base class for arguments
-
-*/
-
+/// \class ofxOscArg
+/// \brief base class for arguments
 class ofxOscArg{
 public:
 	ofxOscArg() {};
@@ -87,13 +77,8 @@ public:
 	virtual string getTypeName() {return "N";}
 };
 
-
-/*
-
-subclasses for each possible argument type
-
-*/
-
+/// \class ofxOscArgInt32
+/// \brief a 32-bit integer argument, type name "i"
 class ofxOscArgInt32 : public ofxOscArg{
 public:
 	ofxOscArgInt32(int32_t value) : value(value) {};
@@ -112,12 +97,16 @@ private:
 	int32_t value;
 };
 
+/// \class ofxOscArgInt
+/// \brief a 32-bit integer argument, type name "i"
 class ofxOscArgInt : public ofxOscArgInt32{
 public:
 	ofxOscArgInt(int32_t value) : ofxOscArgInt32(value) {};
 	~ofxOscArgInt() {};
 };
 
+/// \class ofxOscArgInt64
+/// \brief a 64-bit integer argument, type name "h"
 class ofxOscArgInt64 : public ofxOscArg{
 public:
 	ofxOscArgInt64(int64_t value) : value(value) {};
@@ -136,6 +125,8 @@ private:
 	int64_t value;
 };
 
+/// \class ofxOscArgFloat
+/// \brief a 32-bit float argument, type name "f"
 class ofxOscArgFloat : public ofxOscArg{
 public:
 	ofxOscArgFloat(float value) : value(value) {};
@@ -154,6 +145,8 @@ private:
 	float value;
 };
 
+/// \class ofxOscArgDouble
+/// \brief a 64-bit double argument, type name "d"
 class ofxOscArgDouble : public ofxOscArg{
 public:
 	ofxOscArgDouble(double value) : value(value) {};
@@ -172,6 +165,8 @@ private:
 	double value;
 };
 
+/// \class ofxOscArgString
+/// \brief a null-terminated string argument, type name "s"
 class ofxOscArgString : public ofxOscArg{
 public:
 	ofxOscArgString(const string &value ) : value(value) {};
@@ -191,6 +186,8 @@ private:
 	string value;
 };
 
+/// \class ofxOscArgSymbol
+/// \brief a null-terminated symbol (string) argument, type name "S"
 class ofxOscArgSymbol : public ofxOscArgString{
 public:
 	ofxOscArgSymbol(const string &value) : ofxOscArgString(value) {};
@@ -201,6 +198,8 @@ public:
 	string getTypeName() {return "S";}
 };
 
+/// \class ofxOscArgChar
+/// \brief a null-terminated char argument, type name "c"
 class ofxOscArgChar : public ofxOscArg{
 public:
 	ofxOscArgChar(char _value) : value(value) {};
@@ -219,6 +218,8 @@ private:
 	char value;
 };
 
+/// \class ofxOscArgMidiMessage
+/// \brief a 4-byte MIDI message argument, type name "m"
 class ofxOscArgMidiMessage : public ofxOscArgInt32{
 public:
 	ofxOscArgMidiMessage(int32_t value) : ofxOscArgInt32(value) {};
@@ -229,6 +230,8 @@ public:
 	string getTypeName() {return "m";}
 };
 
+/// \class ofxOscArgBool
+/// \brief a boolean argument, either type name "T" or "F" based on value
 class ofxOscArgBool : public ofxOscArg{
 public:
 	ofxOscArgBool(bool value) : value(value) {};
@@ -251,6 +254,8 @@ private:
 	bool value;
 };
 
+/// \class ofxOscArgTrigger
+/// \brief a trigger impulse, type name "I"
 class ofxOscArgTrigger : public ofxOscArgBool{
 public:
 	ofxOscArgTrigger() : ofxOscArgBool(true) {};
@@ -261,6 +266,8 @@ public:
 	string getTypeName() {return "I";}
 };
 
+/// \class ofxOscArgTimetag
+/// \brief a 64-bit NTP time tag argument, type name "t"
 class ofxOscArgTimetag : public ofxOscArgInt64{
 public:
 	ofxOscArgTimetag(int64_t value) : ofxOscArgInt64(value) {};
@@ -271,6 +278,8 @@ public:
 	string getTypeName() {return "t";}
 };
 
+/// \class ofxOscArgBlob
+/// \brief a binary blob argument, type name "b"
 class ofxOscArgBlob : public ofxOscArg{
 public:
 	ofxOscArgBlob(const ofBuffer &value) : value(value){}
@@ -291,6 +300,8 @@ private:
 	ofBuffer value;
 };
 
+/// \class ofxOscArgRgbaColor
+/// \brief a 32-bit RGBA color argument, type name "r"
 class ofxOscArgRgbaColor : public ofxOscArg{
 public:
 	ofxOscArgRgbaColor(int32_t value) : value(value) {};

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #include "ofxOscBundle.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #include "ofxOscBundle.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -3,23 +3,17 @@
 #include "ofxOscBundle.h"
 
 //--------------------------------------------------------------
-ofxOscBundle::ofxOscBundle() {}
-
-//--------------------------------------------------------------
-ofxOscBundle::~ofxOscBundle() {}
-
-//--------------------------------------------------------------
-ofxOscBundle::ofxOscBundle(const ofxOscBundle& other){ 
+ofxOscBundle::ofxOscBundle(const ofxOscBundle &other){ 
 	copy(other);
 }
 
 //--------------------------------------------------------------
-ofxOscBundle& ofxOscBundle::operator=(const ofxOscBundle& other){
+ofxOscBundle& ofxOscBundle::operator=(const ofxOscBundle &other){
 	return copy(other);
 }
 
 //--------------------------------------------------------------
-ofxOscBundle& ofxOscBundle::copy(const ofxOscBundle& other){
+ofxOscBundle& ofxOscBundle::copy(const ofxOscBundle &other){
 	if(this == &other) return *this;
 	for(int i = 0; i < (int)other.bundles.size(); i++){
 		bundles.push_back(other.bundles[i]);
@@ -37,12 +31,12 @@ void ofxOscBundle::clear(){
 }
 
 //--------------------------------------------------------------
-void ofxOscBundle::addBundle(const ofxOscBundle& bundle){
+void ofxOscBundle::addBundle(const ofxOscBundle &bundle){
 	bundles.push_back(bundle);
 }
 
 //--------------------------------------------------------------
-void ofxOscBundle::addMessage(const ofxOscMessage& message){
+void ofxOscBundle::addMessage(const ofxOscMessage &message){
 	messages.push_back(message);
 }
 

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -73,7 +73,7 @@ ofxOscMessage& ofxOscBundle::getMessageAt(int i){
 // friend functions
 //--------------------------------------------------------------
 std::ostream& operator<<(std::ostream &os, const ofxOscBundle &bundle) {
-	os << bundle.getMessageCount() << " messages "
-	   << bundle.getBundleCount() << " bundles";
+	os << bundle.getMessageCount() << " message(s) "
+	   << bundle.getBundleCount() << " bundle(s)";
 	return os;
 }

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -28,37 +28,76 @@
 
 #include "ofxOscBundle.h"
 
+//--------------------------------------------------------------
+ofxOscBundle::ofxOscBundle() {}
 
-ofxOscBundle::ofxOscBundle()
-{
+//--------------------------------------------------------------
+ofxOscBundle::~ofxOscBundle() {}
+
+//--------------------------------------------------------------
+ofxOscBundle::ofxOscBundle(const ofxOscBundle& other){ 
+	copy(other);
 }
 
-ofxOscBundle::~ofxOscBundle()
-{
+//--------------------------------------------------------------
+ofxOscBundle& ofxOscBundle::operator=(const ofxOscBundle& other){
+	return copy(other);
 }
 
-ofxOscBundle& ofxOscBundle::copy( const ofxOscBundle& other )
-{
-	for ( int i=0; i<(int)other.bundles.size(); i++ )
-	{
-		bundles.push_back( other.bundles[i] );
+//--------------------------------------------------------------
+ofxOscBundle& ofxOscBundle::copy(const ofxOscBundle& other){
+	if(this == &other) return *this;
+	for(int i = 0; i < (int)other.bundles.size(); i++){
+		bundles.push_back(other.bundles[i]);
 	}
-	for ( int i=0; i<(int)other.messages.size(); i++ )
-	{
-		messages.push_back( other.messages[i] );
+	for(int i = 0; i < (int)other.messages.size(); i++){
+		messages.push_back(other.messages[i]);
 	}
 	return *this;
 }
 
-
-
-void ofxOscBundle::addBundle( const ofxOscBundle& bundle )
-{
-	bundles.push_back( bundle );
+//--------------------------------------------------------------
+void ofxOscBundle::clear(){
+	bundles.clear();
+	messages.clear();
 }
 
-void ofxOscBundle::addMessage( const ofxOscMessage& message )
-{
-	messages.push_back( message );
+//--------------------------------------------------------------
+void ofxOscBundle::addBundle(const ofxOscBundle& bundle){
+	bundles.push_back(bundle);
 }
 
+//--------------------------------------------------------------
+void ofxOscBundle::addMessage(const ofxOscMessage& message){
+	messages.push_back(message);
+}
+
+//--------------------------------------------------------------
+int ofxOscBundle::getBundleCount() const{ 
+	return bundles.size();
+}
+
+//--------------------------------------------------------------
+int ofxOscBundle::getMessageCount() const{
+	return messages.size();
+}
+
+//--------------------------------------------------------------
+const ofxOscBundle& ofxOscBundle::getBundleAt(int i) const{
+	return bundles[i];
+}
+
+//--------------------------------------------------------------
+ofxOscBundle& ofxOscBundle::getBundleAt(int i){
+	return bundles[i];
+}
+
+//--------------------------------------------------------------
+const ofxOscMessage& ofxOscBundle::getMessageAt(int i) const{
+	return messages[i];
+}
+
+//--------------------------------------------------------------
+ofxOscMessage& ofxOscBundle::getMessageAt(int i){
+	return messages[i];
+}

--- a/addons/ofxOsc/src/ofxOscBundle.cpp
+++ b/addons/ofxOsc/src/ofxOscBundle.cpp
@@ -69,3 +69,11 @@ const ofxOscMessage& ofxOscBundle::getMessageAt(int i) const{
 ofxOscMessage& ofxOscBundle::getMessageAt(int i){
 	return messages[i];
 }
+
+// friend functions
+//--------------------------------------------------------------
+std::ostream& operator<<(std::ostream &os, const ofxOscBundle &bundle) {
+	os << bundle.getMessageCount() << " messages "
+	   << bundle.getBundleCount() << " bundles";
+	return os;
+}

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -59,6 +59,6 @@ public:
 	
 private:
 		
-	std::vector< ofxOscMessage > messages;
-	std::vector< ofxOscBundle > bundles;
+	vector< ofxOscMessage > messages;
+	vector< ofxOscBundle > bundles;
 };

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -42,6 +42,10 @@ public:
 	/// \return the message at the given index
 	ofxOscMessage& getMessageAt(int i);
 	
+	/// output stream operator for string conversion and printing
+	/// \return number of messages & bundles
+	friend std::ostream& operator<<(std::ostream &os, const ofxOscBundle &sender);
+	
 private:
 		
 	std::vector<ofxOscMessage> messages; //< bundled messages

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -28,37 +28,37 @@
 
 #pragma once
 
-#include <vector>
 #include "ofxOscMessage.h"
 
-class ofxOscBundle
-{
-public:	
+class ofxOscBundle{
+public:
+
 	ofxOscBundle();
 	~ofxOscBundle();
-	ofxOscBundle( const ofxOscBundle& other ) { copy ( other ); }
-	ofxOscBundle& operator= ( const ofxOscBundle& other ) { return copy( other ); }
+	ofxOscBundle(const ofxOscBundle& other);
+	ofxOscBundle& operator=(const ofxOscBundle& other);
 	/// for operator= and copy constructor
-	ofxOscBundle& copy( const ofxOscBundle& other );
+	ofxOscBundle& copy(const ofxOscBundle& other);
 	
 	/// erase contents
-	void clear() { messages.clear(); bundles.clear(); }
+	void clear();
 
 	/// add bundle elements
-	void addBundle( const ofxOscBundle& element );
-	void addMessage( const ofxOscMessage& message );
+	void addBundle(const ofxOscBundle& element);
+	void addMessage(const ofxOscMessage& message);
 	
 	/// get bundle elements
-	int getBundleCount() const { return bundles.size(); }
-	int getMessageCount() const { return messages.size(); }
+	int getBundleCount() const;
+	int getMessageCount() const;
+	
 	/// return the bundle or message at the given index
-	const ofxOscBundle& getBundleAt( int i ) const { return bundles[i]; }
-    ofxOscBundle& getBundleAt( int i ) { return bundles[i]; }
-	const ofxOscMessage& getMessageAt( int i ) const { return messages[i]; }
-    ofxOscMessage& getMessageAt( int i ) { return messages[i]; }
+	const ofxOscBundle& getBundleAt(int i) const;
+	ofxOscBundle& getBundleAt(int i);
+	const ofxOscMessage& getMessageAt(int i) const;
+	ofxOscMessage& getMessageAt(int i);
 	
 private:
 		
-	vector< ofxOscMessage > messages;
-	vector< ofxOscBundle > bundles;
+	vector<ofxOscMessage> messages;
+	vector<ofxOscBundle> bundles;
 };

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "ofxOscMessage.h"

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "ofxOscMessage.h"

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -30,6 +30,8 @@
 
 #include "ofxOscMessage.h"
 
+/// \class ofxOscBundle
+/// \brief an OSC bundle of ofxMessages and/or other ofxOscBundles
 class ofxOscBundle{
 public:
 
@@ -40,25 +42,35 @@ public:
 	/// for operator= and copy constructor
 	ofxOscBundle& copy(const ofxOscBundle& other);
 	
-	/// erase contents
+	/// clear bundle & message contents
 	void clear();
 
-	/// add bundle elements
+	/// add another bundle to the bundle
 	void addBundle(const ofxOscBundle& element);
+	
+	/// add a message to the bundle
 	void addMessage(const ofxOscMessage& message);
 	
-	/// get bundle elements
+	/// \return the current bundle count
 	int getBundleCount() const;
+	
+	/// \return the current message count
 	int getMessageCount() const;
 	
-	/// return the bundle or message at the given index
+	/// \return the bundle at the given index
 	const ofxOscBundle& getBundleAt(int i) const;
+	
+	/// \return the bundle at the given index
 	ofxOscBundle& getBundleAt(int i);
+	
+	/// \return the message at the given index
 	const ofxOscMessage& getMessageAt(int i) const;
+	
+	/// \return the message at the given index
 	ofxOscMessage& getMessageAt(int i);
 	
 private:
 		
-	vector<ofxOscMessage> messages;
-	vector<ofxOscBundle> bundles;
+	vector<ofxOscMessage> messages; //< bundled messages
+	vector<ofxOscBundle> bundles; //< bundled bundles
 };

--- a/addons/ofxOsc/src/ofxOscBundle.h
+++ b/addons/ofxOsc/src/ofxOscBundle.h
@@ -9,21 +9,20 @@
 class ofxOscBundle{
 public:
 
-	ofxOscBundle();
-	~ofxOscBundle();
+	ofxOscBundle() {}
 	ofxOscBundle(const ofxOscBundle& other);
-	ofxOscBundle& operator=(const ofxOscBundle& other);
+	ofxOscBundle& operator=(const ofxOscBundle &other);
 	/// for operator= and copy constructor
-	ofxOscBundle& copy(const ofxOscBundle& other);
+	ofxOscBundle& copy(const ofxOscBundle &other);
 	
 	/// clear bundle & message contents
 	void clear();
 
 	/// add another bundle to the bundle
-	void addBundle(const ofxOscBundle& element);
+	void addBundle(const ofxOscBundle &element);
 	
 	/// add a message to the bundle
-	void addMessage(const ofxOscMessage& message);
+	void addMessage(const ofxOscMessage &message);
 	
 	/// \return the current bundle count
 	int getBundleCount() const;
@@ -45,6 +44,6 @@ public:
 	
 private:
 		
-	vector<ofxOscMessage> messages; //< bundled messages
-	vector<ofxOscBundle> bundles; //< bundled bundles
+	std::vector<ofxOscMessage> messages; //< bundled messages
+	std::vector<ofxOscBundle> bundles; //< bundled bundles
 };

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -120,12 +120,22 @@ void ofxOscMessage::clear(){
 }
 
 //--------------------------------------------------------------
+void ofxOscMessage::setAddress(const string &_address){
+	address = _address;
+}
+
+//--------------------------------------------------------------
 string ofxOscMessage::getAddress() const{ 
 	return address;
 }
 
 //--------------------------------------------------------------
 string ofxOscMessage::getRemoteIp() const{ 
+	return remote_host;
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getRemoteHost() const{
 	return remote_host;
 }
 
@@ -510,11 +520,6 @@ int32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
 
 // set methods
 //--------------------------------------------------------------
-void ofxOscMessage::setAddress(const string &_address){
-	address = _address;
-}
-
-//--------------------------------------------------------------
 void ofxOscMessage::addIntArg(int32_t argument){
 	args.push_back(new ofxOscArgInt32(argument));
 }
@@ -597,5 +602,6 @@ void ofxOscMessage::addRgbaColorArg(int32_t argument){
 // util
 //--------------------------------------------------------------
 void ofxOscMessage::setRemoteEndpoint(const string &host, int port){
-	remote_host = host; remote_port = port;
+	remote_host = host;
+	remote_port = port;
 }

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -13,17 +13,17 @@ ofxOscMessage::~ofxOscMessage(){
 }
 
 //--------------------------------------------------------------
-ofxOscMessage::ofxOscMessage(const ofxOscMessage& other){ 
+ofxOscMessage::ofxOscMessage(const ofxOscMessage &other){
 	copy(other);
 }
 
 //--------------------------------------------------------------
-ofxOscMessage& ofxOscMessage::operator=(const ofxOscMessage& other){ 
+ofxOscMessage& ofxOscMessage::operator=(const ofxOscMessage &other){
 	return copy(other);
 }
 
 //--------------------------------------------------------------
-ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
+ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage &other){
 	if(this == &other) return *this;
 	clear();
 
@@ -96,22 +96,22 @@ void ofxOscMessage::clear(){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::setAddress(const string &address){
+void ofxOscMessage::setAddress(const std::string &address){
 	this->address = address;
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getAddress() const{ 
+std::string ofxOscMessage::getAddress() const{
 	return address;
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getRemoteIp() const{ 
+std::string ofxOscMessage::getRemoteIp() const{
 	return remoteHost;
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getRemoteHost() const{
+std::string ofxOscMessage::getRemoteHost() const{
 	return remoteHost;
 }
 
@@ -139,7 +139,7 @@ ofxOscArgType ofxOscMessage::getArgType(int index) const{
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getArgTypeName(int index) const{
+std::string ofxOscMessage::getArgTypeName(int index) const{
 	if(index >= (int)args.size()) {
 		ofLogError("ofxOscMessage") << "getArgTypeName(): index "
 		                            << index << " out of bounds";
@@ -151,8 +151,8 @@ string ofxOscMessage::getArgTypeName(int index) const{
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getTypeString() const {
-	string types = "";
+std::string ofxOscMessage::getTypeString() const {
+	std::string types = "";
 	for(int i = 0; i < (int)args.size(); ++i) {
 		types += args[i]->getTypeName();
 	}
@@ -160,33 +160,33 @@ string ofxOscMessage::getTypeString() const {
 }
 
 //--------------------------------------------------------------
-int32_t ofxOscMessage::getArgAsInt(int index) const{
+std::int32_t ofxOscMessage::getArgAsInt(int index) const{
 	return getArgAsInt32(index);
 }
 
 //--------------------------------------------------------------
-int32_t ofxOscMessage::getArgAsInt32(int index) const{
+std::int32_t ofxOscMessage::getArgAsInt32(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_INT32){
 		if(getArgType(index) == OFXOSC_TYPE_INT64){
 			// warn about possible lack of precision
 			ofLogWarning("ofxOscMessage")
 				<< "getArgAsInt32(): converting int64 to int32 for argument "
 				<< index;
-			return (int32_t)((ofxOscArgInt64*)args[index])->get();
+			return (std::int32_t)((ofxOscArgInt64*)args[index])->get();
 		}
 		else if (getArgType(index) == OFXOSC_TYPE_FLOAT){
-			return (int32_t)((ofxOscArgFloat*)args[index])->get();
+			return (std::int32_t)((ofxOscArgFloat*)args[index])->get();
 		}
 		else if (getArgType(index) == OFXOSC_TYPE_DOUBLE){
 			// warn about possible lack of precision
 			ofLogWarning("ofxOscMessage")
 				<< "getArgAsInt32(): converting double to int32 for argument "
 				<< index;
-			return (int32_t)((ofxOscArgDouble*)args[index])->get();
+			return (std::int32_t)((ofxOscArgDouble*)args[index])->get();
 		}
 		else if(getArgType(index)  == OFXOSC_TYPE_TRUE || 
 			    getArgType(index) == OFXOSC_TYPE_FALSE){
-			return (int32_t)((ofxOscArgBool*)args[index])->get();
+			return (std::int32_t)((ofxOscArgBool*)args[index])->get();
 		}
 		else{
 			ofLogError("ofxOscMessage") << "getArgAsInt32(): argument "
@@ -200,20 +200,20 @@ int32_t ofxOscMessage::getArgAsInt32(int index) const{
 }
 
 //--------------------------------------------------------------
-int64_t ofxOscMessage::getArgAsInt64(int index) const{
+std::int64_t ofxOscMessage::getArgAsInt64(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_INT64){
 		if(getArgType(index) == OFXOSC_TYPE_INT32){
-			return (int64_t)((ofxOscArgInt32*)args[index])->get();
+			return (std::int64_t)((ofxOscArgInt32*)args[index])->get();
 		}
 		else if(getArgType(index) == OFXOSC_TYPE_FLOAT){
-			return (int64_t)((ofxOscArgFloat*)args[index])->get();
+			return (std::int64_t)((ofxOscArgFloat*)args[index])->get();
 		}
 		else if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
-			return (int64_t)((ofxOscArgDouble*)args[index])->get();
+			return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
 		}
 		else if(getArgType(index)  == OFXOSC_TYPE_TRUE ||
 			    getArgType(index) == OFXOSC_TYPE_FALSE){
-			return (int64_t)((ofxOscArgBool*)args[index])->get();
+			return (std::int64_t)((ofxOscArgBool*)args[index])->get();
 		}
 		else{
 			ofLogError("ofxOscMessage") << "getArgAsInt64(): argument "
@@ -289,7 +289,7 @@ double ofxOscMessage::getArgAsDouble(int index) const{
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getArgAsString(int index) const{
+std::string ofxOscMessage::getArgAsString(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_STRING){
 		// warn about string conversions
 		if(getArgType(index) == OFXOSC_TYPE_INT32){
@@ -338,7 +338,7 @@ string ofxOscMessage::getArgAsString(int index) const{
 }
 
 //--------------------------------------------------------------
-string ofxOscMessage::getArgAsSymbol(int index) const{
+std::string ofxOscMessage::getArgAsSymbol(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_SYMBOL){
 		// warn about string conversions
 		if(getArgType(index) == OFXOSC_TYPE_INT32){
@@ -398,7 +398,7 @@ char ofxOscMessage::getArgAsChar(int index) const{
 }
 
 //--------------------------------------------------------------
-uint32_t ofxOscMessage::getArgAsMidiMessage(int index) const{
+std::uint32_t ofxOscMessage::getArgAsMidiMessage(int index) const{
 	if(getArgType(index) == OFXOSC_TYPE_MIDI_MESSAGE){
 		return ((ofxOscArgMidiMessage*)args[index])->get();
 	}
@@ -466,14 +466,14 @@ bool ofxOscMessage::getArgAsInfinitum(int index) const{
 }
 
 //--------------------------------------------------------------
-uint64_t ofxOscMessage::getArgAsTimetag(int index) const{
+std::uint64_t ofxOscMessage::getArgAsTimetag(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_TIMETAG){
 		if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
 			// warn about possible conversion issue
 			ofLogWarning("ofxOscMessage")
 				<< "getArgAsTimetag(): converting double to Timetag "
 				<< "for argument " << index;
-			return (uint64_t)((ofxOscArgDouble*)args[index])->get();
+			return (std::uint64_t)((ofxOscArgDouble*)args[index])->get();
 		}
 		else{
 			ofLogError("ofxOscMessage") << "getArgAsTimetag(): argument "
@@ -499,7 +499,7 @@ ofBuffer ofxOscMessage::getArgAsBlob(int index) const{
 }
 
 //--------------------------------------------------------------
-uint32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
+std::uint32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_RGBA_COLOR){
 		ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument "
 			<< index << " is not an rgba color";
@@ -512,17 +512,17 @@ uint32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
 
 // set methods
 //--------------------------------------------------------------
-void ofxOscMessage::addIntArg(int32_t argument){
+void ofxOscMessage::addIntArg(std::int32_t argument){
 	args.push_back(new ofxOscArgInt32(argument));
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addInt32Arg(int32_t argument){
+void ofxOscMessage::addInt32Arg(std::int32_t argument){
 	args.push_back(new ofxOscArgInt32(argument));
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addInt64Arg(int64_t argument){
+void ofxOscMessage::addInt64Arg(std::int64_t argument){
 	args.push_back(new ofxOscArgInt64(argument));
 }
 
@@ -537,12 +537,12 @@ void ofxOscMessage::addDoubleArg(double argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addStringArg(const string &argument){
+void ofxOscMessage::addStringArg(const std::string &argument){
 	args.push_back(new ofxOscArgString(argument));
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addSymbolArg(const string &argument){
+void ofxOscMessage::addSymbolArg(const std::string &argument){
 	args.push_back(new ofxOscArgSymbol(argument));
 }
 
@@ -552,7 +552,7 @@ void ofxOscMessage::addCharArg( char argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addMidiMessageArg(uint32_t argument){
+void ofxOscMessage::addMidiMessageArg(std::uint32_t argument){
 	args.push_back(new ofxOscArgMidiMessage(argument));
 }
 
@@ -582,7 +582,7 @@ void ofxOscMessage::addInfinitumArg(){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addTimetagArg(uint64_t argument){
+void ofxOscMessage::addTimetagArg(std::uint64_t argument){
 	args.push_back(new ofxOscArgTimetag(argument));
 }
 
@@ -592,20 +592,20 @@ void ofxOscMessage::addBlobArg(const ofBuffer &argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addRgbaColorArg(uint32_t argument){
+void ofxOscMessage::addRgbaColorArg(std::uint32_t argument){
 	args.push_back(new ofxOscArgRgbaColor(argument));
 }
 
 // util
 //--------------------------------------------------------------
-void ofxOscMessage::setRemoteEndpoint(const string &host, int port){
+void ofxOscMessage::setRemoteEndpoint(const std::string &host, int port){
 	remoteHost = host;
 	remotePort = port;
 }
 
 // friend functions
 //--------------------------------------------------------------
-ostream& operator<<(ostream &os, const ofxOscMessage &message) {
+std::ostream& operator<<(std::ostream &os, const ofxOscMessage &message) {
 	os << message.getAddress();
 	for(int i = 0; i < message.getNumArgs(); ++i) {
 		os << " ";

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -399,7 +399,7 @@ char ofxOscMessage::getArgAsChar(int index) const{
 }
 
 //--------------------------------------------------------------
-int32_t ofxOscMessage::getArgAsMidiMessage(int index) const{
+uint32_t ofxOscMessage::getArgAsMidiMessage(int index) const{
 	if(getArgType(index) == OFXOSC_TYPE_MIDI_MESSAGE){
 		return ((ofxOscArgMidiMessage*)args[index])->get();
 	}
@@ -467,14 +467,14 @@ bool ofxOscMessage::getArgAsInfinitum(int index) const{
 }
 
 //--------------------------------------------------------------
-int64_t ofxOscMessage::getArgAsTimetag(int index) const{
+uint64_t ofxOscMessage::getArgAsTimetag(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_TIMETAG){
 		if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
 			// warn about possible conversion issue
 			ofLogWarning("ofxOscMessage")
 				<< "getArgAsTimetag(): converting double to Timetag "
 				<< "for argument " << index;
-			return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
+			return (uint64_t)((ofxOscArgDouble*)args[index])->get();
 		}
 		else{
 			ofLogError("ofxOscMessage") << "getArgAsTimetag(): argument "
@@ -500,16 +500,11 @@ ofBuffer ofxOscMessage::getArgAsBlob(int index) const{
 }
 
 //--------------------------------------------------------------
-int32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
+uint32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_RGBA_COLOR){
-		if(getArgType(index) == OFXOSC_TYPE_INT32){
-			return ((ofxOscArgInt32*)args[index])->get();
-		}
-		else{
-			ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument "
-				<< index << " is not an rgba color";
-			return 0;
-		}
+		ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument "
+			<< index << " is not an rgba color";
+		return 0;
 	}
 	else{
 		return ((ofxOscArgRgbaColor*)args[index])->get();
@@ -543,12 +538,12 @@ void ofxOscMessage::addDoubleArg(double argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addStringArg(const std::string &argument){
+void ofxOscMessage::addStringArg(const string &argument){
 	args.push_back(new ofxOscArgString(argument));
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addSymbolArg(const std::string &argument){
+void ofxOscMessage::addSymbolArg(const string &argument){
 	args.push_back(new ofxOscArgSymbol(argument));
 }
 
@@ -558,7 +553,7 @@ void ofxOscMessage::addCharArg( char argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addMidiMessageArg(int32_t argument){
+void ofxOscMessage::addMidiMessageArg(uint32_t argument){
 	args.push_back(new ofxOscArgMidiMessage(argument));
 }
 
@@ -588,7 +583,7 @@ void ofxOscMessage::addInfinitumArg(){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addTimetagArg(int64_t argument){
+void ofxOscMessage::addTimetagArg(uint64_t argument){
 	args.push_back(new ofxOscArgTimetag(argument));
 }
 
@@ -598,7 +593,7 @@ void ofxOscMessage::addBlobArg(const ofBuffer &argument){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::addRgbaColorArg(int32_t argument){
+void ofxOscMessage::addRgbaColorArg(uint32_t argument){
 	args.push_back(new ofxOscArgRgbaColor(argument));
 }
 

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -30,544 +30,572 @@
 #include "ofLog.h"
 #include "ofUtils.h"
 
-ofxOscMessage::ofxOscMessage()
+//--------------------------------------------------------------
+ofxOscMessage::ofxOscMessage() {}
 
-{
-}
-
-ofxOscMessage::~ofxOscMessage()
-{
+//--------------------------------------------------------------
+ofxOscMessage::~ofxOscMessage(){
 	clear();
 }
 
-void ofxOscMessage::clear()
-{
-	for ( unsigned int i=0; i<args.size(); ++i )
-		delete args[i];
-	args.clear();
-	address = "";
+//--------------------------------------------------------------
+ofxOscMessage::ofxOscMessage(const ofxOscMessage& other){ 
+	copy(other);
 }
 
-/*
-
-get methods
-
-*/
-
-int ofxOscMessage::getNumArgs() const
-{
-	return (int)args.size();
+//--------------------------------------------------------------
+ofxOscMessage& ofxOscMessage::operator=(const ofxOscMessage& other){ 
+	return copy(other);
 }
 
-ofxOscArgType ofxOscMessage::getArgType( int index ) const
-{
-    if ( index >= (int)args.size() )
-    {
-    	ofLogError("ofxOscMessage") << "getArgType(): index " << index << " out of bounds";
-        return OFXOSC_TYPE_INDEXOUTOFBOUNDS;
-    }
-    else
-        return args[index]->getType();
-}
-
-std::string ofxOscMessage::getArgTypeName( int index ) const
-{
-    if ( index >= (int)args.size() )
-    {
-    	ofLogError("ofxOscMessage") << "getArgTypeName(): index " << index << " out of bounds";
-        return "INDEX OUT OF BOUNDS";
-    }
-    else
-        return args[index]->getTypeName();
-}
-
-std::int32_t ofxOscMessage::getArgAsInt( int index ) const
-{
-	return getArgAsInt32(index);
-}
-
-std::int32_t ofxOscMessage::getArgAsInt32( int index ) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_INT32 )
-    {
-        if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
-        {
-            // warn about possible lack of precision
-            ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting int64 to int32 for argument " << index;
-            return (std::int32_t)((ofxOscArgInt64*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-            return (std::int32_t)((ofxOscArgFloat*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            // warn about possible lack of precision
-            ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting double to int32 for argument " << index;
-            return (std::int32_t)((ofxOscArgDouble*)args[index])->get();
-        }
-        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
-        {
-            return (std::int32_t)((ofxOscArgBool*)args[index])->get();
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsInt32(): argument " << index << " is not a number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgInt32*)args[index])->get();
-}
-
-std::int64_t ofxOscMessage::getArgAsInt64( int index ) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_INT64 )
-    {
-        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            return (std::int64_t)((ofxOscArgInt32*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-            return (std::int64_t)((ofxOscArgFloat*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
-        }
-        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
-        {
-            return (std::int64_t)((ofxOscArgBool*)args[index])->get();
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsInt64(): argument " << index << " is not a number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgInt64*)args[index])->get();
-}
-
-float ofxOscMessage::getArgAsFloat( int index ) const
-{
-	if ( getArgType(index) != OFXOSC_TYPE_FLOAT )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            return (float)((ofxOscArgInt32*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
-        {
-            // warn about possible lack of precision
-            ofLogWarning("ofxOscMessage") << "getArgAsFloat(): converting int64 to float for argument " << index;
-            return (float)((ofxOscArgInt64*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            // warn about possible lack of precision
-            ofLogWarning("ofxOscMessage") << "getArgAsFloat(): converting double to float for argument " << index;
-            return (float)((ofxOscArgDouble*)args[index])->get();
-        }
-        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
-        {
-            return (float)((ofxOscArgBool*)args[index])->get();
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsFloat(): argument " << index << " is not a number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgFloat*)args[index])->get();
-}
-
-double ofxOscMessage::getArgAsDouble( int index ) const
-{
-	if ( getArgType(index) != OFXOSC_TYPE_DOUBLE )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            return (double)((ofxOscArgInt32*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
-        {
-            return (double)((ofxOscArgInt64*)args[index])->get();
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-            return (double)((ofxOscArgFloat*)args[index])->get();
-        }
-        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
-        {
-            return (double)((ofxOscArgBool*)args[index])->get();
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsDouble(): argument " << index << " is not a number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgDouble*)args[index])->get();
-}
-
-std::string ofxOscMessage::getArgAsString( int index ) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_STRING )
-    {
-        // warn about string conversions
-        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting int32 to string for argument " << index;
-            return ofToString(((ofxOscArgInt32*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting int64 to string for argument " << index;
-            return ofToString(((ofxOscArgInt64*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting float to string for argument " << index;
-            return ofToString(((ofxOscArgFloat*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting double to string for argument " << index;
-            return ofToString(((ofxOscArgDouble*)args[index])->get());
-        }
-		else if ( getArgType(index) == OFXOSC_TYPE_SYMBOL )
-        {
-            return ((ofxOscArgSymbol*)args[index])->get();
-        }
-		else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting char to string for argument " << index;
-            return ofToString(((ofxOscArgChar*)args[index])->get());
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsString(): argument " << index << " is not a string interpretable value";
-            return "";
-        }
-    }
-    else
-        return ((ofxOscArgString*)args[index])->get();
-}
-
-std::string ofxOscMessage::getArgAsSymbol(int index) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_SYMBOL )
-    {
-        // warn about string conversions
-        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting int32 to symbol (string) for argument " << index;
-            return ofToString(((ofxOscArgInt32*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting int64 to symbol (string) for argument " << index;
-            return ofToString(((ofxOscArgInt64*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting float to symbol (string) for argument " << index;
-            return ofToString(((ofxOscArgFloat*)args[index])->get());
-        }
-        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting double to symbol (string) for argument " << index;
-            return ofToString(((ofxOscArgDouble*)args[index])->get());
-        }
-		else if ( getArgType(index) == OFXOSC_TYPE_STRING )
-        {
-            return ((ofxOscArgString*)args[index])->get();
-        }
-        else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
-        {
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting char to symbol (string) for argument " << index;
-            return ofToString(((ofxOscArgChar*)args[index])->get());
-        }
-        else
-        {
-            ofLogError("ofxOscMessage") << "getArgAsSymbol(): argument " << index << " is not a symbol (string) interpretable value";
-            return "";
-        }
-    }
-    else
-        return ((ofxOscArgSymbol*)args[index])->get();
-}
-
-char ofxOscMessage::getArgAsChar(int index) const
-{
-    if ( getArgType(index) == OFXOSC_TYPE_CHAR )
-    {
-        return ((ofxOscArgChar*)args[index])->get();
-    }
-    else
-    {
-        ofLogError("ofxOscMessage") << "getArgAsChar(): argument " << index << " is not a char";
-        return 0;
-    }
-}
-
-std::int32_t ofxOscMessage::getArgAsMidiMessage(int index) const
-{
-    if ( getArgType(index) == OFXOSC_TYPE_MIDI_MESSAGE )
-    {
-        return ((ofxOscArgMidiMessage*)args[index])->get();
-    }
-    else
-    {
-        ofLogError("ofxOscMessage") << "getArgAsMidiMessage(): argument " << index << " is not a midi message";
-        return 0;
-    }
-}
-
-bool ofxOscMessage::getArgAsBool(int index) const
-{
-    ofxOscArgType incomingArgType = getArgType( index );
-    if(incomingArgType == OFXOSC_TYPE_TRUE || incomingArgType == OFXOSC_TYPE_FALSE)
-    {
-        return ((ofxOscArgBool*)args[index])->get();
-    }
-    else if(incomingArgType == OFXOSC_TYPE_INT32)
-    {
-        return ((ofxOscArgInt32*)args[index])->get() > 0;
-    }
-    else if(incomingArgType == OFXOSC_TYPE_INT64)
-    {
-        return ((ofxOscArgInt64*)args[index])->get() > 0;
-    }
-    else if(incomingArgType == OFXOSC_TYPE_FLOAT)
-    {
-        return ((ofxOscArgFloat*)args[index])->get() > 0;
-    }
-    else if(incomingArgType == OFXOSC_TYPE_DOUBLE)
-    {
-        return ((ofxOscArgDouble*)args[index])->get() > 0;
-    }
-    else if(incomingArgType == OFXOSC_TYPE_STRING || incomingArgType == OFXOSC_TYPE_SYMBOL)
-    {
-        return ((ofxOscArgString*)args[index])->get() == "true";
-    }
-    else
-    {
-        ofLogError("ofxOscMessage") << "getArgAsBool(): argument " << index << " is not a boolean interpretable value";
-        return false;
-    }
-}
-
-bool ofxOscMessage::getArgAsTrigger(int index) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_TRIGGER )
-    {
-        ofLogError("ofxOscMessage") << "getArgAsTrigger(): argument " << index << " is not a trigger";
-        return false;
-    }
-    else
-        return ((ofxOscArgTrigger*)args[index])->get();
-}
-
-bool ofxOscMessage::getArgAsImpulse(int index) const
-{
-	return getArgAsTrigger(index);
-}
-
-bool ofxOscMessage::getArgAsInfinitum(int index) const
-{
-	return getArgAsTrigger(index);
-}
-
-std::int64_t ofxOscMessage::getArgAsTimetag(int index) const
-{
-	if ( getArgType(index) != OFXOSC_TYPE_TIMETAG )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
-        {
-            // warn about possible conversion issue
-            ofLogWarning("ofxOscMessage") << "getArgAsTimetag(): converting double to Timetag for argument " << index;
-            return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
-        }
-        else
-        {
-        	ofLogError("ofxOscMessage") << "getArgAsTimetag(): argument " << index << " is not a valid number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgTimetag*)args[index])->get();
-}
-
-ofBuffer ofxOscMessage::getArgAsBlob( int index ) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_BLOB )
-	{
-        ofLogError("ofxOscMessage") << "getArgAsBlob(): argument " << index << " is not a blob";
-        return ofBuffer();
-	}
-	else
-        return ((ofxOscArgBlob*)args[index])->get();
-}
-
-std::int32_t ofxOscMessage::getArgAsRgbaColor( int index ) const
-{
-    if ( getArgType(index) != OFXOSC_TYPE_RGBA_COLOR )
-    {
-        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            return ((ofxOscArgInt32*)args[index])->get();
-        }
-        else 
-        {
-            ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument " << index << " is not an rgba color";
-            return 0;
-        }
-    }
-    else
-        return ((ofxOscArgRgbaColor*)args[index])->get();
-}
-
-/*
-
-set methods
-
-*/
-
-void ofxOscMessage::addIntArg( std::int32_t argument )
-{
-	args.push_back( new ofxOscArgInt32( argument ) );
-}
-
-void ofxOscMessage::addInt32Arg( std::int32_t argument )
-{
-	args.push_back( new ofxOscArgInt32( argument ) );
-}
-
-void ofxOscMessage::addInt64Arg( std::int64_t argument )
-{
-	args.push_back( new ofxOscArgInt64( argument ) );
-}
-
-void ofxOscMessage::addFloatArg( float argument )
-{
-	args.push_back( new ofxOscArgFloat( argument ) );
-}
-
-void ofxOscMessage::addDoubleArg( double argument )
-{
-	args.push_back( new ofxOscArgDouble( argument ) );
-}
-
-void ofxOscMessage::addStringArg( const std::string &argument )
-{
-	args.push_back( new ofxOscArgString( argument ) );
-}
-
-void ofxOscMessage::addSymbolArg( const std::string &argument )
-{
-	args.push_back( new ofxOscArgSymbol( argument ) );
-}
-
-void ofxOscMessage::addCharArg( char argument )
-{
-	args.push_back( new ofxOscArgChar( argument ) );
-}
-
-void ofxOscMessage::addMidiMessageArg( std::int32_t argument )
-{
-	args.push_back( new ofxOscArgMidiMessage( argument ) );
-}
-
-void ofxOscMessage::addBoolArg( bool argument )
-{
-	args.push_back( new ofxOscArgBool( argument ) );
-}
-
-void ofxOscMessage::addTriggerArg()
-{
-	args.push_back( new ofxOscArgTrigger() );
-}
-
-void ofxOscMessage::addImpulseArg()
-{
-	args.push_back( new ofxOscArgTrigger() );
-}
-
-void ofxOscMessage::addInfinitumArg()
-{
-	args.push_back( new ofxOscArgTrigger() );
-}
-
-void ofxOscMessage::addTimetagArg( std::int64_t argument )
-{
-	args.push_back( new ofxOscArgTimetag( argument ) );
-}
-
-void ofxOscMessage::addBlobArg( const ofBuffer &argument )
-{
-	args.push_back( new ofxOscArgBlob( argument ) );
-}
-
-void ofxOscMessage::addRgbaColorArg( std::int32_t argument )
-{
-	args.push_back( new ofxOscArgRgbaColor( argument ) );
-}
-
-/*
-
- housekeeping
-
- */
-
-ofxOscMessage& ofxOscMessage::copy( const ofxOscMessage& other )
-{
+ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
+	if(this == &other) return *this;
 	clear();
-	// copy address
+
+	// copy address & remote info
 	address = other.address;
-
 	remote_host = other.remote_host;
 	remote_port = other.remote_port;
 
 	// copy arguments
-	for ( int i=0; i<(int)other.args.size(); ++i )
-	{
-		ofxOscArgType argType = other.getArgType( i );
-		if ( argType == OFXOSC_TYPE_TRUE || argType == OFXOSC_TYPE_FALSE )
-			args.push_back( new ofxOscArgBool( other.getArgAsBool( i ) ) );
-		else if ( argType == OFXOSC_TYPE_INT32 )
-			args.push_back( new ofxOscArgInt32( other.getArgAsInt32( i ) ) );
-		else if ( argType == OFXOSC_TYPE_INT64 )
-			args.push_back( new ofxOscArgInt64( other.getArgAsInt64( i ) ) );
-		else if ( argType == OFXOSC_TYPE_FLOAT )
-			args.push_back( new ofxOscArgFloat( other.getArgAsFloat( i ) ) );
-		else if ( argType == OFXOSC_TYPE_DOUBLE )
-			args.push_back( new ofxOscArgDouble( other.getArgAsDouble( i ) ) );
-		else if ( argType == OFXOSC_TYPE_STRING )
-			args.push_back( new ofxOscArgString( other.getArgAsString( i ) ) );
-		else if ( argType == OFXOSC_TYPE_SYMBOL )
-			args.push_back( new ofxOscArgSymbol( other.getArgAsSymbol( i ) ) );
-		else if ( argType == OFXOSC_TYPE_CHAR )
-			args.push_back( new ofxOscArgChar( other.getArgAsChar( i ) ) );
-		else if ( argType == OFXOSC_TYPE_MIDI_MESSAGE )
-			args.push_back( new ofxOscArgMidiMessage( other.getArgAsMidiMessage( i ) ) );
-		else if ( argType == OFXOSC_TYPE_TRIGGER )
-			args.push_back( new ofxOscArgTrigger() );
-		else if ( argType == OFXOSC_TYPE_TIMETAG )
-			args.push_back( new ofxOscArgTimetag( other.getArgAsTimetag( i ) ) );
-		else if ( argType == OFXOSC_TYPE_BLOB )
-			args.push_back( new ofxOscArgBlob( other.getArgAsBlob( i ) ) );
-		else if ( argType == OFXOSC_TYPE_RGBA_COLOR )
-			args.push_back( new ofxOscArgRgbaColor( other.getArgAsRgbaColor( i ) ) );
-		else
-		{
-			assert( false && "bad argument type" );
+	for(int i = 0; i < (int)other.args.size(); ++i){
+		switch(other.getArgType(i)){
+			case OFXOSC_TYPE_TRUE: case OFXOSC_TYPE_FALSE:
+				args.push_back(new ofxOscArgBool(other.getArgAsBool(i)));
+				break;
+			case OFXOSC_TYPE_INT32:
+				args.push_back(new ofxOscArgInt32(other.getArgAsInt32(i)));
+				break;
+			case OFXOSC_TYPE_INT64:
+				args.push_back(new ofxOscArgInt64(other.getArgAsInt64(i)));
+				break;
+			case OFXOSC_TYPE_FLOAT:
+				args.push_back(new ofxOscArgFloat(other.getArgAsFloat(i)));
+				break;
+			case OFXOSC_TYPE_DOUBLE:
+				args.push_back(new ofxOscArgDouble(other.getArgAsDouble(i)));
+				break;
+			case OFXOSC_TYPE_STRING:
+				args.push_back(new ofxOscArgString(other.getArgAsString(i)));
+				break;
+			case OFXOSC_TYPE_SYMBOL:
+				args.push_back(new ofxOscArgSymbol(other.getArgAsSymbol(i)));
+				break;
+			case OFXOSC_TYPE_CHAR:
+				args.push_back(new ofxOscArgChar(other.getArgAsChar(i)));
+				break;
+			case OFXOSC_TYPE_MIDI_MESSAGE:
+				args.push_back(new ofxOscArgMidiMessage(other.getArgAsMidiMessage(i)));
+				break;
+			case OFXOSC_TYPE_TRIGGER:
+				args.push_back(new ofxOscArgTrigger());
+				break;
+			case OFXOSC_TYPE_TIMETAG:
+				args.push_back(new ofxOscArgTimetag(other.getArgAsTimetag(i)));
+				break;
+			case OFXOSC_TYPE_BLOB:
+				args.push_back(new ofxOscArgBlob(other.getArgAsBlob(i)));
+				break;
+			case OFXOSC_TYPE_RGBA_COLOR:
+				args.push_back(new ofxOscArgRgbaColor(other.getArgAsRgbaColor(i)));
+				break;
+			default:
+				ofLogError("ofxOscMessage") << "copy(): bad argument type "
+					<< other.getArgType(i);
+				assert(false);
+				break;
 		}
 	}
-
+	
 	return *this;
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::clear(){
+	address = "";
+	for(unsigned int i = 0; i < args.size(); ++i){
+		delete args[i];
+	}
+	args.clear();
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getAddress() const{ 
+	return address;
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getRemoteIp() const{ 
+	return remote_host;
+}
+
+//--------------------------------------------------------------
+int ofxOscMessage::getRemotePort() const{
+	return remote_port;
+}
+
+// get methods
+//--------------------------------------------------------------
+int ofxOscMessage::getNumArgs() const{
+	return (int)args.size();
+}
+
+//--------------------------------------------------------------
+ofxOscArgType ofxOscMessage::getArgType(int index) const{
+	if(index >= (int)args.size()) {
+		ofLogError("ofxOscMessage") << "getArgType(): index "
+		                            << index << " out of bounds";
+		return OFXOSC_TYPE_INDEXOUTOFBOUNDS;
+	}
+	else{
+		return args[index]->getType();
+	}
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getArgTypeName(int index) const{
+	if(index >= (int)args.size()) {
+		ofLogError("ofxOscMessage") << "getArgTypeName(): index "
+		                            << index << " out of bounds";
+		return "INDEX OUT OF BOUNDS";
+	}
+	else{
+		return args[index]->getTypeName();
+	}
+}
+
+//--------------------------------------------------------------
+int32_t ofxOscMessage::getArgAsInt(int index) const{
+	return getArgAsInt32(index);
+}
+
+//--------------------------------------------------------------
+int32_t ofxOscMessage::getArgAsInt32(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_INT32){
+		if(getArgType(index) == OFXOSC_TYPE_INT64){
+			// warn about possible lack of precision
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsInt32(): converting int64 to int32 for argument "
+				<< index;
+			return (int32_t)((ofxOscArgInt64*)args[index])->get();
+		}
+		else if (getArgType(index) == OFXOSC_TYPE_FLOAT){
+			return (int32_t)((ofxOscArgFloat*)args[index])->get();
+		}
+		else if (getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			// warn about possible lack of precision
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsInt32(): converting double to int32 for argument "
+				<< index;
+			return (int32_t)((ofxOscArgDouble*)args[index])->get();
+		}
+		else if(getArgType(index)  == OFXOSC_TYPE_TRUE || 
+			    getArgType(index) == OFXOSC_TYPE_FALSE){
+			return (int32_t)((ofxOscArgBool*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsInt32(): argument "
+			                            << index << " is not a number";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgInt32*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+int64_t ofxOscMessage::getArgAsInt64(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_INT64){
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			return (int64_t)((ofxOscArgInt32*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_FLOAT){
+			return (int64_t)((ofxOscArgFloat*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			return (int64_t)((ofxOscArgDouble*)args[index])->get();
+		}
+		else if(getArgType(index)  == OFXOSC_TYPE_TRUE ||
+			    getArgType(index) == OFXOSC_TYPE_FALSE){
+			return (int64_t)((ofxOscArgBool*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsInt64(): argument "
+			                            << index << " is not a number";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgInt64*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+float ofxOscMessage::getArgAsFloat(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_FLOAT){
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			return (float)((ofxOscArgInt32*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_INT64){
+			// warn about possible lack of precision
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsFloat(): converting int64 to float for argument "
+				<< index;
+			return (float)((ofxOscArgInt64*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			// warn about possible lack of precision
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsFloat(): converting double to float for argument "
+				<< index;
+			return (float)((ofxOscArgDouble*)args[index])->get();
+		}
+		else if(getArgType(index)  == OFXOSC_TYPE_TRUE ||
+			    getArgType(index) == OFXOSC_TYPE_FALSE){
+			return (float)((ofxOscArgBool*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsFloat(): argument "
+			                            << index << " is not a number";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgFloat*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+double ofxOscMessage::getArgAsDouble(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_DOUBLE){
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			return (double)((ofxOscArgInt32*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_INT64){
+			return (double)((ofxOscArgInt64*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_FLOAT){
+			return (double)((ofxOscArgFloat*)args[index])->get();
+		}
+		else if( getArgType(index)  == OFXOSC_TYPE_TRUE ||
+			     getArgType(index) == OFXOSC_TYPE_FALSE){
+			return (double)((ofxOscArgBool*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsDouble(): argument "
+			                            << index << " is not a number";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgDouble*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getArgAsString(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_STRING){
+		// warn about string conversions
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsString(): converting int32 to string for argument "
+				<< index;
+			return ofToString(((ofxOscArgInt32*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_INT64){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsString(): converting int64 to string for argument "
+				<< index;
+			return ofToString(((ofxOscArgInt64*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_FLOAT){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsString(): converting float to string for argument "
+				<< index;
+			return ofToString(((ofxOscArgFloat*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsString(): converting double to string for argument "
+				<< index;
+			return ofToString(((ofxOscArgDouble*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_SYMBOL){
+			return ((ofxOscArgSymbol*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_CHAR){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsString(): converting char to string for argument "
+				<< index;
+			return ofToString(((ofxOscArgChar*)args[index])->get());
+		}
+		else{
+			ofLogError("ofxOscMessage")
+				<< "getArgAsString(): argument " << index
+				<< " is not a string interpretable value";
+			return "";
+		}
+	}
+	else{
+		return ((ofxOscArgString*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getArgAsSymbol(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_SYMBOL){
+		// warn about string conversions
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsSymbol(): converting int32 to symbol (string) "
+				<< "for argument " << index;
+			return ofToString(((ofxOscArgInt32*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_INT64){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsSymbol(): converting int64 to symbol (string) "
+				<< "for argument " << index;
+			return ofToString(((ofxOscArgInt64*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_FLOAT){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsSymbol(): converting float to symbol (string) "
+				<< "for argument " << index;
+			return ofToString(((ofxOscArgFloat*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsSymbol(): converting double to symbol (string) "
+				<< "for argument " << index;
+			return ofToString(((ofxOscArgDouble*)args[index])->get());
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_STRING){
+			return ((ofxOscArgString*)args[index])->get();
+		}
+		else if(getArgType(index) == OFXOSC_TYPE_CHAR){
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsSymbol(): converting char to symbol (string) "
+				<< "for argument " << index;
+			return ofToString(((ofxOscArgChar*)args[index])->get());
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsSymbol(): argument "
+				<< index << " is not a symbol (string) interpretable value";
+			return "";
+		}
+	}
+	else{
+		return ((ofxOscArgSymbol*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+char ofxOscMessage::getArgAsChar(int index) const{
+	if(getArgType(index) == OFXOSC_TYPE_CHAR){
+		return ((ofxOscArgChar*)args[index])->get();
+	}
+	else{
+		ofLogError("ofxOscMessage") << "getArgAsChar(): argument "
+			<< index << " is not a char";
+		return 0;
+	}
+}
+
+//--------------------------------------------------------------
+int32_t ofxOscMessage::getArgAsMidiMessage(int index) const{
+	if(getArgType(index) == OFXOSC_TYPE_MIDI_MESSAGE){
+		return ((ofxOscArgMidiMessage*)args[index])->get();
+	}
+	else{
+		ofLogError("ofxOscMessage") << "getArgAsMidiMessage(): argument "
+			<< index << " is not a midi message";
+		return 0;
+	}
+}
+
+//--------------------------------------------------------------
+bool ofxOscMessage::getArgAsBool(int index) const{
+	switch(getArgType(index)){
+		case OFXOSC_TYPE_TRUE: case OFXOSC_TYPE_FALSE:
+			return ((ofxOscArgBool*)args[index])->get();
+		case OFXOSC_TYPE_INT32:
+			return ((ofxOscArgInt32*)args[index])->get() > 0;
+		case OFXOSC_TYPE_INT64:
+			return ((ofxOscArgInt64*)args[index])->get() > 0;
+		case OFXOSC_TYPE_FLOAT:
+			return ((ofxOscArgFloat*)args[index])->get() > 0;
+		case OFXOSC_TYPE_DOUBLE:
+			return ((ofxOscArgDouble*)args[index])->get() > 0;
+		case OFXOSC_TYPE_STRING: case OFXOSC_TYPE_SYMBOL:
+			return ((ofxOscArgString*)args[index])->get() == "true";
+		default:
+			ofLogError("ofxOscMessage") << "getArgAsBool(): argument "
+				<< index << " is not a boolean interpretable value";
+			return false;
+	}
+}
+
+//--------------------------------------------------------------
+bool ofxOscMessage::getArgAsTrigger(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_TRIGGER){
+		ofLogError("ofxOscMessage") << "getArgAsTrigger(): argument "
+			<< index << " is not a trigger";
+		return false;
+	}
+	else{
+		return ((ofxOscArgTrigger*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+bool ofxOscMessage::getArgAsImpulse(int index) const{
+	return getArgAsTrigger(index);
+}
+
+//--------------------------------------------------------------
+bool ofxOscMessage::getArgAsInfinitum(int index) const{
+	return getArgAsTrigger(index);
+}
+
+//--------------------------------------------------------------
+int64_t ofxOscMessage::getArgAsTimetag(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_TIMETAG){
+		if(getArgType(index) == OFXOSC_TYPE_DOUBLE){
+			// warn about possible conversion issue
+			ofLogWarning("ofxOscMessage")
+				<< "getArgAsTimetag(): converting double to Timetag "
+				<< "for argument " << index;
+			return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsTimetag(): argument "
+				<< index << " is not a valid number";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgTimetag*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+ofBuffer ofxOscMessage::getArgAsBlob(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_BLOB){
+		ofLogError("ofxOscMessage") << "getArgAsBlob(): argument "
+			<< index << " is not a blob";
+		return ofBuffer();
+	}
+	else{
+		return ((ofxOscArgBlob*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
+int32_t ofxOscMessage::getArgAsRgbaColor(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_RGBA_COLOR){
+		if(getArgType(index) == OFXOSC_TYPE_INT32){
+			return ((ofxOscArgInt32*)args[index])->get();
+		}
+		else{
+			ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument "
+				<< index << " is not an rgba color";
+			return 0;
+		}
+	}
+	else{
+		return ((ofxOscArgRgbaColor*)args[index])->get();
+	}
+}
+
+// set methods
+//--------------------------------------------------------------
+void ofxOscMessage::setAddress(const string &_address){
+	address = _address;
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addIntArg(int32_t argument){
+	args.push_back(new ofxOscArgInt32(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addInt32Arg(int32_t argument){
+	args.push_back(new ofxOscArgInt32(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addInt64Arg(int64_t argument){
+	args.push_back(new ofxOscArgInt64(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addFloatArg(float argument){
+	args.push_back(new ofxOscArgFloat(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addDoubleArg(double argument){
+	args.push_back(new ofxOscArgDouble(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addStringArg(const std::string &argument){
+	args.push_back(new ofxOscArgString(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addSymbolArg(const std::string &argument){
+	args.push_back(new ofxOscArgSymbol(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addCharArg( char argument){
+	args.push_back(new ofxOscArgChar(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addMidiMessageArg(int32_t argument){
+	args.push_back(new ofxOscArgMidiMessage(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addBoolArg(bool argument){
+	args.push_back(new ofxOscArgBool(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addTriggerArg(){
+	args.push_back(new ofxOscArgTrigger());
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addImpulseArg(){
+	args.push_back(new ofxOscArgTrigger());
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addInfinitumArg(){
+	args.push_back(new ofxOscArgTrigger());
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addTimetagArg(int64_t argument){
+	args.push_back(new ofxOscArgTimetag(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addBlobArg(const ofBuffer &argument){
+	args.push_back(new ofxOscArgBlob(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addRgbaColorArg(int32_t argument){
+	args.push_back(new ofxOscArgRgbaColor(argument));
+}
+
+// util
+//--------------------------------------------------------------
+void ofxOscMessage::setRemoteEndpoint(const string &host, int port){
+	remote_host = host; remote_port = port;
 }

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -31,7 +31,7 @@
 #include "ofUtils.h"
 
 //--------------------------------------------------------------
-ofxOscMessage::ofxOscMessage() {}
+ofxOscMessage::ofxOscMessage() : remoteHost(""), remotePort(0) {}
 
 //--------------------------------------------------------------
 ofxOscMessage::~ofxOscMessage(){
@@ -54,8 +54,8 @@ ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
 
 	// copy address & remote info
 	address = other.address;
-	remote_host = other.remote_host;
-	remote_port = other.remote_port;
+	remoteHost = other.remoteHost;
+	remotePort = other.remotePort;
 
 	// copy arguments
 	for(int i = 0; i < (int)other.args.size(); ++i){
@@ -113,6 +113,8 @@ ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
 //--------------------------------------------------------------
 void ofxOscMessage::clear(){
 	address = "";
+	remoteHost = "";
+	remotePort = 0;
 	for(unsigned int i = 0; i < args.size(); ++i){
 		delete args[i];
 	}
@@ -131,17 +133,17 @@ string ofxOscMessage::getAddress() const{
 
 //--------------------------------------------------------------
 string ofxOscMessage::getRemoteIp() const{ 
-	return remote_host;
+	return remoteHost;
 }
 
 //--------------------------------------------------------------
 string ofxOscMessage::getRemoteHost() const{
-	return remote_host;
+	return remoteHost;
 }
 
 //--------------------------------------------------------------
 int ofxOscMessage::getRemotePort() const{
-	return remote_port;
+	return remotePort;
 }
 
 // get methods
@@ -602,6 +604,6 @@ void ofxOscMessage::addRgbaColorArg(int32_t argument){
 // util
 //--------------------------------------------------------------
 void ofxOscMessage::setRemoteEndpoint(const string &host, int port){
-	remote_host = host;
-	remote_port = port;
+	remoteHost = host;
+	remotePort = port;
 }

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -97,8 +97,8 @@ void ofxOscMessage::clear(){
 }
 
 //--------------------------------------------------------------
-void ofxOscMessage::setAddress(const string &_address){
-	address = _address;
+void ofxOscMessage::setAddress(const string &address){
+	this->address = address;
 }
 
 //--------------------------------------------------------------
@@ -149,6 +149,15 @@ string ofxOscMessage::getArgTypeName(int index) const{
 	else{
 		return args[index]->getTypeName();
 	}
+}
+
+//--------------------------------------------------------------
+string ofxOscMessage::getTypeString() const {
+	string types = "";
+	for(int i = 0; i < (int)args.size(); ++i) {
+		types += args[i]->getTypeName();
+	}
+	return types;
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -28,8 +28,7 @@
 
 #include "ofxOscMessage.h"
 #include "ofLog.h"
-#include <iostream>
-#include <assert.h>
+#include "ofUtils.h"
 
 ofxOscMessage::ofxOscMessage()
 

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -239,7 +239,11 @@ std::string ofxOscMessage::getArgAsString( int index ) const
             ofLogWarning("ofxOscMessage") << "getArgAsString(): converting double to string for argument " << index;
             return ofToString(((ofxOscArgDouble*)args[index])->get());
         }
-        else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
+		else if ( getArgType(index) == OFXOSC_TYPE_SYMBOL )
+        {
+            return ((ofxOscArgSymbol*)args[index])->get();
+        }
+		else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
         {
             ofLogWarning("ofxOscMessage") << "getArgAsString(): converting char to string for argument " << index;
             return ofToString(((ofxOscArgChar*)args[index])->get());
@@ -278,6 +282,10 @@ std::string ofxOscMessage::getArgAsSymbol(int index) const
         {
             ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting double to symbol (string) for argument " << index;
             return ofToString(((ofxOscArgDouble*)args[index])->get());
+        }
+		else if ( getArgType(index) == OFXOSC_TYPE_STRING )
+        {
+            return ((ofxOscArgString*)args[index])->get();
         }
         else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
         {

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -22,6 +22,7 @@ ofxOscMessage& ofxOscMessage::operator=(const ofxOscMessage& other){
 	return copy(other);
 }
 
+//--------------------------------------------------------------
 ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
 	if(this == &other) return *this;
 	clear();
@@ -423,6 +424,18 @@ bool ofxOscMessage::getArgAsBool(int index) const{
 }
 
 //--------------------------------------------------------------
+bool ofxOscMessage::getArgAsNone(int index) const{
+	if(getArgType(index) != OFXOSC_TYPE_NONE){
+		ofLogError("ofxOscMessage") << "getArgAsNone(): argument "
+			<< index << " is not a none/nil";
+		return false;
+	}
+	else{
+		return ((ofxOscArgNone*)args[index])->get();
+	}
+}
+
+//--------------------------------------------------------------
 bool ofxOscMessage::getArgAsTrigger(int index) const{
 	if(getArgType(index) != OFXOSC_TYPE_TRIGGER){
 		ofLogError("ofxOscMessage") << "getArgAsTrigger(): argument "
@@ -543,6 +556,11 @@ void ofxOscMessage::addMidiMessageArg(int32_t argument){
 //--------------------------------------------------------------
 void ofxOscMessage::addBoolArg(bool argument){
 	args.push_back(new ofxOscArgBool(argument));
+}
+
+//--------------------------------------------------------------
+void ofxOscMessage::addNoneArg(){
+	args.push_back(new ofxOscArgNone());
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -1,31 +1,5 @@
-/*
-
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
-   names of its contributors may be used to endorse or promote products
-   derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #include "ofxOscMessage.h"
 #include "ofLog.h"
 #include "ofUtils.h"

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #include "ofxOscMessage.h"
 #include "ofLog.h"
 #include "ofUtils.h"

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -498,7 +498,7 @@ void ofxOscMessage::addInfinitumArg()
 
 void ofxOscMessage::addTimetagArg( std::int64_t argument )
 {
-	args.push_back( new ofxOscArgBool( argument ) );
+	args.push_back( new ofxOscArgTimetag( argument ) );
 }
 
 void ofxOscMessage::addBlobArg( const ofBuffer &argument )

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -76,8 +76,7 @@ ofxOscMessage& ofxOscMessage::copy(const ofxOscMessage& other){
 				break;
 			default:
 				ofLogError("ofxOscMessage") << "copy(): bad argument type "
-					<< other.getArgType(i);
-				assert(false);
+					<< other.getArgType(i) << " '" << (char) other.getArgType(i) << "'";	
 				break;
 		}
 	}

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -603,3 +603,65 @@ void ofxOscMessage::setRemoteEndpoint(const string &host, int port){
 	remoteHost = host;
 	remotePort = port;
 }
+
+// friend functions
+//--------------------------------------------------------------
+ostream& operator<<(ostream &os, const ofxOscMessage &message) {
+	os << message.getAddress();
+	for(int i = 0; i < message.getNumArgs(); ++i) {
+		os << " ";
+		switch(message.getArgType(i)) {
+			case OFXOSC_TYPE_INT32:
+				os << message.getArgAsInt32(i);
+				break;
+			case OFXOSC_TYPE_INT64:
+				os << message.getArgAsInt64(i);
+				break;
+			case OFXOSC_TYPE_FLOAT:
+				os << message.getArgAsFloat(i);
+				break;
+			case OFXOSC_TYPE_DOUBLE:
+				os << message.getArgAsDouble(i);
+				break;
+			case OFXOSC_TYPE_STRING:
+				os << message.getArgAsString(i);
+				break;
+			case OFXOSC_TYPE_SYMBOL:
+				os << message.getArgAsSymbol(i);
+				break;
+			case OFXOSC_TYPE_CHAR:
+				os << message.getArgAsChar(i);
+				break;
+			case OFXOSC_TYPE_MIDI_MESSAGE:
+				os << ofToHex(message.getArgAsMidiMessage(i));
+				break;
+			case OFXOSC_TYPE_TRUE:
+				os << "T";
+				break;
+			case OFXOSC_TYPE_FALSE:
+				os << "F";
+				break;
+			case OFXOSC_TYPE_NONE:
+				os << "NONE";
+				break;
+			case OFXOSC_TYPE_TRIGGER:
+				os << "TRIGGER";
+				break;
+			case OFXOSC_TYPE_TIMETAG:
+				os << "TIMETAG";
+				break;
+			case OFXOSC_TYPE_BLOB:
+				os << "BLOB";
+				break;
+			case OFXOSC_TYPE_BUNDLE:
+				os << "BUNDLE";
+				break;
+			case OFXOSC_TYPE_RGBA_COLOR:
+				os << ofToHex(message.getArgAsRgbaColor(i));
+				break;
+			default:
+				break;
+		}
+	}
+	return os;
+}

--- a/addons/ofxOsc/src/ofxOscMessage.cpp
+++ b/addons/ofxOsc/src/ofxOscMessage.cpp
@@ -89,16 +89,31 @@ std::int32_t ofxOscMessage::getArgAsInt( int index ) const
 
 std::int32_t ofxOscMessage::getArgAsInt32( int index ) const
 {
-	if ( getArgType(index) != OFXOSC_TYPE_INT32 )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+    if ( getArgType(index) != OFXOSC_TYPE_INT32 )
+    {
+        if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
         {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting float to int32 for argument " << index;
+            // warn about possible lack of precision
+            ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting int64 to int32 for argument " << index;
+            return (std::int32_t)((ofxOscArgInt64*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+        {
             return (std::int32_t)((ofxOscArgFloat*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
+        {
+            // warn about possible lack of precision
+            ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting double to int32 for argument " << index;
+            return (std::int32_t)((ofxOscArgDouble*)args[index])->get();
+        }
+        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
+        {
+            return (std::int32_t)((ofxOscArgBool*)args[index])->get();
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsInt32(): argument " << index << " is not a number";
+            ofLogError("ofxOscMessage") << "getArgAsInt32(): argument " << index << " is not a number";
             return 0;
         }
 	}
@@ -108,16 +123,27 @@ std::int32_t ofxOscMessage::getArgAsInt32( int index ) const
 
 std::int64_t ofxOscMessage::getArgAsInt64( int index ) const
 {
-	if ( getArgType(index) != OFXOSC_TYPE_INT64 )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+    if ( getArgType(index) != OFXOSC_TYPE_INT64 )
+    {
+        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
         {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsInt64(): converting float to int64 for argument " << index;
+            return (std::int64_t)((ofxOscArgInt32*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+        {
             return (std::int64_t)((ofxOscArgFloat*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
+        {
+            return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
+        }
+        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
+        {
+            return (std::int64_t)((ofxOscArgBool*)args[index])->get();
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsInt64(): argument " << index << " is not a number";
+            ofLogError("ofxOscMessage") << "getArgAsInt64(): argument " << index << " is not a number";
             return 0;
         }
 	}
@@ -131,12 +157,27 @@ float ofxOscMessage::getArgAsFloat( int index ) const
 	{
 	    if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
         {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsFloat(): converting int32 to float for argument " << index;
             return (float)((ofxOscArgInt32*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
+        {
+            // warn about possible lack of precision
+            ofLogWarning("ofxOscMessage") << "getArgAsFloat(): converting int64 to float for argument " << index;
+            return (float)((ofxOscArgInt64*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
+        {
+            // warn about possible lack of precision
+            ofLogWarning("ofxOscMessage") << "getArgAsFloat(): converting double to float for argument " << index;
+            return (float)((ofxOscArgDouble*)args[index])->get();
+        }
+        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
+        {
+            return (float)((ofxOscArgBool*)args[index])->get();
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsFloat(): argument " << index << " is not a number";
+            ofLogError("ofxOscMessage") << "getArgAsFloat(): argument " << index << " is not a number";
             return 0;
         }
 	}
@@ -150,12 +191,23 @@ double ofxOscMessage::getArgAsDouble( int index ) const
 	{
 	    if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
         {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsDouble(): converting int32 to double for argument " << index;
             return (double)((ofxOscArgInt32*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
+        {
+            return (double)((ofxOscArgInt64*)args[index])->get();
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+        {
+            return (double)((ofxOscArgFloat*)args[index])->get();
+        }
+        else if( getArgType( index )  == OFXOSC_TYPE_TRUE || getArgType( index ) == OFXOSC_TYPE_FALSE)
+        {
+            return (double)((ofxOscArgBool*)args[index])->get();
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsDouble(): argument " << index << " is not a number";
+            ofLogError("ofxOscMessage") << "getArgAsDouble(): argument " << index << " is not a number";
             return 0;
         }
 	}
@@ -166,133 +218,151 @@ double ofxOscMessage::getArgAsDouble( int index ) const
 std::string ofxOscMessage::getArgAsString( int index ) const
 {
     if ( getArgType(index) != OFXOSC_TYPE_STRING )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+    {
+        // warn about string conversions
+        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
         {
-            char buf[1024];
-            sprintf(buf,"%f",((ofxOscArgFloat*)args[index])->get() );
-            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting float to string for argument " << index;
-            return buf;
-        }
-	    else if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            char buf[1024];
-            sprintf(buf,"%i",((ofxOscArgInt32*)args[index])->get() );
             ofLogWarning("ofxOscMessage") << "getArgAsString(): converting int32 to string for argument " << index;
-            return buf;
+            return ofToString(((ofxOscArgInt32*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting int64 to string for argument " << index;
+            return ofToString(((ofxOscArgInt64*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting float to string for argument " << index;
+            return ofToString(((ofxOscArgFloat*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting double to string for argument " << index;
+            return ofToString(((ofxOscArgDouble*)args[index])->get());
+        }
+        else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsString(): converting char to string for argument " << index;
+            return ofToString(((ofxOscArgChar*)args[index])->get());
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsString(): argument " << index << " is not a string";
+            ofLogError("ofxOscMessage") << "getArgAsString(): argument " << index << " is not a string interpretable value";
             return "";
         }
-	}
-	else
+    }
+    else
         return ((ofxOscArgString*)args[index])->get();
 }
 
 std::string ofxOscMessage::getArgAsSymbol(int index) const
 {
     if ( getArgType(index) != OFXOSC_TYPE_SYMBOL )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+    {
+        // warn about string conversions
+        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
         {
-            char buf[1024];
-            sprintf(buf,"%f",((ofxOscArgFloat*)args[index])->get() );
-            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting float to symbol (string) for argument " << index;
-            return buf;
-        }
-	    else if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
-        {
-            char buf[1024];
-            sprintf(buf,"%i",((ofxOscArgInt32*)args[index])->get() );
             ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting int32 to symbol (string) for argument " << index;
-            return buf;
+            return ofToString(((ofxOscArgInt32*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_INT64 )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting int64 to symbol (string) for argument " << index;
+            return ofToString(((ofxOscArgInt64*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting float to symbol (string) for argument " << index;
+            return ofToString(((ofxOscArgFloat*)args[index])->get());
+        }
+        else if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting double to symbol (string) for argument " << index;
+            return ofToString(((ofxOscArgDouble*)args[index])->get());
+        }
+        else if ( getArgType(index) == OFXOSC_TYPE_CHAR )
+        {
+            ofLogWarning("ofxOscMessage") << "getArgAsSymbol(): converting char to symbol (string) for argument " << index;
+            return ofToString(((ofxOscArgChar*)args[index])->get());
         }
         else
         {
-        	ofLogError("ofxOscMessage") << "getArgAsSymbol(): argument " << index << " is not a symbol (string)";
+            ofLogError("ofxOscMessage") << "getArgAsSymbol(): argument " << index << " is not a symbol (string) interpretable value";
             return "";
         }
-	}
-	else
+    }
+    else
         return ((ofxOscArgSymbol*)args[index])->get();
 }
 
 char ofxOscMessage::getArgAsChar(int index) const
 {
     if ( getArgType(index) == OFXOSC_TYPE_CHAR )
-	{
-		return ((ofxOscArgChar*)args[index])->get();
-	}
-	else
     {
-		ofLogError("ofxOscMessage") << "getArgAsSymbol(): argument " << index << " is not a symbol (string)";
-		return 0;
-	}
+        return ((ofxOscArgChar*)args[index])->get();
+    }
+    else
+    {
+        ofLogError("ofxOscMessage") << "getArgAsChar(): argument " << index << " is not a char";
+        return 0;
+    }
 }
 
 std::int32_t ofxOscMessage::getArgAsMidiMessage(int index) const
 {
-	if ( getArgType(index) != OFXOSC_TYPE_INT32 )
-	{
-	    if ( getArgType( index ) == OFXOSC_TYPE_FLOAT )
-        {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsInt32(): converting float to int32 for argument " << index;
-            return (std::int32_t)((ofxOscArgFloat*)args[index])->get();
-        }
-        else
-        {
-        	ofLogError("ofxOscMessage") << "getArgAsInt32(): argument " << index << " is not a number";
-            return 0;
-        }
-	}
-	else
-        return ((ofxOscArgInt32*)args[index])->get();
+    if ( getArgType(index) == OFXOSC_TYPE_MIDI_MESSAGE )
+    {
+        return ((ofxOscArgMidiMessage*)args[index])->get();
+    }
+    else
+    {
+        ofLogError("ofxOscMessage") << "getArgAsMidiMessage(): argument " << index << " is not a midi message";
+        return 0;
+    }
 }
 
 bool ofxOscMessage::getArgAsBool(int index) const
 {
-	ofxOscArgType incomingArgType = getArgType( index );
-	if(incomingArgType == OFXOSC_TYPE_TRUE || incomingArgType == OFXOSC_TYPE_FALSE)
-	{
-		return ((ofxOscArgBool*)args[index])->get();
-	}
-	else if(incomingArgType == OFXOSC_TYPE_INT32)
-	{
-		return ((ofxOscArgInt32*)args[index])->get() > 0;
-	}
-	else if(incomingArgType == OFXOSC_TYPE_INT64)
-	{
-		return ((ofxOscArgInt64*)args[index])->get() > 0;
-	}
-	else if(incomingArgType == OFXOSC_TYPE_FLOAT)
-	{
-		return ((ofxOscArgFloat*)args[index])->get() > 0;
-	}
-	else if(incomingArgType == OFXOSC_TYPE_DOUBLE)
-	{
-		return ((ofxOscArgDouble*)args[index])->get() > 0;
-	}
-	else if(incomingArgType == OFXOSC_TYPE_STRING || incomingArgType == OFXOSC_TYPE_SYMBOL)
-	{
-		return ((ofxOscArgString*)args[index])->get() == "true";
-	}
-	else
-	{
-		ofLogError("ofxOscMessage") << "getArgAsBool(): argument " << index << " is not a boolean interpretable value";
-		return false;
-	}
+    ofxOscArgType incomingArgType = getArgType( index );
+    if(incomingArgType == OFXOSC_TYPE_TRUE || incomingArgType == OFXOSC_TYPE_FALSE)
+    {
+        return ((ofxOscArgBool*)args[index])->get();
+    }
+    else if(incomingArgType == OFXOSC_TYPE_INT32)
+    {
+        return ((ofxOscArgInt32*)args[index])->get() > 0;
+    }
+    else if(incomingArgType == OFXOSC_TYPE_INT64)
+    {
+        return ((ofxOscArgInt64*)args[index])->get() > 0;
+    }
+    else if(incomingArgType == OFXOSC_TYPE_FLOAT)
+    {
+        return ((ofxOscArgFloat*)args[index])->get() > 0;
+    }
+    else if(incomingArgType == OFXOSC_TYPE_DOUBLE)
+    {
+        return ((ofxOscArgDouble*)args[index])->get() > 0;
+    }
+    else if(incomingArgType == OFXOSC_TYPE_STRING || incomingArgType == OFXOSC_TYPE_SYMBOL)
+    {
+        return ((ofxOscArgString*)args[index])->get() == "true";
+    }
+    else
+    {
+        ofLogError("ofxOscMessage") << "getArgAsBool(): argument " << index << " is not a boolean interpretable value";
+        return false;
+    }
 }
 
 bool ofxOscMessage::getArgAsTrigger(int index) const
 {
-	if ( getArgType(index) != OFXOSC_TYPE_TRIGGER )
-	{
-		ofLogError("ofxOscMessage") << "getArgAsTrigger(): argument " << index << " is not a trigger";
-		return NULL;
-	}
-	else
+    if ( getArgType(index) != OFXOSC_TYPE_TRIGGER )
+    {
+        ofLogError("ofxOscMessage") << "getArgAsTrigger(): argument " << index << " is not a trigger";
+        return false;
+    }
+    else
         return ((ofxOscArgTrigger*)args[index])->get();
 }
 
@@ -312,8 +382,9 @@ std::int64_t ofxOscMessage::getArgAsTimetag(int index) const
 	{
 	    if ( getArgType( index ) == OFXOSC_TYPE_DOUBLE )
         {
-	    	ofLogWarning("ofxOscMessage") << "getArgAsTimetag(): converting double to Timetag for argument " << index;
-            return (std::int32_t)((ofxOscArgFloat*)args[index])->get();
+            // warn about possible conversion issue
+            ofLogWarning("ofxOscMessage") << "getArgAsTimetag(): converting double to Timetag for argument " << index;
+            return (std::int64_t)((ofxOscArgDouble*)args[index])->get();
         }
         else
         {
@@ -340,8 +411,15 @@ std::int32_t ofxOscMessage::getArgAsRgbaColor( int index ) const
 {
     if ( getArgType(index) != OFXOSC_TYPE_RGBA_COLOR )
     {
-        ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument " << index << " is not a rgba color";
-        return 0;
+        if ( getArgType( index ) == OFXOSC_TYPE_INT32 )
+        {
+            return ((ofxOscArgInt32*)args[index])->get();
+        }
+        else 
+        {
+            ofLogError("ofxOscMessage") << "getArgAsRgbaColor(): argument " << index << " is not an rgba color";
+            return 0;
+        }
     }
     else
         return ((ofxOscArgRgbaColor*)args[index])->get();

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -113,7 +113,7 @@ public:
 	char getArgAsChar(int index) const;
 	
 	/// \return given argument value as a 4-byte midi message
-	int32_t getArgAsMidiMessage(int index) const;
+	uint32_t getArgAsMidiMessage(int index) const;
 	
 	/// get argument as a bool, converts numeric types automatically
 	/// this argument type matches both OFXOSC_TYPE_TRUE & OFXOSC_TYPE_FALSE
@@ -139,14 +139,14 @@ public:
 	bool getArgAsInfinitum(int index) const;
 	
 	/// \return given argument as a 64-bit NTP time tag
-	int64_t getArgAsTimetag(int index) const;
+	uint64_t getArgAsTimetag(int index) const;
 	
 	/// \return given argument as a binary blob
 	ofBuffer getArgAsBlob(int index) const;
 	
 	/// get an argument as an RGBA color, converts int32 automatically
 	/// \return given argument as a 32-bit color value
-	int32_t getArgAsRgbaColor(int index) const;
+	uint32_t getArgAsRgbaColor(int index) const;
 
 	/// \section Argument Setters
 
@@ -175,7 +175,7 @@ public:
 	void addCharArg(char argument);
 	
 	/// add a 4-byte MIDI message
-	void addMidiMessageArg(int32_t argument);
+	void addMidiMessageArg(uint32_t argument);
 	
 	/// add a bool
 	/// true sends a OFXOSC_TYPE_TRUE & false sends an OFXOSC_TYPE_FALSE
@@ -195,14 +195,14 @@ public:
 	/// alias for addTriggerArg()
 	void addInfinitumArg();
 	
-	/// add a 64-bt NTP time tag
-	void addTimetagArg(int64_t argument);
+	/// add a 64-bit NTP time tag
+	void addTimetagArg(uint64_t argument);
 	
 	/// add a binary blog
 	void addBlobArg(const ofBuffer &argument);
 	
 	/// add a 32-bit color
-	void addRgbaColorArg(int32_t argument);
+	void addRgbaColorArg(uint32_t argument);
 
 	/// set host and port of the remote endpoint,
 	/// this is mainly used by ofxOscReceiver

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -178,7 +178,7 @@ public:
 	void addMidiMessageArg(uint32_t argument);
 	
 	/// add a bool
-	/// true sends a OFXOSC_TYPE_TRUE & false sends an OFXOSC_TYPE_FALSE
+	/// true sends a OFXOSC_TYPE_TRUE & false sends a OFXOSC_TYPE_FALSE
 	void addBoolArg(bool argument);
 	
 	/// add a none/nil (has no value)

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -29,10 +29,6 @@
 #pragma once
 
 #include "ofxOscArg.h"
-#include <vector>
-#include <string>
-
-using namespace std; // could we remove this?
 
 class ofxOscMessage
 {
@@ -48,10 +44,10 @@ public:
 	void clear();
 
 	/// return the address
-	std::string getAddress() const { return address; }
+	string getAddress() const { return address; }
 
 	/// return the remote ip
-	std::string getRemoteIp() const { return remote_host; }
+	string getRemoteIp() const { return remote_host; }
 	/// return the remote port
 	int getRemotePort() const { return remote_port; }
 
@@ -61,7 +57,7 @@ public:
 	ofxOscArgType getArgType( int index ) const;
 	/// return argument type name as string
 	/// - either "int", "float", or "string"
-	std::string getArgTypeName( int index ) const;
+	string getArgTypeName( int index ) const;
 
 	/// get the argument with the given index as an int, float, or string
 	/// ensure that the type matches what you're requesting
@@ -85,51 +81,51 @@ public:
 
 	See : http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
 	*/
-    std::int32_t getArgAsInt( int index ) const;
-	std::int32_t getArgAsInt32( int index ) const;
-	std::int64_t getArgAsInt64( int index ) const;
+    int32_t getArgAsInt( int index ) const;
+	int32_t getArgAsInt32( int index ) const;
+	int64_t getArgAsInt64( int index ) const;
 	float getArgAsFloat( int index ) const;
 	double getArgAsDouble( int index ) const;
-	std::string getArgAsString( int index ) const;
-	std::string getArgAsSymbol( int index ) const;
+	string getArgAsString( int index ) const;
+	string getArgAsSymbol( int index ) const;
 	char getArgAsChar( int index ) const;
-	std::int32_t getArgAsMidiMessage( int index ) const;
+	int32_t getArgAsMidiMessage( int index ) const;
 	bool getArgAsBool(int index) const;
 	bool getArgAsTrigger(int index) const;
 	bool getArgAsImpulse(int index) const;
 	bool getArgAsInfinitum(int index) const;
-	std::int64_t getArgAsTimetag( int index ) const;
+	int64_t getArgAsTimetag( int index ) const;
 	ofBuffer getArgAsBlob( int index ) const;
-	std::int32_t getArgAsRgbaColor( int index ) const;
+	int32_t getArgAsRgbaColor( int index ) const;
 
 	/// message construction
-	void setAddress( const std::string &_address ) { address = _address; };
+	void setAddress( const string &_address ) { address = _address; };
 	/// host and port of the remote endpoint
-    void setRemoteEndpoint( const std::string &host, int port ) { remote_host = host; remote_port = port; }
+    void setRemoteEndpoint( const string &host, int port ) { remote_host = host; remote_port = port; }
 
-	void addIntArg( std::int32_t argument );
-	void addInt32Arg( std::int32_t argument );
-	void addInt64Arg( std::int64_t argument );
+	void addIntArg( int32_t argument );
+	void addInt32Arg( int32_t argument );
+	void addInt64Arg( int64_t argument );
 	void addFloatArg( float argument );
 	void addDoubleArg( double argument );
-	void addStringArg( const std::string &argument );
-	void addSymbolArg( const std::string &argument );
+	void addStringArg( const string &argument );
+	void addSymbolArg( const string &argument );
 	void addCharArg( char argument );
-	void addMidiMessageArg( std::int32_t argument );
+	void addMidiMessageArg( int32_t argument );
 	void addBoolArg( bool argument );
 	void addTriggerArg();
 	void addImpulseArg();
 	void addInfinitumArg();
-	void addTimetagArg( std::int64_t argument );
+	void addTimetagArg( int64_t argument );
 	void addBlobArg( const ofBuffer &argument );
-	void addRgbaColorArg( std::int32_t argument );
+	void addRgbaColorArg( int32_t argument );
 
 private:
 
-    std::string address;
-    std::vector<ofxOscArg*> args;
+    string address;
+    vector<ofxOscArg*> args;
 
-    std::string remote_host;
+    string remote_host;
 	int remote_port;
 
 

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "ofxOscArg.h"

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -108,6 +108,10 @@ public:
 	/// \return given argument value as a bool
 	bool getArgAsBool(int index) const;
 	
+	/// get argument as a none/nil
+	/// \return true if argument was a none/nil
+	bool getArgAsNone(int index) const;
+	
 	/// get argument as a trigger impulse
 	/// \return true if argument was a trigger
 	bool getArgAsTrigger(int index) const;
@@ -164,6 +168,9 @@ public:
 	/// add a bool
 	/// true sends a OFXOSC_TYPE_TRUE & false sends an OFXOSC_TYPE_FALSE
 	void addBoolArg(bool argument);
+	
+	/// add a none/nil (has no value)
+	void addNoneArg();
 	
 	/// add a trigger impulse (has no value)
 	void addTriggerArg();

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -11,25 +11,25 @@ public:
 
 	ofxOscMessage();
 	~ofxOscMessage();
-	ofxOscMessage(const ofxOscMessage& other);
-	ofxOscMessage& operator=(const ofxOscMessage& other);
+	ofxOscMessage(const ofxOscMessage &other);
+	ofxOscMessage& operator=(const ofxOscMessage &other);
 	/// for operator= and copy constructor
-	ofxOscMessage& copy(const ofxOscMessage& other);
+	ofxOscMessage& copy(const ofxOscMessage &other);
 
 	/// clear this message
 	void clear();
 
 	/// set the message address, must start with a /
-	void setAddress(const string &address);
+	void setAddress(const std::string &address);
 
 	/// \return the OSC address
-	string getAddress() const;
+	std::string getAddress() const;
 
 	/// \return the remote host name/ip (deprecated)
-	OF_DEPRECATED_MSG("Use getRemoteHost() instead", string getRemoteIp() const);
+	OF_DEPRECATED_MSG("Use getRemoteHost() instead", std::string getRemoteIp() const);
 	
 	/// \return the remote host name/ip or "" if not set
-	string getRemoteHost() const;
+	std::string getRemoteHost() const;
 	
 	/// \return the remote port or 0 if not set
 	int getRemotePort() const;
@@ -56,7 +56,7 @@ public:
 	///
 	/// you can also check against the type string for all arguments:
 	///
-	///     int i = 0; float f = 0.0; string s = "";
+	///     int i = 0; float f = 0.0; std::string s = "";
 	///     if(message.getTypeString() == "ifs") {
 	///         i = message.getArgAsInt32(0);
 	///         f = message.getArgAsFloat(1);
@@ -72,24 +72,24 @@ public:
 	ofxOscArgType getArgType(int index) const;
 	
 	/// \return argument type tag char as a string
-	string getArgTypeName(int index) const;
+	std::string getArgTypeName(int index) const;
 	
 	/// \return type tags for all arguments as a string, 1 char for each argument
-	string getTypeString() const;
+	std::string getTypeString() const;
 	
 	/// get argument as an integer, converts numeric types automatically
 	/// prints a warning when converting higher precision types
 	/// \return given argument value as a 32-bit int
-	int32_t getArgAsInt(int index) const;
+	std::int32_t getArgAsInt(int index) const;
 	
 	/// get argument as an integer, converts numeric types automatically
 	/// prints a warning when converting higher precision types
 	/// \return given argument value as a 32-bit int
-	int32_t getArgAsInt32(int index) const;
+	std::int32_t getArgAsInt32(int index) const;
 	
 	/// get argument as a 64-bit integer, converts numeric types automatically
 	/// \return given argument value as a 64-bit int
-	int64_t getArgAsInt64(int index) const;
+	std::int64_t getArgAsInt64(int index) const;
 	
 	/// get argument as a float, converts numeric types automatically
 	/// prints a warning when converting higher precision types
@@ -102,18 +102,18 @@ public:
 	
 	/// get argument as a string, converts numeric types with a warning
 	/// \return given argument value as a string
-	string getArgAsString(int index) const;
+	std::string getArgAsString(int index) const;
 	
 	/// get argument as a symbol (string), converts numeric types with a warning
 	/// \return given argument value as a symbol (string)
-	string getArgAsSymbol(int index) const;
+	std::string getArgAsSymbol(int index) const;
 	
 	/// get argument as a string, converts numeric types with a warning
 	/// \return given argument value as a string
 	char getArgAsChar(int index) const;
 	
 	/// \return given argument value as a 4-byte midi message
-	uint32_t getArgAsMidiMessage(int index) const;
+	std::uint32_t getArgAsMidiMessage(int index) const;
 	
 	/// get argument as a bool, converts numeric types automatically
 	/// this argument type matches both OFXOSC_TYPE_TRUE & OFXOSC_TYPE_FALSE
@@ -139,25 +139,25 @@ public:
 	bool getArgAsInfinitum(int index) const;
 	
 	/// \return given argument as a 64-bit NTP time tag
-	uint64_t getArgAsTimetag(int index) const;
+	std::uint64_t getArgAsTimetag(int index) const;
 	
 	/// \return given argument as a binary blob
 	ofBuffer getArgAsBlob(int index) const;
 	
 	/// get an argument as an RGBA color, converts int32 automatically
 	/// \return given argument as a 32-bit color value
-	uint32_t getArgAsRgbaColor(int index) const;
+	std::uint32_t getArgAsRgbaColor(int index) const;
 
 	/// \section Argument Setters
 
 	/// add a 32-bit integer
-	void addIntArg(int32_t argument);
+	void addIntArg(std::int32_t argument);
 	
 	/// add a 32-bit integer
-	void addInt32Arg(int32_t argument);
+	void addInt32Arg(std::int32_t argument);
 	
 	/// add a 64-bit integer
-	void addInt64Arg(int64_t argument);
+	void addInt64Arg(std::int64_t argument);
 	
 	/// add a 32-bit float
 	void addFloatArg(float argument);
@@ -166,16 +166,16 @@ public:
 	void addDoubleArg(double argument);
 	
 	/// add a string
-	void addStringArg(const string &argument);
+	void addStringArg(const std::string &argument);
 	
 	/// add a symbol (string)
-	void addSymbolArg(const string &argument);
+	void addSymbolArg(const std::string &argument);
 	
 	/// add a char
 	void addCharArg(char argument);
 	
 	/// add a 4-byte MIDI message
-	void addMidiMessageArg(uint32_t argument);
+	void addMidiMessageArg(std::uint32_t argument);
 	
 	/// add a bool
 	/// true sends a OFXOSC_TYPE_TRUE & false sends a OFXOSC_TYPE_FALSE
@@ -196,17 +196,17 @@ public:
 	void addInfinitumArg();
 	
 	/// add a 64-bit NTP time tag
-	void addTimetagArg(uint64_t argument);
+	void addTimetagArg(std::uint64_t argument);
 	
 	/// add a binary blog
 	void addBlobArg(const ofBuffer &argument);
 	
 	/// add a 32-bit color
-	void addRgbaColorArg(uint32_t argument);
+	void addRgbaColorArg(std::uint32_t argument);
 
 	/// set host and port of the remote endpoint,
 	/// this is mainly used by ofxOscReceiver
-	void setRemoteEndpoint(const string &host, int port);
+	void setRemoteEndpoint(const std::string &host, int port);
 	
 	/// output stream operator for string conversion and printing
 	/// converts argument contents to strings with following caveats per type:
@@ -220,13 +220,13 @@ public:
 	///   * bundle: printed as BLOB (does not show value)
 	///   * rgba color: printed as 4-byte hex
 	/// \return message address & arguments separated by spaces
-	friend ostream& operator<<(ostream &os, const ofxOscMessage &message);
+	friend std::ostream& operator<<(std::ostream &os, const ofxOscMessage &message);
 
 private:
 
-	string address; //< OSC address, must start with a /
-	vector<ofxOscArg*> args; //< current arguments
+	std::string address; //< OSC address, must start with a /
+	std::vector<ofxOscArg*> args; //< current arguments
 
-	string remoteHost; //< host name/ip the message was sent from
+	std::string remoteHost; //< host name/ip the message was sent from
 	int remotePort; //< port the message was sent from
 };

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -54,10 +54,10 @@ public:
 	/// \return the remote host name/ip (deprecated)
 	OF_DEPRECATED_MSG("Use getRemoteHost() instead", string getRemoteIp() const);
 	
-	/// \return the remote host name/ip
+	/// \return the remote host name/ip or "" if not set
 	string getRemoteHost() const;
 	
-	/// \return the remote port
+	/// \return the remote port or 0 if not set
 	int getRemotePort() const;
 	
 	/// \section Argument Getters
@@ -220,6 +220,6 @@ private:
 	string address; //< OSC address, must start with a /
 	vector<ofxOscArg*> args; //< current arguments
 
-	string remote_host; //< host name/ip the message was sent from
-	int remote_port; //< port the message was sent from
+	string remoteHost; //< host name/ip the message was sent from
+	int remotePort; //< port the message was sent from
 };

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -30,39 +30,41 @@
 
 #include "ofxOscArg.h"
 
-class ofxOscMessage
-{
+class ofxOscMessage{
 public:
+
 	ofxOscMessage();
 	~ofxOscMessage();
-	ofxOscMessage( const ofxOscMessage& other ){ copy ( other ); }
-	ofxOscMessage& operator= ( const ofxOscMessage& other ) { return copy( other ); }
+	ofxOscMessage(const ofxOscMessage& other);
+	ofxOscMessage& operator=(const ofxOscMessage& other);
 	/// for operator= and copy constructor
-	ofxOscMessage& copy( const ofxOscMessage& other );
+	ofxOscMessage& copy(const ofxOscMessage& other);
 
 	/// clear this message, erase all contents
 	void clear();
 
 	/// return the address
-	string getAddress() const { return address; }
+	string getAddress() const;
 
 	/// return the remote ip
-	string getRemoteIp() const { return remote_host; }
+	string getRemoteIp() const;
+	
 	/// return the remote port
-	int getRemotePort() const { return remote_port; }
+	int getRemotePort() const;
 
-	/// return number of argumentsļ
+	/// return number of arguments
 	int getNumArgs() const;
+	
 	/// return argument type code for argument # index
-	ofxOscArgType getArgType( int index ) const;
+	ofxOscArgType getArgType(int index) const;
+	
 	/// return argument type name as string
-	/// - either "int", "float", or "string"
-	string getArgTypeName( int index ) const;
+	string getArgTypeName(int index) const;
 
 	/// get the argument with the given index as an int, float, or string
 	/// ensure that the type matches what you're requesting
 	/// (eg for an int argument, getArgType(index)==OF_TYPE_INT32
-	/// or getArgTypeName(index)=="int32")
+	/// or getArgTypeName(index)=="i")
 	/*
 	OSC 1.1 specifications types:
 			  i - 32bit integer
@@ -81,52 +83,51 @@ public:
 
 	See : http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
 	*/
-    int32_t getArgAsInt( int index ) const;
-	int32_t getArgAsInt32( int index ) const;
-	int64_t getArgAsInt64( int index ) const;
-	float getArgAsFloat( int index ) const;
-	double getArgAsDouble( int index ) const;
-	string getArgAsString( int index ) const;
-	string getArgAsSymbol( int index ) const;
-	char getArgAsChar( int index ) const;
-	int32_t getArgAsMidiMessage( int index ) const;
+	int32_t getArgAsInt(int index) const;
+	int32_t getArgAsInt32(int index) const;
+	int64_t getArgAsInt64(int index) const;
+	float getArgAsFloat(int index) const;
+	double getArgAsDouble(int index) const;
+	string getArgAsString(int index) const;
+	string getArgAsSymbol(int index) const;
+	char getArgAsChar(int index) const;
+	int32_t getArgAsMidiMessage(int index) const;
 	bool getArgAsBool(int index) const;
 	bool getArgAsTrigger(int index) const;
 	bool getArgAsImpulse(int index) const;
 	bool getArgAsInfinitum(int index) const;
-	int64_t getArgAsTimetag( int index ) const;
-	ofBuffer getArgAsBlob( int index ) const;
-	int32_t getArgAsRgbaColor( int index ) const;
+	int64_t getArgAsTimetag(int index) const;
+	ofBuffer getArgAsBlob(int index) const;
+	int32_t getArgAsRgbaColor(int index) const;
 
-	/// message construction
-	void setAddress( const string &_address ) { address = _address; };
-	/// host and port of the remote endpoint
-    void setRemoteEndpoint( const string &host, int port ) { remote_host = host; remote_port = port; }
+	/// set the message address, must start with a /
+	void setAddress(const string &_address);
 
-	void addIntArg( int32_t argument );
-	void addInt32Arg( int32_t argument );
-	void addInt64Arg( int64_t argument );
-	void addFloatArg( float argument );
-	void addDoubleArg( double argument );
-	void addStringArg( const string &argument );
-	void addSymbolArg( const string &argument );
-	void addCharArg( char argument );
-	void addMidiMessageArg( int32_t argument );
-	void addBoolArg( bool argument );
+	void addIntArg(int32_t argument);
+	void addInt32Arg(int32_t argument);
+	void addInt64Arg(int64_t argument);
+	void addFloatArg(float argument);
+	void addDoubleArg(double argument);
+	void addStringArg(const string &argument);
+	void addSymbolArg(const string &argument);
+	void addCharArg(char argument);
+	void addMidiMessageArg(int32_t argument);
+	void addBoolArg(bool argument);
 	void addTriggerArg();
 	void addImpulseArg();
 	void addInfinitumArg();
-	void addTimetagArg( int64_t argument );
-	void addBlobArg( const ofBuffer &argument );
-	void addRgbaColorArg( int32_t argument );
+	void addTimetagArg(int64_t argument);
+	void addBlobArg(const ofBuffer &argument);
+	void addRgbaColorArg(int32_t argument);
+
+	/// host and port of the remote endpoint
+	void setRemoteEndpoint(const string &host, int port);
 
 private:
 
-    string address;
-    vector<ofxOscArg*> args;
+	string address;
+	vector<ofxOscArg*> args;
 
-    string remote_host;
+	string remote_host;
 	int remote_port;
-
-
 };

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -207,6 +207,20 @@ public:
 	/// set host and port of the remote endpoint,
 	/// this is mainly used by ofxOscReceiver
 	void setRemoteEndpoint(const string &host, int port);
+	
+	/// output stream operator for string conversion and printing
+	/// converts argument contents to strings with following caveats per type:
+	///   * true: printed as T
+	///   * false: printed as F
+	///   * midi message:  printed as 4-byte hex
+	///   * none/nil: printed as NONE (has no value)
+	///   * trigger impulse: printed as TRIGGER (has no value)
+	///   * timetag: printed as TIMETAG (does not show value)
+	///   * blob: printed as BLOB (does not show value)
+	///   * bundle: printed as BLOB (does not show value)
+	///   * rgba color: printed as 4-byte hex
+	/// \return message address & arguments separated by spaces
+	friend ostream& operator<<(ostream &os, const ofxOscMessage &message);
 
 private:
 

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "ofxOscArg.h"

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -20,7 +20,7 @@ public:
 	void clear();
 
 	/// set the message address, must start with a /
-	void setAddress(const string &_address);
+	void setAddress(const string &address);
 
 	/// \return the OSC address
 	string getAddress() const;
@@ -54,6 +54,15 @@ public:
 	///         i = message.getArgAsInt32(index);
 	///     }
 	///
+	/// you can also check against the type string for all arguments:
+	///
+	///     int i = 0; float f = 0.0; string s = "";
+	///     if(message.getTypeString() == "ifs") {
+	///         i = message.getArgAsInt32(0);
+	///         f = message.getArgAsFloat(1);
+	///         s = message.getArgAsString(2);
+	///     }
+	///
 	/// see ofxOscArg.h for argument type tag char values
 
 	/// \return number of arguments
@@ -64,6 +73,9 @@ public:
 	
 	/// \return argument type tag char as a string
 	string getArgTypeName(int index) const;
+	
+	/// \return type tags for all arguments as a string, 1 char for each argument
+	string getTypeString() const;
 	
 	/// get argument as an integer, converts numeric types automatically
 	/// prints a warning when converting higher precision types

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -30,6 +30,8 @@
 
 #include "ofxOscArg.h"
 
+/// \class ofxOscMessage
+/// \brief an OSC message with address and arguments
 class ofxOscMessage{
 public:
 
@@ -40,94 +42,184 @@ public:
 	/// for operator= and copy constructor
 	ofxOscMessage& copy(const ofxOscMessage& other);
 
-	/// clear this message, erase all contents
+	/// clear this message
 	void clear();
-
-	/// return the address
-	string getAddress() const;
-
-	/// return the remote ip
-	string getRemoteIp() const;
-	
-	/// return the remote port
-	int getRemotePort() const;
-
-	/// return number of arguments
-	int getNumArgs() const;
-	
-	/// return argument type code for argument # index
-	ofxOscArgType getArgType(int index) const;
-	
-	/// return argument type name as string
-	string getArgTypeName(int index) const;
-
-	/// get the argument with the given index as an int, float, or string
-	/// ensure that the type matches what you're requesting
-	/// (eg for an int argument, getArgType(index)==OF_TYPE_INT32
-	/// or getArgTypeName(index)=="i")
-	/*
-	OSC 1.1 specifications types:
-			  i - 32bit integer
-			  h - 64bit integer
-			  f - 32bit floating point number
-			  d - 64bit (double) floating point number
-			  s - string
-			  S - symbol
-			  c - char
-			  m - 4 byte midi packet (8 digits hexadecimal)
-			  T - TRUE (no value required)
-			  F - FALSE (no value required)
-			  N - NIL (no value required)
-			  I - IMPULSE, act as a trigger (no value required), previously named INFINITUM
-			  t - TIMETAG, an OSC timetag in NTP format, encoded in the data section
-
-	See : http://cnmat.berkeley.edu/system/files/attachments/Nime09OSCfinal.pdf
-	*/
-	int32_t getArgAsInt(int index) const;
-	int32_t getArgAsInt32(int index) const;
-	int64_t getArgAsInt64(int index) const;
-	float getArgAsFloat(int index) const;
-	double getArgAsDouble(int index) const;
-	string getArgAsString(int index) const;
-	string getArgAsSymbol(int index) const;
-	char getArgAsChar(int index) const;
-	int32_t getArgAsMidiMessage(int index) const;
-	bool getArgAsBool(int index) const;
-	bool getArgAsTrigger(int index) const;
-	bool getArgAsImpulse(int index) const;
-	bool getArgAsInfinitum(int index) const;
-	int64_t getArgAsTimetag(int index) const;
-	ofBuffer getArgAsBlob(int index) const;
-	int32_t getArgAsRgbaColor(int index) const;
 
 	/// set the message address, must start with a /
 	void setAddress(const string &_address);
 
+	/// \return the OSC address
+	string getAddress() const;
+
+	/// \return the remote host name/ip (deprecated)
+	OF_DEPRECATED_MSG("Use getRemoteHost() instead", string getRemoteIp() const);
+	
+	/// \return the remote host name/ip
+	string getRemoteHost() const;
+	
+	/// \return the remote port
+	int getRemotePort() const;
+	
+	/// \section Argument Getters
+	///
+	/// get the argument with the given index as an int, float, string, etc
+	///
+	/// some types can be automatically converted to a requested type,
+	/// (ie. int to float) however it is best to ensure that the type matches
+	/// what you're requesting:
+	///
+	///     int i = 0;
+	///     if(message.getArgType(index) == OFXOSC_TYPE_INT32) {
+	///         i = message.getArgAsInt32(index);
+	///     }
+	///
+	/// or use the type tag char:
+	///
+	///		int i = 0;
+	///     if(message.getArgTypeName(index) == "i") {
+	///         i = message.getArgAsInt32(index);
+	///     }
+	///
+	/// see ofxOscArg.h for argument type tag char values
+
+	/// \return number of arguments
+	int getNumArgs() const;
+	
+	/// \return argument type code for a given index
+	ofxOscArgType getArgType(int index) const;
+	
+	/// \return argument type tag char as a string
+	string getArgTypeName(int index) const;
+	
+	/// get argument as an integer, converts numeric types automatically
+	/// prints a warning when converting higher precision types
+	/// \return given argument value as a 32-bit int
+	int32_t getArgAsInt(int index) const;
+	
+	/// get argument as an integer, converts numeric types automatically
+	/// prints a warning when converting higher precision types
+	/// \return given argument value as a 32-bit int
+	int32_t getArgAsInt32(int index) const;
+	
+	/// get argument as a 64-bit integer, converts numeric types automatically
+	/// \return given argument value as a 64-bit int
+	int64_t getArgAsInt64(int index) const;
+	
+	/// get argument as a float, converts numeric types automatically
+	/// prints a warning when converting higher precision types
+	/// \return given argument value as a float
+	float getArgAsFloat(int index) const;
+	
+	/// get argument as a double, converts numeric types automatically
+	/// \return given argument value as a double
+	double getArgAsDouble(int index) const;
+	
+	/// get argument as a string, converts numeric types with a warning
+	/// \return given argument value as a string
+	string getArgAsString(int index) const;
+	
+	/// get argument as a symbol (string), converts numeric types with a warning
+	/// \return given argument value as a symbol (string)
+	string getArgAsSymbol(int index) const;
+	
+	/// get argument as a string, converts numeric types with a warning
+	/// \return given argument value as a string
+	char getArgAsChar(int index) const;
+	
+	/// \return given argument value as a 4-byte midi message
+	int32_t getArgAsMidiMessage(int index) const;
+	
+	/// get argument as a bool, converts numeric types automatically
+	/// this argument type matches both OFXOSC_TYPE_TRUE & OFXOSC_TYPE_FALSE
+	/// \return given argument value as a bool
+	bool getArgAsBool(int index) const;
+	
+	/// get argument as a trigger impulse
+	/// \return true if argument was a trigger
+	bool getArgAsTrigger(int index) const;
+	
+	/// get argument as a trigger impulse
+	/// this is an alias for getArgAsTrigger()
+	/// \return true if argument was a trigger
+	bool getArgAsImpulse(int index) const;
+	
+	/// get argument as a trigger impulse
+	/// this is an alias for getArgAsTrigger()
+	/// \return true if argument was a trigger
+	bool getArgAsInfinitum(int index) const;
+	
+	/// \return given argument as a 64-bit NTP time tag
+	int64_t getArgAsTimetag(int index) const;
+	
+	/// \return given argument as a binary blob
+	ofBuffer getArgAsBlob(int index) const;
+	
+	/// get an argument as an RGBA color, converts int32 automatically
+	/// \return given argument as a 32-bit color value
+	int32_t getArgAsRgbaColor(int index) const;
+
+	/// \section Argument Setters
+
+	/// add a 32-bit integer
 	void addIntArg(int32_t argument);
+	
+	/// add a 32-bit integer
 	void addInt32Arg(int32_t argument);
+	
+	/// add a 64-bit integer
 	void addInt64Arg(int64_t argument);
+	
+	/// add a 32-bit float
 	void addFloatArg(float argument);
+	
+	/// add a 64-bit double
 	void addDoubleArg(double argument);
+	
+	/// add a string
 	void addStringArg(const string &argument);
+	
+	/// add a symbol (string)
 	void addSymbolArg(const string &argument);
+	
+	/// add a char
 	void addCharArg(char argument);
+	
+	/// add a 4-byte MIDI message
 	void addMidiMessageArg(int32_t argument);
+	
+	/// add a bool
+	/// true sends a OFXOSC_TYPE_TRUE & false sends an OFXOSC_TYPE_FALSE
 	void addBoolArg(bool argument);
+	
+	/// add a trigger impulse (has no value)
 	void addTriggerArg();
+	
+	/// add a trigger impulse (has no value)
+	/// alias for addTriggerArg()
 	void addImpulseArg();
+	
+	/// add a trigger impulse (has no value)
+	/// alias for addTriggerArg()
 	void addInfinitumArg();
+	
+	/// add a 64-bt NTP time tag
 	void addTimetagArg(int64_t argument);
+	
+	/// add a binary blog
 	void addBlobArg(const ofBuffer &argument);
+	
+	/// add a 32-bit color
 	void addRgbaColorArg(int32_t argument);
 
-	/// host and port of the remote endpoint
+	/// set host and port of the remote endpoint,
+	/// this is mainly used by ofxOscReceiver
 	void setRemoteEndpoint(const string &host, int port);
 
 private:
 
-	string address;
-	vector<ofxOscArg*> args;
+	string address; //< OSC address, must start with a /
+	vector<ofxOscArg*> args; //< current arguments
 
-	string remote_host;
-	int remote_port;
+	string remote_host; //< host name/ip the message was sent from
+	int remote_port; //< port the message was sent from
 };

--- a/addons/ofxOsc/src/ofxOscParameterSync.cpp
+++ b/addons/ofxOsc/src/ofxOscParameterSync.cpp
@@ -8,14 +8,14 @@ ofxOscParameterSync::ofxOscParameterSync(){
 
 //--------------------------------------------------------------
 ofxOscParameterSync::~ofxOscParameterSync(){
-	ofRemoveListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
+	ofRemoveListener(syncGroup.parameterChangedE(), this, &ofxOscParameterSync::parameterChanged);
 }
 
 //--------------------------------------------------------------
-void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const string& host, int remotePort){
+void ofxOscParameterSync::setup(ofParameterGroup &group, int localPort, const std::string &host, int remotePort){
 	syncGroup = group;
-	ofAddListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
-	sender.setup(host,remotePort);
+	ofAddListener(syncGroup.parameterChangedE(), this, &ofxOscParameterSync::parameterChanged);
+	sender.setup(host, remotePort);
 	receiver.setup(localPort);
 }
 
@@ -29,7 +29,7 @@ void ofxOscParameterSync::update(){
 }
 
 //--------------------------------------------------------------
-void ofxOscParameterSync::parameterChanged(ofAbstractParameter & parameter){
+void ofxOscParameterSync::parameterChanged(ofAbstractParameter &parameter){
 	if(updatingParameter) return;
 	sender.sendParameter(parameter);
 }

--- a/addons/ofxOsc/src/ofxOscParameterSync.cpp
+++ b/addons/ofxOsc/src/ofxOscParameterSync.cpp
@@ -7,15 +7,17 @@
 
 #include "ofxOscParameterSync.h"
 
-ofxOscParameterSync::ofxOscParameterSync() {
+//--------------------------------------------------------------
+ofxOscParameterSync::ofxOscParameterSync(){
 	updatingParameter = false;
 }
 
+//--------------------------------------------------------------
 ofxOscParameterSync::~ofxOscParameterSync(){
 	ofRemoveListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
 }
 
-
+//--------------------------------------------------------------
 void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const std::string& host, int remotePort){
 	syncGroup = group;
 	ofAddListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
@@ -23,6 +25,7 @@ void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const s
 	receiver.setup(localPort);
 }
 
+//--------------------------------------------------------------
 void ofxOscParameterSync::update(){
 	if(receiver.hasWaitingMessages()){
 		updatingParameter = true;
@@ -31,7 +34,8 @@ void ofxOscParameterSync::update(){
 	}
 }
 
-void ofxOscParameterSync::parameterChanged( ofAbstractParameter & parameter ){
+//--------------------------------------------------------------
+void ofxOscParameterSync::parameterChanged(ofAbstractParameter & parameter){
 	if(updatingParameter) return;
 	sender.sendParameter(parameter);
 }

--- a/addons/ofxOsc/src/ofxOscParameterSync.cpp
+++ b/addons/ofxOsc/src/ofxOscParameterSync.cpp
@@ -1,10 +1,4 @@
-/*
- * ofxOscParameterSync.cpp
- *
- *  Created on: 13/07/2012
- *      Author: arturo
- */
-
+// copyright (c) openFrameworks team 2012-2017
 #include "ofxOscParameterSync.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscParameterSync.cpp
+++ b/addons/ofxOsc/src/ofxOscParameterSync.cpp
@@ -12,7 +12,7 @@ ofxOscParameterSync::~ofxOscParameterSync(){
 }
 
 //--------------------------------------------------------------
-void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const std::string& host, int remotePort){
+void ofxOscParameterSync::setup(ofParameterGroup & group, int localPort, const string& host, int remotePort){
 	syncGroup = group;
 	ofAddListener(syncGroup.parameterChangedE(),this,&ofxOscParameterSync::parameterChanged);
 	sender.setup(host,remotePort);

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -14,7 +14,7 @@ public:
 	ofxOscParameterSync();
 	~ofxOscParameterSync();
 
-	/// set the parameter group & local/remote connection info
+	/// set the parameter group & connection info
 	/// the remote and local ports must be different to avoid collisions
 	void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
 	

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -16,7 +16,7 @@ public:
 
 	/// set the parameter group & connection info
 	/// the remote and local ports must be different to avoid collisions
-	void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
+	void setup(ofParameterGroup &group, int localPort, const std::string &remoteHost, int remotePort);
 	
 	/// process any incoming messages
 	void update();
@@ -24,7 +24,7 @@ public:
 private:
 
 	/// parameter change callaback
-	void parameterChanged(ofAbstractParameter & parameter);
+	void parameterChanged(ofAbstractParameter &parameter);
 	
 	ofxOscSender sender; //< sync sender
 	ofxOscReceiver receiver; //< sync receiver

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -12,17 +12,19 @@
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
 
-class ofxOscParameterSync {
+class ofxOscParameterSync{
 public:
+
 	ofxOscParameterSync();
 	~ofxOscParameterSync();
 
 	/// the remote and local ports must be different to avoid collisions
-    void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
+	void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
 	void update();
 
 private:
-	void parameterChanged( ofAbstractParameter & parameter );
+
+	void parameterChanged(ofAbstractParameter & parameter);
 	ofxOscSender sender;
 	ofxOscReceiver receiver;
 	ofParameterGroup syncGroup;

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -12,21 +12,28 @@
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
 
+/// \class ofxOscParamaterSync
+/// \brief a high-level sync object for ofParamaters over OSC
 class ofxOscParameterSync{
 public:
 
 	ofxOscParameterSync();
 	~ofxOscParameterSync();
 
+	/// set the parameter group & local/remote connection info
 	/// the remote and local ports must be different to avoid collisions
 	void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
+	
+	/// process any incoming messages
 	void update();
 
 private:
 
+	/// parameter change callaback
 	void parameterChanged(ofAbstractParameter & parameter);
-	ofxOscSender sender;
-	ofxOscReceiver receiver;
-	ofParameterGroup syncGroup;
-	bool updatingParameter;
+	
+	ofxOscSender sender; //< sync sender
+	ofxOscReceiver receiver; //< sync receiver
+	ofParameterGroup syncGroup; //< target parameter group
+	bool updatingParameter; //< is a parameter being updated?
 };

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -1,10 +1,4 @@
-/*
- * ofxOscParameterSync.h
- *
- *  Created on: 13/07/2012
- *      Author: arturo
- */
-
+// copyright (c) openFrameworks team 2012-2017
 #pragma once
 
 #include "ofxOscSender.h"

--- a/addons/ofxOsc/src/ofxOscParameterSync.h
+++ b/addons/ofxOsc/src/ofxOscParameterSync.h
@@ -18,7 +18,7 @@ public:
 	~ofxOscParameterSync();
 
 	/// the remote and local ports must be different to avoid collisions
-    void setup(ofParameterGroup & group, int localPort, const std::string& remoteHost, int remotePort);
+    void setup(ofParameterGroup & group, int localPort, const string& remoteHost, int remotePort);
 	void update();
 
 private:

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -41,19 +41,6 @@ bool ofxOscReceiver::setup(int port){
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::setPort(int port) {
-	if(listenSocket) { // restart
-		stop();
-		this->port = port;
-		return start();
-	}
-	else { // not running
-		this->port = port;
-		return true;
-	}
-}
-
-//--------------------------------------------------------------
 bool ofxOscReceiver::start() {
 	if(listenSocket) {
 		return true;
@@ -186,6 +173,19 @@ bool ofxOscReceiver::getParameter(ofAbstractParameter &parameter){
 		}
 	}
 	return true;
+}
+
+//--------------------------------------------------------------
+bool ofxOscReceiver::setPort(int port) {
+	if(listenSocket) { // restart
+		stop();
+		this->port = port;
+		return start();
+	}
+	else { // not running
+		this->port = port;
+		return true;
+	}
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -103,7 +103,7 @@ void ofxOscReceiver::stop() {
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::isListening(){
+bool ofxOscReceiver::isListening() const{
 	return listenSocket != nullptr;
 }
 
@@ -189,7 +189,7 @@ bool ofxOscReceiver::setPort(int port) {
 }
 
 //--------------------------------------------------------------
-int ofxOscReceiver::getPort(){
+int ofxOscReceiver::getPort() const{
 	return port;
 }
 
@@ -281,4 +281,14 @@ void ofxOscReceiver::ProcessMessage(const osc::ReceivedMessage &m, const osc::Ip
 
 	// send msg to main thread
 	messagesChannel.send(std::move(msg));
+}
+
+// friend functions
+//--------------------------------------------------------------
+std::ostream& operator<<(std::ostream &os, const ofxOscReceiver &receiver) {
+	os << receiver.getPort();
+	if(receiver.isListening()) {
+		os << " listening";
+	}
+	return os;
 }

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -61,7 +61,12 @@ bool ofxOscReceiver::setup(int port){
 		listenSocket = std::move(newPtr);
 	}
 	catch(std::exception &e){
-		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port " << port << ": " << e.what();
+		string what = e.what();
+		// strip endline as ofLogError already adds one
+		if(!what.empty() && what.back() == '\n') {
+			what = what.substr(0, what.size()-1);
+		}
+		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port " << port << ": " << what;
 		if(socket != nullptr){
 			delete socket;
 			socket = nullptr;

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -46,7 +46,6 @@ ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver& other){
 	if(this == &other) return *this;
 	allowReuse = other.allowReuse;
 	listen_port = other.listen_port;
-	// should the new listener be started with the same port another is using?
 	if(other.listen_socket){
 		setup(listen_port);
 	}

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -43,7 +43,7 @@ bool ofxOscReceiver::setup(int port){
 			port = this->port;
 		}
 		else {
-			ofLogError("ofxOscReceiver") << "cannot restart with port value of 0";
+			ofLogError("ofxOscReceiver") << "cannot (re)start with port value of 0";
 			return false;
 		}
 	}

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -28,12 +28,6 @@
 
 #include "ofxOscReceiver.h"
 
-#ifndef TARGET_WIN32
-        #include <pthread.h>
-#endif
-#include <iostream>
-#include <assert.h>
-
 ofxOscReceiver::ofxOscReceiver()
 :allowReuse(true)
 ,listen_port(0)
@@ -195,7 +189,7 @@ bool ofxOscReceiver::getParameter(ofAbstractParameter & parameter)
 	ofxOscMessage msg;
 	while(messagesChannel.tryReceive(msg)){
 		ofAbstractParameter * p = &parameter;
-        std::vector<std::string> address = ofSplitString(msg.getAddress(),"/",true);
+        vector<string> address = ofSplitString(msg.getAddress(),"/",true);
         for(unsigned int i=0;i<address.size();i++){
             if(p) {
                 if(address[i]==p->getEscapedName()){

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -69,7 +69,7 @@ bool ofxOscReceiver::start() {
 		if(!what.empty() && what.back() == '\n') {
 			what = what.substr(0, what.size()-1);
 		}
-		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port "
+		ofLogError("ofxOscReceiver") << "couldn't create receiver on port "
 		                             << port << ": " << what;
 		if(socket != nullptr){
 			delete socket;

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -37,6 +37,17 @@ bool ofxOscReceiver::setup(int port){
 		clear();
 	}
 	
+	// reuse current port?
+	if(port == 0) {
+		if(this->port > 0) {
+			port = this->port;
+		}
+		else {
+			ofLogError("ofxOscReceiver") << "cannot restart with port value of 0";
+			return false;
+		}
+	}
+	
 	// create socket
 	osc::UdpListeningReceiveSocket *socket = nullptr;
 	try{
@@ -64,7 +75,7 @@ bool ofxOscReceiver::setup(int port){
 				listenSocket->Run();
 			}
 			catch(std::exception &e){
-				ofLogWarning() << e.what();
+				ofLogWarning("ofxOscReceiver") << e.what();
 			}
 		}
 	});
@@ -82,7 +93,11 @@ bool ofxOscReceiver::setup(int port){
 //--------------------------------------------------------------
 void ofxOscReceiver::clear() {
 	listenSocket.reset();
-	port = 0;
+}
+
+//--------------------------------------------------------------
+bool ofxOscReceiver::isListening(){
+	return listenSocket != nullptr;
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -257,8 +257,10 @@ void ofxOscReceiver::ProcessMessage(const osc::ReceivedMessage &m, const osc::Ip
 			msg.addBlobArg(buffer);
 		}
 		else {
-			ofLogError("ofxOscReceiver") << "ProcessMessage: argument in message "
-				<< m.AddressPattern() << " is an unknown type";
+			ofLogError("ofxOscReceiver") << "ProcessMessage(): argument in message "
+				<< m.AddressPattern() << " is an unknown type "
+				<< (int) arg->TypeTag() << " '" << (char) arg->TypeTag() << "'";
+				break;
 		}
 	}
 

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -245,3 +245,7 @@ void ofxOscReceiver::enableReuse(){
 		setup(listen_port);
 	}
 }
+
+int ofxOscReceiver::getPort() {
+	return listen_port;
+}

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #include "ofxOscReceiver.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -6,17 +6,22 @@
 ofxOscReceiver::ofxOscReceiver() : allowReuse(true), port(0) {}
 
 //--------------------------------------------------------------
-ofxOscReceiver::ofxOscReceiver(const ofxOscReceiver & mom){
+ofxOscReceiver::~ofxOscReceiver(){
+	clear();
+}
+
+//--------------------------------------------------------------
+ofxOscReceiver::ofxOscReceiver(const ofxOscReceiver &mom){
 	copy(mom);
 }
 
 //--------------------------------------------------------------
-ofxOscReceiver& ofxOscReceiver::operator=(const ofxOscReceiver & mom){
+ofxOscReceiver& ofxOscReceiver::operator=(const ofxOscReceiver &mom){
 	return copy(mom);
 }
 
 //--------------------------------------------------------------
-ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver& other){
+ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver &other){
 	if(this == &other) return *this;
 	allowReuse = other.allowReuse;
 	port = other.port;
@@ -113,21 +118,21 @@ bool ofxOscReceiver::hasWaitingMessages(){
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::getNextMessage(ofxOscMessage * message){
+bool ofxOscReceiver::getNextMessage(ofxOscMessage *message){
 	return getNextMessage(*message);
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::getNextMessage(ofxOscMessage & message){
+bool ofxOscReceiver::getNextMessage(ofxOscMessage &message){
 	return messagesChannel.tryReceive(message);
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::getParameter(ofAbstractParameter & parameter){
+bool ofxOscReceiver::getParameter(ofAbstractParameter &parameter){
 	ofxOscMessage msg;
 	while(messagesChannel.tryReceive(msg)){
 		ofAbstractParameter * p = &parameter;
-		vector<string> address = ofSplitString(msg.getAddress(),"/", true);
+		std::vector<std::string> address = ofSplitString(msg.getAddress(),"/", true);
 		for(unsigned int i = 0; i < address.size(); i++){
 			if(p){
 				if(address[i] == p->getEscapedName()){
@@ -198,7 +203,7 @@ void ofxOscReceiver::enableReuse(){
 
 // PROTECTED
 //--------------------------------------------------------------
-void ofxOscReceiver::ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint){
+void ofxOscReceiver::ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName &remoteEndpoint){
 	// convert the message to an ofxOscMessage
 	ofxOscMessage msg;
 

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -108,7 +108,7 @@ bool ofxOscReceiver::isListening() const{
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::hasWaitingMessages(){
+bool ofxOscReceiver::hasWaitingMessages() const{
 	return !messagesChannel.empty();
 }
 

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #include "ofxOscReceiver.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -61,7 +61,7 @@ bool ofxOscReceiver::setup(int port){
 		listenSocket = std::move(newPtr);
 	}
 	catch(std::exception &e){
-		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port: " << port << " " << e.what();
+		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port " << port << ": " << e.what();
 		if(socket != nullptr){
 			delete socket;
 			socket = nullptr;

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -217,6 +217,9 @@ void ofxOscReceiver::ProcessMessage(const osc::ReceivedMessage &m, const osc::Ip
 		else if(arg->IsBool()){
 			msg.addBoolArg(arg->AsBoolUnchecked());
 		}
+		else if(arg->IsNil()){
+			msg.addNoneArg();
+		}
 		else if(arg->IsInfinitum()){
 			msg.addTriggerArg();
 		}

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -67,7 +67,7 @@ bool ofxOscReceiver::setup( int listen_port )
     
 	// if we're already running, shutdown before running again
 	if ( listen_socket ){
-		shutdown();
+		clear();
 	}
 	
 	// create socket
@@ -110,9 +110,10 @@ bool ofxOscReceiver::setup( int listen_port )
     return true;
 }
 
-void ofxOscReceiver::shutdown()
+void ofxOscReceiver::clear()
 {
 	listen_socket.reset();
+	listen_port = 0;
 }
 
 void ofxOscReceiver::ProcessMessage( const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint )

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -27,7 +27,7 @@ ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver& other){
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::setup(int port){
+bool ofxOscReceiver::setup(int port, bool start){
 	if(osc::UdpSocket::GetUdpBufferSize() == 0){
 	   osc::UdpSocket::SetUdpBufferSize(65535);
 	}
@@ -37,7 +37,7 @@ bool ofxOscReceiver::setup(int port){
 		clear();
 	}
 	
-	// reuse current port?
+	// reuse current port value?
 	if(port == 0) {
 		if(this->port > 0) {
 			port = this->port;
@@ -49,46 +49,48 @@ bool ofxOscReceiver::setup(int port){
 	}
 	
 	// create socket
-	osc::UdpListeningReceiveSocket *socket = nullptr;
-	try{
-		socket = new osc::UdpListeningReceiveSocket(osc::IpEndpointName(osc::IpEndpointName::ANY_ADDRESS, port), this, allowReuse);
-		auto deleter = [](osc::UdpListeningReceiveSocket*socket){
-			// tell the socket to shutdown
-			socket->Break();
-			delete socket;
-		};
-		auto newPtr = std::unique_ptr<osc::UdpListeningReceiveSocket, decltype(deleter)>(socket, deleter);
-		listenSocket = std::move(newPtr);
-	}
-	catch(std::exception &e){
-		string what = e.what();
-		// strip endline as ofLogError already adds one
-		if(!what.empty() && what.back() == '\n') {
-			what = what.substr(0, what.size()-1);
+	if(start) {
+		osc::UdpListeningReceiveSocket *socket = nullptr;
+		try{
+			socket = new osc::UdpListeningReceiveSocket(osc::IpEndpointName(osc::IpEndpointName::ANY_ADDRESS, port), this, allowReuse);
+			auto deleter = [](osc::UdpListeningReceiveSocket*socket){
+				// tell the socket to shutdown
+				socket->Break();
+				delete socket;
+			};
+			auto newPtr = std::unique_ptr<osc::UdpListeningReceiveSocket, decltype(deleter)>(socket, deleter);
+			listenSocket = std::move(newPtr);
 		}
-		ofLogError("ofxOscReceiver") << "couldn't create receive socket on port " << port << ": " << what;
-		if(socket != nullptr){
-			delete socket;
-			socket = nullptr;
-		}
-		return false;
-	}
-
-	listenThread = std::thread([this]{
-		while(listenSocket){
-			try{
-				listenSocket->Run();
+		catch(std::exception &e){
+			string what = e.what();
+			// strip endline as ofLogError already adds one
+			if(!what.empty() && what.back() == '\n') {
+				what = what.substr(0, what.size()-1);
 			}
-			catch(std::exception &e){
-				ofLogWarning("ofxOscReceiver") << e.what();
+			ofLogError("ofxOscReceiver") << "couldn't create receive socket on port " << port << ": " << what;
+			if(socket != nullptr){
+				delete socket;
+				socket = nullptr;
 			}
+			return false;
 		}
-	});
 
-	// detach thread so we don't have to wait on it before creating a new socket
-	// or on destruction, the custom deleter for the socket unique_ptr already
-	// does the right thing
-	listenThread.detach();
+		listenThread = std::thread([this]{
+			while(listenSocket){
+				try{
+					listenSocket->Run();
+				}
+				catch(std::exception &e){
+					ofLogWarning("ofxOscReceiver") << e.what();
+				}
+			}
+		});
+
+		// detach thread so we don't have to wait on it before creating a new socket
+		// or on destruction, the custom deleter for the socket unique_ptr already
+		// does the right thing
+		listenThread.detach();
+	}
 
 	this->port = port;
 	

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -56,6 +56,9 @@ public:
 
 	/// listen_port is the port to listen for messages on
 	bool setup( int listen_port );
+	
+	/// stop listening and clear the receiver 
+	void clear();
 
 	/// returns true if there are any messages waiting for collection
 	bool hasWaitingMessages();
@@ -82,8 +85,6 @@ protected:
 
 private:
 	void setup(osc::UdpListeningReceiveSocket * socket);
-	// shutdown the listener
-	void shutdown();
 
 	// start the listening thread
 #ifdef TARGET_WIN32

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -31,18 +31,6 @@ public:
 	/// \return true if listening started successfully
 	bool setup(int port);
 	
-	/// set the receiver port manually, does not start listening
-	///
-	/// restarts receiver if already running
-	///
-	/// this is not required if you called setup()
-	///
-	/// multiple receivers can share the same port if port reuse is
-	/// enabled (true by default)
-	///
-	/// \returns true if port set successfully
-	bool setPort(int port);
-	
 	/// start listening manually using the current port value
 	///
 	/// this is not required if you called setup()
@@ -68,6 +56,18 @@ public:
 	/// try to get waiting message an ofParameter
 	/// \return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter &parameter);
+
+	/// set the receiver port manually, does not start listening
+	///
+	/// restarts receiver if already running
+	///
+	/// this is not required if you called setup()
+	///
+	/// multiple receivers can share the same port if port reuse is
+	/// enabled (true by default)
+	///
+	/// \returns true if port set successfully
+	bool setPort(int port);
 
 	/// \return listening port or 0 if port has not been set
 	int getPort();

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -45,7 +45,7 @@ public:
 	bool isListening() const;
 
 	/// \return true if there are any messages waiting for collection
-	bool hasWaitingMessages();
+	bool hasWaitingMessages() const;
 
 	/// take the next message on the queue of received messages, copy its
 	/// details into message, and remove it from the queue

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -28,24 +28,14 @@
 
 #pragma once
 
-#include <deque>
-#include "ofMain.h"
-
-#ifdef TARGET_WIN32
-// threads
-#include <windows.h>
-#else
-// threads
-#include <pthread.h>
-#endif
+#include "ofxOscMessage.h"
+#include "ofParameter.h"
+#include "ofThreadChannel.h"
 
 // osc
 #include "OscTypes.h"
 #include "OscPacketListener.h"
 #include "UdpSocket.h"
-
-// ofxOsc
-#include "ofxOscMessage.h"
 
 class ofxOscReceiver : public osc::OscPacketListener
 {
@@ -84,15 +74,6 @@ protected:
 	virtual void ProcessMessage( const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint );
 
 private:
-	void setup(osc::UdpListeningReceiveSocket * socket);
-
-	// start the listening thread
-#ifdef TARGET_WIN32
-	static DWORD WINAPI startThread( void* ofxOscReceiverInstance );
-#else
-	static void* startThread( void* ofxOscReceiverInstance );
-#endif
-
 	// socket to listen on
 	std::unique_ptr<osc::UdpListeningReceiveSocket, std::function<void(osc::UdpListeningReceiveSocket*)>> listen_socket;
 
@@ -101,5 +82,4 @@ private:
 
 	bool allowReuse;
 	int listen_port;
-
 };

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -23,21 +23,33 @@ public:
 	ofxOscReceiver& copy(const ofxOscReceiver &other);
 
 	/// set up the receiver with the port to listen for messages on
+	/// and start listening
 	///
 	/// multiple receivers can share the same port if port reuse is
 	/// enabled (true by default)
 	///
-	/// if port is set to 0, receiver will try to use current port value to
-	/// restart listening
-	///
-	/// if start is true, receiver will start listening (default)
-	/// if start is false, port value is set without starting
-	///
-	/// \return true on success
-	bool setup(int port=0, bool start=true);
+	/// \return true if listening started successfully
+	bool setup(int port);
 	
-	/// stop listening and clear the receiver, does not clear port value
-	void clear();
+	/// set the receiver port manually
+	///
+	/// does not *start* listening, restarts receiver if already running
+	///
+	/// multiple receivers can share the same port if port reuse is
+	/// enabled (true by default)
+	///
+	/// \returns true if port set successfully
+	bool setPort(int port);
+	
+	/// start listening manually using the current port value
+	///
+	/// note: this is not required if you called setup()
+	///
+	/// \return true if listening started or was already running
+	bool start();
+	
+	/// stop listening, does not clear port value
+	void stop();
 	
 	/// \return true if the receiver is listening
 	bool isListening();
@@ -55,7 +67,7 @@ public:
 	/// \return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter &parameter);
 
-	/// \return listening port or 0 if setup was not called
+	/// \return listening port or 0 if port has not been set
 	int getPort();
 	
 	/// disables port reuse reuse which allows the same port to be used by several sockets

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -31,9 +31,11 @@ public:
 	/// \return true if listening started successfully
 	bool setup(int port);
 	
-	/// set the receiver port manually
+	/// set the receiver port manually, does not start listening
 	///
-	/// does not *start* listening, restarts receiver if already running
+	/// restarts receiver if already running
+	///
+	/// this is not required if you called setup()
 	///
 	/// multiple receivers can share the same port if port reuse is
 	/// enabled (true by default)
@@ -43,7 +45,7 @@ public:
 	
 	/// start listening manually using the current port value
 	///
-	/// note: this is not required if you called setup()
+	/// this is not required if you called setup()
 	///
 	/// \return true if listening started or was already running
 	bool start();

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -32,46 +32,50 @@
 #include "ofParameter.h"
 #include "ofThreadChannel.h"
 
-// osc
 #include "OscTypes.h"
 #include "OscPacketListener.h"
 #include "UdpSocket.h"
 
-class ofxOscReceiver : public osc::OscPacketListener
-{
+class ofxOscReceiver : public osc::OscPacketListener {
 public:
+
 	ofxOscReceiver();
 	ofxOscReceiver(const ofxOscReceiver & mom);
-	ofxOscReceiver & operator=(const ofxOscReceiver & mom);
+	ofxOscReceiver& operator=(const ofxOscReceiver & mom);
+	/// for operator= and copy constructor
+	ofxOscReceiver& copy(const ofxOscReceiver& other);
 
 	/// listen_port is the port to listen for messages on
-	bool setup( int listen_port );
+	bool setup(int listen_port);
 	
 	/// stop listening and clear the receiver 
 	void clear();
 
 	/// returns true if there are any messages waiting for collection
 	bool hasWaitingMessages();
+
 	/// take the next message on the queue of received messages, copy its details into message, and
 	/// remove it from the queue. return false if there are no more messages to be got, otherwise
 	/// return true
-	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage( ofxOscMessage* msg));
-	bool getNextMessage( ofxOscMessage& msg );
+	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage* msg));
+	bool getNextMessage(ofxOscMessage& msg);
 
+	/// try to get waiting message an ofParameter
+	/// return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter & parameter);
 
+	/// return current port or 0 if setup was not called
+	int getPort();
+	
 	/// disables port reuse reuse which allows to use the same port by several sockets
 	void disableReuse();
 
 	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
 	void enableReuse();
 
-	/// return current port or 0 if setup was not called
-	int getPort();
-
 protected:
 	/// process an incoming osc message and add it to the queue
-	virtual void ProcessMessage( const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint );
+	virtual void ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint);
 
 private:
 	// socket to listen on

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -21,16 +21,24 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver& other);
 
-	/// set up the receiver with the port to listen for messages on,
+	/// set up the receiver with the port to listen for messages on
+	///
 	/// multiple receivers can share the same port if port reuse is
 	/// enabled (true by default)
+	///
+	/// if port is set to 0, receiver will try to use current port value to
+	/// restart listening
+	///
 	/// \return true is listening was started
-	bool setup(int port);
+	bool setup(int port=0);
 	
-	/// stop listening and clear the receiver 
+	/// stop listening and clear the receiver, does not clear port value
 	void clear();
+	
+	/// \return true if the receiver is listening
+	bool isListening();
 
-	/// /return true if there are any messages waiting for collection
+	/// \return true if there are any messages waiting for collection
 	bool hasWaitingMessages();
 
 	/// take the next message on the queue of received messages, copy its

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -10,12 +10,20 @@
 #include "OscPacketListener.h"
 #include "UdpSocket.h"
 
+/// \struct ofxOscSenderSettings
+/// \brief OSC message sender settings
+struct ofxOscReceiverSettings {
+	int port = 0;        //< port to listen on
+	bool reuse = true;   //< should the port be reused by other receivers?
+	bool start = true;   //< start listening after setup?
+};
+
 /// \class ofxOscReceiver
 /// \brief OSC message receiver which listens on a network port
 class ofxOscReceiver : public osc::OscPacketListener {
 public:
 
-	ofxOscReceiver();
+	ofxOscReceiver() {};
 	~ofxOscReceiver();
 	ofxOscReceiver(const ofxOscReceiver &mom);
 	ofxOscReceiver& operator=(const ofxOscReceiver &mom);
@@ -28,12 +36,23 @@ public:
 	/// multiple receivers can share the same port if port reuse is
 	/// enabled (true by default)
 	///
-	/// \return true if listening started successfully
+	/// \return true if listening started
 	bool setup(int port);
 	
-	/// start listening manually using the current port value
+	/// set up the receiver with the given settings
 	///
-	/// this is not required if you called setup()
+	/// starts listening if start is true (true by default)
+	///
+	/// multiple receivers can share the same port if port reuse is
+	/// enabled (true by default)
+	///
+	/// \return true if listening was started or start was not required
+	bool setup(const ofxOscReceiverSettings &settings);
+	
+	/// start listening manually using the current settings
+	///
+	/// this is not required if you called setup(port)
+	/// or setup(settings) with start set to true
 	///
 	/// \return true if listening started or was already running
 	bool start();
@@ -57,27 +76,11 @@ public:
 	/// \return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter &parameter);
 
-	/// set the receiver port manually, does not start listening
-	///
-	/// restarts receiver if already running
-	///
-	/// this is not required if you called setup()
-	///
-	/// multiple receivers can share the same port if port reuse is
-	/// enabled (true by default)
-	///
-	/// \returns true if port set successfully
-	bool setPort(int port);
-
-	/// \return listening port or 0 if port has not been set
+	/// \return listening port
 	int getPort() const;
 	
-	/// disables port reuse reuse which allows the same port to be used by several sockets
-	void disableReuse();
-
-	/// enable broadcast capabilities
-	/// usually no need to call this, enabled by default
-	void enableReuse();
+	/// \return the current receiver settings
+	const ofxOscReceiverSettings &getSettings() const;
 	
 	/// output stream operator for string conversion and printing
 	/// \return current port value and "listening" if receiver is listening
@@ -97,6 +100,5 @@ private:
 	std::thread listenThread; //< listener thread
 	ofThreadChannel<ofxOscMessage> messagesChannel; //< message passing thread channel
 
-	bool allowReuse; //< all the port to be reused by several sockets?
-	int port; //< port to listen on
+	ofxOscReceiverSettings settings; //< current settings
 };

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -47,9 +47,11 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver& other);
 
-	/// set up the receiver with the port to listen for messages on
+	/// set up the receiver with the port to listen for messages on,
+	/// multiple receivers can share the same port if port reuse is
+	/// enabled (true by default)
 	/// \return true is listening was started
-	bool setup(int listen_port);
+	bool setup(int port);
 	
 	/// stop listening and clear the receiver 
 	void clear();
@@ -67,7 +69,7 @@ public:
 	/// \return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter & parameter);
 
-	/// \return current port or 0 if setup was not called
+	/// \return listening port or 0 if setup was not called
 	int getPort();
 	
 	/// disables port reuse reuse which allows the same port to be used by several sockets
@@ -86,11 +88,11 @@ private:
 
 	/// socket to listen on, unique for each port
 	/// shared between objects is allowReuse is true
-	std::unique_ptr<osc::UdpListeningReceiveSocket, std::function<void(osc::UdpListeningReceiveSocket*)>> listen_socket;
+	std::unique_ptr<osc::UdpListeningReceiveSocket, std::function<void(osc::UdpListeningReceiveSocket*)>> listenSocket;
 
-	std::thread listen_thread; //< listener thread
+	std::thread listenThread; //< listener thread
 	ofThreadChannel<ofxOscMessage> messagesChannel; //< message passing thread channel
 
 	bool allowReuse; //< all the port to be reused by several sockets?
-	int listen_port; //< port to listen on
+	int port; //< port to listen on
 };

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "ofxOscMessage.h"

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -36,6 +36,8 @@
 #include "OscPacketListener.h"
 #include "UdpSocket.h"
 
+/// \class ofxOscReceiver
+/// \brief OSC message receiver which listens on a network port
 class ofxOscReceiver : public osc::OscPacketListener {
 public:
 
@@ -45,45 +47,50 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver& other);
 
-	/// listen_port is the port to listen for messages on
+	/// set up the receiver with the port to listen for messages on
+	/// \return true is listening was started
 	bool setup(int listen_port);
 	
 	/// stop listening and clear the receiver 
 	void clear();
 
-	/// returns true if there are any messages waiting for collection
+	/// /return true if there are any messages waiting for collection
 	bool hasWaitingMessages();
 
-	/// take the next message on the queue of received messages, copy its details into message, and
-	/// remove it from the queue. return false if there are no more messages to be got, otherwise
-	/// return true
-	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage* msg));
+	/// take the next message on the queue of received messages, copy its
+	/// details into message, and remove it from the queue
+	/// \return false if there are no more messages to be got, otherwise return true
 	bool getNextMessage(ofxOscMessage& msg);
-
+	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage* msg));
+	
 	/// try to get waiting message an ofParameter
-	/// return true if message was handled by the given parameter
+	/// \return true if message was handled by the given parameter
 	bool getParameter(ofAbstractParameter & parameter);
 
-	/// return current port or 0 if setup was not called
+	/// \return current port or 0 if setup was not called
 	int getPort();
 	
-	/// disables port reuse reuse which allows to use the same port by several sockets
+	/// disables port reuse reuse which allows the same port to be used by several sockets
 	void disableReuse();
 
-	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
+	/// enable broadcast capabilities
+	/// usually no need to call this, enabled by default
 	void enableReuse();
 
 protected:
+
 	/// process an incoming osc message and add it to the queue
 	virtual void ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint);
 
 private:
-	// socket to listen on
+
+	/// socket to listen on, unique for each port
+	/// shared between objects is allowReuse is true
 	std::unique_ptr<osc::UdpListeningReceiveSocket, std::function<void(osc::UdpListeningReceiveSocket*)>> listen_socket;
 
-	std::thread listen_thread;
-	ofThreadChannel<ofxOscMessage> messagesChannel;
+	std::thread listen_thread; //< listener thread
+	ofThreadChannel<ofxOscMessage> messagesChannel; //< message passing thread channel
 
-	bool allowReuse;
-	int listen_port;
+	bool allowReuse; //< all the port to be reused by several sockets?
+	int listen_port; //< port to listen on
 };

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -69,7 +69,7 @@ protected:
 private:
 
 	/// socket to listen on, unique for each port
-	/// shared between objects is allowReuse is true
+	/// shared between objects if allowReuse is true
 	std::unique_ptr<osc::UdpListeningReceiveSocket, std::function<void(osc::UdpListeningReceiveSocket*)>> listenSocket;
 
 	std::thread listenThread; //< listener thread

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -29,8 +29,11 @@ public:
 	/// if port is set to 0, receiver will try to use current port value to
 	/// restart listening
 	///
-	/// \return true is listening was started
-	bool setup(int port=0);
+	/// if start is true, receiver will start listening (default)
+	/// if start is false, port value is set without starting
+	///
+	/// \return true on success
+	bool setup(int port=0, bool start=true);
 	
 	/// stop listening and clear the receiver, does not clear port value
 	void clear();

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -16,10 +16,11 @@ class ofxOscReceiver : public osc::OscPacketListener {
 public:
 
 	ofxOscReceiver();
-	ofxOscReceiver(const ofxOscReceiver & mom);
-	ofxOscReceiver& operator=(const ofxOscReceiver & mom);
+	~ofxOscReceiver();
+	ofxOscReceiver(const ofxOscReceiver &mom);
+	ofxOscReceiver& operator=(const ofxOscReceiver &mom);
 	/// for operator= and copy constructor
-	ofxOscReceiver& copy(const ofxOscReceiver& other);
+	ofxOscReceiver& copy(const ofxOscReceiver &other);
 
 	/// set up the receiver with the port to listen for messages on
 	///
@@ -48,11 +49,11 @@ public:
 	/// details into message, and remove it from the queue
 	/// \return false if there are no more messages to be got, otherwise return true
 	bool getNextMessage(ofxOscMessage& msg);
-	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage* msg));
+	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage *msg));
 	
 	/// try to get waiting message an ofParameter
 	/// \return true if message was handled by the given parameter
-	bool getParameter(ofAbstractParameter & parameter);
+	bool getParameter(ofAbstractParameter &parameter);
 
 	/// \return listening port or 0 if setup was not called
 	int getPort();
@@ -67,7 +68,7 @@ public:
 protected:
 
 	/// process an incoming osc message and add it to the queue
-	virtual void ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint);
+	virtual void ProcessMessage(const osc::ReceivedMessage &m, const osc::IpEndpointName &remoteEndpoint);
 
 private:
 

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -73,6 +73,9 @@ public:
 	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
 	void enableReuse();
 
+	/// return current port or 0 if setup was not called
+	int getPort();
+
 protected:
 	/// process an incoming osc message and add it to the queue
 	virtual void ProcessMessage( const osc::ReceivedMessage &m, const osc::IpEndpointName& remoteEndpoint );

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -42,7 +42,7 @@ public:
 	void stop();
 	
 	/// \return true if the receiver is listening
-	bool isListening();
+	bool isListening() const;
 
 	/// \return true if there are any messages waiting for collection
 	bool hasWaitingMessages();
@@ -70,7 +70,7 @@ public:
 	bool setPort(int port);
 
 	/// \return listening port or 0 if port has not been set
-	int getPort();
+	int getPort() const;
 	
 	/// disables port reuse reuse which allows the same port to be used by several sockets
 	void disableReuse();
@@ -78,6 +78,10 @@ public:
 	/// enable broadcast capabilities
 	/// usually no need to call this, enabled by default
 	void enableReuse();
+	
+	/// output stream operator for string conversion and printing
+	/// \return current port value and "listening" if receiver is listening
+	friend std::ostream& operator<<(std::ostream &os, const ofxOscReceiver &receiver);
 
 protected:
 

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "ofxOscMessage.h"

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -80,15 +80,15 @@ void ofxOscSender::sendBundle(const ofxOscBundle& bundle){
 	if(!socket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
-	//setting this much larger as it gets trimmed down to the size its using before being sent.
-	//TODO: much better if we could make this dynamic? Maybe have ofxOscBundle return its size?
+	
+	// setting this much larger as it gets trimmed down to the size its using before being sent.
+	// TODO: much better if we could make this dynamic? Maybe have ofxOscBundle return its size?
 	static const int OUTPUT_BUFFER_SIZE = 327680;
 	char buffer[OUTPUT_BUFFER_SIZE];
 	osc::OutboundPacketStream p(buffer, OUTPUT_BUFFER_SIZE);
 
-	// serialise the bundle
+	// serialise the bundle and send
 	appendBundle(bundle, p);
-
 	socket->Send(p.Data(), p.Size());
 }
 
@@ -97,13 +97,14 @@ void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
 	if(!socket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
-	//setting this much larger as it gets trimmed down to the size its using before being sent.
-	//TODO: much better if we could make this dynamic? Maybe have ofxOscMessage return its size?
+	
+	// setting this much larger as it gets trimmed down to the size its using before being sent.
+	// TODO: much better if we could make this dynamic? Maybe have ofxOscMessage return its size?
 	static const int OUTPUT_BUFFER_SIZE = 327680;
 	char buffer[OUTPUT_BUFFER_SIZE];
 	osc::OutboundPacketStream p(buffer, OUTPUT_BUFFER_SIZE);
 
-	// serialise the message
+	// serialise the message and send
 	if(wrapInBundle) {
 		p << osc::BeginBundleImmediate;
 	}
@@ -111,12 +112,11 @@ void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
 	if(wrapInBundle) {
 		p << osc::EndBundle;
 	}
-
 	socket->Send(p.Data(), p.Size());
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::sendParameter( const ofAbstractParameter & parameter){
+void ofxOscSender::sendParameter(const ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()) return;
 	if(parameter.type() == typeid(ofParameterGroup).name()){
 		string address = "/";
@@ -131,8 +131,8 @@ void ofxOscSender::sendParameter( const ofAbstractParameter & parameter){
 	else{
 		string address = "";
 		const vector<string> hierarchy = parameter.getGroupHierarchyNames();
-		for(int i=0;i<(int)hierarchy.size()-1;i++){
-			address+= "/" + hierarchy[i];
+		for(int i = 0; i < (int)hierarchy.size()-1; i++){
+			address += "/" + hierarchy[i];
 		}
 		if(address.length()) {
 			address += "/";
@@ -178,7 +178,7 @@ void ofxOscSender::appendBundle(const ofxOscBundle& bundle, osc::OutboundPacketS
 		appendBundle(bundle.getBundleAt(i), p);
 	}
 	for(int i = 0; i < bundle.getMessageCount(); i++){
-		appendMessage( bundle.getMessageAt(i), p);
+		appendMessage(bundle.getMessageAt(i), p);
 	}
 	p << osc::EndBundle;
 }
@@ -238,7 +238,7 @@ void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPack
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::appendParameter( ofxOscBundle & _bundle, const ofAbstractParameter & parameter, const string &address){
+void ofxOscSender::appendParameter(ofxOscBundle & _bundle, const ofAbstractParameter & parameter, const string &address){
 	if(parameter.type() == typeid(ofParameterGroup).name()){
 		ofxOscBundle bundle;
 		const ofParameterGroup & group = static_cast<const ofParameterGroup &>(parameter);
@@ -253,25 +253,25 @@ void ofxOscSender::appendParameter( ofxOscBundle & _bundle, const ofAbstractPara
 	else{
 		if(parameter.isSerializable()){
 			ofxOscMessage msg;
-			appendParameter(msg,parameter,address);
+			appendParameter(msg, parameter, address);
 			_bundle.addMessage(msg);
 		}
 	}
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address){
+void ofxOscSender::appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address){
 	msg.setAddress(address+parameter.getEscapedName());
-	if(parameter.type()==typeid(ofParameter<int>).name()){
+	if(parameter.type() == typeid(ofParameter<int>).name()){
 		msg.addIntArg(parameter.cast<int>());
 	}
-	else if(parameter.type()==typeid(ofParameter<float>).name()){
+	else if(parameter.type() == typeid(ofParameter<float>).name()){
 		msg.addFloatArg(parameter.cast<float>());
 	}
-	else if(parameter.type()==typeid(ofParameter<double>).name()){
+	else if(parameter.type() == typeid(ofParameter<double>).name()){
 		msg.addDoubleArg(parameter.cast<double>());
 	}
-	else if(parameter.type()==typeid(ofParameter<bool>).name()){
+	else if(parameter.type() == typeid(ofParameter<bool>).name()){
 		msg.addBoolArg(parameter.cast<bool>());
 	}
 	else{

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -34,7 +34,7 @@
 #include "UdpSocket.h"
 
 //--------------------------------------------------------------
-ofxOscSender::ofxOscSender() : broadcast(true), hostname(""), port(0) {}
+ofxOscSender::ofxOscSender() : broadcast(true), host(""), port(0) {}
 
 //--------------------------------------------------------------
 ofxOscSender::ofxOscSender(const ofxOscSender & mom) : broadcast(mom.broadcast){
@@ -50,34 +50,34 @@ ofxOscSender& ofxOscSender::operator=(const ofxOscSender & mom){
 ofxOscSender& ofxOscSender::copy(const ofxOscSender& other){
 	if(this == &other) return *this;
 	broadcast = other.broadcast;
-	hostname = other.hostname;
+	host = other.host;
 	port = other.port;
-	if(other.socket){
-		setup(hostname, port);
+	if(other.sendSocket){
+		setup(host, port);
 	}
 	return *this;
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::setup(const string &hostname, int port){
+void ofxOscSender::setup(const string &host, int port){
 	if(osc::UdpSocket::GetUdpBufferSize() == 0){
 	   osc::UdpSocket::SetUdpBufferSize(65535);
 	}
-	socket.reset(new osc::UdpTransmitSocket(osc::IpEndpointName(hostname.c_str(), port), broadcast));
-	this->hostname = hostname;
+	sendSocket.reset(new osc::UdpTransmitSocket(osc::IpEndpointName(host.c_str(), port), broadcast));
+	this->host = host;
 	this->port = port;
 }
 
 //--------------------------------------------------------------
 void ofxOscSender::clear(){
-	socket.reset();
-	hostname = "";
+	sendSocket.reset();
+	host = "";
 	port = 0;
 }
 
 //--------------------------------------------------------------
 void ofxOscSender::sendBundle(const ofxOscBundle& bundle){
-	if(!socket){
+	if(!sendSocket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
 	
@@ -89,12 +89,12 @@ void ofxOscSender::sendBundle(const ofxOscBundle& bundle){
 
 	// serialise the bundle and send
 	appendBundle(bundle, p);
-	socket->Send(p.Data(), p.Size());
+	sendSocket->Send(p.Data(), p.Size());
 }
 
 //--------------------------------------------------------------
 void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
-	if(!socket){
+	if(!sendSocket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
 	
@@ -112,7 +112,7 @@ void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
 	if(wrapInBundle) {
 		p << osc::EndBundle;
 	}
-	socket->Send(p.Data(), p.Size());
+	sendSocket->Send(p.Data(), p.Size());
 }
 
 //--------------------------------------------------------------
@@ -144,8 +144,8 @@ void ofxOscSender::sendParameter(const ofAbstractParameter & parameter){
 }
 
 //--------------------------------------------------------------
-string ofxOscSender::getHostname(){
-	return hostname;
+string ofxOscSender::getHost(){
+	return host;
 }
 
 //--------------------------------------------------------------
@@ -156,16 +156,16 @@ int ofxOscSender::getPort(){
 //--------------------------------------------------------------
 void ofxOscSender::disableBroadcast(){
 	broadcast = false;
-	if(socket){
-		setup(hostname, port);
+	if(sendSocket){
+		setup(host, port);
 	}
 }
 
 //--------------------------------------------------------------
 void ofxOscSender::enableBroadcast(){
 	broadcast = true;
-	if(socket){
-		setup(hostname, port);
+	if(sendSocket){
+		setup(host, port);
 	}
 }
 

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -126,7 +126,7 @@ void ofxOscSender::setHost(const std::string &host) {
 }
 
 //--------------------------------------------------------------
-std::string ofxOscSender::getHost(){
+std::string ofxOscSender::getHost() const{
 	return host;
 }
 
@@ -136,7 +136,7 @@ void ofxOscSender::setPort(int port){
 }
 
 //--------------------------------------------------------------
-int ofxOscSender::getPort(){
+int ofxOscSender::getPort() const{
 	return port;
 }
 
@@ -268,4 +268,11 @@ void ofxOscSender::appendParameter(ofxOscMessage &msg, const ofAbstractParameter
 	else{
 		msg.addStringArg(parameter.toString());
 	}
+}
+
+// friend functions
+//--------------------------------------------------------------
+std::ostream& operator<<(std::ostream &os, const ofxOscSender &sender) {
+	os << sender.getHost() << " " << sender.getPort();
+	return os;
 }

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -121,8 +121,18 @@ void ofxOscSender::sendParameter(const ofAbstractParameter &parameter){
 }
 
 //--------------------------------------------------------------
+void ofxOscSender::setHost(const std::string &host) {
+	setup(host, this->port);
+}
+
+//--------------------------------------------------------------
 std::string ofxOscSender::getHost(){
 	return host;
+}
+
+//--------------------------------------------------------------
+void ofxOscSender::setPort(int port){
+	setup(this->host, port);
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -205,8 +205,7 @@ void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPack
 			}
 			default:
 				ofLogError("ofxOscSender") << "appendMessage(): bad argument type "
-					<< message.getArgType(i);
-				assert(false);
+					<< message.getArgType(i) << " '" << (char) message.getArgType(i) << "'";
 				break;
 		}
 	}

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -173,34 +173,36 @@ void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPack
 			case OFXOSC_TYPE_DOUBLE:
 				p << message.getArgAsDouble(i);
 				break;
-			case OFXOSC_TYPE_STRING: case OFXOSC_TYPE_SYMBOL:
+			case OFXOSC_TYPE_STRING:
 				p << message.getArgAsString(i).c_str();
+				break;
+			case OFXOSC_TYPE_SYMBOL:
+				p << osc::Symbol(message.getArgAsString(i).c_str());
 				break;
 			case OFXOSC_TYPE_CHAR:
 				p << message.getArgAsChar(i);
 				break;
 			case OFXOSC_TYPE_MIDI_MESSAGE:
-				p << message.getArgAsMidiMessage(i);
+				p << osc::MidiMessage(message.getArgAsMidiMessage(i));
 				break;
 			case OFXOSC_TYPE_TRUE: case OFXOSC_TYPE_FALSE:
 				p << message.getArgAsBool(i);
 				break;
 			case OFXOSC_TYPE_NONE:
-				p << message.getArgAsNone(i);
+				p << osc::NilType();
 				break;
 			case OFXOSC_TYPE_TRIGGER:
-				p << message.getArgAsTrigger(i);
+				p << osc::InfinitumType();
 				break;
 			case OFXOSC_TYPE_TIMETAG:
-				p << (osc::int64)message.getArgAsTimetag(i);
+				p << osc::TimeTag(message.getArgAsTimetag(i));
 				break;
 			case OFXOSC_TYPE_RGBA_COLOR:
-				p << message.getArgAsRgbaColor(i);
+				p << osc::RgbaColor(message.getArgAsRgbaColor(i));
 				break;
 			case OFXOSC_TYPE_BLOB: {
 				ofBuffer buff = message.getArgAsBlob(i);
-				osc::Blob b(buff.getData(), (unsigned long)buff.size());
-				p << b;
+				p << osc::Blob(buff.getData(), (unsigned long)buff.size());
 				break;
 			}
 			default:

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -241,8 +241,8 @@ void ofxOscSender::appendMessage( const ofxOscMessage& message, osc::OutboundPac
 			p << message.getArgAsTrigger( i );
 		else if ( message.getArgType( i ) == OFXOSC_TYPE_TIMETAG )
 			p << (osc::int64)message.getArgAsTimetag( i );
-		//else if ( message.getArgType( i ) == OFXOSC_TYPE_RGBA_COLOR )
-		//	p << message.getArgAsRgbaColor( i );
+		else if ( message.getArgType( i ) == OFXOSC_TYPE_RGBA_COLOR )
+			p << message.getArgAsRgbaColor( i );
         else if ( message.getArgType( i ) == OFXOSC_TYPE_BLOB ){
             ofBuffer buff = message.getArgAsBlob(i);
             osc::Blob b(buff.getData(), (unsigned long)buff.size());

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -38,6 +38,7 @@
 
 ofxOscSender::ofxOscSender()
 :broadcast(true)
+,hostname("")
 ,port(0)
 {
 }
@@ -88,6 +89,16 @@ void ofxOscSender::enableBroadcast()
 	if(socket){
 		setup(hostname, port);
 	}
+}
+
+std::string ofxOscSender::getHostname()
+{
+	return hostname;
+}
+
+int ofxOscSender::getPort()
+{
+	return port;
 }
 
 void ofxOscSender::shutdown()

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -1,32 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #include "ofxOscSender.h"
 #include "ofUtils.h"
 #include "ofParameterGroup.h"

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -38,6 +38,7 @@ ofxOscSender& ofxOscSender::copy(const ofxOscSender& other){
 
 //--------------------------------------------------------------
 void ofxOscSender::setup(const std::string &host, int port){
+	// manually set larger buffer size instead of oscpack per-message size
 	if(osc::UdpSocket::GetUdpBufferSize() == 0){
 	   osc::UdpSocket::SetUdpBufferSize(65535);
 	}

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -185,6 +185,9 @@ void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPack
 			case OFXOSC_TYPE_TRUE: case OFXOSC_TYPE_FALSE:
 				p << message.getArgAsBool(i);
 				break;
+			case OFXOSC_TYPE_NONE:
+				p << message.getArgAsNone(i);
+				break;
 			case OFXOSC_TYPE_TRIGGER:
 				p << message.getArgAsTrigger(i);
 				break;

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -10,6 +10,11 @@
 ofxOscSender::ofxOscSender() : broadcast(true), host(""), port(0) {}
 
 //--------------------------------------------------------------
+ofxOscSender::~ofxOscSender() {
+	clear();
+}
+
+//--------------------------------------------------------------
 ofxOscSender::ofxOscSender(const ofxOscSender & mom) : broadcast(mom.broadcast){
 	copy(mom);
 }
@@ -32,7 +37,7 @@ ofxOscSender& ofxOscSender::copy(const ofxOscSender& other){
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::setup(const string &host, int port){
+void ofxOscSender::setup(const std::string &host, int port){
 	if(osc::UdpSocket::GetUdpBufferSize() == 0){
 	   osc::UdpSocket::SetUdpBufferSize(65535);
 	}
@@ -47,7 +52,7 @@ void ofxOscSender::clear(){
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::sendBundle(const ofxOscBundle& bundle){
+void ofxOscSender::sendBundle(const ofxOscBundle &bundle){
 	if(!sendSocket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
@@ -64,7 +69,7 @@ void ofxOscSender::sendBundle(const ofxOscBundle& bundle){
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
+void ofxOscSender::sendMessage(const ofxOscMessage &message, bool wrapInBundle){
 	if(!sendSocket){
 		ofLogError("ofxOscSender") << "trying to send before setup";
 	}
@@ -87,11 +92,11 @@ void ofxOscSender::sendMessage(const ofxOscMessage& message, bool wrapInBundle){
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::sendParameter(const ofAbstractParameter & parameter){
+void ofxOscSender::sendParameter(const ofAbstractParameter &parameter){
 	if(!parameter.isSerializable()) return;
 	if(parameter.type() == typeid(ofParameterGroup).name()){
-		string address = "/";
-		const vector<string> hierarchy = parameter.getGroupHierarchyNames();
+		std::string address = "/";
+		const std::vector<std::string> hierarchy = parameter.getGroupHierarchyNames();
 		for(int i = 0; i < (int)hierarchy.size()-1; i++){
 			address += hierarchy[i] + "/";
 		}
@@ -100,8 +105,8 @@ void ofxOscSender::sendParameter(const ofAbstractParameter & parameter){
 		sendBundle(bundle);
 	}
 	else{
-		string address = "";
-		const vector<string> hierarchy = parameter.getGroupHierarchyNames();
+		std::string address = "";
+		const std::vector<std::string> hierarchy = parameter.getGroupHierarchyNames();
 		for(int i = 0; i < (int)hierarchy.size()-1; i++){
 			address += "/" + hierarchy[i];
 		}
@@ -115,7 +120,7 @@ void ofxOscSender::sendParameter(const ofAbstractParameter & parameter){
 }
 
 //--------------------------------------------------------------
-string ofxOscSender::getHost(){
+std::string ofxOscSender::getHost(){
 	return host;
 }
 
@@ -142,7 +147,7 @@ void ofxOscSender::enableBroadcast(){
 
 // PRIVATE
 //--------------------------------------------------------------
-void ofxOscSender::appendBundle(const ofxOscBundle& bundle, osc::OutboundPacketStream& p){
+void ofxOscSender::appendBundle(const ofxOscBundle &bundle, osc::OutboundPacketStream &p){
 	// recursively serialise the bundle
 	p << osc::BeginBundleImmediate;
 	for(int i = 0; i < bundle.getBundleCount(); i++){
@@ -155,7 +160,7 @@ void ofxOscSender::appendBundle(const ofxOscBundle& bundle, osc::OutboundPacketS
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPacketStream& p){
+void ofxOscSender::appendMessage(const ofxOscMessage &message, osc::OutboundPacketStream &p){
 	p << osc::BeginMessage(message.getAddress().c_str());
 	for(int i = 0; i < message.getNumArgs(); ++i) {
 		switch(message.getArgType(i)){
@@ -213,11 +218,11 @@ void ofxOscSender::appendMessage(const ofxOscMessage& message, osc::OutboundPack
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::appendParameter(ofxOscBundle & _bundle, const ofAbstractParameter & parameter, const string &address){
+void ofxOscSender::appendParameter(ofxOscBundle &_bundle, const ofAbstractParameter &parameter, const std::string &address){
 	if(parameter.type() == typeid(ofParameterGroup).name()){
 		ofxOscBundle bundle;
-		const ofParameterGroup & group = static_cast<const ofParameterGroup &>(parameter);
-		for(size_t i = 0; i < group.size(); i++){
+		const ofParameterGroup &group = static_cast<const ofParameterGroup &>(parameter);
+		for(std::size_t i = 0; i < group.size(); i++){
 			const ofAbstractParameter & p = group[i];
 			if(p.isSerializable()){
 				appendParameter(bundle, p, address+group.getEscapedName()+"/");
@@ -235,7 +240,7 @@ void ofxOscSender::appendParameter(ofxOscBundle & _bundle, const ofAbstractParam
 }
 
 //--------------------------------------------------------------
-void ofxOscSender::appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address){
+void ofxOscSender::appendParameter(ofxOscMessage &msg, const ofAbstractParameter &parameter, const std::string &address){
 	msg.setAddress(address+parameter.getEscapedName());
 	if(parameter.type() == typeid(ofParameter<int>).name()){
 		msg.addIntArg(parameter.cast<int>());

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -75,6 +75,13 @@ void ofxOscSender::setup( const std::string &hostname, int port )
     this->port = port;
 }
 
+void ofxOscSender::clear()
+{
+	socket.reset();
+	hostname = "";
+	port = 0;
+}
+
 void ofxOscSender::disableBroadcast()
 {
 	broadcast = false;
@@ -99,11 +106,6 @@ std::string ofxOscSender::getHostname()
 int ofxOscSender::getPort()
 {
 	return port;
-}
-
-void ofxOscSender::shutdown()
-{
-	socket.reset();
 }
 
 void ofxOscSender::sendBundle( const ofxOscBundle& bundle )

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -44,8 +44,6 @@ void ofxOscSender::setup(const string &host, int port){
 //--------------------------------------------------------------
 void ofxOscSender::clear(){
 	sendSocket.reset();
-	host = "";
-	port = 0;
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #include "ofxOscSender.h"
 #include "ofUtils.h"
 #include "ofParameterGroup.h"

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -31,10 +31,7 @@
 #include "ofUtils.h"
 #include "ofParameterGroup.h"
 
-
 #include "UdpSocket.h"
-
-#include <assert.h>
 
 ofxOscSender::ofxOscSender()
 :broadcast(true)
@@ -64,7 +61,7 @@ ofxOscSender & ofxOscSender::operator=(const ofxOscSender & mom){
 	return *this;
 }
 
-void ofxOscSender::setup( const std::string &hostname, int port )
+void ofxOscSender::setup( const string &hostname, int port )
 {
     if( osc::UdpSocket::GetUdpBufferSize() == 0 ){
     	osc::UdpSocket::SetUdpBufferSize(65535);
@@ -98,7 +95,7 @@ void ofxOscSender::enableBroadcast()
 	}
 }
 
-std::string ofxOscSender::getHostname()
+string ofxOscSender::getHostname()
 {
 	return hostname;
 }
@@ -147,8 +144,8 @@ void ofxOscSender::sendMessage( const ofxOscMessage& message, bool wrapInBundle 
 void ofxOscSender::sendParameter( const ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()) return;
 	if(parameter.type()==typeid(ofParameterGroup).name()){
-        std::string address = "/";
-        const std::vector<std::string> hierarchy = parameter.getGroupHierarchyNames();
+        string address = "/";
+        const vector<string> hierarchy = parameter.getGroupHierarchyNames();
 		for(int i=0;i<(int)hierarchy.size()-1;i++){
 			address+=hierarchy[i] + "/";
 		}
@@ -156,8 +153,8 @@ void ofxOscSender::sendParameter( const ofAbstractParameter & parameter){
 		appendParameter(bundle,parameter,address);
 		sendBundle(bundle);
 	}else{
-        std::string address = "";
-        const std::vector<std::string> hierarchy = parameter.getGroupHierarchyNames();
+        string address = "";
+        const vector<string> hierarchy = parameter.getGroupHierarchyNames();
 		for(int i=0;i<(int)hierarchy.size()-1;i++){
 			address+= "/" + hierarchy[i];
 		}
@@ -169,11 +166,11 @@ void ofxOscSender::sendParameter( const ofAbstractParameter & parameter){
 }
 
 
-void ofxOscSender::appendParameter( ofxOscBundle & _bundle, const ofAbstractParameter & parameter, const std::string &address){
+void ofxOscSender::appendParameter( ofxOscBundle & _bundle, const ofAbstractParameter & parameter, const string &address){
 	if(parameter.type()==typeid(ofParameterGroup).name()){
 		ofxOscBundle bundle;
 		const ofParameterGroup & group = static_cast<const ofParameterGroup &>(parameter);
-		for(std::size_t i=0;i<group.size();i++){
+		for(size_t i=0;i<group.size();i++){
 			const ofAbstractParameter & p = group[i];
 			if(p.isSerializable()){
 				appendParameter(bundle,p,address+group.getEscapedName()+"/");
@@ -189,7 +186,7 @@ void ofxOscSender::appendParameter( ofxOscBundle & _bundle, const ofAbstractPara
 	}
 }
 
-void ofxOscSender::appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const std::string &address){
+void ofxOscSender::appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address){
 	msg.setAddress(address+parameter.getEscapedName());
 	if(parameter.type()==typeid(ofParameter<int>).name()){
 		msg.addIntArg(parameter.cast<int>());

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -16,29 +16,30 @@ class ofxOscSender{
 public:
 
 	ofxOscSender();
-	ofxOscSender(const ofxOscSender & mom);
-	ofxOscSender& operator=(const ofxOscSender & mom);
+	~ofxOscSender();
+	ofxOscSender(const ofxOscSender &mom);
+	ofxOscSender& operator=(const ofxOscSender &mom);
 	/// for operator= and copy constructor
-	ofxOscSender& copy(const ofxOscSender& other);
+	ofxOscSender& copy(const ofxOscSender &other);
 
 	/// set up the sender with the destination host name/ip and port
-	void setup(const string &host, int port);
+	void setup(const std::string &host, int port);
 	
 	/// clear the sender, does not clear host or port values
 	void clear();
 
 	/// send the given message
 	/// if wrapInBundle is true (default), message sent in a timetagged bundle
-	void sendMessage(const ofxOscMessage& message, bool wrapInBundle=true);
+	void sendMessage(const ofxOscMessage &message, bool wrapInBundle=true);
 	
 	/// send the given bundle
-	void sendBundle(const ofxOscBundle& bundle);
+	void sendBundle(const ofxOscBundle &bundle);
 	
 	/// create & send a message with data from an ofParameter
-	void sendParameter(const ofAbstractParameter & parameter);
+	void sendParameter(const ofAbstractParameter &parameter);
 
 	/// \return current host name/ip or "" if setup was not called
-	string getHost();
+	std::string getHost();
 
 	/// \return current port or 0 if setup was not called
 	int getPort();
@@ -54,13 +55,13 @@ public:
 private:
 		
 	// helper methods for constructing messages
-	void appendBundle(const ofxOscBundle& bundle, osc::OutboundPacketStream& p);
-	void appendMessage(const ofxOscMessage& message, osc::OutboundPacketStream& p);
-	void appendParameter(ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
-	void appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
+	void appendBundle(const ofxOscBundle &bundle, osc::OutboundPacketStream &p);
+	void appendMessage(const ofxOscMessage &message, osc::OutboundPacketStream &p);
+	void appendParameter(ofxOscBundle &bundle, const ofAbstractParameter &parameter, const std::string &address);
+	void appendParameter(ofxOscMessage &msg, const ofAbstractParameter &parameter, const std::string &address);
 
 	std::unique_ptr<osc::UdpTransmitSocket> sendSocket; //< sender socket
 	bool broadcast; //< allow multicast broadcasting ip range?
-	string host; //< destination host name/ip
+	std::string host; //< destination host name/ip
 	int port; //< destination port
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -10,12 +10,21 @@
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
 
+/// \struct ofxOscSenderSettings
+/// \brief OSC message sender settings
+struct ofxOscSenderSettings {
+	std::string host = "localhost"; //< destination host name/ip
+	int port = 0;                   //< destination port
+	bool broadcast = true;          //< allow multicast (broadcasting) ip range?
+};
+
 /// \class ofxOscSender
 /// \brief OSC message sender which sends to a specific host & port
 class ofxOscSender{
 public:
 
-	ofxOscSender();
+
+	ofxOscSender() {}
 	~ofxOscSender();
 	ofxOscSender(const ofxOscSender &mom);
 	ofxOscSender& operator=(const ofxOscSender &mom);
@@ -25,6 +34,10 @@ public:
 	/// set up the sender with the destination host name/ip and port
 	/// \return true on success
 	bool setup(const std::string &host, int port);
+	
+	/// set up the sender with the given settings
+	/// \returns true on success
+	bool setup(const ofxOscSenderSettings &settings);
 	
 	/// clear the sender, does not clear host or port values
 	void clear();
@@ -39,27 +52,14 @@ public:
 	/// create & send a message with data from an ofParameter
 	void sendParameter(const ofAbstractParameter &parameter);
 
-	/// set the desintation host name/ip
-	/// \return true on success
-	bool setHost(const std::string &host);
-
-	/// \return current host name/ip or "" if setup was not called
+	/// \return current host name/ip
 	std::string getHost() const;
 
-	/// set the destination port
-	/// \return true on success
-	bool setPort(int port);
-
-	/// \return current port or 0 if setup was not called
+	/// \return current port
 	int getPort() const;
 	
-	/// disable broadcast capabilities
-	/// usually call this before setup
-	void disableBroadcast();
-
-	/// enabled broadcast capabilities
-	/// usually no need to call this, enabled by default
-	void enableBroadcast();
+	/// \return the current sender settings
+	const ofxOscSenderSettings &getSettings() const;
 	
 	/// output stream operator for string conversion and printing
 	/// \return host name/ip and port separated by a space
@@ -73,8 +73,6 @@ private:
 	void appendParameter(ofxOscBundle &bundle, const ofAbstractParameter &parameter, const std::string &address);
 	void appendParameter(ofxOscMessage &msg, const ofAbstractParameter &parameter, const std::string &address);
 
+	ofxOscSenderSettings settings; //< current settings
 	std::unique_ptr<osc::UdpTransmitSocket> sendSocket; //< sender socket
-	bool broadcast; //< allow multicast broadcasting ip range?
-	std::string host; //< destination host name/ip
-	int port; //< destination port
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -42,13 +42,13 @@ public:
 	void setHost(const std::string &host);
 
 	/// \return current host name/ip or "" if setup was not called
-	std::string getHost();
+	std::string getHost() const;
 
 	/// set the destination port
 	void setPort(int port);
 
 	/// \return current port or 0 if setup was not called
-	int getPort();
+	int getPort() const;
 	
 	/// disable broadcast capabilities
 	/// usually call this before setup
@@ -57,6 +57,10 @@ public:
 	/// enabled broadcast capabilities
 	/// usually no need to call this, enabled by default
 	void enableBroadcast();
+	
+	/// output stream operator for string conversion and printing
+	/// \return host name/ip and port separated by a space
+	friend std::ostream& operator<<(std::ostream &os, const ofxOscSender &sender);
 
 private:
 		

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -36,10 +36,6 @@ an ofxOscSender sends messages to a single host/port
 
 */
 
-namespace osc{
-	class UdpTransmitSocket;
-}
-
 #include "OscTypes.h"
 #include "OscOutboundPacketStream.h"
 #include "UdpSocket.h"
@@ -48,50 +44,52 @@ namespace osc{
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
 
-class ofxOscSender
-{
+class ofxOscSender{
 public:
+
 	ofxOscSender();
 	ofxOscSender(const ofxOscSender & mom);
-	ofxOscSender & operator=(const ofxOscSender & mom);
+	ofxOscSender& operator=(const ofxOscSender & mom);
+	/// for operator= and copy constructor
+	ofxOscSender& copy(const ofxOscSender& other);
 
 	/// send messages to hostname and port
-	void setup( const string &hostname, int port );
+	void setup(const string &hostname, int port);
 	
 	/// clear the sender 
 	void clear();
 
 	/// send the given message
-	void sendMessage( const ofxOscMessage& message, bool wrapInBundle = true );
+	void sendMessage(const ofxOscMessage& message, bool wrapInBundle = true);
+	
 	/// send the given bundle
-	void sendBundle( const ofxOscBundle& bundle );
+	void sendBundle(const ofxOscBundle& bundle);
+	
 	/// creates a message using an ofParameter
-	void sendParameter( const ofAbstractParameter & parameter);
-
-	/// disables broadcast capabilities, usually call this before setup
-	void disableBroadcast();
-
-	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
-	void enableBroadcast();
+	void sendParameter(const ofAbstractParameter & parameter);
 
 	/// return current hostname or "" if setup was not called
 	string getHostname();
 
 	/// return current port or 0 if setup was not called
 	int getPort();
+	
+	/// disables broadcast capabilities, usually call this before setup
+	void disableBroadcast();
+
+	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
+	void enableBroadcast();
 
 private:
-	void setup(osc::UdpTransmitSocket * socket);
 		
 	// helper methods for constructing messages
-	void appendBundle( const ofxOscBundle& bundle, osc::OutboundPacketStream& p );
-	void appendMessage( const ofxOscMessage& message, osc::OutboundPacketStream& p );
-    void appendParameter( ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
-    void appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
+	void appendBundle(const ofxOscBundle& bundle, osc::OutboundPacketStream& p);
+	void appendMessage(const ofxOscMessage& message, osc::OutboundPacketStream& p);
+	void appendParameter(ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
+	void appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
 
- 	std::unique_ptr<osc::UdpTransmitSocket> socket;
- 	bool broadcast;
- 	string hostname;
- 	int port;
-
+	std::unique_ptr<osc::UdpTransmitSocket> socket;
+	bool broadcast;
+	string hostname;
+	int port;
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -1,31 +1,5 @@
-/*
- 
- Copyright (c) 2007-2009, Damian Stewart
- All rights reserved.
- 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
- * Neither the name of the developer nor the
- names of its contributors may be used to endorse or promote products
- derived from this software without specific prior written permission.
- 
- THIS SOFTWARE IS PROVIDED BY DAMIAN STEWART ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL DAMIAN STEWART BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
+// copyright (c) openFrameworks team 2010-2017
+// copyright (c) damian stewart 2007-2009
 #pragma once
 
 #include "OscTypes.h"

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -59,6 +59,9 @@ public:
 
 	/// send messages to hostname and port
 	void setup( const std::string &hostname, int port );
+	
+	/// clear the sender 
+	void clear();
 
 	/// send the given message
 	void sendMessage( const ofxOscMessage& message, bool wrapInBundle = true );
@@ -81,7 +84,6 @@ public:
 
 private:
 	void setup(osc::UdpTransmitSocket * socket);
-	void shutdown();
 		
 	// helper methods for constructing messages
 	void appendBundle( const ofxOscBundle& bundle, osc::OutboundPacketStream& p );

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -28,14 +28,6 @@
 
 #pragma once
 
-/**
-
-ofxOscSender
-
-an ofxOscSender sends messages to a single host/port
-
-*/
-
 #include "OscTypes.h"
 #include "OscOutboundPacketStream.h"
 #include "UdpSocket.h"
@@ -44,6 +36,8 @@ an ofxOscSender sends messages to a single host/port
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
 
+/// \class ofxOscSender
+/// \brief OSC message sender which sends to a specific host & port
 class ofxOscSender{
 public:
 
@@ -53,31 +47,34 @@ public:
 	/// for operator= and copy constructor
 	ofxOscSender& copy(const ofxOscSender& other);
 
-	/// send messages to hostname and port
+	/// set up the sender with the destination host name/ip and port
 	void setup(const string &hostname, int port);
 	
 	/// clear the sender 
 	void clear();
 
 	/// send the given message
-	void sendMessage(const ofxOscMessage& message, bool wrapInBundle = true);
+	/// if wrapInBundle is true (default), message sent in a timetagged bundle
+	void sendMessage(const ofxOscMessage& message, bool wrapInBundle=true);
 	
 	/// send the given bundle
 	void sendBundle(const ofxOscBundle& bundle);
 	
-	/// creates a message using an ofParameter
+	/// create & send a message with data from an ofParameter
 	void sendParameter(const ofAbstractParameter & parameter);
 
-	/// return current hostname or "" if setup was not called
+	/// return current host name/ip or "" if setup was not called
 	string getHostname();
 
 	/// return current port or 0 if setup was not called
 	int getPort();
 	
-	/// disables broadcast capabilities, usually call this before setup
+	/// disable broadcast capabilities
+	/// usually call this before setup
 	void disableBroadcast();
 
-	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
+	/// enabled broadcast capabilities
+	/// usually no need to call this, enabled by default
 	void enableBroadcast();
 
 private:
@@ -88,8 +85,8 @@ private:
 	void appendParameter(ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
 	void appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
 
-	std::unique_ptr<osc::UdpTransmitSocket> socket;
-	bool broadcast;
-	string hostname;
-	int port;
+	std::unique_ptr<osc::UdpTransmitSocket> socket; //< sender socket
+	bool broadcast; //< allow multicast broadcasting ip range?
+	string hostname; //< destination host/ip
+	int port; //< destination port
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -23,7 +23,8 @@ public:
 	ofxOscSender& copy(const ofxOscSender &other);
 
 	/// set up the sender with the destination host name/ip and port
-	void setup(const std::string &host, int port);
+	/// \return true on success
+	bool setup(const std::string &host, int port);
 	
 	/// clear the sender, does not clear host or port values
 	void clear();
@@ -39,13 +40,15 @@ public:
 	void sendParameter(const ofAbstractParameter &parameter);
 
 	/// set the desintation host name/ip
-	void setHost(const std::string &host);
+	/// \return true on success
+	bool setHost(const std::string &host);
 
 	/// \return current host name/ip or "" if setup was not called
 	std::string getHost() const;
 
 	/// set the destination port
-	void setPort(int port);
+	/// \return true on success
+	bool setPort(int port);
 
 	/// \return current port or 0 if setup was not called
 	int getPort() const;

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -39,16 +39,14 @@ an ofxOscSender sends messages to a single host/port
 namespace osc{
 	class UdpTransmitSocket;
 }
-#include <string>
+
 #include "OscTypes.h"
 #include "OscOutboundPacketStream.h"
 #include "UdpSocket.h"
 
 #include "ofxOscBundle.h"
-#include "ofxOscMessage.h"
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
-
 
 class ofxOscSender
 {
@@ -58,7 +56,7 @@ public:
 	ofxOscSender & operator=(const ofxOscSender & mom);
 
 	/// send messages to hostname and port
-	void setup( const std::string &hostname, int port );
+	void setup( const string &hostname, int port );
 	
 	/// clear the sender 
 	void clear();
@@ -77,7 +75,7 @@ public:
 	void enableBroadcast();
 
 	/// return current hostname or "" if setup was not called
-	std::string getHostname();
+	string getHostname();
 
 	/// return current port or 0 if setup was not called
 	int getPort();
@@ -88,12 +86,12 @@ private:
 	// helper methods for constructing messages
 	void appendBundle( const ofxOscBundle& bundle, osc::OutboundPacketStream& p );
 	void appendMessage( const ofxOscMessage& message, osc::OutboundPacketStream& p );
-    void appendParameter( ofxOscBundle & bundle, const ofAbstractParameter & parameter, const std::string &address);
-    void appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const std::string &address);
+    void appendParameter( ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
+    void appendParameter( ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
 
  	std::unique_ptr<osc::UdpTransmitSocket> socket;
  	bool broadcast;
- 	std::string hostname;
+ 	string hostname;
  	int port;
 
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -38,8 +38,14 @@ public:
 	/// create & send a message with data from an ofParameter
 	void sendParameter(const ofAbstractParameter &parameter);
 
+	/// set the desintation host name/ip
+	void setHost(const std::string &host);
+
 	/// \return current host name/ip or "" if setup was not called
 	std::string getHost();
+
+	/// set the destination port
+	void setPort(int port);
 
 	/// \return current port or 0 if setup was not called
 	int getPort();

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -1,5 +1,5 @@
 // copyright (c) openFrameworks team 2010-2017
-// copyright (c) damian stewart 2007-2009
+// copyright (c) Damian Stewart 2007-2009
 #pragma once
 
 #include "OscTypes.h"

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -48,7 +48,7 @@ public:
 	ofxOscSender& copy(const ofxOscSender& other);
 
 	/// set up the sender with the destination host name/ip and port
-	void setup(const string &hostname, int port);
+	void setup(const string &host, int port);
 	
 	/// clear the sender 
 	void clear();
@@ -64,7 +64,7 @@ public:
 	void sendParameter(const ofAbstractParameter & parameter);
 
 	/// return current host name/ip or "" if setup was not called
-	string getHostname();
+	string getHost();
 
 	/// return current port or 0 if setup was not called
 	int getPort();
@@ -85,8 +85,8 @@ private:
 	void appendParameter(ofxOscBundle & bundle, const ofAbstractParameter & parameter, const string &address);
 	void appendParameter(ofxOscMessage & msg, const ofAbstractParameter & parameter, const string &address);
 
-	std::unique_ptr<osc::UdpTransmitSocket> socket; //< sender socket
+	std::unique_ptr<osc::UdpTransmitSocket> sendSocket; //< sender socket
 	bool broadcast; //< allow multicast broadcasting ip range?
-	string hostname; //< destination host/ip
+	string host; //< destination host name/ip
 	int port; //< destination port
 };

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -73,6 +73,12 @@ public:
 	/// enabled broadcast capabilities (usually no need to call this, enabled by default)
 	void enableBroadcast();
 
+	/// return current hostname or "" if setup was not called
+	std::string getHostname();
+
+	/// return current port or 0 if setup was not called
+	int getPort();
+
 private:
 	void setup(osc::UdpTransmitSocket * socket);
 	void shutdown();

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -24,7 +24,7 @@ public:
 	/// set up the sender with the destination host name/ip and port
 	void setup(const string &host, int port);
 	
-	/// clear the sender 
+	/// clear the sender, does not clear host or port values
 	void clear();
 
 	/// send the given message

--- a/addons/ofxOsc/src/ofxOscSender.h
+++ b/addons/ofxOsc/src/ofxOscSender.h
@@ -37,10 +37,10 @@ public:
 	/// create & send a message with data from an ofParameter
 	void sendParameter(const ofAbstractParameter & parameter);
 
-	/// return current host name/ip or "" if setup was not called
+	/// \return current host name/ip or "" if setup was not called
 	string getHost();
 
-	/// return current port or 0 if setup was not called
+	/// \return current port or 0 if setup was not called
 	int getPort();
 	
 	/// disable broadcast capabilities

--- a/examples/communication/oscChatSystemExample/src/ofApp.cpp
+++ b/examples/communication/oscChatSystemExample/src/ofApp.cpp
@@ -41,14 +41,14 @@ void ofApp::update(){
 	while(serverReceiver.hasWaitingMessages()){
 		// get the next message
 		ofxOscMessage m;
-		serverReceiver.getNextMessage(&m);
+		serverReceiver.getNextMessage(m);
 		//Log received message for easier debugging of participants' messages:
-		ofLogVerbose("Server recvd msg " + getOscMsgAsString(m) + " from " + m.getRemoteIp());
+		ofLogVerbose("Server recvd msg " + getOscMsgAsString(m) + " from " + m.getRemoteHost());
 
 		// check the address of the incoming message
 		if(m.getAddress() == "/typing"){
 			//Identify host of incoming msg
-			string incomingHost = m.getRemoteIp();
+			string incomingHost = m.getRemoteHost();
 			//See if incoming host is a new one:
 			if(std::find(knownClients.begin(), knownClients.end(), incomingHost)
 			   == knownClients.end()){
@@ -85,7 +85,7 @@ void ofApp::update(){
 	while(clientReceiver.hasWaitingMessages()){
 		// get the next message
 		ofxOscMessage m;
-		clientReceiver.getNextMessage(&m);
+		clientReceiver.getNextMessage(m);
 		ofLogNotice("Client just received a message");
 		// check the address of the incoming message
 		if(m.getAddress() == "/chatlog"){
@@ -261,7 +261,7 @@ void ofApp::broadcastReceivedMessage(string chatmessage){
 		serverSender.setup(knownClients[i], serverRecvPort + 1);
 		m.setRemoteEndpoint(knownClients[i], serverRecvPort + 1);
 		serverSender.sendMessage(m, false);
-		ofLogVerbose("Server broadcast message " + m.getArgAsString(0) + " to " + m.getRemoteIp()
+		ofLogVerbose("Server broadcast message " + m.getArgAsString(0) + " to " + m.getRemoteHost()
 					 + ":" + ofToString(m.getRemotePort()));
 	}
 }


### PR DESCRIPTION
This is a work-in-progress cleanup/bugfix PR for various things I've noticed with ofxOsc:

* ofxOscMessage: inconsistent type conversions (sometimes we do, sometime we don't arbitrarily)
* ofxOscSender & ofxOscReceiver:  no way to access current host & port info
* formatting is all over the place

As this is a WIP PR, let's discuss but please wait until I/we all agree on the changes before merging.

Details So Far
--------------

* with permission of original author, Damian Stewart, removed explicit license headers and kept simple attribution
* cleaned up and made overall formatting consistent
* added light commenting for all classes & member functions
* added support for "N" nil type as ofxOscArgNone
* only included required headers instead of ofMain.h
* removed "using namespace std" and  removed use of std:: for primitive types (string & int types)
* fixed midi message, time tag, & rgba color int/uint conversion to/from oscpack issues by changing them to unsigned values to match the corresponding oscpack types
* removed bad argument type asserts in favor of better error prints

### ofxOscMessage

* fixed wrong type when adding Timetag arg
* numeric type conversion now works between all numeric types
* removed warning prints for numeric type conversions which do not lose precision (i.e. float -> int32 OK, but int64 -> int32: might be an issue) and kept them for string conversions (slower)
* added getRemoteHost() and deprecated getRemoteIp() (use of *Host used across API)
* promoted shutdown() to public clear() member function
* added getTypeString() for multiple argument type checking:
~~~
    int i = 0; float f = 0.0; string s = "";
    if(message.getTypeString() == "ifs") {
        i = message.getArgAsInt32(0);
        f = message.getArgAsFloat(1);
        s = message.getArgAsString(2);
    } 
~~~
* added stream conversion function for easy printing, prints address and arguments separated by spaces

### ofxOscSender

* added getHost() & getPort()
* promoted shutdown() to public clear() member function
* fixed RgbaColor type not being sent to outgoing packet stream
* fixed wrong type values being sent for non-primitives as oscpack types were not being used (midi message, nil, infinitum, time tag, etc)

### ofxOscReceiver

* added getPort()
* promoted shutdown() to public clear() member function
* added isListening()
* listener can be restarted with current port value when calling setup() with a 0 
* added setup() start arg to allow setting port value without starting thread