### PR TITLE
Fixes invalid generated ios bundle identifiers

### DIFF
--- a/scripts/templates/ios/ofxiOS-Info.plist
+++ b/scripts/templates/ios/ofxiOS-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_NAME:identifier}</string>
+	<string>${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Fixes 

https://github.com/openframeworks/projectGenerator/issues/158

This automatically removes invalid characters (like underscores in an addon's example name).