### PR TITLE
ofUTF8 utilities:

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -784,6 +784,75 @@ void ofAppendUTF8(string & str, uint32_t utf8){
 }
 
 //--------------------------------------------------
+void ofUTF8Append(string & str, uint32_t utf8){
+	try{
+		utf8::append(utf8, back_inserter(str));
+	}catch(...){}
+}
+
+//--------------------------------------------------
+void ofUTF8Insert(string & str, size_t pos, uint32_t utf8){
+	std::string newText;
+	size_t i = 0;
+	for(auto c: ofUTF8Iterator(str)){
+		if(i==pos){
+			ofUTF8Append(newText, utf8);
+		}
+		ofUTF8Append(newText, c);
+		i+=1;
+	}
+	if(i==pos){
+		ofUTF8Append(newText, utf8);
+	}
+	str = newText;
+}
+
+//--------------------------------------------------
+void ofUTF8Erase(string & str, size_t start, size_t len){
+	std::string newText;
+	size_t i = 0;
+	for(auto c: ofUTF8Iterator(str)){
+		if(i<start || i>=start + len){
+			ofUTF8Append(newText, c);
+		}
+		i+=1;
+	}
+	str = newText;
+}
+
+//--------------------------------------------------
+std::string ofUTF8Substring(const string & str, size_t start, size_t len){
+	size_t i=0;
+	std::string newText;
+	for(auto c: ofUTF8Iterator(str)){
+		if(i>=start){
+			ofUTF8Append(newText, c);
+		}
+		i += 1;
+		if(i==start + len){
+			break;
+		}
+	}
+	return newText;
+}
+
+//--------------------------------------------------
+std::string ofUTF8ToString(uint32_t utf8){
+	std::string str;
+	ofUTF8Append(str, utf8);
+	return str;
+}
+
+//--------------------------------------------------
+size_t ofUTF8Length(const std::string & str){
+	try{
+		return utf8::distance(str.begin(), str.end());
+	}catch(...){
+		return 0;
+	}
+}
+
+//--------------------------------------------------
 string ofVAArgsToString(const char * format, ...){
 	va_list args;
 	va_start(args, format);

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -417,7 +417,14 @@ string ofTrimFront(const string & src, const string & locale = "");
 string ofTrimBack(const string & src, const string & locale = "");
 string ofTrim(const string & src, const string & locale = "");
 
-void ofAppendUTF8(string & str, uint32_t utf8);
+OF_DEPRECATED_MSG("Use ofUTF8Append instead", void ofAppendUTF8(string & str, uint32_t utf8));
+
+void ofUTF8Append(string & str, uint32_t utf8);
+void ofUTF8Insert(string & str, size_t pos, uint32_t utf8);
+void ofUTF8Erase(string & str, size_t start, size_t len);
+std::string ofUTF8Substring(const string & str, size_t start, size_t len);
+std::string ofUTF8ToString(uint32_t utf8);
+size_t ofUTF8Length(const std::string & str);
 
 /// \brief Convert a variable length argument to a string.
 /// \param format a printf-style format string.


### PR DESCRIPTION
Some more functions to work with UTF8 std::strings.

when using utf8 in std::string some functions like .size(), .insert()
and others, don't work properly when there's multicharacter codepoints
in the string.

This adds some functions to use instead of the corresponding string
methods:

```cpp
void ofUTF8Append(string & str, uint32_t utf8);
void ofUTF8Insert(string & str, size_t pos, uint32_t utf8);
void ofUTF8Erase(string & str, size_t start, size_t len);
std::string ofUTF8Substring(const string & str, size_t start, size_t len);
std::string ofUTF8ToString(uint32_t utf8);
size_t ofUTF8Length(const std::string & str);
```