### PR TITLE
Fixes for ofBitmapFont getBoundingBox();

### DIFF
--- a/libs/openFrameworks/graphics/ofBitmapFont.cpp
+++ b/libs/openFrameworks/graphics/ofBitmapFont.cpp
@@ -418,11 +418,11 @@ ofMesh ofBitmapFont::getMesh(const string & text, int x, int y, ofDrawBitmapMode
 		if(text[c] == '\n'){
 
 			sy += lineHeight*newLineDirection;
-			if(mode == OF_BITMAPMODE_SIMPLE) {
+//			if(mode == OF_BITMAPMODE_SIMPLE) {
 				sx = x;
-			} else {
-				sx = 0;
-			}
+//			} else {
+//				sx = 0;
+//			}
 
 			column = 0;
 		} else if (text[c] == '\t'){
@@ -474,20 +474,19 @@ const ofTexture & ofBitmapFont::getTexture() const{
 }
 
 
-ofRectangle ofBitmapFont::getBoundingBox(const string & text, int x, int y) const{
+ofRectangle ofBitmapFont::getBoundingBox(const string & text, int x, int y, ofDrawBitmapMode mode, bool vFlipped) const{
     if(text.empty()){
         return ofRectangle(x,y,0,0);
     }
 
-	const ofMesh & mesh = getMesh(text,x,y);
-	glm::vec2 max(numeric_limits<float>::min(),numeric_limits<float>::min());
+	const ofMesh & mesh = getMesh(text,x,y, mode, vFlipped);
+	glm::vec2 max(numeric_limits<float>::lowest(),numeric_limits<float>::lowest());
 	glm::vec2 min(numeric_limits<float>::max(),numeric_limits<float>::max());
-	for(std::size_t i=0;i< mesh.getNumVertices(); i++){
-		const auto & p = mesh.getVertex(i);
+	for(const auto & p : mesh.getVertices()){
 		if(p.x<min.x) min.x = p.x;
 		if(p.y<min.y) min.y = p.y;
 		if(p.x>max.x) max.x = p.x;
 		if(p.y>max.y) max.y = p.y;
 	}
-	return ofRectangle(min.x,min.y,max.x-min.x,max.y-min.y);
+	return ofRectangle(min,max);
 }

--- a/libs/openFrameworks/graphics/ofBitmapFont.h
+++ b/libs/openFrameworks/graphics/ofBitmapFont.h
@@ -5,6 +5,7 @@
 #include "ofPixels.h"
 #include "ofTexture.h"
 #include "ofMesh.h"
+#include "ofGraphics.h"
 class ofRectangle;
 
 /*
@@ -22,7 +23,7 @@ public:
 	~ofBitmapFont();
 	ofMesh getMesh(const string & text, int x, int y, ofDrawBitmapMode mode=OF_BITMAPMODE_MODEL_BILLBOARD, bool vFlipped=true) const;
 	const ofTexture & getTexture() const;
-	ofRectangle getBoundingBox(const string & text, int x, int y) const;
+	ofRectangle getBoundingBox(const string & text, int x, int y, ofDrawBitmapMode mode = ofGetStyle().drawBitmapMode, bool vFlipped = ofIsVFlipped()) const;
 private:
 	static void init();
 	static ofPixels pixels;


### PR DESCRIPTION
- incorrect use of numeric_limits<float>::min() caused wrong results. Replaced for numeric_limits<float>::lowest()
- Added  ofDrawBitmapMode mode = ofGetStyle().drawBitmapMode, bool vFlipped = ofIsVFlipped() arguments to getBoundingBox. This allows to get the correct mesh and doesn't break previous way of use of this function.
