### PR TITLE
new key events:

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -315,6 +315,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 	glfwSetCursorPosCallback(windowP, motion_cb);
 	glfwSetCursorEnterCallback(windowP, entry_cb);
 	glfwSetKeyCallback(windowP, keyboard_cb);	
+	glfwSetCharCallback(windowP, char_cb);
 	glfwSetWindowSizeCallback(windowP, resize_cb);
 	glfwSetWindowCloseCallback(windowP, exit_cb);
 	glfwSetScrollCallback(windowP, scroll_cb);
@@ -1295,17 +1296,115 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int keycode, int scancod
 		case GLFW_KEY_TAB:
 			key = OF_KEY_TAB;
 			break;   
+		case GLFW_KEY_KP_0:
+			key = '0';
+			break;
+		case GLFW_KEY_KP_1:
+			key = '1';
+			break;
+		case GLFW_KEY_KP_2:
+			key = '2';
+			break;
+		case GLFW_KEY_KP_3:
+			key = '3';
+			break;
+		case GLFW_KEY_KP_4:
+			key = '4';
+			break;
+		case GLFW_KEY_KP_5:
+			key = '5';
+			break;
+		case GLFW_KEY_KP_6:
+			key = '6';
+			break;
+		case GLFW_KEY_KP_7:
+			key = '7';
+			break;
+		case GLFW_KEY_KP_8:
+			key = '8';
+			break;
+		case GLFW_KEY_KP_9:
+			key = '9';
+			break;
+		case GLFW_KEY_KP_DIVIDE:
+			key = '/';
+			break;
+		case GLFW_KEY_KP_MULTIPLY:
+			key = '*';
+			break;
+		case GLFW_KEY_KP_SUBTRACT:
+			key = '-';
+			break;
+		case GLFW_KEY_KP_ADD:
+			key = '+';
+			break;
+		case GLFW_KEY_KP_DECIMAL:
+			key = '.';
+			break;
+		case GLFW_KEY_KP_EQUAL:
+			key = '=';
+			break;
 		default:
 			codepoint = keycodeToUnicode(instance, keycode, scancode, mods);
 			key = codepoint;
 			break;
 	}
 
-	if(action == GLFW_PRESS || action == GLFW_REPEAT){
-		instance->events().notifyKeyPressed(key,keycode,scancode,codepoint);
-	}else if (action == GLFW_RELEASE){
-		instance->events().notifyKeyReleased(key,keycode,scancode,codepoint);
+	int modifiers = 0;
+	if(mods & GLFW_KEY_LEFT_SHIFT){
+		modifiers |= OF_KEY_SHIFT;
+		modifiers |= OF_KEY_LEFT_SHIFT;
 	}
+	if(mods & GLFW_KEY_RIGHT_SHIFT){
+		modifiers |= OF_KEY_SHIFT;
+		modifiers |= OF_KEY_RIGHT_SHIFT;
+	}
+	if(mods & GLFW_KEY_LEFT_ALT){
+		modifiers |= OF_KEY_ALT;
+		modifiers |= OF_KEY_LEFT_ALT;
+	}
+	if(mods & GLFW_KEY_RIGHT_ALT){
+		modifiers |= OF_KEY_ALT;
+		modifiers |= OF_KEY_RIGHT_ALT;
+	}
+	if(mods & GLFW_KEY_LEFT_CONTROL){
+		modifiers |= OF_KEY_CONTROL;
+		modifiers |= OF_KEY_LEFT_CONTROL;
+	}
+	if(mods & GLFW_KEY_RIGHT_CONTROL){
+		modifiers |= OF_KEY_CONTROL;
+		modifiers |= OF_KEY_RIGHT_CONTROL;
+	}
+	if(mods & GLFW_KEY_LEFT_CONTROL){
+		modifiers |= OF_KEY_CONTROL;
+		modifiers |= OF_KEY_LEFT_CONTROL;
+	}
+	if(mods & GLFW_KEY_RIGHT_CONTROL){
+		modifiers |= OF_KEY_CONTROL;
+		modifiers |= OF_KEY_RIGHT_CONTROL;
+	}
+	if(mods & GLFW_KEY_LEFT_SUPER){
+		modifiers |= OF_KEY_SUPER;
+		modifiers |= OF_KEY_LEFT_SUPER;
+	}
+	if(mods & GLFW_KEY_RIGHT_SUPER){
+		modifiers |= OF_KEY_SUPER;
+		modifiers |= OF_KEY_RIGHT_SUPER;
+	}
+
+	if(action == GLFW_PRESS || action == GLFW_REPEAT){
+		ofKeyEventArgs keyE(ofKeyEventArgs::Pressed,key,keycode,scancode,codepoint,modifiers);
+		instance->events().notifyKeyEvent(keyE);
+	}else if (action == GLFW_RELEASE){
+		ofKeyEventArgs keyE(ofKeyEventArgs::Released,key,keycode,scancode,codepoint,modifiers);
+		instance->events().notifyKeyEvent(keyE);
+	}
+}
+
+//------------------------------------------------------------
+void ofAppGLFWWindow::char_cb(GLFWwindow* windowP_, uint32_t key){
+	ofAppGLFWWindow * instance = setCurrent(windowP_);
+	instance->events().charEvent.notify(key);
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -175,6 +175,7 @@ private:
 	static void 	motion_cb(GLFWwindow* windowP_, double x, double y);
 	static void 	entry_cb(GLFWwindow* windowP_, int entered);
 	static void 	keyboard_cb(GLFWwindow* windowP_, int key, int scancode, int action, int mods);
+	static void 	char_cb(GLFWwindow* windowP_, uint32_t key);
 	static void 	resize_cb(GLFWwindow* windowP_, int w, int h);
 	static void 	exit_cb(GLFWwindow* windowP_);
 	static void		scroll_cb(GLFWwindow* windowP_, double x, double y);

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -395,6 +395,16 @@ int ofGetWindowHeight(){
 }
 
 //--------------------------------------------------
+std::string ofGetClipboardString(){
+	return mainLoop()->getCurrentWindow()->getClipboardString();
+}
+
+//--------------------------------------------------
+void ofSetClipboardString(const std::string & str){
+	mainLoop()->getCurrentWindow()->setClipboardString(str);
+}
+
+//--------------------------------------------------
 bool ofDoesHWOrientation(){
 	return mainLoop()->getCurrentWindow()->doesHWOrientation();
 }

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -80,6 +80,9 @@ int 		ofGetHeight();
 int 		ofGetWindowWidth();			// ofGetWindowWidth is correct for actual window coordinates - so doesn't change with orientation.
 int 		ofGetWindowHeight();
 
+std::string ofGetClipboardString();
+void		ofSetClipboardString(const std::string & str);
+
 /// \returns a random number between 0 and the width of the window.
 float ofRandomWidth();
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -279,82 +279,89 @@ bool ofCoreEvents::notifyDraw(){
 
 //------------------------------------------
 bool ofCoreEvents::notifyKeyPressed(int key, int keycode, int scancode, uint32_t codepoint){
-	// FIXME: modifiers are being reported twice, for generic and for left/right
-	// add operators to the arguments class so it can be checked for both
-	bool attended = false;
-    if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
-        pressedKeys.insert(OF_KEY_CONTROL);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_CONTROL);
-		attended = ofNotifyEvent( keyPressed, keyEventArgs );
-    }
-    else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
-        pressedKeys.insert(OF_KEY_SHIFT);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_SHIFT);
-		attended = ofNotifyEvent( keyPressed, keyEventArgs );
-    }
-    else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
-        pressedKeys.insert(OF_KEY_ALT);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_ALT);
-		attended = ofNotifyEvent( keyPressed, keyEventArgs );
-    }
-    else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
-        pressedKeys.insert(OF_KEY_SUPER);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,OF_KEY_SUPER);
-		attended = ofNotifyEvent( keyPressed, keyEventArgs );
-    }
-
-	pressedKeys.insert(key);
-	if(!attended){
-		ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,key,keycode,scancode,codepoint);
-		return ofNotifyEvent( keyPressed, keyEventArgs );
-	}else{
-		return attended;
-	}
+	ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Pressed,key,keycode,scancode,codepoint,0);
+	return notifyKeyEvent(keyEventArgs);
 }
 
 //------------------------------------------
 bool ofCoreEvents::notifyKeyReleased(int key, int keycode, int scancode, uint32_t codepoint){
-	// FIXME: modifiers are being reported twice, for generic and for left/right
-	// add operators to the arguments class so it can be checked for both
-	bool attended = false;
-    if(key == OF_KEY_RIGHT_CONTROL || key == OF_KEY_LEFT_CONTROL){
-        pressedKeys.erase(OF_KEY_CONTROL);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_CONTROL);
-		attended = ofNotifyEvent( keyReleased, keyEventArgs );
-    }
-    else if(key == OF_KEY_RIGHT_SHIFT || key == OF_KEY_LEFT_SHIFT){
-        pressedKeys.erase(OF_KEY_SHIFT);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_SHIFT);
-		attended = ofNotifyEvent( keyReleased, keyEventArgs );
-    }
-    else if(key == OF_KEY_LEFT_ALT || key == OF_KEY_RIGHT_ALT){
-        pressedKeys.erase(OF_KEY_ALT);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_ALT);
-		attended = ofNotifyEvent( keyReleased, keyEventArgs );
-    }
-    else if(key == OF_KEY_LEFT_SUPER || key == OF_KEY_RIGHT_SUPER){
-        pressedKeys.erase(OF_KEY_SUPER);
-        ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,OF_KEY_SUPER);
-		attended = ofNotifyEvent( keyReleased, keyEventArgs );
-    }
-    
-	pressedKeys.erase(key);
-	if(!attended){
-		ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,key,keycode,scancode,codepoint);
-		return ofNotifyEvent( keyReleased, keyEventArgs );
-	}else{
-		return attended;
-	}
+	ofKeyEventArgs keyEventArgs(ofKeyEventArgs::Released,key,keycode,scancode,codepoint,0);
+	return notifyKeyEvent(keyEventArgs);
 }
 
 
 //------------------------------------------
-bool ofCoreEvents::notifyKeyEvent(const ofKeyEventArgs & keyEvent){
-	switch(keyEvent.type){
+bool ofCoreEvents::notifyKeyEvent(ofKeyEventArgs & e){
+	bool attended = false;
+	switch(e.type){
 		case ofKeyEventArgs::Pressed:
-			return notifyKeyPressed(keyEvent.key, keyEvent.keycode, keyEvent.scancode, keyEvent.codepoint);
+			// FIXME: modifiers are being reported twice, for generic and for left/right
+			// add operators to the arguments class so it can be checked for both
+			if(e.key == OF_KEY_RIGHT_CONTROL || e.key == OF_KEY_LEFT_CONTROL){
+				pressedKeys.insert(OF_KEY_CONTROL);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_CONTROL;
+				attended = ofNotifyEvent( keyPressed, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_RIGHT_SHIFT || e.key == OF_KEY_LEFT_SHIFT){
+				pressedKeys.insert(OF_KEY_SHIFT);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_SHIFT;
+				attended = ofNotifyEvent( keyPressed, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_LEFT_ALT || e.key == OF_KEY_RIGHT_ALT){
+				pressedKeys.insert(OF_KEY_ALT);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_ALT;
+				attended = ofNotifyEvent( keyPressed, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_LEFT_SUPER || e.key == OF_KEY_RIGHT_SUPER){
+				pressedKeys.insert(OF_KEY_SUPER);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_SUPER;
+				attended = ofNotifyEvent( keyPressed, keyEventArgs );
+			}
+
+			pressedKeys.insert(e.key);
+			if(!attended){
+				return ofNotifyEvent( keyPressed, e );
+			}else{
+				return attended;
+			}
 		case ofKeyEventArgs::Released:
-			return notifyKeyReleased(keyEvent.key, keyEvent.keycode, keyEvent.scancode, keyEvent.codepoint);
+			// FIXME: modifiers are being reported twice, for generic and for left/right
+			// add operators to the arguments class so it can be checked for both
+			if(e.key == OF_KEY_RIGHT_CONTROL || e.key == OF_KEY_LEFT_CONTROL){
+				pressedKeys.erase(OF_KEY_CONTROL);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_CONTROL;
+				attended = ofNotifyEvent( keyReleased, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_RIGHT_SHIFT || e.key == OF_KEY_LEFT_SHIFT){
+				pressedKeys.erase(OF_KEY_SHIFT);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_SHIFT;
+				attended = ofNotifyEvent( keyReleased, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_LEFT_ALT || e.key == OF_KEY_RIGHT_ALT){
+				pressedKeys.erase(OF_KEY_ALT);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_ALT;
+				attended = ofNotifyEvent( keyReleased, keyEventArgs );
+			}
+			else if(e.key == OF_KEY_LEFT_SUPER || e.key == OF_KEY_RIGHT_SUPER){
+				pressedKeys.erase(OF_KEY_SUPER);
+				ofKeyEventArgs keyEventArgs = e;
+				keyEventArgs.key = OF_KEY_SUPER;
+				attended = ofNotifyEvent( keyReleased, keyEventArgs );
+			}
+
+			pressedKeys.erase(e.key);
+			if(!attended){
+				return ofNotifyEvent( keyReleased, e );
+			}else{
+				return attended;
+			}
 	}
 	return false;
 }

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -44,12 +44,13 @@ public:
 	,scancode(0)
 	,codepoint(0){}
 
-	ofKeyEventArgs(Type type, int key, int keycode, int scancode, unsigned int codepoint)
+	ofKeyEventArgs(Type type, int key, int keycode, int scancode, unsigned int codepoint, int modifiers)
 	:type(type)
 	,key(key)
 	,keycode(keycode)
 	,scancode(scancode)
-	,codepoint(codepoint){
+	,codepoint(codepoint)
+	,modifiers(modifiers){
 
 	}
 
@@ -63,14 +64,22 @@ public:
 	}
 
 	Type type;
-	/// \brief For special keys, one of OF_KEY_* (@see ofConstants.h). For all other keys, the Unicode code point you'd expect if this key combo (including modifier keys that may be down) was pressed in a text editor (same as codepoint). 
+	/// For special keys, one of OF_KEY_* (@see ofConstants.h). For all other keys, the Unicode code point you'd expect if this key combo (including modifier keys that may be down) was pressed in a text editor (same as codepoint).
 	int key; 
-	/// \brief The keycode returned by the windowing system, independent of any modifier keys or keyboard layout settings. For ofAppGLFWWindow this value is one of GLFW_KEY_* (@see glfw3.h) - typically, ASCII representation of the symbol on the physical key, so A key always returns 0x41 even if shift, alt, ctrl are down. 
+	/// The keycode returned by the windowing system, independent of any modifier keys or keyboard layout settings. For ofAppGLFWWindow this value is one of GLFW_KEY_* (@see glfw3.h) - typically, ASCII representation of the symbol on the physical key, so A key always returns 0x41 even if shift, alt, ctrl are down.
 	int keycode;
-	/// \brief The raw scan code returned by the keyboard, OS and hardware specific. 
+	/// The raw scan code returned by the keyboard, OS and hardware specific.
 	int scancode;
-	/// \brief The Unicode code point you'd expect if this key combo (including modifier keys) was pressed in a text editor, or -1 for non-printable characters. 
+	/// The Unicode code point you'd expect if this key combo (including modifier keys) was pressed in a text editor, or -1 for non-printable characters.
 	uint32_t codepoint;
+
+	bool hasModifier(int modifier){
+		return modifiers & modifier;
+	}
+
+private:
+	/// Key modifiers
+	int modifiers;
 };
 
 class ofMouseEventArgs : public ofEventArgs, public glm::vec2 {
@@ -224,6 +233,7 @@ class ofCoreEvents {
 
 	ofEvent<ofMessage>			messageEvent;
 	ofEvent<ofDragInfo>			fileDragEvent;
+	ofEvent<uint32_t>			charEvent;
 
 	void disable();
 	void enable();
@@ -248,7 +258,7 @@ class ofCoreEvents {
 
 	bool notifyKeyPressed(int key, int keycode=-1, int scancode=-1, uint32_t codepoint=0);
 	bool notifyKeyReleased(int key, int keycode=-1, int scancode=-1, uint32_t codepoint=0);
-	bool notifyKeyEvent(const ofKeyEventArgs & keyEvent);
+	bool notifyKeyEvent(ofKeyEventArgs & keyEvent);
 
 	bool notifyMousePressed(int x, int y, int button);
 	bool notifyMouseReleased(int x, int y, int button);


### PR DESCRIPTION
char event: maps to glfw char event that allows to get proper events
for combinations of dead keys to allow to get characters like ò or
anything that needs a sequence of keys to be produced

ofKeyEventArgs modifiers: the key event arguments now has modifiers
that can be queried like:

keyArgs.hasModifier(OF_KEY_SHIFT)

ofGetClipboardString & ofSetClipboardString: which were only previously
accessible thorugh the window pointer

Adds some missing key transformations to glfw window, like the keypad numbers and operator keys