### PR TITLE
Fix broken function signature.

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -372,11 +372,11 @@ int ofLoadURLAsync(const string&  url, const string&  name){
 	return getFileLoader().getAsync(url,name);
 }
 
-ofHttpResponse ofSaveURLTo(const string& url, const string& path){
+ofHttpResponse ofSaveURLTo(const string& url, const std::filesystem::path& path){
 	return getFileLoader().saveTo(url,path);
 }
 
-int ofSaveURLAsync(const string& url, const string& path){
+int ofSaveURLAsync(const string& url, const std::filesystem::path& path){
 	return getFileLoader().saveAsync(url,path);
 }
 


### PR DESCRIPTION
This is probably not covered by a test case, else it would have been found.

Basically, cpp doesn't match .h.