### PR TITLE
Fix audio sample rate issue #5588

### DIFF
--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -170,6 +170,8 @@ bool ofRtAudioSoundStream::setup(const ofSoundStreamSettings & settings_)
 	options.priority = 1;
 	outputBuffer.setDeviceID(outputParameters.deviceId);
 	inputBuffer.setDeviceID(inputParameters.deviceId);
+	outputBuffer.setSampleRate(settings.sampleRate);
+	inputBuffer.setSampleRate(settings.sampleRate);
 	unsigned int bufferSize = settings.bufferSize;
 	try {
 		audio->openStream((settings.numOutputChannels > 0) ? &outputParameters : nullptr, (settings.numInputChannels > 0) ? &inputParameters : nullptr, RTAUDIO_FLOAT32,

--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -33,7 +33,7 @@ ofSoundBuffer::ofSoundBuffer(short * shortBuffer, std::size_t numFrames, std::si
 
 void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
 	this->channels = numChannels;
-	this->samplerate = sampleRate;
+	setSampleRate(samplerate);
 	buffer.resize(numFrames * numChannels);
 	for(std::size_t i = 0; i < size(); i++){
 		buffer[i] = shortBuffer[i]/float(numeric_limits<short>::max());
@@ -43,7 +43,7 @@ void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, s
 
 void ofSoundBuffer::copyFrom(const float * floatBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
 	this->channels = numChannels;
-	this->samplerate = sampleRate;
+	setSampleRate(samplerate);
 	buffer.assign(floatBuffer, floatBuffer + (numFrames * numChannels));
 	checkSizeAndChannelsConsistency("copyFrom");
 }


### PR DESCRIPTION
-soundstream in and out buffer's samplerate is set at setup.

https://github.com/openframeworks/openFrameworks/issues/5588