### PR TITLE
Fix for gles/customEGLWindowSettingsExample core dump

### DIFF
--- a/examples/gles/customEGLWindowSettingsExample/src/main.cpp
+++ b/examples/gles/customEGLWindowSettingsExample/src/main.cpp
@@ -4,21 +4,20 @@
 
 //========================================================================
 int main( ){
-
 	ofAppEGLWindow::Settings settings;
 
 	settings.eglWindowOpacity = 127;
-        settings.frameBufferAttributes[EGL_DEPTH_SIZE]   = 0; // 0 bits for depth
-        settings.frameBufferAttributes[EGL_STENCIL_SIZE] = 0; // 0 bits for stencil
-	
-	ofAppEGLWindow window;
-        window.setup(settings);
+	settings.frameBufferAttributes[EGL_DEPTH_SIZE]   = 0; // 0 bits for depth
+	settings.frameBufferAttributes[EGL_STENCIL_SIZE] = 0; // 0 bits for stencil
 
-	ofSetupOpenGL(&window, 1024,768, OF_FULLSCREEN);// <-------- setup the GL context
+	settings.width = 1024;
+	settings.height = 768;
+	settings.windowMode = OF_FULLSCREEN;
+	ofCreateWindow(settings);			// <-------- setup the GL context
 
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:
-	ofRunApp( new ofApp());
+	ofRunApp(new ofApp());
 
 }


### PR DESCRIPTION
Old way of setting up the window caused a core dump.
This is a fix for #5483 