### PR TITLE
ofxGUi: fix textinput field initial state

### DIFF
--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -140,7 +140,7 @@ ofxInputField<Type>::ofxInputField(ofParameter<Type> _val, float width, float he
 template<typename Type>
 ofxInputField<Type>* ofxInputField<Type>::setup(ofParameter<Type> _val, float width, float height){
 	value.makeReferenceTo(_val);
-	input = toString(value.get());
+	visibleInput = input = toString(value.get());
 	b.x = 0;
 	b.y = 0;
 	b.width = width;


### PR DESCRIPTION
+ textinputfield would not show any text, as visibleinput would default
  to empty string. this makes it default to its input.