### PR TITLE
Fix for Qt Creator in macOS

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -48,11 +48,11 @@ Module{
 
     Probe{
         id: CORE
-        property stringList includes
-        property stringList cflags
-        property stringList ldflags
-        property stringList system_libs
-        property stringList static_libs
+        property stringList includes: [];
+        property stringList cflags: [];
+        property stringList ldflags: [];
+        property stringList system_libs: [];
+        property stringList static_libs: [];
         configure: {
             var configs = [];
             if(platform === "linux"  || platform === "linux64"){

--- a/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
@@ -47,7 +47,7 @@ CppApplication{
 
     Properties{
         condition: of.platform === "osx"
-        cpp.minimumOsxVersion: 10.8
+        cpp.minimumOsxVersion: "10.8"
     }
 
     Probe{

--- a/libs/openFrameworksCompiled/project/qtcreator/openFrameworks.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/openFrameworks.qbs
@@ -48,7 +48,7 @@ Product{
 
     Properties{
         condition: of.platform === "osx"
-        cpp.minimumOsxVersion: 10.9
+        cpp.minimumOsxVersion: "10.9"
     }
 
     property stringList FILES_EXCLUDE: {


### PR DESCRIPTION
Changes to qbs files so that Qt Creator can compile again in macOS. Only tested in 10.11, someone should test in Linux. Fixes #5572 