### PR TITLE
set shader defines to 0 if not using tex, col

### DIFF
--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -330,10 +330,14 @@ namespace{
         header += "#define MAX_LIGHTS " + ofToString(max(1,maxLights)) + "\n";
         if(hasTexture){
             header += "#define HAS_TEXTURE 1\n";
-        }
+		} else {
+			header += "#define HAS_TEXTURE 0\n";
+		}
         if(hasColor){
             header += "#define HAS_COLOR 1\n";
-        }
+		} else {
+			header += "#define HAS_COLOR 0\n";
+		}
         return header;
     }
 


### PR DESCRIPTION
+ materials shaders expect HAS_COLOR and HAS_TEXTURE to be
  defined and to be either 0, or 1.

Closes issue #5523 