### PR TITLE
Settings for EGLWindow were getting lost.

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -60,8 +60,10 @@ public:
 	static bool needsPolling(){ return true; }
 	static void pollEvents();
 
+	using ofAppBaseGLESWindow::setup;
 	void setup(const Settings & settings);
 	void setup(const ofGLESWindowSettings & settings);
+
 	void update();
 	void draw();
 	void close();


### PR DESCRIPTION
When setup(const ofWindowSettings &) was called, it was expected
that the inherited setup(const ofWindowSettings &) method would be called.
But it was not.

Instead, a temporary of type ofGLESWindowSettings was being created
and setup(const ofGLESWindowSettings &) was being called.
When the temporary was created, the EGL settings were lost.

By adding a "using" statement, the proper method is called.

This is a fix for #5485