### PR TITLE
fix issue with ofLight crashing during app exit

### DIFF
--- a/libs/openFrameworks/gl/ofLight.cpp
+++ b/libs/openFrameworks/gl/ofLight.cpp
@@ -77,11 +77,13 @@ ofLight::Data::Data(){
 
 ofLight::Data::~Data(){
 	if(glIndex==-1) return;
-	ofGetGLRenderer()->setLightAmbientColor(glIndex,ofColor(0,0,0,255));
-	ofGetGLRenderer()->setLightDiffuseColor(glIndex,ofColor(0,0,0,255));
-	ofGetGLRenderer()->setLightSpecularColor(glIndex,ofColor(0,0,0,255));
-	ofGetGLRenderer()->setLightPosition(glIndex,glm::vec4(0,0,1,0));
-	ofGetGLRenderer()->disableLight(glIndex);
+	if ( auto r = rendererP.lock() ){
+		r->setLightAmbientColor( glIndex, ofColor( 0, 0, 0, 255 ) );
+		r->setLightDiffuseColor( glIndex, ofColor( 0, 0, 0, 255 ) );
+		r->setLightSpecularColor( glIndex, ofColor( 0, 0, 0, 255 ) );
+		r->setLightPosition( glIndex, glm::vec4( 0, 0, 1, 0 ) );
+		r->disableLight( glIndex );
+	}
 }
 
 //----------------------------------------
@@ -118,6 +120,7 @@ void ofLight::setup() {
 		}
 		if( bLightFound ){
             // run this the first time, since it was not found before //
+			data->rendererP = ofGetGLRenderer();
             onPositionChanged();
             setAmbientColor( getAmbientColor() );
             setDiffuseColor( getDiffuseColor() );
@@ -142,13 +145,17 @@ void ofLight::enable() {
 	data->isEnabled = true;
     onPositionChanged(); // update the position //
 	onOrientationChanged();
-	ofGetGLRenderer()->enableLight(data->glIndex);
+	if ( auto r = data->rendererP.lock() ){
+		r->enableLight( data->glIndex );
+	}
 }
 
 //----------------------------------------
 void ofLight::disable() {
 	data->isEnabled = false;
-	ofGetGLRenderer()->disableLight(data->glIndex);
+	if ( auto r = data->rendererP.lock() ){
+		r->disableLight( data->glIndex );
+	}
 }
 
 //----------------------------------------
@@ -186,7 +193,9 @@ bool ofLight::getIsSpotlight() const{
 //----------------------------------------
 void ofLight::setSpotlightCutOff( float spotCutOff ) {
     data->spotCutOff = CLAMP(spotCutOff, 0, 90);
-    ofGetGLRenderer()->setLightSpotlightCutOff(data->glIndex, spotCutOff);
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightSpotlightCutOff( data->glIndex, spotCutOff );
+	}
 }
 
 //----------------------------------------
@@ -200,7 +209,9 @@ float ofLight::getSpotlightCutOff() const{
 //----------------------------------------
 void ofLight::setSpotConcentration( float exponent ) {
     data->exponent = CLAMP(exponent, 0, 128);
-	ofGetGLRenderer()->setLightSpotConcentration(data->glIndex, exponent);
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightSpotConcentration( data->glIndex, exponent );
+	}
 }
 
 //----------------------------------------
@@ -227,8 +238,9 @@ void ofLight::setAttenuation( float constant, float linear, float quadratic ) {
 	data->attenuation_constant    = constant;
 	data->attenuation_linear      = linear;
 	data->attenuation_quadratic   = quadratic;
-
-    ofGetGLRenderer()->setLightAttenuation(data->glIndex, constant, linear, quadratic);
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightAttenuation( data->glIndex, constant, linear, quadratic );
+	}
 }
 
 //----------------------------------------
@@ -264,19 +276,26 @@ int ofLight::getType() const{
 //----------------------------------------
 void ofLight::setAmbientColor(const ofFloatColor& c) {
 	data->ambientColor = c;
-	ofGetGLRenderer()->setLightAmbientColor(data->glIndex, c);
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightAmbientColor( data->glIndex, c );
+	}
 }
 
 //----------------------------------------
 void ofLight::setDiffuseColor(const ofFloatColor& c) {
 	data->diffuseColor = c;
-	ofGetGLRenderer()->setLightDiffuseColor(data->glIndex, c);
+
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightDiffuseColor( data->glIndex, c );
+	}
 }
 
 //----------------------------------------
 void ofLight::setSpecularColor(const ofFloatColor& c) {
 	data->specularColor = c;
-	ofGetGLRenderer()->setLightSpecularColor(data->glIndex, c);
+	if ( auto r = data->rendererP.lock() ){
+		r->setLightSpecularColor( data->glIndex, c );
+	}
 }
 
 //----------------------------------------
@@ -320,7 +339,9 @@ void ofLight::onPositionChanged() {
 	// if we are a positional light and not directional, update light position
 	if(getIsSpotlight() || getIsPointLight() || getIsAreaLight()) {
 		data->position = {getGlobalPosition().x, getGlobalPosition().y, getGlobalPosition().z, 1.f};
-		ofGetGLRenderer()->setLightPosition(data->glIndex, data->position);
+		if ( auto r = data->rendererP.lock() ){
+			r->setLightPosition( data->glIndex, data->position );
+		}
 	}
 }
 
@@ -331,12 +352,16 @@ void ofLight::onOrientationChanged() {
 		// if we are a directional light and not positional, update light position (direction)
 		auto lookAtDir = glm::normalize(getGlobalOrientation() * glm::vec4(0,0,-1, 1)).xyz();
 		data->position = {lookAtDir.x,lookAtDir.y,lookAtDir.z,0.f};
-		ofGetGLRenderer()->setLightPosition(data->glIndex,data->position);
+		if ( auto r = data->rendererP.lock() ){
+			r->setLightPosition( data->glIndex, data->position );
+		}
 	}else if(getIsSpotlight() || getIsAreaLight()) {
 		// determines the axis of the cone light
 		auto lookAtDir = glm::normalize(getGlobalOrientation() * glm::vec4(0,0,-1, 1)).xyz();
 		data->direction = lookAtDir;
-		ofGetGLRenderer()->setLightSpotDirection(data->glIndex, glm::vec4(data->direction, 0.0f));
+		if ( auto r = data->rendererP.lock() ){
+			r->setLightSpotDirection( data->glIndex, glm::vec4( data->direction, 0.0f ) );
+		}
 	}
 	if(getIsAreaLight()){
 		data->up = getUpDir();

--- a/libs/openFrameworks/gl/ofLight.h
+++ b/libs/openFrameworks/gl/ofLight.h
@@ -102,6 +102,8 @@ public:
 	    float height;
 		glm::vec3 up;
 		glm::vec3 right;
+		/// weak link back to renderer for which this light was created/setup
+		std::weak_ptr<ofBaseGLRenderer> rendererP;
 	};
 	
 private:


### PR DESCRIPTION
Upon destruction `ofLight` called a global method to retrieve the current renderer. In most cases this is legit, but upon app teardown the renderer might have already been destroyed before to the `ofLight` object, which could lead to `BAD_ACCESS` errors when closing apps using `ofLight`. 

As this is an issue within `ofLight`, it affects the programmable as well as the fixed function renderers.

+ This PR suggests using a `weak_ptr` inside the `ofLight`'s `data` member to keep a non-owning link back from the light to the renderer.
+  This allows the light to check whether the renderer is still alive before calling methods on it.
+  This should also accelerate access to the renderer as the renderer itself doesn't need to be resolved on every call, only the `weak_ptr` locked.

Closes Issue #5522