### PR TITLE
ofxGui: add color picker

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -62,7 +62,6 @@ class ofxBaseGui {
 		static void setDefaultWidth(int width);
 		static void setDefaultHeight(int height);
 
-		virtual ofAbstractParameter & getParameter() = 0;
 		static void loadFont(const std::string& filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, int dpi = 0);
 		static void setUseTTF(bool bUseTTF);
 
@@ -70,23 +69,26 @@ class ofxBaseGui {
 		void unregisterMouseEvents();
 
 		virtual void sizeChangedCB();
-		void setParent(ofxBaseGui * parent);
+		virtual void setParent(ofxBaseGui * parent);
 		ofxBaseGui * getParent();
 
+		virtual ofAbstractParameter & getParameter() = 0;
 		virtual bool mouseMoved(ofMouseEventArgs & args) = 0;
 		virtual bool mousePressed(ofMouseEventArgs & args) = 0;
 		virtual bool mouseDragged(ofMouseEventArgs & args) = 0;
 		virtual bool mouseReleased(ofMouseEventArgs & args) = 0;
 		virtual bool mouseScrolled(ofMouseEventArgs & args) = 0;
-		virtual void mouseEntered(ofMouseEventArgs & args){
+		virtual void mouseEntered(ofMouseEventArgs &){
 		}
-		virtual void mouseExited(ofMouseEventArgs & args){
+		virtual void mouseExited(ofMouseEventArgs &){
 		}
 
 	protected:
 		virtual void render() = 0;
-		bool isGuiDrawing();
 		virtual bool setValue(float mx, float my, bool bCheckBounds) = 0;
+		virtual void generateDraw() = 0;
+
+		bool isGuiDrawing();
 		void bindFontTexture();
 		void unbindFontTexture();
 		ofMesh getTextMesh(const std::string & text, float x, float y);
@@ -120,7 +122,6 @@ class ofxBaseGui {
 		static void loadStencilFromHex(ofImage & img, unsigned char * data);
 
 		void setNeedsRedraw();
-		virtual void generateDraw() = 0;
 
 	private:
 		bool needsRedraw;

--- a/addons/ofxGui/src/ofxColorPicker.cpp
+++ b/addons/ofxGui/src/ofxColorPicker.cpp
@@ -1,0 +1,488 @@
+//
+//  ofxColorPicker.cpp
+//  ofxColorPicker
+//
+//  Based on ofxColorPicker by Lukasz Karluk on 13/08/2015.
+//
+//
+
+#include "ofxColorPicker.h"
+#include "ofGraphics.h"
+
+
+namespace {
+constexpr int COLOR_WHEEL_RES = 200;
+
+struct PolCord {
+	float angle;
+	float radius;
+};
+
+PolCord getPolarCoordinate(const glm::vec2 & p, float radius){
+
+	float px = p.x - radius;						// point x from center.
+	float py = p.y - radius;						// point x from center.
+	float pl = sqrt(px * px + py * py);     // point length from center.
+	float pa = atan2(px, py);				// point angle around center.
+
+	pa *= RAD_TO_DEG;
+	pa -= 90;
+	pl /= radius;
+
+	PolCord pc;
+	pc.angle = pa;
+	pc.radius = pl;
+
+	return pc;
+}
+
+glm::vec2 getPoint(float a, float r){
+	glm::vec2 p;
+	p.x = r * cos(-a * DEG_TO_RAD);
+	p.y = r * sin(-a * DEG_TO_RAD);
+
+	return p;
+}
+
+float saturate(float v){
+	return std::min(1.f, std::max(0.f, v));
+}
+
+template<class ColorType>
+ofColor_<ColorType> getCircularColor(float angle, float radius, float scale){
+	radius = saturate(radius);
+
+	angle = ofWrap(angle, 0, 360);
+
+	float da;
+
+	ofColor_<ColorType> c;
+
+	if(angle < 60) {
+
+		da  = angle / 60;
+		c.r = c.limit() * scale;
+		c.g = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.b = c.limit() * (1 - radius) * scale;
+		c.a = c.limit();
+
+	} else if(angle < 120) {
+
+		da  = (120 - angle) / 60;
+		c.r = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.g = c.limit() * scale;
+		c.b = c.limit() * (1 - radius) * scale;
+		c.a = c.limit();
+
+	} else if(angle < 180) {
+
+		da  = 1 - (180 - angle) / 60;
+		c.r = c.limit() * (1 - radius) * scale;
+		c.g = c.limit() * scale;
+		c.b = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.a = c.limit();
+
+	} else if(angle < 240) {
+
+		da  = (240 - angle) / 60;
+		c.r = c.limit() * (1 - radius) * scale;
+		c.g = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.b = c.limit() * scale;
+		c.a = c.limit();
+
+	} else if(angle < 300) {
+
+		da  = 1 - (300 - angle) / 60;
+		c.r = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.g = c.limit() * (1 - radius) * scale;
+		c.b = c.limit() * scale;
+		c.a = c.limit();
+
+	} else if(angle <= 360) {
+
+		da  = (360 - angle) / 60;
+		c.r = c.limit() * scale;
+		c.g = c.limit() * (1 - radius) * scale;
+		c.b = c.limit() * (da + (1 - da) * (1 - radius)) * scale;
+		c.a = c.limit();
+	}
+
+	return c;
+}
+
+ofMesh rectangle(const ofRectangle & r, const ofFloatColor & c){
+	ofMesh mesh;
+	mesh.addVertex(r.position);
+	mesh.addVertex(glm::vec3(r.x + r.width, r.y, 0));
+	mesh.addVertex(glm::vec3(r.x + r.width, r.y + r.height, 0));
+
+	mesh.addVertex(glm::vec3(r.x + r.width, r.y + r.height, 0));
+	mesh.addVertex(glm::vec3(r.x, r.y + r.height, 0));
+	mesh.addVertex(glm::vec3(r.x, r.y, 0));
+
+	mesh.addColor(c);
+	mesh.addColor(c);
+	mesh.addColor(c);
+
+	mesh.addColor(c);
+	mesh.addColor(c);
+	mesh.addColor(c);
+
+	return mesh;
+}
+}
+
+template<class ColorType>
+ofxColorPicker_<ColorType>::ofxColorPicker_() {
+	colorScale = 1.0;
+	colorRadius = 0;
+	colorAngle = 0;
+
+	setShape(b);
+}
+
+template<class ColorType>
+ofxColorPicker_<ColorType>::ofxColorPicker_(ofParameter<ofColor_<ColorType>> parameter, float w, float h){
+	colorScale = 1.0;
+	colorRadius = 0;
+	colorAngle = 0;
+
+	setup(parameter, w, h);
+}
+
+template<class ColorType>
+ofxColorPicker_<ColorType> * ofxColorPicker_<ColorType>::setup(ofParameter<ofColor_<ColorType>> parameter, float w, float h){
+	this->color.makeReferenceTo(parameter);
+
+	listener = color.newListener([this](ofColor_<ColorType> & c){
+		if(bSettingColor){
+			return;
+		}
+
+		ofFloatColor cf = c;
+		float hue, saturation, brightness;
+		cf.getHsb(hue,saturation,brightness);
+		colorScale = brightness;
+		colorRadius = saturation;
+		colorAngle = 360.f * hue;
+		setNeedsRedraw();
+	});
+	setShape(b.x, b.y, w, h);
+	return this;
+}
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::setShape(float x, float y, float w, float h) {
+	b.x = x;
+	b.y = y;
+	b.width = w;
+	b.height = h;
+
+	setNeedsRedraw();
+}
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::setShape(ofRectangle r){
+	setShape(r.x, r.y, r.width, r.height);
+}
+
+template<class ColorType>
+ofMesh ofxColorPicker_<ColorType>::getBackground(){
+	return rectangle(rectBackground, thisFillColor);
+}
+
+template<class ColorType>
+ofMesh ofxColorPicker_<ColorType>::getColorPoint(){
+	int x = rectColorWheel.x;
+	int y = rectColorWheel.y;
+	int w = rectColorWheel.width;
+	int h = rectColorWheel.height;
+
+	colorPoint = getPoint(colorAngle, colorRadius * colorWheelRadius) + glm::vec2(colorWheelRadius);
+	colorPoint.x += x;
+	colorPoint.y += y;
+
+	colorPoint.x = ofClamp( colorPoint.x, x, x + w );
+	colorPoint.y = ofClamp( colorPoint.y, y, y + h );
+
+	ofPolyline circle;
+	circle.arc(glm::vec3(0), 1, 1, 0, 360, true, 20);
+	ofMesh meshColorPoint;
+
+	auto center = glm::vec3(colorPoint, 0);
+	for(size_t i=0;i<circle.size();i++){
+		auto next = (i + 1) % circle.size();
+		meshColorPoint.addVertex(center);
+		meshColorPoint.addVertex(center + circle[i] * 4);
+		meshColorPoint.addVertex(center + circle[next] * 4);
+
+		meshColorPoint.addColor(ofFloatColor::black);
+		meshColorPoint.addColor(ofFloatColor::black);
+		meshColorPoint.addColor(ofFloatColor::black);
+	}
+	for(size_t i=0;i<circle.size();i++){
+		auto next = (i + 1) % circle.size();
+		meshColorPoint.addVertex(center);
+		meshColorPoint.addVertex(center + circle[i] * 2);
+		meshColorPoint.addVertex(center + circle[next] * 2);
+
+		meshColorPoint.addColor(ofFloatColor::white);
+		meshColorPoint.addColor(ofFloatColor::white);
+		meshColorPoint.addColor(ofFloatColor::white);
+	}
+	return meshColorPoint;
+}
+
+template<class ColorType>
+ofMesh ofxColorPicker_<ColorType>::getColorWheel() {
+	ofPolyline circle;
+	circle.arc(glm::vec3(0), 1, 1, 0, 360, false, COLOR_WHEEL_RES);
+
+	ofMesh meshColorWheel;
+	auto center = glm::vec3(rectColorWheel.x + colorWheelRadius, rectColorWheel.y + colorWheelRadius, 0);
+	for(size_t i=0;i<circle.size();i++){
+		auto next = (i + 1) % circle.size();
+		meshColorWheel.addVertex(center);
+		meshColorWheel.addVertex(center + circle[i] * colorWheelRadius);
+		meshColorWheel.addVertex(center + circle[next] * colorWheelRadius);
+
+		int j = i % COLOR_WHEEL_RES;
+		float p = j / (float)COLOR_WHEEL_RES;
+		float a = p * TWO_PI;
+
+		ofFloatColor c0 = getCircularColor<float>(a * RAD_TO_DEG, 1.0, colorScale);
+		meshColorWheel.addColor(ofFloatColor::white);
+		meshColorWheel.addColor(c0);
+		meshColorWheel.addColor(c0);
+	}
+    
+	return meshColorWheel;
+}
+
+template<class ColorType>
+ofMesh ofxColorPicker_<ColorType>::getColorScaleBar() {
+    int padding = 2;
+	int x = rectColorScaleBar.x;
+	int y = rectColorScaleBar.y;
+	int w = rectColorScaleBar.width;
+	int h = rectColorScaleBar.height;
+
+
+	ofMesh meshColorScaleBar;
+
+	auto borderColor = ofColor(149, 255);
+	meshColorScaleBar.append(rectangle(rectColorScaleBar, borderColor));
+
+
+	int rx, ry;
+	rx = x + 2;
+	ry = y + 2;
+
+	w = rectColorScaleBar.width - padding * 2;
+	h = rectColorScaleBar.height - padding * 2;
+	rx = rectColorScaleBar.x + 2;
+	ry = rectColorScaleBar.y + 2;
+	ofRectangle colorBar(rx, ry, w, h);
+	meshColorScaleBar.append(rectangle(colorBar, ofFloatColor::white));
+	ofFloatColor c0 = ofFloatColor::black;
+	ofFloatColor c1 = getCircularColor<float>(colorAngle, colorRadius, 1.0);
+
+	meshColorScaleBar.setColor(6, c1);
+	meshColorScaleBar.setColor(7, c1);
+	meshColorScaleBar.setColor(8, c0);
+
+	meshColorScaleBar.setColor(9, c0);
+	meshColorScaleBar.setColor(10, c0);
+	meshColorScaleBar.setColor(11, c1);
+
+	//--
+
+	int rw = w;
+	int rh = h - 4;
+	int bx, by;
+	int ch = 3;
+	int cy = (1. - colorScale) * (rh + ch);
+
+	//-- grey rect for handle. bx and by are border values.
+	bx = 4;
+	by = 2;
+	ofRectangle handle(rx - bx, ry + cy - by, rw + bx * 2, ch + by * 2);
+	meshColorScaleBar.append(rectangle(handle, borderColor));
+
+	//-- white rect for handle. bx and by are border values.
+	bx = 3;
+	by = 1;
+	ofRectangle handleBorder(rx - bx, ry + cy - by, rw + bx * 2, ch + by * 2);
+	meshColorScaleBar.append(rectangle(handleBorder, ofFloatColor::white));
+    
+	return meshColorScaleBar;
+}
+
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::setColorScale(float value) {
+    if(colorScale == value) {
+        return;
+    }
+	colorScale = value;
+	bSettingColor = true;
+	color = getCircularColor<ColorType>(colorAngle, colorRadius, colorScale);
+	bSettingColor = false;
+}
+
+template<class ColorType>
+float ofxColorPicker_<ColorType>::getColorScale() {
+    return colorScale;
+}
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::setColorRadius (float value) {
+    colorRadius = value;
+	bSettingColor = true;
+	color = getCircularColor<ColorType>(colorAngle, colorRadius, colorScale);
+	bSettingColor = false;
+}
+
+template<class ColorType>
+float ofxColorPicker_<ColorType>::getColorRadius() {
+    return colorRadius;
+}
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::setColorAngle(float value) {
+    colorAngle = value * 360;
+	bSettingColor = true;
+	color = getCircularColor<ColorType>(colorAngle, colorRadius, colorScale);
+	bSettingColor = false;
+}
+
+template<class ColorType>
+float ofxColorPicker_<ColorType>::getColorAngle() {
+    return colorAngle / 360.0;
+}
+
+
+template<class ColorType>
+ofAbstractParameter & ofxColorPicker_<ColorType>::getParameter(){
+	return color;
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::mouseMoved(ofMouseEventArgs &){
+	return false;
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::mousePressed(ofMouseEventArgs & mouse){
+	if(!isGuiDrawing()){
+		return false;
+	}
+
+	if(rectColorScaleBar.inside(mouse)){
+		state = ChangingScale;
+	}else if(rectColorWheel.inside(mouse)){
+		state = ChangingWheel;
+	}
+
+	return rectBackground.inside(mouse);
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::mouseDragged(ofMouseEventArgs & mouse){
+	if(!isGuiDrawing()){
+		return false;
+	}
+	switch (state) {
+		case ChangingScale:{
+			int relY = mouse.y - rectColorScaleBar.y;
+			float scale = 1.f - saturate(relY / rectColorScaleBar.height);
+			setColorScale(scale);
+
+			setNeedsRedraw();
+			return true;
+		}
+		case ChangingWheel:{
+			auto p = mouse - rectColorWheel.position.xy();
+			auto pc = getPolarCoordinate(p, colorWheelRadius);
+
+			colorAngle	= pc.angle;
+			colorRadius	= saturate(pc.radius);
+
+			bSettingColor = true;
+			color = getCircularColor<ColorType>(colorAngle, colorRadius, colorScale);
+			bSettingColor = false;
+			setNeedsRedraw();
+			return true;
+		}
+		default: return false;
+	}
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::mouseReleased(ofMouseEventArgs &){
+	switch (state) {
+		case ChangingScale:
+		case ChangingWheel:
+			state = Waiting;
+			return true;
+		default:
+			return false;
+	}
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::mouseScrolled(ofMouseEventArgs & mouse){
+	if(rectColorScaleBar.inside(mouse)){
+		colorScale += mouse.scrollY * 0.001;
+		colorScale = saturate(colorScale);
+		setNeedsRedraw();
+		return true;
+	}else{
+		return false;
+	}
+}
+
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::render(){
+	geometry.draw();
+}
+
+template<class ColorType>
+bool ofxColorPicker_<ColorType>::setValue(float mx, float my, bool bCheckBounds){
+	return false;
+}
+
+template<class ColorType>
+void ofxColorPicker_<ColorType>::generateDraw(){
+	int minWH = std::min(b.width, b.height);
+
+	colorWheelRadius = (int)std::min(b.width * 0.5f * 0.75f, b.height * 0.9f);
+	colorWheelPad = (int)(minWH * 0.05);
+
+	rectBackground.x = (int)(b.x);
+	rectBackground.y = (int)(b.y);
+	rectBackground.width = (int)(b.width);
+	rectBackground.height = (int)(b.height);
+
+	rectColorWheel.x = (int)(b.x + colorWheelPad);
+	rectColorWheel.y = (int)(b.y + (rectBackground.height - colorWheelRadius * 2.f) / 2.f);
+	rectColorWheel.width = (int)(colorWheelRadius * 2);
+	rectColorWheel.height = (int)(colorWheelRadius * 2);
+
+	rectColorScaleBar.width = (int)(colorWheelRadius * 0.2);
+	rectColorScaleBar.height = rectColorWheel.height;
+	rectColorScaleBar.x = (int)(rectBackground.getMaxX() - rectColorScaleBar.width - colorWheelPad);
+	rectColorScaleBar.y	= (int)(rectColorWheel.y);
+
+	geometry.clear();
+	geometry.append(getBackground());
+	geometry.append(getColorWheel());
+	geometry.append(getColorPoint());
+	geometry.append(getColorScaleBar());
+}
+
+
+template class ofxColorPicker_<unsigned char>;
+template class ofxColorPicker_<unsigned short>;
+template class ofxColorPicker_<float>;

--- a/addons/ofxGui/src/ofxColorPicker.h
+++ b/addons/ofxGui/src/ofxColorPicker.h
@@ -1,0 +1,80 @@
+//
+//  ofxColorPicker.h
+//  ofxColorPicker
+//
+//  Based on ofxColorPicker by Lukasz Karluk on 13/08/2015.
+//
+//
+
+#pragma once
+
+#include "ofColor.h"
+#include "ofEvents.h"
+#include "ofxBaseGui.h"
+#include "ofxSlider.h"
+
+
+
+template<typename ColorType>
+class ofxColorPicker_: public ofxBaseGui {
+
+public :
+	
+	ofxColorPicker_();
+	ofxColorPicker_(ofParameter<ofColor_<ColorType>> parameter, float w = defaultWidth, float h = defaultWidth / 9. * 16.);
+	ofxColorPicker_ * setup(ofParameter<ofColor_<ColorType>> parameter, float w = defaultWidth, float h = defaultWidth / 9. * 16.);
+
+	void setShape(float x, float y, float w, float h);
+	void setShape(ofRectangle r);
+    
+    void setColorScale(float value);
+    float getColorScale();
+    
+    void setColorRadius(float value);
+    float getColorRadius();
+    
+    void setColorAngle(float value);
+	float getColorAngle();
+
+	ofAbstractParameter & getParameter();
+	
+private :
+	void render();
+	bool setValue(float mx, float my, bool bCheckBounds);
+	void generateDraw();
+
+	ofMesh getBackground();
+	ofMesh getColorPoint();
+	ofMesh getColorWheel();
+	ofMesh getColorScaleBar();
+
+	bool mouseMoved(ofMouseEventArgs & args);
+	bool mousePressed(ofMouseEventArgs & args);
+	bool mouseDragged(ofMouseEventArgs & args);
+	bool mouseReleased(ofMouseEventArgs & args);
+	bool mouseScrolled(ofMouseEventArgs & args);
+
+	glm::vec2 colorPoint;
+    float colorScale;
+    float colorRadius;
+	float colorAngle;
+	bool bSettingColor = false;
+
+    int colorWheelRadius;
+    int colorWheelPad;
+
+	ofRectangle rectBackground;
+	ofRectangle rectColorWheel;
+	ofRectangle rectColorScaleBar;
+
+	ofVboMesh geometry;
+	ofParameter<ofColor_<ColorType>> color;
+
+	enum State{
+		Waiting,
+		ChangingWheel,
+		ChangingScale,
+	}state = Waiting;
+
+	ofEventListener listener;
+};

--- a/addons/ofxGui/src/ofxGui.h
+++ b/addons/ofxGui/src/ofxGui.h
@@ -6,6 +6,7 @@
 #include "ofxPanel.h"
 #include "ofxButton.h"
 #include "ofxLabel.h"
+#include "ofxColorPicker.h"
 
 void ofxGuiSetFont(const string & fontPath,int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=false, int dpi=0);
 void ofxGuiSetBitmapFont();

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -115,6 +115,19 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	return this;
 }
 
+void ofxGuiGroup::setWidthElements(float w){
+	for(std::size_t i = 0; i < collection.size(); i++){
+		collection[i]->setSize(w, collection[i]->getHeight());
+		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
+		ofxGuiGroup * subgroup = dynamic_cast<ofxGuiGroup*>(collection[i]);
+		if(subgroup != nullptr){
+			subgroup->setWidthElements(w * .98);
+		}
+	}
+	sizeChangedCB();
+	setNeedsRedraw();
+}
+
 void ofxGuiGroup::add(ofxBaseGui * element){
 	collection.push_back(element);
 
@@ -143,22 +156,8 @@ void ofxGuiGroup::add(ofxBaseGui * element){
 	setNeedsRedraw();
 }
 
-void ofxGuiGroup::setWidthElements(float w){
-    for(std::size_t i = 0; i < collection.size(); i++){
-		collection[i]->setSize(w, collection[i]->getHeight());
-		collection[i]->setPosition(b.x + b.width - w, collection[i]->getPosition().y);
-		ofxGuiGroup * subgroup = dynamic_cast <ofxGuiGroup *>(collection[i]);
-		if(subgroup != nullptr){
-			subgroup->setWidthElements(w * .98);
-		}
-	}
-	sizeChangedCB();
-	setNeedsRedraw();
-}
-
 void ofxGuiGroup::add(const ofParameterGroup & parameters){
 	ofxGuiGroup * panel = new ofxGuiGroup(parameters);
-	panel->parent = this;
 	add(panel);
 }
 
@@ -409,6 +408,7 @@ void ofxGuiGroup::minimize(){
 		parent->sizeChangedCB();
 	}
 	setNeedsRedraw();
+	onMinimize();
 }
 
 void ofxGuiGroup::maximize(){
@@ -420,6 +420,7 @@ void ofxGuiGroup::maximize(){
 		parent->sizeChangedCB();
 	}
 	setNeedsRedraw();
+	onMaximize();
 }
 
 void ofxGuiGroup::minimizeAll(){
@@ -440,6 +441,18 @@ void ofxGuiGroup::maximizeAll(){
 	}
 }
 
+bool ofxGuiGroup::isMinimized() const{
+	return minimized;
+}
+
+void ofxGuiGroup::onMinimize(){
+
+}
+
+void ofxGuiGroup::onMaximize(){
+
+}
+
 void ofxGuiGroup::sizeChangedCB(){
 	float y;
 	if(parent){
@@ -451,7 +464,11 @@ void ofxGuiGroup::sizeChangedCB(){
 		collection[i]->setPosition(collection[i]->getPosition().x, y + spacing);
 		y += collection[i]->getHeight() + spacing;
 	}
-	b.height = y - b.y;
+	if(minimized){
+		b.height = header + spacing + spacingNextElement + 1 /*border*/;
+	}else{
+		b.height = y - b.y;
+	}
 	if(parent){
 		parent->sizeChangedCB();
 	}

--- a/addons/ofxGui/src/ofxGuiGroup.h
+++ b/addons/ofxGui/src/ofxGuiGroup.h
@@ -39,6 +39,7 @@ class ofxGuiGroup : public ofxBaseGui {
 		void maximize();
 		void minimizeAll();
 		void maximizeAll();
+		bool isMinimized() const;
 
 		void setWidthElements(float w);
 
@@ -72,6 +73,8 @@ class ofxGuiGroup : public ofxBaseGui {
 	protected:
 		virtual void render();
 		virtual bool setValue(float mx, float my, bool bCheck);
+		virtual void onMinimize();
+		virtual void onMaximize();
 
 		float spacing, spacingNextElement;
 		float header;

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -130,31 +130,35 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
     ofxGuiGroup::setup(value.getName(), "", 0, 0);
     parameters.clear();
 
-    const string names[4] = {"r", "g", "b", "a"};
-
-    this->value.makeReferenceTo(value);
-    this->value.addListener(this, & ofxColorSlider_::changeValue);
+	const string names[4] = {"r", "g", "b", "a"};
 
     ofColor_<ColorType> val = value;
     ofColor_<ColorType> min = value.getMin();
     ofColor_<ColorType> max = value.getMax();
 
+	picker.setup(value, width, width * 9. / 11.);
+
     for (int i=0; i<4; i++) {
     	ofParameter<ColorType> p(names[i], val[i], min[i], max[i]);
         add(new ofxSlider<ColorType>(p, width, height));
         p.addListener(this, & ofxColorSlider_::changeSlider);
-        collection[i]->setFillColor(value.get());
+		collection[i]->setFillColor(value.get());
+		collection[i]->setTextColor(p / p.getMax() > 0.75 ? ofFloatColor(0.) : ofFloatColor(1.));
     }
+	add(&picker);
+	picker.getParameter().template cast<ofColor_<ColorType>>().addListener(this, & ofxColorSlider_::changeValue);
 
-    sliderChanging = false;
+
+	sliderChanging = false;
+	minimize();
     return this;
 }
 
 
 template<class ColorType>
 ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(const std::string& controlName, const ofColor_<ColorType> & v, const ofColor_<ColorType> & min, const ofColor_<ColorType> & max, float width, float height){
-    value.set(controlName, v, min, max);
-	return setup(value,width,height);
+	ofParameter<ofColor_<ColorType>> color(controlName, v, min, max);
+	return setup(color,width,height);
 }
 
 template<class ColorType>
@@ -162,14 +166,16 @@ void ofxColorSlider_<ColorType>::changeSlider(const void * parameter, ColorType 
     sliderChanging = true;
     ofParameter<float> & param = *(ofParameter<float>*)parameter;
     int i = parameters.getPosition(param.getName());
-    ofColor_<ColorType> data = value;
+	ofColor_<ColorType> data = picker.getParameter().template cast<ofColor_<ColorType>>();
     data[i] = _value;
-    value = data;
+	picker.getParameter().template cast<ofColor_<ColorType>>() = data;
 
 
     for (int i=0; i<4; i++){
-    	collection[i]->setFillColor(value.get());
-    }
+		collection[i]->setFillColor(data);
+		auto p = parameters[i].template cast<ColorType>();
+		collection[i]->setTextColor(p / p.getMax() > 0.75 ? ofFloatColor(0.) : ofFloatColor(1.));
+	}
     sliderChanging = false;
 }
 
@@ -181,23 +187,41 @@ void ofxColorSlider_<ColorType>::changeValue(ofColor_<ColorType> & value){
     for (int i=0; i<4; i++){
         parameters[i].template cast<ColorType>() = value[i];
     	collection[i]->setFillColor(value);
-    }
+		auto p = parameters[i].template cast<ColorType>();
+		collection[i]->setTextColor(p / p.getMax() > 0.75 ? ofFloatColor(0.) : ofFloatColor(1.));
+	}
 }
 
 template<class ColorType>
 ofAbstractParameter & ofxColorSlider_<ColorType>::getParameter(){
-	return value;
+	return picker.getParameter();
 }
 
 template<class ColorType>
 ofColor_<ColorType> ofxColorSlider_<ColorType>::operator=(const ofColor_<ColorType> & v){
-	value = v;
-	return value;
+	picker.getParameter().template cast<ofColor_<ColorType>>() = v;
+	return picker.getParameter().template cast<ofColor_<ColorType>>();
 }
 
 template<class ColorType>
 ofxColorSlider_<ColorType>::operator const ofColor_<ColorType> & (){
-	return value;
+	return picker.getParameter().template cast<ofColor_<ColorType>>();
+}
+
+template<class ColorType>
+void ofxColorSlider_<ColorType>::onMinimize(){
+	originalHeaderBackground = thisHeaderBackgroundColor;
+	originalHeaderText = thisTextColor;
+	setHeaderBackgroundColor(picker.getParameter().template cast<ofColor_<ColorType>>().get());
+	setTextColor(picker.getColorScale() > 0.5 ? ofFloatColor(0.) : ofFloatColor(1.));
+	setNeedsRedraw();
+}
+
+template<class ColorType>
+void ofxColorSlider_<ColorType>::onMaximize(){
+	setHeaderBackgroundColor(originalHeaderBackground);
+	setTextColor(originalHeaderText);
+	setNeedsRedraw();
 }
 
 template class ofxColorSlider_<unsigned char>;

--- a/addons/ofxGui/src/ofxSliderGroup.h
+++ b/addons/ofxGui/src/ofxSliderGroup.h
@@ -2,6 +2,7 @@
 
 #include "ofxGuiGroup.h"
 #include "ofxSlider.h"
+#include "ofxColorPicker.h"
 
 template<class VecType>
 class ofxVecSlider_ : public ofxGuiGroup {
@@ -49,10 +50,14 @@ public:
 	ofColor_<ColorType> operator=(const ofColor_<ColorType> & v);
 	operator const ofColor_<ColorType> & ();
 protected:
+	void onMinimize();
+	void onMaximize();
     void changeSlider(const void * parameter, ColorType & value);
-    void changeValue(ofColor_<ColorType> & value);
-    ofParameter<ofColor_<ColorType> > value;
+	void changeValue(ofColor_<ColorType> & value);
     bool sliderChanging;
+	ofColor originalHeaderBackground;
+	ofColor originalHeaderText;
+	ofxColorPicker_<ColorType> picker;
 };
 
 typedef ofxColorSlider_<unsigned char> ofxColorSlider;


### PR DESCRIPTION
Based on @julapy ofxColorPicker and used whenever an ofParameter<ofColor> is added to a group.

By default colors now appear minimized since the picker takes a lot of space.
![screenshot from 2017-04-20 17-40-50](https://cloud.githubusercontent.com/assets/48240/25239777/50d81d46-25f1-11e7-95d3-a589027e49ab.png)
