### PR TITLE
Const corrections for std::filesystem::path, convert additional std::string to std::filesystem::path

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundPlayer.cpp
@@ -43,7 +43,7 @@ ofxAndroidSoundPlayer::~ofxAndroidSoundPlayer(){
 
 
 //------------------------------------------------------------
-bool ofxAndroidSoundPlayer::load(std::filesystem::path fileName, bool stream){
+bool ofxAndroidSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
 	if(!javaSoundPlayer){
 		ofLogError("ofxAndroidSoundPlayer") << "loadSound(): java SoundPlayer not loaded";
 		return false;

--- a/addons/ofxAndroid/src/ofxAndroidSoundPlayer.h
+++ b/addons/ofxAndroid/src/ofxAndroidSoundPlayer.h
@@ -8,7 +8,7 @@ public:
 	ofxAndroidSoundPlayer();
 	virtual ~ofxAndroidSoundPlayer();
 
-	bool load(std::filesystem::path fileName, bool stream = false);
+	bool load(const std::filesystem::path& fileName, bool stream = false);
 	void unload();
 	void play();
 	void stop();

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -37,7 +37,7 @@ ofxEmscriptenSoundPlayer::~ofxEmscriptenSoundPlayer(){
 }
 
 
-bool ofxEmscriptenSoundPlayer::load(std::filesystem::path fileName, bool stream){
+bool ofxEmscriptenSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
 	if(context!=-1){
 		sound = html5audio_sound_load(context,ofToDataPath(fileName).c_str());
 	}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
@@ -8,7 +8,7 @@ public:
 	~ofxEmscriptenSoundPlayer();
 
 
-	bool load(std::filesystem::path fileName, bool stream = false);
+	bool load(const std::filesystem::path& fileName, bool stream = false);
 	void unload();
 	void play();
 	void stop();

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -85,7 +85,7 @@ ofxOpenALSoundPlayer::~ofxOpenALSoundPlayer() {
 
 //--------------------------------------------------------------
 
-bool ofxOpenALSoundPlayer::load(std::filesystem::path filePath, bool stream) {
+bool ofxOpenALSoundPlayer::load(const std::filesystem::path& filePath, bool stream) {
 	
 	if(!SoundEngineInitialized) {
 		ofxOpenALSoundPlayer::initializeSoundEngine();

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
@@ -61,7 +61,7 @@ public:
 	ofxOpenALSoundPlayer();
 	~ofxOpenALSoundPlayer();
 	
-	bool	load(std::filesystem::path fileName, bool stream=false);
+	bool	load(const std::filesystem::path& fileName, bool stream=false);
 	void	unload();
 
 	void	play();

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.h
@@ -15,7 +15,7 @@ public:
     ofxiOSSoundPlayer();
     ~ofxiOSSoundPlayer();
     
-    bool load(std::filesystem::path fileName, bool stream = false);
+    bool load(const std::filesystem::path& fileName, bool stream = false);
     void unload();
     void play();
     void stop();

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
@@ -16,7 +16,7 @@ ofxiOSSoundPlayer::~ofxiOSSoundPlayer() {
     unload();
 }
 
-bool ofxiOSSoundPlayer::load(std::filesystem::path fileName, bool stream) {
+bool ofxiOSSoundPlayer::load(const std::filesystem::path& fileName, bool stream) {
     if(soundPlayer != NULL) {
         unload();
     }

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -639,7 +639,7 @@ public:
 	///
 	/// It expects that the file will be in the [PLY Format](http://en.wikipedia.org/wiki/PLY_(file_format)).
 	/// It will only load meshes saved in the PLY ASCII format; the binary format is not supported.
-    void load(std::filesystem::path path);
+    void load(const std::filesystem::path& path);
 
 	///  \brief Saves the mesh at the passed path in the [PLY Format](http://en.wikipedia.org/wiki/PLY_(file_format)).
 	///
@@ -650,7 +650,7 @@ public:
 	///  If you're planning on reloading the mesh into ofMesh, ofMesh currently only supports loading the ASCII format.
 	///
 	///  For more information, see the [PLY format specification](http://paulbourke.net/dataformats/ply/).
-    void save(std::filesystem::path path, bool useBinary = false) const;
+    void save(const std::filesystem::path& path, bool useBinary = false) const;
 
 	/// \}
 

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1024,7 +1024,7 @@ void ofMesh_<V,N,C,T>::append(const ofMesh_<V,N,C,T> & mesh){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::load(std::filesystem::path path){
+void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 	ofFile is(path, ofFile::ReadOnly);
 	auto & data = *this;
 
@@ -1264,7 +1264,7 @@ void ofMesh_<V,N,C,T>::load(std::filesystem::path path){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::save(std::filesystem::path path, bool useBinary) const{
+void ofMesh_<V,N,C,T>::save(const std::filesystem::path& path, bool useBinary) const{
 	ofFile os(path, ofFile::WriteOnly);
 	const auto & data = *this;
 

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -192,12 +192,12 @@ ofShader & ofShader::operator=(ofShader && mom){
 }
 
 //--------------------------------------------------------------
-bool ofShader::load(std::filesystem::path shaderName) {
+bool ofShader::load(const std::filesystem::path& shaderName) {
 	return load(shaderName.string() + ".vert", shaderName.string() + ".frag");
 }
 
 //--------------------------------------------------------------
-bool ofShader::load(std::filesystem::path vertName, std::filesystem::path fragName, std::filesystem::path geomName) {
+bool ofShader::load(const std::filesystem::path& vertName, const std::filesystem::path& fragName, const std::filesystem::path& geomName) {
 	if(vertName.empty() == false) setupShaderFromFile(GL_VERTEX_SHADER, vertName);
 	if(fragName.empty() == false) setupShaderFromFile(GL_FRAGMENT_SHADER, fragName);
 #ifndef TARGET_OPENGLES
@@ -211,7 +211,7 @@ bool ofShader::load(std::filesystem::path vertName, std::filesystem::path fragNa
 
 #if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
 //--------------------------------------------------------------
-bool ofShader::loadCompute(std::filesystem::path shaderName) {
+bool ofShader::loadCompute(const std::filesystem::path& shaderName) {
 	return setupShaderFromFile(GL_COMPUTE_SHADER, shaderName) && linkProgram();
 }
 #endif
@@ -288,7 +288,7 @@ bool ofShader::setup(const TransformFeedbackSettings & settings) {
 #endif
 
 //--------------------------------------------------------------
-bool ofShader::setupShaderFromFile(GLenum type, std::filesystem::path filename) {
+bool ofShader::setupShaderFromFile(GLenum type, const std::filesystem::path& filename) {
 	ofBuffer buffer = ofBufferFromFile(filename);
 	// we need to make absolutely sure to have an absolute path here, so that any #includes
 	// within the shader files have a root directory to traverse from.
@@ -303,7 +303,7 @@ bool ofShader::setupShaderFromFile(GLenum type, std::filesystem::path filename) 
 }
 
 //--------------------------------------------------------------
-ofShader::Source ofShader::sourceFromFile(GLenum type, std::filesystem::path filename) {
+ofShader::Source ofShader::sourceFromFile(GLenum type, const std::filesystem::path& filename) {
 	ofBuffer buffer = ofBufferFromFile(filename);
 	// we need to make absolutely sure to have an absolute path here, so that any #includes
 	// within the shader files have a root directory to traverse from.

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -42,10 +42,10 @@ public:
 	ofShader(ofShader && shader);
 	ofShader & operator=(ofShader && shader);
 
-	bool load(std::filesystem::path shaderName);
-	bool load(std::filesystem::path vertName, std::filesystem::path fragName, std::filesystem::path geomName="");
+	bool load(const std::filesystem::path& shaderName);
+	bool load(const std::filesystem::path& vertName, const std::filesystem::path& fragName, const std::filesystem::path& geomName="");
 #if !defined(TARGET_OPENGLES) && defined(glDispatchCompute)
-	bool loadCompute(std::filesystem::path shaderName);
+	bool loadCompute(const std::filesystem::path& shaderName);
 #endif
 
 	struct Settings {
@@ -220,7 +220,7 @@ public:
 	// these methods create and compile a shader from source or file
 	// type: GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, GL_GEOMETRY_SHADER_EXT etc.
 	bool setupShaderFromSource(GLenum type, string source, string sourceDirectoryPath = "");
-	bool setupShaderFromFile(GLenum type, std::filesystem::path filename);
+	bool setupShaderFromFile(GLenum type, const std::filesystem::path& filename);
 
 	// links program with all compiled shaders
 	bool linkProgram();
@@ -269,7 +269,7 @@ private:
 #endif
 
 	bool setupShaderFromSource(Source && source);
-	ofShader::Source sourceFromFile(GLenum type, std::filesystem::path filename);
+	ofShader::Source sourceFromFile(GLenum type, const std::filesystem::path& filename);
 	void checkProgramInfoLog();
 	bool checkProgramLinkStatus();
 	void checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLevel);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -444,8 +444,9 @@ static std::string linuxFontPathByName(const std::string& fontname){
 #endif
 
 //-----------------------------------------------------------
-static bool loadFontFace(std::filesystem::path fontname, FT_Face & face, std::filesystem::path & filename){
-	filename = ofToDataPath(fontname,true);
+static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename){
+	std::filesystem::path fontname;
+	filename = ofToDataPath(_fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
 	int fontID = 0;
 	if(!fontFile.exists()){
@@ -762,7 +763,7 @@ ofTrueTypeFont::glyph ofTrueTypeFont::loadGlyph(uint32_t utf8) const{
 }
 
 //-----------------------------------------------------------
-bool ofTrueTypeFont::load(std::filesystem::path filename, int fontSize, bool antialiased, bool fullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
+bool ofTrueTypeFont::load(const std::filesystem::path& filename, int fontSize, bool antialiased, bool fullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
 	ofTtfSettings settings(filename,fontSize);
 	settings.antialiased = antialiased;
 	settings.contours = makeContours;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -183,7 +183,7 @@ public:
     /// \param simplifyAmt the amount to simplify the vector contours.  Larger number means more simplified.
     /// \param dpi the dots per inch used to specify rendering size.
 	/// \returns true if the font was loaded correctly.
-    bool load(std::filesystem::path filename,
+    bool load(const std::filesystem::path& filename,
                   int fontsize,
                   bool _bAntiAliased=true,
                   bool _bFullCharacterSet=true,

--- a/libs/openFrameworks/sound/ofBaseSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofBaseSoundPlayer.h
@@ -16,7 +16,7 @@ public:
 	ofBaseSoundPlayer(){};
 	virtual ~ofBaseSoundPlayer(){};
 	
-    virtual bool load(std::filesystem::path fileName, bool stream = false)=0;
+    virtual bool load(const std::filesystem::path& fileName, bool stream = false)=0;
 	virtual void unload()=0;
 	virtual void play() = 0;
 	virtual void stop() = 0;

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.cpp
@@ -185,9 +185,9 @@ void ofFmodSoundPlayer::closeFmod(){
 }
 
 //------------------------------------------------------------
-bool ofFmodSoundPlayer::load(std::filesystem::path fileName, bool stream){
+bool ofFmodSoundPlayer::load(const std::filesystem::path& _fileName, bool stream){
 
-	fileName = ofToDataPath(fileName);
+	auto fileName = ofToDataPath(_fileName);
 
 	// fmod uses IO posix internally, might have trouble
 	// with unicode paths...
@@ -214,7 +214,7 @@ bool ofFmodSoundPlayer::load(std::filesystem::path fileName, bool stream){
 	int fmodFlags =  FMOD_SOFTWARE;
 	if(stream)fmodFlags =  FMOD_SOFTWARE | FMOD_CREATESTREAM;
 
-    result = FMOD_System_CreateSound(sys, fileName.string().c_str(),  fmodFlags, nullptr, &sound);
+    result = FMOD_System_CreateSound(sys, fileName.data(),  fmodFlags, nullptr, &sound);
 
 	if (result != FMOD_OK){
 		bLoadedOk = false;

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -41,7 +41,7 @@ class ofFmodSoundPlayer : public ofBaseSoundPlayer {
 		ofFmodSoundPlayer();
 		virtual ~ofFmodSoundPlayer();
 
-        bool load(std::filesystem::path fileName, bool stream = false);
+        bool load(const std::filesystem::path& fileName, bool stream = false);
 		void unload();
 		void play();
 		void stop();

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -171,7 +171,7 @@ void ofOpenALSoundPlayer::close(){
 }
 
 // ----------------------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfReadFile(std::filesystem::path path, vector<short> & buffer, vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfReadFile(const std::filesystem::path& path, vector<short> & buffer, vector<float> & fftAuxBuffer){
 	SF_INFO sfInfo;
 	SNDFILE* f = sf_open(path.c_str(),SFM_READ,&sfInfo);
 	if(!f){
@@ -225,7 +225,7 @@ bool ofOpenALSoundPlayer::sfReadFile(std::filesystem::path path, vector<short> &
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123ReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123ReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	int err = MPG123_OK;
 	mpg123_handle * f = mpg123_new(nullptr,&err);
 	if(mpg123_open(f,path.c_str())!=MPG123_OK){
@@ -263,7 +263,7 @@ bool ofOpenALSoundPlayer::mpg123ReadFile(std::filesystem::path path,vector<short
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfStream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfStream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	if(!streamf){
 		SF_INFO sfInfo;
 		streamf = sf_open(path.c_str(),SFM_READ,&sfInfo);
@@ -326,7 +326,7 @@ bool ofOpenALSoundPlayer::sfStream(std::filesystem::path path,vector<short> & bu
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123Stream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123Stream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
 	if(!mp3streamf){
 		int err = MPG123_OK;
 		mp3streamf = mpg123_new(nullptr,&err);
@@ -377,7 +377,7 @@ bool ofOpenALSoundPlayer::mpg123Stream(std::filesystem::path path,vector<short> 
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::stream(std::filesystem::path fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::stream(const std::filesystem::path& fileName, vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)=="mp3" || ofFilePath::getFileExt(fileName)=="MP3" || mp3streamf){
 		if(!mpg123Stream(fileName,buffer,fftAuxBuffer)) return false;
@@ -397,7 +397,7 @@ bool ofOpenALSoundPlayer::stream(std::filesystem::path fileName, vector<short> &
 	return true;
 }
 
-bool ofOpenALSoundPlayer::readFile(std::filesystem::path fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::readFile(const std::filesystem::path& fileName, vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)!="mp3" && ofFilePath::getFileExt(fileName)!="MP3"){
 		if(!sfReadFile(fileName,buffer,fftAuxBuffer)) return false;
@@ -420,7 +420,7 @@ bool ofOpenALSoundPlayer::readFile(std::filesystem::path fileName, vector<short>
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::load(std::filesystem::path fileName, bool is_stream){
+bool ofOpenALSoundPlayer::load(const std::filesystem::path& fileName, bool is_stream){
 
 	fileName = ofToDataPath(fileName);
 

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -420,9 +420,9 @@ bool ofOpenALSoundPlayer::readFile(const std::filesystem::path& fileName, vector
 }
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::load(const std::filesystem::path& fileName, bool is_stream){
+bool ofOpenALSoundPlayer::load(const std::filesystem::path& _fileName, bool is_stream){
 
-	fileName = ofToDataPath(fileName);
+	std::filesystem::path fileName = ofToDataPath(_fileName);
 
 	bMultiPlay = false;
 	isStreaming = is_stream;

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -51,7 +51,7 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		ofOpenALSoundPlayer();
 		virtual ~ofOpenALSoundPlayer();
 
-        bool load(std::filesystem::path fileName, bool stream = false);
+        bool load(const std::filesystem::path& fileName, bool stream = false);
 		void unload();
 		void play();
 		void stop();
@@ -95,15 +95,15 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		static void runWindow(vector<float> & signal);
 		static void initSystemFFT(int bands);
 
-        bool sfReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-        bool sfStream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool sfReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool sfStream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
 #ifdef OF_USING_MPG123
-        bool mpg123ReadFile(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-        bool mpg123Stream(std::filesystem::path path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool mpg123ReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool mpg123Stream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
 #endif
 
-        bool readFile(std::filesystem::path fileName,vector<short> & buffer);
-        bool stream(std::filesystem::path fileName, vector<short> & buffer);
+        bool readFile(const std::filesystem::path& fileName,vector<short> & buffer);
+        bool stream(const std::filesystem::path& fileName, vector<short> & buffer);
 
 		bool isStreaming;
 		bool bMultiPlay;

--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -75,7 +75,7 @@ shared_ptr<ofBaseSoundPlayer> ofSoundPlayer::getPlayer(){
 }
 
 //--------------------------------------------------------------------
-bool ofSoundPlayer::load(std::filesystem::path fileName, bool stream){
+bool ofSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
 	if( player ){
 		return player->load(fileName, stream);
 	}

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -87,7 +87,7 @@ public:
     ///
     /// \param fileName Path to the sound file, relative to your app's data folder.
     /// \param stream set "true" to enable streaming from disk (for large files).
-    bool load(std::filesystem::path fileName, bool stream = false);
+    bool load(const std::filesystem::path& fileName, bool stream = false);
     OF_DEPRECATED_MSG("Use load",bool loadSound(string fileName, bool stream = false));
 
     /// \brief Stops and unloads the current sound.


### PR DESCRIPTION
Replaces https://github.com/openframeworks/openFrameworks/pull/5215