### PR TITLE
Fix warnings in Xcode 8.

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1204,7 +1204,7 @@ void ofAppGLFWWindow::mouse_cb(GLFWwindow* windowP_, int button, int state, int 
 	if (state == GLFW_PRESS) {
 		action = ofMouseEventArgs::Pressed;
 		instance->buttonPressed=true;
-	} else if (state == GLFW_RELEASE) {
+	} else {
 		action = ofMouseEventArgs::Released;
 		instance->buttonPressed=false;
 	}

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -845,7 +845,7 @@ bool ofTrueTypeFont::load(const ofTtfSettings & _settings){
 			if(settings.contours){
 				if(printVectorInfo){
 					std::string str;
-					ofAppendUTF8(str,g);
+					ofUTF8Append(str,g);
 					ofLogNotice("ofTrueTypeFont") <<  "character " << str;
 				}
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -42,7 +42,7 @@ typedef enum _playerLoopType{
 	AVAssetReaderTrackOutput * _assetReaderVideoTrackOutput;
 	AVAssetReaderTrackOutput * _assetReaderAudioTrackOutput;
 	
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 	CMVideoFormatDescriptionRef _videoInfo;
 	AVPlayerItemVideoOutput * _videoOutput;
 #endif
@@ -96,7 +96,7 @@ typedef enum _playerLoopType{
 @property (nonatomic, retain) AVAssetReaderTrackOutput * assetReaderVideoTrackOutput;
 @property (nonatomic, retain) AVAssetReaderTrackOutput * assetReaderAudioTrackOutput;
 
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 @property (nonatomic, retain) AVPlayerItemVideoOutput *videoOutput;
 #endif
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -24,7 +24,7 @@ static NSString * const kRateKey = @"rate";
 @synthesize assetReader = _assetReader;
 @synthesize assetReaderVideoTrackOutput = _assetReaderVideoTrackOutput;
 @synthesize assetReaderAudioTrackOutput = _assetReaderAudioTrackOutput;
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 @synthesize videoOutput = _videoOutput;
 #endif
 
@@ -43,7 +43,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		asyncLock = [[NSLock alloc] init];
 		deallocCond = nil;
 		
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 		// create videooutput
 		_videoOutput = nil;
 		_videoInfo = nil;
@@ -90,7 +90,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	return self;
 }
 
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 - (void)createVideoOutput
 {
 #ifdef TARGET_IOS
@@ -328,7 +328,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 									 object:self.playerItem];
 #endif
 			
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 			// safety
 			if (self.videoOutput == nil) {
 				[self createVideoOutput];
@@ -418,7 +418,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	__block CMSampleBufferRef currentVideoSampleBuffer = videoSampleBuffer;
 	__block CMSampleBufferRef currentAudioSampleBuffer = audioSampleBuffer;
 	
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 	__block AVPlayerItemVideoOutput* currentVideoOutput = _videoOutput;
 	__block CMVideoFormatDescriptionRef currentVideoInfo = _videoInfo;
 	
@@ -501,7 +501,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 											object:currentItem];
 #endif
 				
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 				// remove output
 				[currentItem removeOutput:currentVideoOutput];
 				
@@ -826,7 +826,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	
 	
 
-#if !USE_VIDEO_OUTPUT
+#if !defined(USE_VIDEO_OUTPUT)
 	[self updateFromAssetReader];
 #else
 	// get new sample
@@ -845,7 +845,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 #endif
 }
 
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 - (void)updateFromVideoOutput {
 	OSStatus err = noErr;
 	
@@ -1137,7 +1137,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		return;
 	}
 	
-#if USE_VIDEO_OUTPUT
+#if defined(USE_VIDEO_OUTPUT)
 	[_player.currentItem stepByCount:frames];
 #else
 	if (frames < 0) {
@@ -1382,7 +1382,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	
 	if (!bWasPlayingBackwards && value < 0.0) {
 		
-#if !USE_VIDEO_OUTPUT
+#if !defined(USE_VIDEO_OUTPUT)
 		// not supported
 		NSLog(@"ERROR: Backwards playback is not supported. Minimum requirement is OSX 10.8 or iOS 6.0");
 		value = 0.0;


### PR DESCRIPTION
Warning fixes for Xcode 8.
-defines, deprecations, and uninited-vars.
