### PR TITLE
#1741 of av foundation player adding video streaming

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -89,9 +89,10 @@ bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
 	
 	bool bLoaded = false;
 	
-    if(videoPlayer == nullptr) {
+	if(videoPlayer == nullptr) {
 		// create a new player if its not allocated
 		videoPlayer = [[ofAVFoundationVideoPlayer alloc] init];
+		[videoPlayer setStreaming:bStream];
 		[videoPlayer setWillBeUpdatedExternally:YES];
 	}
 	

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -92,11 +92,10 @@ bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
 	if(videoPlayer == nullptr) {
 		// create a new player if its not allocated
 		videoPlayer = [[ofAVFoundationVideoPlayer alloc] init];
-		[videoPlayer setStreaming:bStream];
 		[videoPlayer setWillBeUpdatedExternally:YES];
 	}
 	
-	bLoaded = [videoPlayer loadWithURL:url async:bAsync];
+	bLoaded = [videoPlayer loadWithURL:url async:bAsync stream:bStream];
 
 	pixels.clear();
 	videoTexture.clear();

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -81,6 +81,7 @@ typedef enum _playerLoopType{
     BOOL bSampleVideo; // default to YES
     BOOL bSampleAudio; // default to NO
 	BOOL bIsUnloaded;
+	BOOL bStream;
 	
 	NSLock* asyncLock;
 	NSCondition* deallocCond;
@@ -161,5 +162,7 @@ typedef enum _playerLoopType{
 - (BOOL)getAutoplay;
 - (void)setWillBeUpdatedExternally:(BOOL)value;
 - (void)close;
+- (void)setStreaming:(BOOL)value;
+
 
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -103,7 +103,7 @@ typedef enum _playerLoopType{
 
 - (BOOL)loadWithFile:(NSString*)file async:(BOOL)bAsync;
 - (BOOL)loadWithPath:(NSString*)path async:(BOOL)bAsync;
-- (BOOL)loadWithURL:(NSURL*)url async:(BOOL)bAsync;
+- (BOOL)loadWithURL:(NSURL*)url async:(BOOL)bAsync stream:(BOOL)isStream;
 - (void)unloadVideoAsync;
 - (void)unloadVideo;
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1366,16 +1366,23 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		value = 0.0;
 #else
 		if (!self.playerItem.canPlayReverse) {
-			NSLog(@"ERROR: can not play backwards: not supported (check your codec)");
+			if (!bStream) {
+				NSLog(@"ERROR: can not play backwards: not supported (check your codec)");
+			} else {
+				NSLog(@"ERROR: can not play backwards a stream");
+			}
+			
 			value = 0.0;
 		}
 		if (self.videoOutput == nil) {
 			NSLog(@"ERROR: can not play backwards: no video output");
 			value = 0.0;
 		}
-		
-		bWasPlayingBackwards = YES;
 #endif
+	}
+	
+	if (value < 0.0) {
+		bWasPlayingBackwards = YES;
 	}
 	
 	speed = value;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -141,15 +141,21 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	NSURL * fileURL = [[NSBundle mainBundle] URLForResource:[fileSplit objectAtIndex:0]
 											  withExtension:[fileSplit objectAtIndex:1]];
 	
-	return [self loadWithURL:fileURL async:bAsync];
+	return [self loadWithURL:fileURL async:bAsync stream:NO];
 }
 
 - (BOOL)loadWithPath:(NSString*)path async:(BOOL)bAsync{
 	NSURL * fileURL = [NSURL fileURLWithPath:path];
-	return [self loadWithURL:fileURL async:bAsync];
+	return [self loadWithURL:fileURL async:bAsync stream:NO];
+}
+
+- (BOOL)loadWithURL:(NSURL*)url async:(BOOL)bAsync stream:(BOOL)isStream {
+	bStream = isStream;
+	return [self loadWithURL:url async:bAsync];
 }
 
 - (BOOL)loadWithURL:(NSURL*)url async:(BOOL)bAsync {
+	
 	
 	NSDictionary *options = @{(id)AVURLAssetPreferPreciseDurationAndTimingKey:@(YES)};
 	AVURLAsset* asset = [AVURLAsset URLAssetWithURL:url options:options];

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1313,7 +1313,13 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (void)setPosition:(float)position {
 	if ([self isReady]) {
-		double time = [self getDurationInSec] * position;
+		
+		double time = position;
+		
+		if (!bStream) {
+			time = [self getDurationInSec] * position;
+		}
+		
 		[self seekToTime:CMTimeMakeWithSeconds(time, NSEC_PER_SEC)];
 	}
 }

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -226,7 +226,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 			}
 			
 			NSArray * videoTracks = [asset tracksWithMediaType:AVMediaTypeVideo];
-			if([videoTracks count] == 0) {
+			if(!bStream && [videoTracks count] == 0) {
 				NSLog(@"no video tracks found.");
 				// reset
 				bReady = _bReady;
@@ -262,24 +262,26 @@ static const void *PlayerRateContext = &ItemStatusContext;
 			self.asset = asset;
 			duration = _duration;
 			
-			// create asset reader
-			BOOL bOk = [self createAssetReaderWithTimeRange:CMTimeRangeMake(kCMTimeZero, duration)];
-			if(bOk == NO) {
-				NSLog(@"problem with creating asset reader.");
-				if(bAsync == NO){
-					dispatch_semaphore_signal(sema);
+			if (!bStream) {
+				// create asset reader
+				BOOL bOk = [self createAssetReaderWithTimeRange:CMTimeRangeMake(kCMTimeZero, duration)];
+				if(bOk == NO) {
+					NSLog(@"problem with creating asset reader.");
+					if(bAsync == NO){
+						dispatch_semaphore_signal(sema);
+					}
+					[asyncLock unlock];
+					return;
 				}
-				[asyncLock unlock];
-				return;
+				
+				AVAssetTrack * videoTrack = [videoTracks objectAtIndex:0];
+				frameRate = videoTrack.nominalFrameRate;
+				videoWidth = [videoTrack naturalSize].width;
+				videoHeight = [videoTrack naturalSize].height;
+				
+				NSLog(@"video file loaded at %li x %li @ %f fps", (long)videoWidth, (long)videoHeight, frameRate);
 			}
 			
-			
-			AVAssetTrack * videoTrack = [videoTracks objectAtIndex:0];
-			frameRate = videoTrack.nominalFrameRate;
-			videoWidth = [videoTrack naturalSize].width;
-			videoHeight = [videoTrack naturalSize].height;
-			
-			NSLog(@"video loaded at %li x %li @ %f fps", (long)videoWidth, (long)videoHeight, frameRate);
 			
 //			currentTime = CMTimeMakeWithSeconds((1.0/frameRate), NSEC_PER_SEC);//kCMTimeZero;
 			currentTime = CMTimeMakeWithSeconds(0.0, NSEC_PER_SEC);//kCMTimeZero;
@@ -813,16 +815,17 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		bNewFrame = NO;
 		return;
 	}
+	
+	
 
 #if !USE_VIDEO_OUTPUT
 	[self updateFromAssetReader];
 #else
 	// get new sample
-	if (self.player.rate > 0.0) {
+	if (!bStream && self.player.rate > 0.0) {
 		// playing forward
 		// pull out frames from assetreader
 		[self updateFromAssetReader];
-		
 	} else {
 		// playing paused or playing backwards
 		// get samples from videooutput
@@ -846,14 +849,22 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		bNewFrame = YES;
 		currentTime = time;
 		
+		// get buffer
 		CVPixelBufferRef buffer = [self.videoOutput copyPixelBufferForItemTime:time itemTimeForDisplay:NULL];
+		
+		// set videosize in case it is not set yet
+		if (videoWidth == 0 || videoHeight == 0) {
+			CGSize presentationSize = _playerItem.presentationSize;
+			videoWidth = presentationSize.width;
+			videoHeight = presentationSize.height;
+		}		
 		
 		// create or update video format description
 		if (!_videoInfo || !CMVideoFormatDescriptionMatchesImageBuffer(_videoInfo, buffer)) {
 			if (_videoInfo) {
 				CFRelease(_videoInfo);
 				_videoInfo = nil;
-			}
+			}		
 			err = CMVideoFormatDescriptionCreateForImageBuffer(NULL, buffer, &_videoInfo);
 		}
 		if (err) {
@@ -986,7 +997,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		  ((CMTimeCompare(videoSampleTime, currentTime) == -1) ))       // timestamp is less then currentTime.
 		   
 	{
-		CMSampleBufferRef videoBufferTemp;
+		CMSampleBufferRef videoBufferTemp = nil;
 
 		@try {
 			videoBufferTemp = [self.assetReaderVideoTrackOutput copyNextSampleBuffer];
@@ -1184,7 +1195,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	time = CMTimeMaximum(time, kCMTimeZero);
 	time = CMTimeMinimum(time, duration);
 	
-	[self createAssetReaderWithTimeRange:CMTimeRangeMake(time, duration)];
+	if (!bStream && (CMTimeCompare(time, videoSampleTime) < 0)) {
+		// if jumping back in time
+		[self createAssetReaderWithTimeRange:CMTimeRangeMake(time, duration)];
+	}
 	
 	// set reader to real requested time
 	[_player seekToTime:time
@@ -1352,7 +1366,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		return;
 	}
 	
-	if (!bSeeking && bWasPlayingBackwards && value > 0.0) {
+	if (!bStream && !bSeeking && bWasPlayingBackwards && value > 0.0) {
 		// create assetReaders if we played backwards earlier
 		[self createAssetReaderWithTimeRange:CMTimeRangeMake(currentTime, duration)];
 		bWasPlayingBackwards = NO;
@@ -1403,6 +1417,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (void)setWillBeUpdatedExternally:(BOOL)value {
 	bWillBeUpdatedExternally = value;
+}
+
+- (void)setStreaming:(BOOL)value {
+	bStream = value;
 }
 
 @end

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1313,13 +1313,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (void)setPosition:(float)position {
 	if ([self isReady]) {
-		
-		double time = position;
-		
-		if (!bStream) {
-			time = [self getDurationInSec] * position;
-		}
-		
+		double time = [self getDurationInSec] * position;
 		[self seekToTime:CMTimeMakeWithSeconds(time, NSEC_PER_SEC)];
 	}
 }

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -84,6 +84,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		// do not sample audio by default
 		// we are lacking interfaces for audiodata
 		bSampleAudio = NO;
+		
+		bStream = NO;
 	}
 	return self;
 }


### PR DESCRIPTION
`ofBaseVideoPlayer` only offers `setPosition` which needs the duration of the media.
in case of a stream we do not have a duration, therefore setting the position (or frame) will fail.