### PR TITLE
Add basic support for ortho zooming to ofEasyCam

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -40,6 +40,20 @@ void ofEasyCam::begin(ofRectangle _viewport){
 	}
 	viewport = getViewport(_viewport);
 	ofCamera::begin(viewport);
+
+	if (getOrtho()) {
+		ofPushMatrix();
+		ofScale(orthoScale);
+	}
+}
+
+//----------------------------------------
+void ofEasyCam::end(){
+	if (getOrtho()) {
+		ofPopMatrix();
+	}
+
+	ofCamera::end();
 }
 
 //----------------------------------------
@@ -59,6 +73,8 @@ void ofEasyCam::reset(){
 	moveX = 0;
 	moveY = 0;
 	moveZ = 0;
+
+	orthoScale = 1.0f;
 
 	bApplyInertia = false;
 	bDoTranslate = false;
@@ -411,15 +427,19 @@ void ofEasyCam::mouseDragged(ofMouseEventArgs & mouse){
 
 //----------------------------------------
 void ofEasyCam::mouseScrolled(ofMouseEventArgs & mouse){
-	if (doInertia) {
-		bApplyInertia = true;
+	if (!getOrtho()) {
+		if (doInertia) {
+			bApplyInertia = true;
+		}
+		ofRectangle area = getControlArea();
+		prevPosition = ofCamera::getGlobalPosition();
+		prevAxisZ = getZAxis();
+		moveZ = mouse.scrollY * 30 * sensitivityZ * (getDistance() + FLT_EPSILON)/ area.height;
+		bDoScrollZoom = true;
+		bIsBeingScrolled = true;
+	} else {
+		orthoScale /= 1 + (mouse.scrollY * 0.035f);
 	}
-	ofRectangle area = getControlArea();
-	prevPosition = ofCamera::getGlobalPosition();
-	prevAxisZ = getZAxis();
-	moveZ = mouse.scrollY * 30 * sensitivityZ * (getDistance() + FLT_EPSILON)/ area.height;
-	bDoScrollZoom = true;
-	bIsBeingScrolled = true;
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -18,6 +18,7 @@ public:
 	/// \{
 
 	virtual void begin(ofRectangle viewport = ofRectangle());
+	virtual void end();
 
     /// \brief Reset the camera position and orientation.
 	void reset();
@@ -197,6 +198,8 @@ private:
 	float sensitivityRotX = 1.0f;
 	float sensitivityRotY = 1.0f;
 	float sensitivityRotZ = 1.0f;
+
+	float orthoScale = 1.0f;
 
 	glm::vec2 lastMouse, prevMouse;
 	glm::vec2 mouseVel;


### PR DESCRIPTION
I took a stab at adding zooming support to ofEasyCam when in ortho mode. It feels a little dirty by using `ofPushMatrix()/ofPopMatrix()` and `ofScale()` - I feel like the proper way to do it would be by manipulating the viewport or similar in `begin()` but it works as a start at least.

In addition, there are a couple issues like...
- no separate sensitivity setting. Maybe it should use the existing sensitivityZ?
- "zoom" between perspective (ie position) and ortho (ie scale) are not in sync

Anyway, just throwing this out there to see what others think..
ping @ofZach re: https://twitter.com/zachlieberman/status/859185792681476096 hehe