### PR TITLE
ofXml: Feature - get name of node

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -183,6 +183,10 @@ std::string ofXml::getValue() const{
 	return this->xml.text().as_string();
 }
 
+std::string ofXml::getName() const{
+	return this->xml.name();
+}
+
 void ofXml::setName(const std::string & name){
 	if(xml==doc->document_element()){
 		xml = doc->append_child(pugi::node_element);

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -153,6 +153,7 @@ public:
 	}
 
 	std::string getValue() const;
+	std::string getName() const;
 
 	template<typename T>
 	void set(const T & value){


### PR DESCRIPTION
Adds the ability for ofXml to obtain the name of the current node (i.e. the name of the tag). This is exposed via ofXml::getName(), returns a String, and is implemented via pugi's xml_node::name() funcion.