### PR TITLE
add check for invalid alnum input with number text

### DIFF
--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -427,8 +427,13 @@ bool ofxInputField<Type>::charPressed(uint32_t & key){
 			moveCursor(insertKeystroke(key));
 		}else if(key == '.' || key == '-' || key == '+'){
 			moveCursor(insertKeystroke(key));
-		}else{
-			moveCursor(insertAlphabetic(key));
+		}else {
+			int cursorPos = insertAlphabetic( key );
+			if ( cursorPos < 0 ){
+				return false;
+			} else{
+				moveCursor(cursorPos);
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
in an ofxGUI slider/number text field, inserting an invalid character would make the full field disappear, as the cursor would move to -1. This PR adds a check for this edge case.