### PR TITLE
#5554 ofXml: adds load(const ofBuffer&)

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -23,6 +23,17 @@ bool ofXml::load(const std::filesystem::path & file){
 	}
 }
 
+bool ofXml::load(const ofBuffer & buffer){
+	auto auxDoc = std::make_shared<pugi::xml_document>();
+	if(auxDoc->load_file(buffer.getData())){
+		doc = auxDoc;
+		xml = doc->root();
+		return true;
+	}else{
+		return false;
+	}
+}
+
 bool ofXml::parse(const std::string & xmlStr){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
 	if(auxDoc->load(xmlStr.c_str())){

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -24,14 +24,7 @@ bool ofXml::load(const std::filesystem::path & file){
 }
 
 bool ofXml::load(const ofBuffer & buffer){
-	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load_file(buffer.getData())){
-		doc = auxDoc;
-		xml = doc->root();
-		return true;
-	}else{
-		return false;
-	}
+	return parse(buffer.getText());
 }
 
 bool ofXml::parse(const std::string & xmlStr){

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -95,6 +95,7 @@ public:
 	ofXml();
 
 	bool load(const std::filesystem::path & file);
+	bool load(const ofBuffer & buffer);
 	bool parse(const std::string & xmlStr);
 	bool save(const std::filesystem::path & file) const;
 	std::string toString(const std::string & indent = "\t") const;


### PR DESCRIPTION
In the old ofXml it was called `loadFromBuffer`, but I named it the same way `ofImage` does and added an `load(const ofBuffer& buffer)` function.