### PR TITLE
Use std::make_shared and std::make_unique where possible.

### DIFF
--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -26,9 +26,9 @@ of3dPrimitive::of3dPrimitive(const of3dPrimitive & mom):ofNode(mom){
     texCoords = mom.texCoords;
     usingVbo = mom.usingVbo;
 	if(usingVbo){
-		mesh = shared_ptr<ofMesh>(new ofVboMesh);
+		mesh = std::make_shared<ofVboMesh>();
 	}else{
-		mesh = shared_ptr<ofMesh>(new ofMesh);
+		mesh = std::make_shared<ofMesh>();
 	}
 	*mesh = *mom.mesh;
 }
@@ -268,9 +268,9 @@ void of3dPrimitive::setUseVbo(bool useVbo){
 	if(useVbo!=usingVbo){
 		shared_ptr<ofMesh> newMesh;
 		if(useVbo){
-			newMesh = shared_ptr<ofMesh>(new ofVboMesh);
+			newMesh = std::make_shared<ofVboMesh>();
 		}else{
-			newMesh = shared_ptr<ofMesh>(new ofMesh);
+			newMesh = std::make_shared<ofMesh>();
 		}
 		*newMesh = *mesh;
 		mesh = newMesh;

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -169,9 +169,9 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
 		if(settings.glesVersion>=2){
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+			currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 		}else{
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+			currentRenderer = std::make_shared<ofGLRenderer>(this);
 		}
 	#else
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
@@ -182,9 +182,9 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		}
 		if(settings.glVersionMajor>=3){
 			glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+			currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 		}else{
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+			currentRenderer = std::make_shared<ofGLRenderer>(this);
 		}
 	#endif
 

--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -75,7 +75,7 @@ void ofAppNoWindow::setup(const ofWindowSettings & settings){
 	width = settings.width;
 	height = settings.height;
 
-	currentRenderer = shared_ptr<ofBaseRenderer>(new ofNoopRenderer);
+	currentRenderer = std::make_shared<ofNoopRenderer>();
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -42,20 +42,20 @@ ofMainLoop::~ofMainLoop() {
 
 shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & settings){
 #ifdef TARGET_NODISPLAY
-	shared_ptr<ofAppNoWindow> window = shared_ptr<ofAppNoWindow>(new ofAppNoWindow());
+	shared_ptr<ofAppNoWindow> window = std::make_shared<ofAppNoWindow>();
 #else
 	#if defined(TARGET_OF_IOS)
-	shared_ptr<ofAppiOSWindow> window = shared_ptr<ofAppiOSWindow>(new ofAppiOSWindow());
+	shared_ptr<ofAppiOSWindow> window = std::make_shared<ofAppiOSWindow>();
 	#elif defined(TARGET_ANDROID)
-	shared_ptr<ofAppAndroidWindow> window = shared_ptr<ofAppAndroidWindow>(new ofAppAndroidWindow());
+	shared_ptr<ofAppAndroidWindow> window = std::make_shared<ofAppAndroidWindow>();
 	#elif defined(TARGET_RASPBERRY_PI)
-	shared_ptr<ofAppEGLWindow> window = shared_ptr<ofAppEGLWindow>(new ofAppEGLWindow());
+	shared_ptr<ofAppEGLWindow> window = std::make_shared<ofAppEGLWindow>();
 	#elif defined(TARGET_EMSCRIPTEN)
-	shared_ptr<ofxAppEmscriptenWindow> window = shared_ptr<ofxAppEmscriptenWindow>(new ofxAppEmscriptenWindow);
+	shared_ptr<ofxAppEmscriptenWindow> window = std::make_shared<ofxAppEmscriptenWindow>();
 	#elif defined(TARGET_OPENGLES)
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+	shared_ptr<ofAppGLFWWindow> window = std::make_shared<ofAppGLFWWindow>();
 	#else
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+	shared_ptr<ofAppGLFWWindow> window = std::make_shared<ofAppGLFWWindow>();
 	#endif
 #endif
 	addWindow(window);

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <stddef.h>
 #include <functional>
+#include "ofTypes.h"
 
 
 /*! \cond PRIVATE */
@@ -68,7 +69,7 @@ namespace priv{
 
 	// -------------------------------------
 	inline std::unique_ptr<StdFunctionId> make_function_id(){
-		return std::unique_ptr<StdFunctionId>(new StdFunctionId());
+		return std::make_unique<StdFunctionId>();
 	}
 
 	// -------------------------------------
@@ -241,7 +242,7 @@ namespace priv{
 		};
 
 		std::unique_ptr<EventToken> make_token(const Function & f){
-			return std::unique_ptr<EventToken>(new EventToken(self,*f.id));
+			return std::make_unique<EventToken>(self,*f.id);
 		}
 
 		template<typename TFunction>
@@ -425,7 +426,7 @@ protected:
 
 	template<class TObj, typename TMethod>
 	std::unique_ptr<FunctionId<TObj,TMethod>> make_function_id(TObj * listener, TMethod method){
-		return std::unique_ptr<FunctionId<TObj,TMethod>>(new FunctionId<TObj,TMethod>(listener,method));
+		return std::make_unique<FunctionId<TObj,TMethod>>(listener,method);
 	}
 
 	template<class TObj>

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -42,7 +42,7 @@ ofBufferObject::ofBufferObject()
 }
 
 void ofBufferObject::allocate(){
-	data = shared_ptr<Data>(new Data());
+	data = std::make_shared<Data>();
 }
 
 void ofBufferObject::allocate(GLsizeiptr bytes, GLenum usage){

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -842,7 +842,7 @@ void ofTexture::setAlphaMask(ofTexture & mask){
 	if(mask.texData.textureTarget!=this->texData.textureTarget){
 		ofLogError("ofTexture") << "Cannot set alpha mask with different texture target";
 	}else{
-		texData.alphaMask = shared_ptr<ofTexture>(new ofTexture(mask));
+		texData.alphaMask = std::make_shared<ofTexture>(mask);
 	}
 }
 

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -57,7 +57,7 @@ static void ofBeginSaveScreen(string filename, ofCairoRenderer::Type type, bool 
 	
 	storedRenderer = ofGetCurrentRenderer();
 	
-	cairoScreenshot = shared_ptr<ofCairoRenderer>(new ofCairoRenderer);
+	cairoScreenshot = std::make_unique<ofCairoRenderer>();
 	cairoScreenshot->setup(filename, type, bMultipage, b3D, outputsize);
 
 	rendererCollection = make_shared<ofRendererCollection>();

--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -60,7 +60,7 @@ float * ofSoundGetSpectrum(int nBands){
 //---------------------------------------------------------------------------
 ofSoundPlayer::ofSoundPlayer (){
 #ifdef OF_SOUND_PLAYER_TYPE
-	player	= shared_ptr<OF_SOUND_PLAYER_TYPE>(new OF_SOUND_PLAYER_TYPE);
+	player	= std::make_shared<OF_SOUND_PLAYER_TYPE>();
 #endif
 }
 

--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -142,7 +142,7 @@ vector<ofSoundDevice> ofSoundStreamListDevices(){
 //------------------------------------------------------------
 ofSoundStream::ofSoundStream(){
 	#ifdef OF_SOUND_STREAM_TYPE
-		setSoundStream( shared_ptr<OF_SOUND_STREAM_TYPE>(new OF_SOUND_STREAM_TYPE) );
+		setSoundStream(std::make_shared<OF_SOUND_STREAM_TYPE>());
 	#endif
 }
 

--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -52,7 +52,7 @@ ofLogLevel ofGetLogLevel(string module){
 
 //--------------------------------------------------
 void ofLogToFile(const std::filesystem::path & path, bool append){
-	ofLog::setChannel(shared_ptr<ofFileLoggerChannel>(new ofFileLoggerChannel(path,append)));
+	ofLog::setChannel(std::make_shared<ofFileLoggerChannel>(path,append));
 }
 
 //--------------------------------------------------

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -25,7 +25,7 @@ void ofVideoGrabber::setGrabber(shared_ptr<ofBaseVideoGrabber> newGrabber){
 //--------------------------------------------------------------------
 shared_ptr<ofBaseVideoGrabber> ofVideoGrabber::getGrabber(){
 	if(!grabber){
-		setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		setGrabber(std::make_shared<OF_VID_GRABBER_TYPE>());
 	}
 	return grabber;
 }
@@ -42,7 +42,7 @@ bool ofVideoGrabber::setup(int w, int h, bool setUseTexture){
 #endif
 
 	if(!grabber){
-		setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		setGrabber(std::make_shared<OF_VID_GRABBER_TYPE>());
 	}
 
 	bUseTexture = setUseTexture;
@@ -110,7 +110,7 @@ ofPixelFormat ofVideoGrabber::getPixelFormat() const{
 vector<ofVideoDevice> ofVideoGrabber::listDevices() const{
 	if(!grabber){
 		ofVideoGrabber * mutThis = const_cast<ofVideoGrabber*>(this);
-		mutThis->setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		mutThis->setGrabber(std::make_shared<OF_VID_GRABBER_TYPE>());
 	}
 	return grabber->listDevices();
 }

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -22,7 +22,7 @@ void ofVideoPlayer::setPlayer(shared_ptr<ofBaseVideoPlayer> newPlayer){
 //---------------------------------------------------------------------------
 shared_ptr<ofBaseVideoPlayer> ofVideoPlayer::getPlayer(){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer(std::make_shared<OF_VID_PLAYER_TYPE>());
 	}
 	return player;
 }
@@ -66,7 +66,7 @@ ofPixelFormat ofVideoPlayer::getPixelFormat() const{
 //---------------------------------------------------------------------------
 bool ofVideoPlayer::load(string name){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer(std::make_shared<OF_VID_PLAYER_TYPE>());
 		player->setPixelFormat(internalPixelFormat);
 	}
 	
@@ -99,7 +99,7 @@ bool ofVideoPlayer::load(string name){
 //---------------------------------------------------------------------------
 void ofVideoPlayer::loadAsync(string name){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer(std::make_shared<OF_VID_PLAYER_TYPE>());
 		player->setPixelFormat(internalPixelFormat);
 	}
 	


### PR DESCRIPTION
Cleaner, more modern syntax.  Reduce the `new` keyword.  Not possible to replace shared_ptr constructors with custom deleters.