### PR TITLE
remove dependency ofMatrixStack<->ofFbo

### DIFF
--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -7,36 +7,36 @@
 
 #include "ofMatrixStack.h"
 #include "ofAppBaseWindow.h"
-#include "ofFbo.h"
+#include "ofBaseTypes.h"
 
 ofMatrixStack::ofMatrixStack(const ofAppBaseWindow * window)
 :vFlipped(true)
 ,orientation(OF_ORIENTATION_DEFAULT)
 ,handedness(OF_LEFT_HANDED)
-,currentFbo(nullptr)
+,currentRenderSurface(nullptr)
 ,currentWindow(const_cast<ofAppBaseWindow*>(window))
 ,currentMatrixMode(OF_MATRIX_MODELVIEW)
 ,currentMatrix(&modelViewMatrix)
-,flipFboMatrix(true)
+,flipRenderSurfaceMatrix(true)
 {
 
 }
 
-void ofMatrixStack::setRenderSurface(const ofFbo & fbo){
-	currentFbo = const_cast<ofFbo*>(&fbo);
-	flipFboMatrix = true;
+void ofMatrixStack::setRenderSurface(const ofBaseDraws & renderSurface_){
+	currentRenderSurface = const_cast<ofBaseDraws*>(&renderSurface_);
+	flipRenderSurfaceMatrix = true;
 	setOrientation(orientation,vFlipped);
 }
 
-void ofMatrixStack::setRenderSurfaceNoMatrixFlip(const ofFbo & fbo) {
-	currentFbo = const_cast<ofFbo*>(&fbo);
-	flipFboMatrix = false;
+void ofMatrixStack::setRenderSurfaceNoMatrixFlip(const ofBaseDraws & renderSurface_) {
+	currentRenderSurface = const_cast<ofBaseDraws*>(&renderSurface_);
+	flipRenderSurfaceMatrix = false;
 	setOrientation(orientation, vFlipped);
 }
 
 void ofMatrixStack::setRenderSurface(const ofAppBaseWindow & window){
 	currentWindow = const_cast<ofAppBaseWindow*>(&window);
-	currentFbo = nullptr;
+	currentRenderSurface = nullptr;
 	setOrientation(orientation,vFlipped);
 }
 
@@ -91,12 +91,12 @@ bool ofMatrixStack::isVFlipped() const{
 }
 
 bool ofMatrixStack::customMatrixNeedsFlip() const{
-	return vFlipped != (bool(currentFbo) && flipFboMatrix);
+	return vFlipped != (bool(currentRenderSurface) && flipRenderSurfaceMatrix);
 }
 
 int ofMatrixStack::getRenderSurfaceWidth() const{
-	if(currentFbo){
-		return currentFbo->getWidth();
+	if(currentRenderSurface){
+		return currentRenderSurface->getWidth();
 	}else if(currentWindow){
 		return currentWindow->getWindowSize().x;
 	}else{
@@ -105,8 +105,8 @@ int ofMatrixStack::getRenderSurfaceWidth() const{
 }
 
 int ofMatrixStack::getRenderSurfaceHeight() const{
-	if(currentFbo){
-		return currentFbo->getHeight();
+	if(currentRenderSurface){
+		return currentRenderSurface->getHeight();
 	}else if(currentWindow){
 		return currentWindow->getWindowSize().y;
 	}else{
@@ -124,7 +124,7 @@ ofHandednessType ofMatrixStack::getHandedness() const{
 
 
 bool ofMatrixStack::doesHWOrientation() const{
-	return currentFbo || (currentWindow && currentWindow->doesHWOrientation());
+	return currentRenderSurface || (currentWindow && currentWindow->doesHWOrientation());
 }
 
 void ofMatrixStack::viewport(float x, float y, float width, float height, bool vflip){
@@ -164,8 +164,8 @@ ofRectangle ofMatrixStack::getNativeViewport() const{
 }
 
 ofRectangle ofMatrixStack::getFullSurfaceViewport() const{
-	if(currentFbo){
-		return ofRectangle(0,0,currentFbo->getWidth(),currentFbo->getHeight());
+	if(currentRenderSurface){
+		return ofRectangle(0,0,currentRenderSurface->getWidth(),currentRenderSurface->getHeight());
 	}else if(currentWindow){
 		return ofRectangle(0,0,currentWindow->getWidth(),currentWindow->getHeight());
 	}else{
@@ -422,7 +422,7 @@ void ofMatrixStack::updatedRelatedMatrices(){
 }
 
 bool ofMatrixStack::doesHardwareOrientation() const{
-	if(currentFbo){
+	if(currentRenderSurface){
 		return true;
 	}else{
 		return currentWindow->doesHWOrientation();

--- a/libs/openFrameworks/utils/ofMatrixStack.h
+++ b/libs/openFrameworks/utils/ofMatrixStack.h
@@ -13,6 +13,7 @@
 #include "ofRectangle.h"
 #include "ofGraphics.h"
 
+class ofBaseDraws;
 class ofAppBaseWindow;
 class ofFbo;
 
@@ -20,8 +21,8 @@ class ofMatrixStack {
 public:
 	ofMatrixStack(const ofAppBaseWindow * window);
 
-	void setRenderSurface(const ofFbo & fbo);
-	void setRenderSurfaceNoMatrixFlip(const ofFbo & fbo);
+	void setRenderSurface(const ofBaseDraws & fbo);
+	void setRenderSurfaceNoMatrixFlip(const ofBaseDraws & fbo);
 	void setRenderSurface(const ofAppBaseWindow & window);
 
 	void setOrientation(ofOrientation orientation, bool vFlip);
@@ -75,7 +76,7 @@ private:
     ofOrientation orientation;
 	ofRectangle currentViewport;
 	ofHandednessType handedness;
-	ofFbo * currentFbo;
+	ofBaseDraws * currentRenderSurface;
 	ofAppBaseWindow * currentWindow;
 
     ofMatrixMode currentMatrixMode;
@@ -97,7 +98,7 @@ private:
 	std::stack <glm::mat4> projectionMatrixStack;
 	std::stack <glm::mat4> textureMatrixStack;
 	std::stack <std::pair<ofOrientation,bool> > orientationStack;
-	bool flipFboMatrix;
+	bool flipRenderSurfaceMatrix;
 
 	int getRenderSurfaceWidth() const;
 	int getRenderSurfaceHeight() const;


### PR DESCRIPTION
+ `ofMatrixStack` currently depends on `ofFbo`, although it really only calls methods from `ofFbo`'s base class, `ofBaseDraws` - `ofMatrixStack` exclusively queries into the RenderSurface's geometry.

The proposed changes update `ofMatrixStack` to require just an `ofBaseDraws`-compatible object to be passed as target render surface.

This allows other renderers, such as the vulkan renderer, to use this object, without having access to `ofFbo`.