### PR TITLE
Fixed typo when removing listeners on buttons

### DIFF
--- a/addons/ofxGui/src/ofxButton.h
+++ b/addons/ofxGui/src/ofxButton.h
@@ -25,7 +25,7 @@ public:
 
 	template<class ListenerClass, typename ListenerMethod>
 	void removeListener(ListenerClass * listener, ListenerMethod method){
-		value.addListener(listener,method);
+		value.removeListener(listener,method);
 	}
 	virtual ofAbstractParameter & getParameter();
 


### PR DESCRIPTION
This is an obvious typo.  I'm not sure if you want a bug report.
I can make one if needed.

Typo introduced in 3337737fc571f2ff86a4673b40f951201d893e3a