### PR TITLE
Download correct RPI libs when arch is not spec'd

### DIFF
--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -114,6 +114,11 @@ if [ "$ARCH" == "" ]; then
             else
                 ARCH=64gcc6
             fi
+        elif [ "$ARCH" == "armv7l" ]; then 
+            # Check for Raspberry Pi
+            if [ -f /opt/vc/include/bcm_host.h ]; then 
+                ARCH=armv6l
+            fi 
         elif [ "$ARCH" == "i686" ] || [ "$ARCH" == "i386" ]; then
             cat << EOF
 32bit linux is not officially supported anymore but compiling


### PR DESCRIPTION
This is a problem that people working with the master branch (not the nightlies or releases) encounter when following the instructions.

Related
https://github.com/openframeworks/openFrameworks/issues/5500
https://github.com/bakercp/ofxIO/issues/22
https://forum.openframeworks.cc/t/raspberry-pi-3-arm6-or-arm7/26800/4
