### PR TITLE
Fixed documentation for ofFilePath::getBasename()

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -353,9 +353,9 @@ public:
 	/// \returns filename
     static string getFileName(const std::filesystem::path& filePath, bool bRelativeToData = true);
 	
-	/// Get a file path without its last component,
-	/// ie. "images/duck.jpg" -> "images" and
-	/// "images/some/folder" -> "images/some"
+	/// Get a file name without its extension,
+	/// ie. "images/duck.jpg" -> "duck" and
+	/// "images/some/folder" -> "folder"
 	///
 	/// \param filePath file path
 	/// \returns basename


### PR DESCRIPTION
I had made this PR before but I deleted it because I couldn't fix some git problems in it. was easier to make a whole new PR.
