### PR TITLE
Adding support for OF_KEY_SPACE

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1444,6 +1444,9 @@ void ofAppGLFWWindow::keyboard_cb(GLFWwindow* windowP_, int keycode, int scancod
 			break;
 		case GLFW_KEY_KP_EQUAL:
 			key = codepoint = '=';
+			break; 
+		case GLFW_KEY_SPACE:
+			key = codepoint = OF_KEY_SPACE;
 			break;
 		default:
 			codepoint = keycodeToUnicode(instance, scancode, mods);

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -718,12 +718,13 @@ enum ofMatrixMode {OF_MATRIX_MODELVIEW=0, OF_MATRIX_PROJECTION, OF_MATRIX_TEXTUR
 
 
 	#define OF_KEY_RETURN		13
-	#define OF_KEY_ESC			27
-	#define OF_KEY_TAB          9
-
+	#define OF_KEY_ESC		27
+	#define OF_KEY_TAB		9
 
 	#define OF_KEY_BACKSPACE	8
-	#define OF_KEY_DEL			127
+	#define OF_KEY_DEL		127
+
+	#define OF_KEY_SPACE		32
 
 
 	// For legacy reasons we are mixing up control keys


### PR DESCRIPTION
Using OF_KEY_SPACE instead of GLFW_KEY_SPACE to keep homogeneity, and more readable than `' '`
