### PR TITLE
External time mode

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -66,6 +66,8 @@ void		ofSetTimeModeSystem();
 uint64_t	ofGetFixedStepForFps(double fps);
 void		ofSetTimeModeFixedRate(uint64_t stepNanos = ofGetFixedStepForFps(60)); //default nanos for 1 frame at 60fps
 void		ofSetTimeModeFiltered(float alpha = 0.9);
+void		ofSetTimeModeExternal(std::function<ofTime()> timeFunction, ofTime startTime);
+void		ofSetTimeModeExternalFiltered(std::function<ofTime()> timeFunction, ofTime startTime, float alpha);
 
 void		ofSetOrientation(ofOrientation orientation, bool vFlip=true);
 ofOrientation			ofGetOrientation();

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -189,6 +189,10 @@ void ofCoreEvents::setTimeModeFiltered(float alpha){
 	fps.setFilterAlpha(alpha);
 }
 
+void ofCoreEvents::resetStartTime(){
+	fps = ofFpsCounter(fps.getFps());
+}
+
 //--------------------------------------
 void ofCoreEvents::setFrameRate(int _targetRate){
 	// given this FPS, what is the amount of millis per frame

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -273,6 +273,7 @@ class ofCoreEvents {
 	void setTimeModeSystem();
 	void setTimeModeFixedRate(uint64_t nanosecsPerFrame);
 	void setTimeModeFiltered(float alpha);
+	void resetStartTime();
 
 	void setFrameRate(int _targetRate);
 	float getFrameRate() const;

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -5,6 +5,7 @@
 
 #include "ofBaseSoundPlayer.h"
 #include "ofFileUtils.h"
+#include "ofUtils.h"
 
 
 extern "C" {
@@ -31,6 +32,8 @@ void ofFmodSoundSetVolume(float vol);
 void ofFmodSoundUpdate();						// calls FMOD update.
 float * ofFmodSoundGetSpectrum(int nBands);		// max 512...
 void ofFmodSetBuffersize(unsigned int bs);
+void ofFmodSetSamplerate(unsigned int sr);
+ofTime ofFmodGetDSPTime();
 
 
 // --------------------- player functions:

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1,14 +1,22 @@
 #pragma once
 
 #include "ofConstants.h"
-#if !_MSC_VER
-#define BOOST_NO_CXX11_SCOPED_ENUMS
-#define BOOST_NO_SCOPED_ENUMS
+
+#if OF_USING_STD_FS
+	#include <experimental/filesystem>
+	namespace std {
+		namespace filesystem = std::experimental::filesystem;
+	}
+#else
+	#if !_MSC_VER
+	#define BOOST_NO_CXX11_SCOPED_ENUMS
+	#define BOOST_NO_SCOPED_ENUMS
+	#endif
+	#include <boost/filesystem.hpp>
+	namespace std {
+		namespace filesystem = boost::filesystem;
+	}
 #endif
-#include <boost/filesystem.hpp>
-namespace std {
-	namespace filesystem = boost::filesystem;
-}
 
 //----------------------------------------------------------
 // ofBuffer

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -89,6 +89,7 @@ struct ofTime{
 	enum Mode{
 		System,
 		FixedRate,
+		External,
 	} mode = System;
 
 	uint64_t getAsMilliseconds() const;


### PR DESCRIPTION
Adds a new time mode, external, that allows to set the global OF
time calls to return the time based on an external source.

A common case could be a sound source for synchronizing animations,
to sound.

This includes a new funcion in fmod: ofFmodGetDSPTime that can be used
with this new functionality as:

```
ofSetTimeModeExternal(ofFmodGetDSPTime, ofTime());
```

although for sound is recomended to use:

```
ofSetTimeModeExternalFiltered(ofFmodGetDSPTime, ofTime(), 0.99);
```

or similar since the different update rates can make the ofGetLastFrameTime
very noisy otherwise