### PR TITLE
scale number of make jobs to number of processors on linux

### DIFF
--- a/scripts/linux/compileOF.sh
+++ b/scripts/linux/compileOF.sh
@@ -14,7 +14,14 @@ SCRIPTPATH=`pwd`
 popd > /dev/null
 
 BUILD="install"
-JOBS=`nproc --all`
+
+# if nproc exists, use it to scale the number of jobs to number of processors
+if hash nproc 2>/dev/null; then
+  JOBS=`nproc --all`
+else
+  JOBS=1
+fi
+
 while getopts tj: opt ; do
 	case "$opt" in
 		t)  # testing, only build Debug

--- a/scripts/linux/compileOF.sh
+++ b/scripts/linux/compileOF.sh
@@ -14,7 +14,7 @@ SCRIPTPATH=`pwd`
 popd > /dev/null
 
 BUILD="install"
-JOBS=1
+JOBS=`nproc --all`
 while getopts tj: opt ; do
 	case "$opt" in
 		t)  # testing, only build Debug


### PR DESCRIPTION
Essentially `make -j8` vs `make -j1` as default.

Is there reason for it to be a default of 1? I imagine the rPI might have a little difficulty, but it doesn't seem like that was part of the reasoning from the [original commit](https://github.com/openframeworks/openFrameworks/commit/10a5baaf15fb7ea44a7a2cba6eca0d5aac529b7c)