### PR TITLE
glm transition - deprecations implicit conversions, remove implicit conversions from the core.

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -132,9 +132,9 @@ void ofNode::setParent(ofNode& parent, bool bMaintainGlobalTransform) {
 		clearParent(bMaintainGlobalTransform);
 	}
 	if(bMaintainGlobalTransform) {
-		auto postParentPosition = position - parent.getGlobalPosition();
+		auto postParentPosition = position.get() - parent.getGlobalPosition();
 		auto postParentOrientation = orientation.get() * glm::inverse(parent.getGlobalOrientation());
-		auto postParentScale = scale / parent.getGlobalScale();
+		auto postParentScale = scale.get() / parent.getGlobalScale();
 		parent.addListener(*this);
 		setOrientation(postParentOrientation);
 		setPosition(postParentPosition);
@@ -597,7 +597,7 @@ void ofNode::orbitDeg(float longitude, float latitude, float radius, const glm::
 	p = q * p;							   // rotate p on unit sphere based on quaternion
 	p = p * radius;						   // scale p by radius from its position on unit sphere
 
-	setGlobalPosition(centerPoint + p);
+	setGlobalPosition(centerPoint + p.xyz());
 	setOrientation(q);
 
 	onOrientationChanged();
@@ -620,7 +620,7 @@ void ofNode::orbitRad(float longitude, float latitude, float radius, const glm::
 	p = q * p;							   // rotate p on unit sphere based on quaternion
 	p = p * radius;						   // scale p by radius from its position on unit sphere
 
-	setGlobalPosition(centerPoint + p);
+	setGlobalPosition(centerPoint + p.xyz());
 	setOrientation(q);
 
 	onOrientationChanged();

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -756,7 +756,7 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
         GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
  
 		int currentMonitor = getCurrentMonitor();
-		ofVec3f screenSize = getScreenSize();
+		auto screenSize = getScreenSize();
 		
 		if( orientation == OF_ORIENTATION_90_LEFT || orientation == OF_ORIENTATION_90_RIGHT ){
 			std::swap(screenSize.x, screenSize.y);
@@ -811,8 +811,7 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 		
 		// make sure to save current pos if not specified in settings
 		if( settings.isPositionSet() ) {
-			ofVec3f pos = getWindowPosition();
-			settings.setPosition(ofVec2f(pos.x, pos.y));
+			settings.setPosition(getWindowPosition());
 		}
  
         //make sure the window is getting the mouse/key events

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -1138,14 +1138,14 @@ void ofVertices( const vector <glm::vec2> & polyPoints ){
 //----------------------------------------------------------
 void ofVertices( const vector <ofVec3f> & polyPoints ){
 	for( const auto & p: polyPoints ){
-		ofGetCurrentRenderer()->getPath().lineTo(p);
+		ofGetCurrentRenderer()->getPath().lineTo(glm::vec3(p.x, p.y, p.z));
 	}
 }
 
 //----------------------------------------------------------
 void ofVertices( const vector <ofVec2f> & polyPoints ){
 	for( const auto & p: polyPoints ){
-		ofGetCurrentRenderer()->getPath().lineTo(p);
+		ofGetCurrentRenderer()->getPath().lineTo(glm::vec3(p.x, p.y, 0.0));
 	}
 }
 
@@ -1176,14 +1176,14 @@ void ofCurveVertices( const vector <glm::vec2> & curvePoints){
 //----------------------------------------------------------
 void ofCurveVertices( const vector <ofVec3f> & curvePoints){
 	for( const auto & p: curvePoints ){
-		ofGetCurrentRenderer()->getPath().curveTo(p);
+		ofGetCurrentRenderer()->getPath().curveTo(glm::vec3(p.x, p.y, p.z));
 	}
 }
 
 //----------------------------------------------------------
 void ofCurveVertices( const vector <ofVec2f> & curvePoints){
 	for( const auto & p: curvePoints ){
-		ofGetCurrentRenderer()->getPath().curveTo(p);
+		ofGetCurrentRenderer()->getPath().curveTo(glm::vec3(p.x, p.y, 0.0));
 	}
 }
 

--- a/libs/openFrameworks/math/ofMatrix3x3.h
+++ b/libs/openFrameworks/math/ofMatrix3x3.h
@@ -42,11 +42,11 @@ public:
 				float _g=0.0, float _h=0.0, float _i=0.0 );
 
 
-	ofMatrix3x3( const glm::mat3 & mat) {
+	OF_DEPRECATED_MSG("Use glm::mat3.", ofMatrix3x3( const glm::mat3 & mat)) {
 		*this = reinterpret_cast<const ofMatrix3x3&>(mat);
 	}
 
-	operator glm::mat3(){
+	OF_DEPRECATED_MSG("Use glm::mat3.", operator glm::mat3()) {
 		return *reinterpret_cast<glm::mat3*>(this);
 	}
 	

--- a/libs/openFrameworks/math/ofMatrix4x4.h
+++ b/libs/openFrameworks/math/ofMatrix4x4.h
@@ -70,11 +70,11 @@ public:
 		makeIdentityMatrix();
 	}
 
-	ofMatrix4x4( const glm::mat4 & mat) {
+	OF_DEPRECATED_MSG("Use glm::mat4.", ofMatrix4x4( const glm::mat4 & mat)) {
 		*this = reinterpret_cast<const ofMatrix4x4&>(mat);
 	}
 
-	operator glm::mat4(){
+	OF_DEPRECATED_MSG("Use glm::mat4.", operator glm::mat4()) {
 		return *reinterpret_cast<glm::mat4*>(this);
 	}
 

--- a/libs/openFrameworks/math/ofQuaternion.h
+++ b/libs/openFrameworks/math/ofQuaternion.h
@@ -43,9 +43,9 @@ public:
     
     // rotation order is axis3,axis2,axis1
     inline ofQuaternion(float angle1, const ofVec3f& axis1, float angle2, const ofVec3f& axis2, float angle3, const ofVec3f& axis3);
-    
-	inline ofQuaternion(const glm::quat & q);
-	inline operator glm::quat() const;
+
+	OF_DEPRECATED_MSG("Use glm::vec4.", inline ofQuaternion(const glm::quat & q));
+	OF_DEPRECATED_MSG("Use glm::vec4.", inline operator glm::quat() const);
 
     /// \}
     

--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -126,11 +126,10 @@ public:
 	
 	/// \}
 
-	ofVec2f(const glm::vec2 & v);
-	ofVec2f(const glm::vec3 & v);
-	ofVec2f(const glm::vec4 & v);
-
-	operator glm::vec2() const;
+	OF_DEPRECATED_MSG("Use glm::vec2.", ofVec2f(const glm::vec2 & v));
+	OF_DEPRECATED_MSG("Use glm::vec2.", ofVec2f(const glm::vec3 & v));
+	OF_DEPRECATED_MSG("Use glm::vec2.", ofVec2f(const glm::vec4 & v));
+	OF_DEPRECATED_MSG("Use glm::vec2.", operator glm::vec2() const);
 
 	//---------------------
 	/// \name Access components

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -125,10 +125,10 @@ public:
 	/// ~~~~
     ofVec3f( const ofVec4f& vec );
 
-	ofVec3f( const glm::vec2 & vec );
-	ofVec3f( const glm::vec3 & vec );
-	ofVec3f( const glm::vec4 & vec );
-	operator glm::vec3() const;
+	OF_DEPRECATED_MSG("Use glm::vec3.", ofVec3f( const glm::vec2 & vec ));
+	OF_DEPRECATED_MSG("Use glm::vec3.", ofVec3f( const glm::vec3 & vec ));
+	OF_DEPRECATED_MSG("Use glm::vec3.", ofVec3f( const glm::vec4 & vec ));
+	OF_DEPRECATED_MSG("Use glm::vec3.", operator glm::vec3() const);
 
 	/// \}
 

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -24,10 +24,10 @@ public:
 	ofVec4f( float _x, float _y, float _z, float _w );
 	ofVec4f( const ofVec2f& vec);
 	ofVec4f( const ofVec3f& vec);
-	ofVec4f( const glm::vec2& vec);
-	ofVec4f( const glm::vec3& vec);
-	ofVec4f( const glm::vec4& vec);
-	operator glm::vec4() const;
+	OF_DEPRECATED_MSG("Use glm::vec4.", ofVec4f( const glm::vec2& vec));
+	OF_DEPRECATED_MSG("Use glm::vec4.", ofVec4f( const glm::vec3& vec));
+	OF_DEPRECATED_MSG("Use glm::vec4.", ofVec4f( const glm::vec4& vec));
+	OF_DEPRECATED_MSG("Use glm::vec4.", operator glm::vec4() const);
 
     /// \}
 

--- a/libs/openFrameworks/math/ofVectorMath.h
+++ b/libs/openFrameworks/math/ofVectorMath.h
@@ -243,88 +243,88 @@ namespace glm {
 
 //--------------------------------------------------------------
 inline glm::vec3 operator+(const glm::vec3 & v1, const ofVec3f & v2){
-	return v1 + glm::vec3(v2);
+	return v1 + glm::vec3(v2.x, v2.y, v2.z);
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 operator-(const glm::vec3 & v1, const ofVec3f & v2){
-	return v1 - glm::vec3(v2);
+	return v1 - glm::vec3(v2.x, v2.y, v2.z);
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 operator*(const glm::vec3 & v1, const ofVec3f & v2){
-	return v1 * glm::vec3(v2);
+	return v1 * glm::vec3(v2.x, v2.y, v2.z);
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 operator/(const glm::vec3 & v1, const ofVec3f & v2){
-	return v1 / glm::vec3(v2);
+	return v1 / glm::vec3(v2.x, v2.y, v2.z);
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 & operator+=(glm::vec3 & v1, const ofVec3f & v2){
-	v1 += glm::vec3(v2);
+	v1 += glm::vec3(v2.x, v2.y, v2.z);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 & operator-=(glm::vec3 & v1, const ofVec3f & v2){
-	v1 -= glm::vec3(v2);
+	v1 -= glm::vec3(v2.x, v2.y, v2.z);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 & operator*=(glm::vec3 & v1, const ofVec3f & v2){
-	v1 *= glm::vec3(v2);
+	v1 *= glm::vec3(v2.x, v2.y, v2.z);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec3 & operator/=(glm::vec3 & v1, const ofVec3f & v2){
-	v1 /= glm::vec3(v2);
+	v1 /= glm::vec3(v2.x, v2.y, v2.z);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 operator+(const glm::vec2 & v1, const ofVec2f & v2){
-	return v1 + glm::vec2(v2);
+	return v1 + glm::vec2(v2.x, v2.y);
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 operator-(const glm::vec2 & v1, const ofVec2f & v2){
-	return v1 - glm::vec2(v2);
+	return v1 - glm::vec2(v2.x, v2.y);
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 operator*(const glm::vec2 & v1, const ofVec2f & v2){
-	return v1 * glm::vec2(v2);
+	return v1 * glm::vec2(v2.x, v2.y);
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 operator/(const glm::vec2 & v1, const ofVec2f & v2){
-	return v1 / glm::vec2(v2);
+	return v1 / glm::vec2(v2.x, v2.y);
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 & operator+=(glm::vec2 & v1, const ofVec2f & v2){
-	v1 += glm::vec2(v2);
+	v1 += glm::vec2(v2.x, v2.y);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 & operator-=(glm::vec2 & v1, const ofVec2f & v2){
-	v1 -= glm::vec2(v2);
+	v1 -= glm::vec2(v2.x, v2.y);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 & operator*=(glm::vec2 & v1, const ofVec2f & v2){
-	v1 *= glm::vec2(v2);
+	v1 *= glm::vec2(v2.x, v2.y);
 	return v1;
 }
 
 //--------------------------------------------------------------
 inline glm::vec2 & operator/=(glm::vec2 & v1, const ofVec2f & v2){
-	v1 /= glm::vec2(v2);
+	v1 /= glm::vec2(v2.x, v2.y);
 	return v1;
 }


### PR DESCRIPTION
This is related to #5440, the effort to ease the glm transition.

I looked into deprecating entire classes (e.g. `ofVec2f`, etc), but it created a huge mess of deprecation warnings, so instead I opted to just add deprecation warnings in those places where glm/of conversions were happening implicitly. 

I also discovered a few remaining places where `ofVec*`  was being used explicitly and a few interesting places in `ofNode` where when adding an `glm::vec3 + glm::vec4` resulted in an intermediate conversion to `ofVec3f`. 

Currently this shouldn't produce any deprecations warnings from the core itself, but only with non-conforming examples and user code that still employs `ofVec*`. 