### PR TITLE
Progress on #5440.

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -654,6 +654,21 @@ public:
 
 	/// \}
 
+#ifndef OF_USE_LEGACY_MESH
+	OF_DEPRECATED_MSG("Use glm::vec2.", ofMesh_(ofPrimitiveMode mode, const vector<ofVec2f>& verts));
+	ofMesh_(ofPrimitiveMode mode, const vector<glm::vec2>& verts);
+	void addVertex(const glm::vec2& v);
+	void addVertices(const vector<glm::vec2>& verts);
+	OF_DEPRECATED_MSG("Use glm::vec2.", void addVertices(const vector<ofVec2f>& verts));
+	OF_DEPRECATED_MSG("Use glm::vec3.", void addVertices(const vector<ofVec3f>& verts));
+	void addVertices(const glm::vec2* verts, std::size_t amt);
+	OF_DEPRECATED_MSG("Use glm::vec2.", void addVertices(const ofVec2f* verts, std::size_t amt));
+	OF_DEPRECATED_MSG("Use glm::vec3.", void addVertices(const ofVec3f* verts, std::size_t amt));
+	void setVertex(ofIndexType index, const glm::vec2& v);
+	OF_DEPRECATED_MSG("Use glm::vec3.",void addNormals(const vector<ofVec3f>& norms));
+	OF_DEPRECATED_MSG("Use glm::vec3.",void addNormals(const ofVec3f* norms, std::size_t amt));
+#endif
+
 private:
 
 	vector<V> vertices;

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2840,6 +2840,99 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::axis( float size ) {
 }
 
 
+#ifndef OF_USE_LEGACY_MESH
+
+template<class V, class N, class C, class T>
+ofMesh_<V,N,C,T>::ofMesh_(ofPrimitiveMode mode, const vector<ofVec2f>& verts): ofMesh_(mode, {})
+{
+	addVertices(verts);
+}
+
+template<class V, class N, class C, class T>
+ofMesh_<V,N,C,T>::ofMesh_(ofPrimitiveMode mode, const vector<glm::vec2>& verts): ofMesh_(mode, {})
+{
+	addVertices(verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertex(const glm::vec2& v)
+{
+	addVertex(V(v.x, v.y, 0));
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const vector<glm::vec2>& verts)
+{
+	std::vector<V> _verts;
+	for (auto& v: verts) _verts.push_back(V(v.x, v.y, 0));
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const vector<ofVec2f>& verts)
+{
+	std::vector<V> _verts;
+	for (auto& v: verts) _verts.push_back(V(v.x, v.y, 0));
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const vector<ofVec3f>& verts)
+{
+	std::vector<V> _verts;
+	for (auto& v: verts) _verts.push_back(v);
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const glm::vec2* verts, std::size_t amt)
+{
+	std::vector<V> _verts;
+	for (std::size_t i = 0; i < amt; ++i) _verts.push_back(V(verts[i].x, verts[i].y, 0));
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const ofVec2f* verts, std::size_t amt)
+{
+	std::vector<V> _verts;
+	for (std::size_t i = 0; i < amt; ++i) _verts.push_back(V(verts[i].x, verts[i].y, 0));
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addVertices(const ofVec3f* verts, std::size_t amt)
+{
+	std::vector<V> _verts;
+	for (std::size_t i = 0; i < amt; ++i) _verts.push_back(verts[i]);
+	addVertices(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::setVertex(ofIndexType index, const glm::vec2& v)
+{
+	setVertex(index, V(v.x, v.y, 0));
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addNormals(const vector<ofVec3f>& verts)
+{
+	std::vector<N> _verts;
+	for (auto& v: verts) _verts.push_back(v);
+	addNormals(_verts);
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::addNormals(const ofVec3f* verts, std::size_t amt)
+{
+	std::vector<N> _verts;
+	for (std::size_t i = 0; i < amt; ++i) _verts.push_back(N(verts[i].x, verts[i].y, 0));
+	addNormals(_verts);
+}
+
+#endif
+
+
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -491,7 +491,31 @@ public:
 	
 	/// \}
    
-    
+
+// Functions for backward compatibility.
+#ifndef OF_USE_LEGACY_MESH
+    ofPolyline_(const vector<glm::vec2>& verts);
+	OF_DEPRECATED_MSG("Use glm::vec2.", ofPolyline_(const vector<ofVec2f>& verts));
+    void addVertex(const glm::vec2& p);
+    void addVertices(const vector<glm::vec2>& verts);
+	OF_DEPRECATED_MSG("Use glm::vec2.", void addVertices(const vector<ofVec2f>& verts));
+	OF_DEPRECATED_MSG("Use glm::vec3.", void addVertices(const vector<ofVec3f>& verts));
+    void addVertices(const glm::vec2* verts, int numverts);
+    OF_DEPRECATED_MSG("Use glm::vec2.", void addVertices(const ofVec2f* verts, int numverts));
+	OF_DEPRECATED_MSG("Use glm::vec3.", void addVertices(const ofVec3f* verts, int numverts));
+    void insertVertex(const glm::vec2 &p, int index);
+    void lineTo(const glm::vec2& to);
+    void arc(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, bool clockwise, int circleResolution = 20);
+    void arc(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20);
+    void arcNegative(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20);
+    void curveTo( const glm::vec2& to, int curveResolution = 20 );
+    void bezierTo( const glm::vec2& cp1, const glm::vec2& cp2, const glm::vec2& to, int curveResolution = 20);
+    void quadBezierTo( const glm::vec2& p1, const glm::vec2& p2, const glm::vec2& p3,  int curveResolution = 20 );
+    static bool inside(const glm::vec2& p, const ofPolyline_ & polyline);
+    bool inside(const glm::vec2& p) const;
+    T getClosestPoint(const glm::vec2& target, unsigned int* nearestIndex = nullptr) const;
+#endif
+
 private:
 	void setCircleResolution(int res);
     float wrapAngle(float angleRad);

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -1165,3 +1165,141 @@ typename vector<T>::const_reverse_iterator ofPolyline_<T>::rend() const{
 	return points.rend();
 }
 
+
+#ifndef OF_USE_LEGACY_MESH
+
+template<class T>
+ofPolyline_<T>::ofPolyline_(const vector<glm::vec2>& verts): ofPolyline_()
+{
+	addVertices(verts);
+}
+
+template<class T>
+ofPolyline_<T>::ofPolyline_(const vector<ofVec2f>& verts): ofPolyline_()
+{
+	addVertices(verts);
+}
+
+template<class T>
+void ofPolyline_<T>::addVertex(const glm::vec2& p)
+{
+	addVertex(p.x, p.y);
+}
+
+template<class T>
+void ofPolyline_<T>::addVertices(const vector<glm::vec2>& verts)
+{
+    std::vector<T> _verts;
+    for (auto& v: verts) _verts.push_back(T(v.x, v.y, 0));
+    addVertices(_verts);
+}
+
+template<class T>
+void ofPolyline_<T>::addVertices(const vector<ofVec2f>& verts)
+{
+    std::vector<T> _verts;
+    for (auto& v: verts) _verts.push_back(T(v.x, v.y, 0));
+    addVertices(_verts);
+}
+
+
+template<class T>
+void ofPolyline_<T>::addVertices(const vector<ofVec3f>& verts)
+{
+	std::vector<T> _verts;
+	for (auto& v: verts) _verts.push_back(v);
+	addVertices(_verts);
+}
+
+
+template<class T>
+void ofPolyline_<T>::addVertices(const glm::vec2* verts, int numverts)
+{
+    std::vector<T> _verts;
+    for (int i = 0; i < numverts; ++i) _verts.push_back(T(verts[i].x, verts[i].y, 0));
+    addVertices(_verts);
+}
+
+template<class T>
+void ofPolyline_<T>::addVertices(const ofVec2f* verts, int numverts)
+{
+    std::vector<T> _verts;
+    for (int i = 0; i < numverts; ++i) _verts.push_back(T(verts[i].x, verts[i].y, 0));
+    addVertices(_verts);
+}
+
+template<class T>
+void ofPolyline_<T>::addVertices(const ofVec3f* verts, int numverts)
+{
+	std::vector<T> _verts;
+	for (int i = 0; i < numverts; ++i) _verts.push_back(verts[i]);
+	addVertices(_verts);
+}
+
+template<class T>
+void ofPolyline_<T>::insertVertex(const glm::vec2 &p, int index)
+{
+	insertVertex(p.x, p.y, 0, index);
+}
+
+template<class T>
+void ofPolyline_<T>::lineTo(const glm::vec2& to)
+{
+	lineTo(to.x, to.y, 0);
+}
+
+template<class T>
+void ofPolyline_<T>::arc(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, bool clockwise, int circleResolution)
+{
+    arc(T(center.x, center.y, 0), radiusX, radiusY, angleBegin, angleEnd, clockwise, circleResolution);
+}
+
+template<class T>
+void ofPolyline_<T>::arc(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution)
+{
+    arc(center, radiusX, radiusY, angleBegin, angleEnd, true, circleResolution);
+}
+
+template<class T>
+void ofPolyline_<T>::arcNegative(const glm::vec2& center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution)
+{
+    arc(center, radiusX, radiusY, angleBegin, angleEnd, false, circleResolution);
+}
+
+template<class T>
+void ofPolyline_<T>::curveTo( const glm::vec2& to, int curveResolution)
+{
+	curveTo(T(to.x, to.y, 0), curveResolution);
+}
+
+template<class T>
+void ofPolyline_<T>::bezierTo( const glm::vec2& cp1, const glm::vec2& cp2, const glm::vec2& to, int curveResolution)
+{
+	curveTo(T(cp1.x, cp1.y, 0), T(cp2.x, cp2.y, 0), T(to.x, to.y, 0), curveResolution);
+}
+
+template<class T>
+void ofPolyline_<T>::quadBezierTo( const glm::vec2& p1, const glm::vec2& p2, const glm::vec2& p3,  int curveResolution)
+{
+	quadBezierTo(T(p1.x, p1.y, 0), T(p2.x, p2.y, 0), T(p3.x, p3.y, 0), curveResolution);
+}
+
+template<class T>
+bool ofPolyline_<T>::inside(const glm::vec2& p, const ofPolyline_ & polyline)
+{
+	return inside(T(p.x, p.y, 0), polyline);
+}
+
+template<class T>
+bool ofPolyline_<T>::inside(const glm::vec2& p) const
+{
+	return inside(T(p.x, p.y, 0));
+}
+
+template<class T>
+T ofPolyline_<T>::getClosestPoint(const glm::vec2& target, unsigned int* nearestIndex) const
+{
+	return getClosestPoint(T(target.x, target.y, 0), nearestIndex);
+}
+
+#endif


### PR DESCRIPTION
Adds better backward compatibility during the `glm::vec*` / `ofVec*` transition. 