### PR TITLE
Markdown heading fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ openFrameworks is a C++ toolkit for creative coding.  If you are new to OF, welc
 
 [![Slack Status](https://ofslack.herokuapp.com/badge.svg)](https://ofslack.herokuapp.com)
 
-##Build status
+## Build status
 
 Linux, OSX, iOS and Android     [![Build Status](https://travis-ci.org/openframeworks/openFrameworks.svg?branch=master)](https://travis-ci.org/openframeworks/openFrameworks)
 


### PR DESCRIPTION
I found a couple areas where there was no space after the hashtag, thus making the markdown for headings not work. I'm going through fixing them.