### PR TITLE
ofxAndroid - bug fix in pause/resume that caused random crashes

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycle.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycle.java
@@ -278,24 +278,34 @@ public class OFAndroidLifeCycle
 	
 	public static void glResume(ViewGroup glContainer)
 	{
-		View glView = getGLView();
-		glView.setVisibility(View.INVISIBLE);
-		ViewGroup parent = (ViewGroup)glView.getParent();
-		if(parent != glContainer){
-			if(parent != null){
-				Log.d(TAG, "remove surface");
-				parent.removeView(glView);
-			}
-			glContainer.addView(glView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-			Log.d(TAG, "addView surface");
-		}
 		Log.d(TAG, "glResume");
+		
+		OFGLSurfaceView glView = getGLView();
+		glView.setVisibility(View.INVISIBLE);
+			
+		glContainer.addView(glView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+		Log.d(TAG, "addView surface");
+		
+		glView.onResume();
+		
 		pushState(State.resume);
 	}
 	
 	public static void glPause()
 	{
 		Log.d(TAG, "glPause");
+		
+		OFGLSurfaceView glView = getGLView();
+		
+		glView.onPause();
+		
+		ViewGroup parent = (ViewGroup)glView.getParent();
+		
+		if(parent != null){
+			Log.d(TAG, "remove surface");
+			parent.removeView(glView);
+		}
+		
 		pushState(State.pause);
 	}
 	

--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycleHelper.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidLifeCycleHelper.java
@@ -233,7 +233,6 @@ public class OFAndroidLifeCycleHelper
 			public void run() {
 				OFAndroid.enableTouchEvents();
 				OFAndroid.enableOrientationChangeEvents();
-				glView.onResume();
 				synchronized (OFAndroidObject.ofObjects) {
 					for(OFAndroidObject object : OFAndroidObject.ofObjects){
 						object.onResume();
@@ -267,7 +266,6 @@ public class OFAndroidLifeCycleHelper
 						object.onPause();
 					}
 				}
-				OFAndroidLifeCycle.getGLView().onPause();
 			}
 		});
 		


### PR DESCRIPTION
We found an issue caused by supposedly incorrect handling of onPause/onResume.

It seems that glView.onPause/ onResume should be called synchronously and not later in another thread, and that it's important to call onPause before removing the view and call onResume only after adding the view. 