### PR TITLE
Remove using namespace std

### DIFF
--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -20,7 +20,6 @@
 #include "ofGLProgrammableRenderer.h"
 #include "ofGLRenderer.h"
 #include "ofBaseTypes.h"
-using namespace std;
 
 static bool paused=true;
 static bool surfaceDestroyed=false;
@@ -37,7 +36,7 @@ static ofAppAndroidWindow * window;
 
 static ofOrientation orientation = OF_ORIENTATION_DEFAULT;
 
-static queue<ofTouchEventArgs> touchEventArgsQueue;
+static std::queue<ofTouchEventArgs> touchEventArgsQueue;
 static std::mutex mtx;
 static bool threadedTouchEvents = false;
 static bool appSetup = false;
@@ -121,9 +120,9 @@ void ofAppAndroidWindow::setup(const ofGLESWindowSettings & settings){
 	glesVersion = settings.glesVersion;
 	ofLogError() << "setup gles" << glesVersion;
 	if(glesVersion<2){
-		currentRenderer = make_shared<ofGLRenderer>(this);
+		currentRenderer = std::make_shared<ofGLRenderer>(this);
 	}else{
-		currentRenderer = make_shared<ofGLProgrammableRenderer>(this);
+		currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 	}
 
 	jclass javaClass = ofGetJNIEnv()->FindClass("cc/openframeworks/OFAndroid");
@@ -229,7 +228,7 @@ ofCoreEvents & ofAppAndroidWindow::events(){
 	return coreEvents;
 }
 
-shared_ptr<ofBaseRenderer> & ofAppAndroidWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppAndroidWindow::renderer(){
 	return currentRenderer;
 }
 
@@ -252,8 +251,8 @@ Java_cc_openframeworks_OFAndroid_setAppDataDir( JNIEnv*  env, jobject  thiz, jst
 {
 	jboolean iscopy;
 	const char *mfile = env->GetStringUTFChars(data_dir, &iscopy);
-	__android_log_print(ANDROID_LOG_INFO,"ofAppAndroidWindow",("setting app dir name to: \"" + string(mfile) + "\"").c_str());
-    ofSetDataPathRoot(string(mfile)+"/");
+	__android_log_print(ANDROID_LOG_INFO,"ofAppAndroidWindow",("setting app dir name to: \"" + std::string(mfile) + "\"").c_str());
+    ofSetDataPathRoot(std::string(mfile)+"/");
     env->ReleaseStringUTFChars(data_dir, mfile);
 }
 
@@ -374,7 +373,7 @@ Java_cc_openframeworks_OFAndroid_render( JNIEnv*  env, jclass  thiz )
 
 	if(!threadedTouchEvents){
 		mtx.lock();
-		queue<ofTouchEventArgs> events = touchEventArgsQueue;
+		std::queue<ofTouchEventArgs> events = touchEventArgsQueue;
 		while(!touchEventArgsQueue.empty()) touchEventArgsQueue.pop();
 		mtx.unlock();
 
@@ -572,7 +571,7 @@ Java_cc_openframeworks_OFAndroid_onMenuItemSelected( JNIEnv*  env, jobject  thiz
 	jboolean iscopy;
 	const char * menu_id_str = env->GetStringUTFChars(menu_id, &iscopy);
 	if(!menu_id_str) return false;
-	string id_str(menu_id_str);
+	std::string id_str(menu_id_str);
 	return ofxAndroidEvents().menuItemSelected.notify(nullptr,id_str);
 }
 
@@ -581,7 +580,7 @@ Java_cc_openframeworks_OFAndroid_onMenuItemChecked( JNIEnv*  env, jobject  thiz,
 	jboolean iscopy;
 	const char *menu_id_str = env->GetStringUTFChars(menu_id, &iscopy);
 	if(!menu_id_str) return false;
-	string id_str(menu_id_str);
+	std::string id_str(menu_id_str);
 	return ofxAndroidEvents().menuItemChecked.notify(nullptr,id_str);
 }
 

--- a/addons/ofxAndroid/src/ofAppAndroidWindow.h
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.h
@@ -45,7 +45,7 @@ public:
 
 	bool	doesHWOrientation(){return true;}
 
-	void	setWindowTitle(string title){}
+	void	setWindowTitle(std::string title){}
 
 	ofWindowMode	getWindowMode() {return OF_WINDOW;}
 
@@ -59,13 +59,13 @@ public:
 	ofOrientation	getOrientation();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
 
 	void	setThreadedEvents(bool threadedEvents);
 	void 	setAccumulateTouchEvents(bool accumEvents);
 
 private:
 	ofCoreEvents coreEvents;
-	shared_ptr<ofBaseRenderer> currentRenderer;
+	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	int glesVersion;
 };

--- a/addons/ofxAndroid/src/ofxAndroidCircBuffer.h
+++ b/addons/ofxAndroid/src/ofxAndroidCircBuffer.h
@@ -23,7 +23,7 @@ public:
 	}
 
 private:
-	vector<Content> buffer;
+	std::vector<Content> buffer;
 	int readIndex;
 	int writeIndex;
 	int buffer_size;

--- a/addons/ofxAndroid/src/ofxAndroidLogChannel.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidLogChannel.cpp
@@ -13,7 +13,7 @@ ofxAndroidLogChannel::ofxAndroidLogChannel(){
 
 }
 
-void ofxAndroidLogChannel::log(ofLogLevel level, const string & module, const string& msg){
+void ofxAndroidLogChannel::log(ofLogLevel level, const std::string & module, const std::string& msg){
 	android_LogPriority androidPrio;
 	switch (level){
 	case OF_LOG_VERBOSE:
@@ -39,7 +39,7 @@ void ofxAndroidLogChannel::log(ofLogLevel level, const string & module, const st
 }
 
 
-void ofxAndroidLogChannel::log(ofLogLevel logLevel, const string & module, const char* format, ...){
+void ofxAndroidLogChannel::log(ofLogLevel logLevel, const std::string & module, const char* format, ...){
 	android_LogPriority androidPrio;
 	switch (logLevel){
 	case OF_LOG_VERBOSE:
@@ -68,7 +68,7 @@ void ofxAndroidLogChannel::log(ofLogLevel logLevel, const string & module, const
 }
 
 
-void ofxAndroidLogChannel::log(ofLogLevel logLevel, const string & module, const char* format, va_list args){
+void ofxAndroidLogChannel::log(ofLogLevel logLevel, const std::string & module, const char* format, va_list args){
 	android_LogPriority androidPrio;
 	switch (logLevel){
 	case OF_LOG_VERBOSE:

--- a/addons/ofxAndroid/src/ofxAndroidLogChannel.h
+++ b/addons/ofxAndroid/src/ofxAndroidLogChannel.h
@@ -13,7 +13,7 @@ class ofxAndroidLogChannel: public ofBaseLoggerChannel{
 public:
 	ofxAndroidLogChannel();
 
-	void log(ofLogLevel level, const string & module, const string& msg);
-	void log(ofLogLevel logLevel, const string & module, const char* format, ...);
-	void log(ofLogLevel logLevel, const string & module, const char* format, va_list args);
+	void log(ofLogLevel level, const std::string & module, const std::string& msg);
+	void log(ofLogLevel logLevel, const std::string & module, const char* format, ...);
+	void log(ofLogLevel logLevel, const std::string & module, const char* format, va_list args);
 };

--- a/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidSoundStream.cpp
@@ -47,7 +47,7 @@ ofxAndroidSoundStream::~ofxAndroidSoundStream(){
 
 std::vector<ofSoundDevice> ofxAndroidSoundStream::getDeviceList(ofSoundDevice::Api api) const{
     ofLogWarning("ofxAndroidSoundStream") << "getDeviceList() isn't implemented on android";
-    return vector<ofSoundDevice>();
+    return std::vector<ofSoundDevice>();
 }
 
 void ofxAndroidSoundStream::setDeviceID(int deviceID){

--- a/addons/ofxAndroid/src/ofxAndroidUtils.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.cpp
@@ -63,7 +63,7 @@ bool ofxAndroidIsMobileOnline(){
 	return ofGetJNIEnv()->CallStaticBooleanMethod(javaClass,isMobileOnline);
 }
 
-string ofxAndroidGetStringRes(string id){
+std::string ofxAndroidGetStringRes(std::string id){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -102,7 +102,7 @@ void ofxAndroidPauseApp(){
 	ofGetJNIEnv()->CallStaticVoidMethod(javaClass,pauseApp);
 }
 
-void ofxAndroidAlertBox(string msg){
+void ofxAndroidAlertBox(std::string msg){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -121,7 +121,7 @@ void ofxAndroidAlertBox(string msg){
 }
 
 
-int ofxAndroidProgressBox(string msg){
+int ofxAndroidProgressBox(std::string msg){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -158,7 +158,7 @@ void ofxAndroidDismissProgressBox(int id){
 
 
 
-void ofxAndroidOkCancelBox(string msg){
+void ofxAndroidOkCancelBox(std::string msg){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -176,7 +176,7 @@ void ofxAndroidOkCancelBox(string msg){
 	ofGetJNIEnv()->DeleteLocalRef((jobject)jMsg);
 }
 
-void ofxAndroidYesNoBox(string msg){
+void ofxAndroidYesNoBox(std::string msg){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -195,7 +195,7 @@ void ofxAndroidYesNoBox(string msg){
 }
 
 
-void ofxAndroidAlertTextBox(string question, string text){
+void ofxAndroidAlertTextBox(std::string question, std::string text){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -215,7 +215,7 @@ void ofxAndroidAlertTextBox(string question, string text){
 	ofGetJNIEnv()->DeleteLocalRef((jobject)jQuestion);
 }
 
-bool ofxAndroidAlertListBox(string title, const vector<string> & list){
+bool ofxAndroidAlertListBox(std::string title, const std::vector<std::string> & list){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -244,7 +244,7 @@ bool ofxAndroidAlertListBox(string title, const vector<string> & list){
 	return res;
 }
 
-void ofxAndroidToast(string msg){
+void ofxAndroidToast(std::string msg){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -345,7 +345,7 @@ void ofxAndroidDisableMulticast(){
 	ofGetJNIEnv()->CallStaticVoidMethod(javaClass,method);
 }
 
-void ofxAndroidSetViewItemChecked(string item_name, bool checked){
+void ofxAndroidSetViewItemChecked(std::string item_name, bool checked){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -361,7 +361,7 @@ void ofxAndroidSetViewItemChecked(string item_name, bool checked){
 	ofGetJNIEnv()->CallStaticVoidMethod(javaClass,setViewItemChecked,ofGetJNIEnv()->NewStringUTF(item_name.c_str()),checked);
 }
 
-string ofxAndroidRandomUUID(){
+std::string ofxAndroidRandomUUID(){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -397,7 +397,7 @@ void ofxAndroidMonitorNetworkState(){
 	ofGetJNIEnv()->CallStaticVoidMethod(javaClass,method);
 }
 
-string ofxAndroidGetTextBoxResult(){
+std::string ofxAndroidGetTextBoxResult(){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){
@@ -417,7 +417,7 @@ string ofxAndroidGetTextBoxResult(){
 	return ofGetJNIEnv()->GetStringUTFChars(str,&isCopy);
 }
 
-void ofxAndroidLaunchBrowser(string url){
+void ofxAndroidLaunchBrowser(std::string url){
 	jclass javaClass = ofGetJavaOFAndroid();
 
 	if(javaClass==0){

--- a/addons/ofxAndroid/src/ofxAndroidUtils.h
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.h
@@ -59,16 +59,16 @@ bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodNam
 bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodName, std::string methodSignature, ...);
 bool ofxJavaCallBoolMethod(jobject object, std::string className, std::string methodName, std::string methodSignature, ...);
 
-void ofxAndroidAlertBox(string msg);
-int ofxAndroidProgressBox(string msg);
+void ofxAndroidAlertBox(std::string msg);
+int ofxAndroidProgressBox(std::string msg);
 void ofxAndroidDismissProgressBox(int id);
-void ofxAndroidOkCancelBox(string msg);
-void ofxAndroidYesNoBox(string msg);
-void ofxAndroidAlertTextBox(string question, string text);
-string ofxAndroidGetTextBoxResult();
-bool ofxAndroidAlertListBox(string title, const vector<string> & list);
+void ofxAndroidOkCancelBox(std::string msg);
+void ofxAndroidYesNoBox(std::string msg);
+void ofxAndroidAlertTextBox(std::string question, std::string text);
+std::string ofxAndroidGetTextBoxResult();
+bool ofxAndroidAlertListBox(std::string title, const std::vector<std::string> & list);
 
-void ofxAndroidToast(string msg);
+void ofxAndroidToast(std::string msg);
 
 void ofxAndroidLockScreenSleep();
 void ofxAndroidUnlockScreenSleep();
@@ -77,13 +77,13 @@ bool ofxAndroidIsOnline();
 bool ofxAndroidIsWifiOnline();
 bool ofxAndroidIsMobileOnline();
 
-string ofxAndroidGetStringRes(string id);
+std::string ofxAndroidGetStringRes(std::string id);
 
-string ofxAndroidRandomUUID();
+std::string ofxAndroidRandomUUID();
 
 void ofxAndroidMonitorNetworkState();
 
-void ofxAndroidLaunchBrowser(string url);
+void ofxAndroidLaunchBrowser(std::string url);
 
 void ofxAndroidNotifyLoadPercent(float percent);
 
@@ -92,7 +92,7 @@ bool ofxAndroidCheckSDCardMounted();
 void ofxAndroidEnableMulticast();
 void ofxAndroidDisableMulticast();
 
-void ofxAndroidSetViewItemChecked(string item_name, bool checked);
+void ofxAndroidSetViewItemChecked(std::string item_name, bool checked);
 
 enum ofxAndroidSwipeDir{
 	OFX_ANDROID_SWIPE_UP    = 1,

--- a/addons/ofxAndroid/src/ofxAndroidVibrator.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVibrator.cpp
@@ -50,7 +50,7 @@ jobject ofxAndroidVibrator::getVibratorService(){
 	return vibratorService;
 }
 
-jmethodID ofxAndroidVibrator::getVibratorMethodID(string name, string signature){
+jmethodID ofxAndroidVibrator::getVibratorMethodID(std::string name, std::string signature){
 	jclass vibratorClass = ofGetJNIEnv()->FindClass("android/os/Vibrator");
 	if(!vibratorClass){
 		ofLogError("ofxAndroidVibrator") << "getVibratorMethodID(): couldn't get Vibrator class";

--- a/addons/ofxAndroid/src/ofxAndroidVibrator.h
+++ b/addons/ofxAndroid/src/ofxAndroidVibrator.h
@@ -19,5 +19,5 @@ public:
 	static void stop();
 private:
 	static jobject getVibratorService();
-	static jmethodID getVibratorMethodID(string name, string signature);
+	static jmethodID getVibratorMethodID(std::string name, std::string signature);
 };

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -36,8 +36,8 @@ struct ofxAndroidVideoGrabber::Data{
 	void loadTexture();
 };
 
-map<int,weak_ptr<ofxAndroidVideoGrabber::Data>> & instances(){
-	static auto * instances = new map<int,weak_ptr<ofxAndroidVideoGrabber::Data>>;
+std::map<int,std::weak_ptr<ofxAndroidVideoGrabber::Data>> & instances(){
+	static auto * instances = new std::map<int,std::weak_ptr<ofxAndroidVideoGrabber::Data>>;
 	return *instances;
 }
 
@@ -145,7 +145,7 @@ void ofxAndroidVideoGrabber::Data::loadTexture(){
 ofxAndroidVideoGrabber::ofxAndroidVideoGrabber()
 :data(new Data){
 	if(data->cameraId!=-1){
-		instances().insert(std::pair<int,weak_ptr<ofxAndroidVideoGrabber::Data>>(data->cameraId,data));
+		instances().insert(std::pair<int,std::weak_ptr<ofxAndroidVideoGrabber::Data>>(data->cameraId,data));
 	}
 }
 
@@ -177,9 +177,9 @@ void ofxAndroidVideoGrabber::Data::onAppResume(){
 	ofLogVerbose("ofxAndroidVideoGrabber") << "ofResumeVideoGrabbers(): textures allocated";
 	appPaused = false;
 }
-vector<ofVideoDevice> ofxAndroidVideoGrabber::listDevices() const{
+std::vector<ofVideoDevice> ofxAndroidVideoGrabber::listDevices() const{
 
-	vector<ofVideoDevice> devices;
+	std::vector<ofVideoDevice> devices;
 
 	int numDevices = getNumCameras();
 	for(int i = 0; i < numDevices; i++){

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.h
@@ -19,7 +19,7 @@ public:
 	ofxAndroidVideoGrabber();
 	~ofxAndroidVideoGrabber();
 
-	vector<ofVideoDevice>	listDevices() const;
+	std::vector<ofVideoDevice>	listDevices() const;
 	bool setup(int w, int h);
 	bool isInitialized() const;
 
@@ -90,5 +90,5 @@ private:
 
 	// only to be used internally to resize;
 	ofPixelsRef getAuxBuffer();
-	shared_ptr<Data> data;
+	std::shared_ptr<Data> data;
 };

--- a/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
@@ -97,7 +97,7 @@ ofxAndroidVideoPlayer::~ofxAndroidVideoPlayer(){
 
 
 //---------------------------------------------------------------------------
-bool ofxAndroidVideoPlayer::load(string fileName){
+bool ofxAndroidVideoPlayer::load(std::string fileName){
 
 	if(!javaVideoPlayer){
 		ofLogError("ofxAndroidVideoPlayer") << "load(): java soundVideoPlayer not loaded";

--- a/addons/ofxAndroid/src/ofxAndroidVideoPlayer.h
+++ b/addons/ofxAndroid/src/ofxAndroidVideoPlayer.h
@@ -20,7 +20,7 @@ class ofxAndroidVideoPlayer: public ofBaseVideoPlayer{
 		ofxAndroidVideoPlayer();
 		virtual ~ofxAndroidVideoPlayer();
 
-		bool load(string fileName);
+		bool load(std::string fileName);
 		void close(); // empty!
 		void update();
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.cpp
@@ -5,7 +5,7 @@
 
 #include "ofxAssimpAnimation.h"
 
-ofxAssimpAnimation::ofxAssimpAnimation(shared_ptr<const aiScene> scene, aiAnimation * animation) {
+ofxAssimpAnimation::ofxAssimpAnimation(std::shared_ptr<const aiScene> scene, aiAnimation * animation) {
     this->scene = scene;
     this->animation = animation;
     animationCurrTime = 0;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.h
@@ -15,7 +15,7 @@ class ofxAssimpAnimation {
 
 public:
     
-    ofxAssimpAnimation(shared_ptr<const aiScene> scene, aiAnimation * animation);
+    ofxAssimpAnimation(std::shared_ptr<const aiScene> scene, aiAnimation * animation);
     ~ofxAssimpAnimation();
     
     aiAnimation * getAnimation();
@@ -47,7 +47,7 @@ protected:
     
     void updateAnimationNodes();
     
-    shared_ptr<const aiScene> scene;
+    std::shared_ptr<const aiScene> scene;
     aiAnimation * animation;
     float animationCurrTime;
     float animationPrevTime;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
@@ -27,7 +27,7 @@ public:
     ofVbo vbo;
     
     ofxAssimpTexture assimpTexture;
-    vector<ofIndexType> indices;
+    std::vector<ofIndexType> indices;
     
     ofMaterial material;
     
@@ -36,8 +36,8 @@ public:
     bool twoSided;
     bool hasChanged;
 
-    vector<aiVector3D> animatedPos;
-    vector<aiVector3D> animatedNorm;
+    std::vector<aiVector3D> animatedPos;
+    std::vector<aiVector3D> animatedNorm;
 
     ofMesh cachedMesh;
     bool validCache;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -15,7 +15,7 @@ ofxAssimpModelLoader::~ofxAssimpModelLoader(){
 }
 
 //------------------------------------------
-bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
+bool ofxAssimpModelLoader::loadModel(std::string modelName, bool optimize){
     
     file.open(modelName, ofFile::ReadOnly, true); // Since it may be a binary file we should read it in binary -Ed
     if(!file.exists()) {
@@ -37,7 +37,7 @@ bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
     unsigned int flags = initImportProperties(optimize);
     
     // loads scene from file
-    scene = shared_ptr<const aiScene>(aiImportFileExWithProperties(file.getAbsolutePath().c_str(), flags, NULL, store.get()), aiReleaseImport);
+    scene = std::shared_ptr<const aiScene>(aiImportFileExWithProperties(file.getAbsolutePath().c_str(), flags, NULL, store.get()), aiReleaseImport);
     
     bool bOk = processScene();
     return bOk;
@@ -59,7 +59,7 @@ bool ofxAssimpModelLoader::loadModel(ofBuffer & buffer, bool optimize, const cha
     unsigned int flags = initImportProperties(optimize);
     
     // loads scene from memory buffer - note this will not work for multipart files (obj, md3, etc)
-    scene = shared_ptr<const aiScene>(aiImportFileFromMemoryWithProperties(buffer.getData(), buffer.size(), flags, extension, store.get()), aiReleaseImport);
+    scene = std::shared_ptr<const aiScene>(aiImportFileFromMemoryWithProperties(buffer.getData(), buffer.size(), flags, extension, store.get()), aiReleaseImport);
     
     bool bOk = processScene();
     return bOk;
@@ -98,7 +98,7 @@ bool ofxAssimpModelLoader::processScene() {
         
         return true;
     }else{
-        ofLogError("ofxAssimpModelLoader") << "loadModel(): " + (string) aiGetErrorString();
+        ofLogError("ofxAssimpModelLoader") << "loadModel(): " + (std::string) aiGetErrorString();
         clear();
         return false;
     }
@@ -136,7 +136,7 @@ void ofxAssimpModelLoader::calculateDimensions(){
 	normalizedScale = MAX(scene_max.y - scene_min.y,normalizedScale);
 	normalizedScale = MAX(scene_max.z - scene_min.z,normalizedScale);
     if (abs(normalizedScale) < std::numeric_limits<float>::epsilon()){
-        ofLogWarning("ofxAssimpModelLoader") << "Error calculating normalized scale of scene" << endl;
+        ofLogWarning("ofxAssimpModelLoader") << "Error calculating normalized scale of scene" << std::endl;
         normalizedScale = 1.0;
     } else {
         normalizedScale = 1.f / normalizedScale;
@@ -241,10 +241,10 @@ void ofxAssimpModelLoader::loadGLResources(){
         // TODO: handle other aiTextureTypes
         if(AI_SUCCESS == mtl->GetTexture(aiTextureType_DIFFUSE, texIndex, &texPath)){
             ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): loading image from \"" << texPath.data << "\"";
-            string modelFolder = file.getEnclosingDirectory();
-            string relTexPath = ofFilePath::getEnclosingDirectory(texPath.data,false);
-            string texFile = ofFilePath::getFileName(texPath.data);
-            string realPath = ofFilePath::join(ofFilePath::join(modelFolder, relTexPath), texFile);
+            std::string modelFolder = file.getEnclosingDirectory();
+            std::string relTexPath = ofFilePath::getEnclosingDirectory(texPath.data,false);
+            std::string texFile = ofFilePath::getFileName(texPath.data);
+            std::string realPath = ofFilePath::join(ofFilePath::join(modelFolder, relTexPath), texFile);
             
             if(ofFile::doesFileExist(realPath) == false) {
                 ofLogError("ofxAssimpModelLoader") << "loadGLResource(): texture doesn't exist: \""
@@ -422,7 +422,7 @@ void ofxAssimpModelLoader::updateBones() {
 		const aiMesh* mesh = modelMeshes[i].mesh;
         
 		// calculate bone matrices
-		vector<aiMatrix4x4> boneMatrices(mesh->mNumBones);
+		std::vector<aiMatrix4x4> boneMatrices(mesh->mNumBones);
 		for(unsigned int a=0; a<mesh->mNumBones; ++a) {
 			const aiBone* bone = mesh->mBones[a];
             
@@ -794,8 +794,8 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
 }
 
 //-------------------------------------------
-vector<string> ofxAssimpModelLoader::getMeshNames(){
-	vector<string> names(scene->mNumMeshes);
+std::vector<std::string> ofxAssimpModelLoader::getMeshNames(){
+	std::vector<std::string> names(scene->mNumMeshes);
 	for(int i=0; i<(int)scene->mNumMeshes; i++){
 		names[i] = scene->mMeshes[i]->mName.data;
 	}
@@ -808,13 +808,13 @@ int ofxAssimpModelLoader::getNumMeshes(){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getMesh(string name){
+ofMesh ofxAssimpModelLoader::getMesh(std::string name){
 	ofMesh ofm;
 	// default to triangle mode
 	ofm.setMode(OF_PRIMITIVE_TRIANGLES);
 	aiMesh * aim = NULL;
 	for(int i=0; i<(int)scene->mNumMeshes; i++){
-		if(string(scene->mMeshes[i]->mName.data)==name){
+		if(std::string(scene->mMeshes[i]->mName.data)==name){
 			aim = scene->mMeshes[i];
 			break;
 		}
@@ -843,9 +843,9 @@ ofMesh ofxAssimpModelLoader::getMesh(int num){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(string name){
+ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(std::string name){
 	for(int i=0; i<(int)modelMeshes.size(); i++){
-		if(string(modelMeshes[i].mesh->mName.data)==name){
+		if(std::string(modelMeshes[i].mesh->mName.data)==name){
 			if(!modelMeshes[i].validCache){
 				modelMeshes[i].cachedMesh.clearVertices();
 				modelMeshes[i].cachedMesh.clearNormals();
@@ -882,9 +882,9 @@ ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(int num){
 }
 
 //-------------------------------------------
-ofMaterial ofxAssimpModelLoader::getMaterialForMesh(string name){
+ofMaterial ofxAssimpModelLoader::getMaterialForMesh(std::string name){
 	for(int i=0; i<(int)modelMeshes.size(); i++){
-		if(string(modelMeshes[i].mesh->mName.data)==name){
+		if(std::string(modelMeshes[i].mesh->mName.data)==name){
 			return modelMeshes[i].material;
 		}
 	}
@@ -903,9 +903,9 @@ ofMaterial ofxAssimpModelLoader::getMaterialForMesh(int num){
 }
 
 //-------------------------------------------
-ofTexture ofxAssimpModelLoader::getTextureForMesh(string name){
+ofTexture ofxAssimpModelLoader::getTextureForMesh(std::string name){
 	for(int i=0; i<(int)modelMeshes.size(); i++){
-		if(string(modelMeshes[i].mesh->mName.data)==name){
+		if(std::string(modelMeshes[i].mesh->mName.data)==name){
             if(modelMeshes[i].hasTexture()) {
                 return modelMeshes[i].getTextureRef();
             }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -28,7 +28,7 @@ class ofxAssimpModelLoader{
         ~ofxAssimpModelLoader();
         ofxAssimpModelLoader();
 
-        bool loadModel(string modelName, bool optimize=false);
+        bool loadModel(std::string modelName, bool optimize=false);
         bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
         void createEmptyModel();
         void createLightsFromAiModel();
@@ -64,19 +64,19 @@ class ofxAssimpModelLoader{
         void setScaleNormalization(bool normalize);
         void setNormalizationFactor(float factor);
 
-        vector<string> getMeshNames();
+        std::vector<std::string> getMeshNames();
         int getNumMeshes();
 
-        ofMesh getMesh(string name);
+        ofMesh getMesh(std::string name);
         ofMesh getMesh(int num);
 
-        ofMesh getCurrentAnimatedMesh(string name);
+        ofMesh getCurrentAnimatedMesh(std::string name);
         ofMesh getCurrentAnimatedMesh(int num);
 
-        ofMaterial getMaterialForMesh(string name);
+        ofMaterial getMaterialForMesh(std::string name);
         ofMaterial getMaterialForMesh(int num);
 
-        ofTexture getTextureForMesh(string name);
+        ofTexture getTextureForMesh(std::string name);
         ofTexture getTextureForMesh(int num);
 
 
@@ -138,16 +138,16 @@ class ofxAssimpModelLoader{
         bool normalizeScale;
         double normalizedScale;
 
-        vector<float> rotAngle;
-        vector<ofPoint> rotAxis;
+        std::vector<float> rotAngle;
+        std::vector<ofPoint> rotAxis;
         ofPoint scale;
         ofPoint pos;
         ofMatrix4x4 modelMatrix;
 
-        vector<ofLight> lights;
-        vector<ofxAssimpTexture> textures;
-        vector<ofxAssimpMeshHelper> modelMeshes;
-        vector<ofxAssimpAnimation> animations;
+        std::vector<ofLight> lights;
+        std::vector<ofxAssimpTexture> textures;
+        std::vector<ofxAssimpMeshHelper> modelMeshes;
+        std::vector<ofxAssimpAnimation> animations;
         int currentAnimation; // DEPRECATED - to be removed with deprecated animation functions.
 
         bool bUsingTextures;
@@ -157,6 +157,6 @@ class ofxAssimpModelLoader{
         float normalizeFactor;
 
         // the main Asset Import scene that does the magic.
-        shared_ptr<const aiScene> scene;
-        shared_ptr<aiPropertyStore> store; 
+        std::shared_ptr<const aiScene> scene;
+        std::shared_ptr<aiPropertyStore> store; 
 };

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
@@ -12,7 +12,7 @@ ofxAssimpTexture::ofxAssimpTexture() {
     texturePath = "";
 }
 
-ofxAssimpTexture::ofxAssimpTexture(ofTexture texture, string texturePath) {
+ofxAssimpTexture::ofxAssimpTexture(ofTexture texture, std::string texturePath) {
     this->texture = texture;
     this->texturePath = texturePath;
 }
@@ -21,7 +21,7 @@ ofTexture & ofxAssimpTexture::getTextureRef() {
     return texture;
 }
 
-string ofxAssimpTexture::getTexturePath() {
+std::string ofxAssimpTexture::getTexturePath() {
     return texturePath;
 }
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
@@ -14,15 +14,15 @@ class ofxAssimpTexture {
 public:
     
     ofxAssimpTexture();
-    ofxAssimpTexture(ofTexture texture, string texturePath);
+    ofxAssimpTexture(ofTexture texture, std::string texturePath);
 
     ofTexture & getTextureRef();
-    string getTexturePath();
+    std::string getTexturePath();
     bool hasTexture();
     
 private:
     
     ofTexture texture;
-    string texturePath;
+    std::string texturePath;
     
 };

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
@@ -28,8 +28,8 @@ inline ofDefaultVec3 aiVecToOfVec(const aiVector3D& v){
 }
 
 //--------------------------------------------------------------
-inline vector<ofDefaultVec3> aiVecVecToOfVecVec(const vector<aiVector3D>& v){
-	vector<ofDefaultVec3> ofv(v.size());
+inline std::vector<ofDefaultVec3> aiVecVecToOfVecVec(const std::vector<aiVector3D>& v){
+	std::vector<ofDefaultVec3> ofv(v.size());
 	memcpy(ofv.data(),v.data(),v.size()*sizeof(ofDefaultVec3));
 	return ofv;
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -16,7 +16,7 @@ ofxAppEmscriptenWindow * ofxAppEmscriptenWindow::instance = NULL;
 #define CASE_STR(x,y) case x: str = y; break
 
 static const char* eglErrorString(EGLint err) {
-    string str;
+    std::string str;
     switch (err) {
         CASE_STR(EGL_SUCCESS, "no error");
         CASE_STR(EGL_NOT_INITIALIZED, "EGL not, or could not be, initialized");
@@ -118,7 +118,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
 
 	setWindowShape(settings.width,settings.height);
 
-	_renderer = make_shared<ofGLProgrammableRenderer>(this);
+	_renderer = std::make_shared<ofGLProgrammableRenderer>(this);
 	((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
 
     emscripten_set_keydown_callback(0,this,1,&keydown_cb);
@@ -298,7 +298,7 @@ int	ofxAppEmscriptenWindow::getHeight(){
 	return getWindowSize().y;
 }
 
-void ofxAppEmscriptenWindow::setWindowTitle(string title){
+void ofxAppEmscriptenWindow::setWindowTitle(std::string title){
 
 }
 
@@ -354,7 +354,7 @@ ofCoreEvents & ofxAppEmscriptenWindow::events(){
 	return _events;
 }
 
-shared_ptr<ofBaseRenderer> & ofxAppEmscriptenWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofxAppEmscriptenWindow::renderer(){
 	return _renderer;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -47,7 +47,7 @@ public:
 	int		getWidth();
 	int		getHeight();
 
-	void	setWindowTitle(string title);
+	void	setWindowTitle(std::string title);
 
 	ofWindowMode 	getWindowMode();
 
@@ -64,7 +64,7 @@ public:
 	EGLSurface getEGLSurface();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
 
 
 private:
@@ -83,7 +83,7 @@ private:
     static ofxAppEmscriptenWindow * instance;
     bool bEnableSetupScreen;
     ofCoreEvents _events;
-    shared_ptr<ofBaseRenderer> _renderer;
+    std::shared_ptr<ofBaseRenderer> _renderer;
 };
 
 #endif /* OFAPPEMSCRIPTENWINDOW_H_ */

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -9,7 +9,7 @@
 #include "html5audio.h"
 #include "ofUtils.h"
 
-vector<float> ofxEmscriptenSoundPlayer::systemSpectrum;
+std::vector<float> ofxEmscriptenSoundPlayer::systemSpectrum;
 
 int ofxEmscriptenAudioContext(){
 	static bool initialized=false;

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
@@ -36,7 +36,7 @@ public:
 
 private:
 	void setPositionSecs(double s);
-	static vector<float> systemSpectrum;
+	static std::vector<float> systemSpectrum;
 	int context;
 	int sound;
 	bool multiplay;

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -26,7 +26,7 @@ ofxEmscriptenSoundStream::~ofxEmscriptenSoundStream() {
 
 std::vector<ofSoundDevice> ofxEmscriptenSoundStream::getDeviceList(ofSoundDevice::Api api) const{
 	ofLogWarning() << "ofSoundStream::getDeviceList() not supported in emscripten";
-	return vector<ofSoundDevice>();
+	return std::vector<ofSoundDevice>();
 }
 
 bool ofxEmscriptenSoundStream::setup(const ofSoundStreamSettings & settings) {

--- a/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.cpp
@@ -15,12 +15,12 @@ ofxEmscriptenURLFileLoader::ofxEmscriptenURLFileLoader() {
 ofxEmscriptenURLFileLoader::~ofxEmscriptenURLFileLoader() {
 }
 
-ofHttpResponse ofxEmscriptenURLFileLoader::get(const string & url){
+ofHttpResponse ofxEmscriptenURLFileLoader::get(const std::string & url){
 	getAsync(url,url);
 	return ofHttpResponse();
 }
 
-int ofxEmscriptenURLFileLoader::getAsync(const string &  url, const string &  name){
+int ofxEmscriptenURLFileLoader::getAsync(const std::string &  url, const std::string &  name){
 	ofHttpRequest * req = new ofHttpRequest(url,name,false);
 #if __EMSCRIPTEN_major__>1 || (__EMSCRIPTEN_major__==1 && __EMSCRIPTEN_minor__>22)
 	emscripten_async_wget2_data(url.c_str(), "GET", "", req, true, &onload_cb, &onerror_cb, NULL);
@@ -28,12 +28,12 @@ int ofxEmscriptenURLFileLoader::getAsync(const string &  url, const string &  na
 	return req->getId();
 }
 
-ofHttpResponse ofxEmscriptenURLFileLoader::saveTo(const string &  url, const std::filesystem::path &  path){
+ofHttpResponse ofxEmscriptenURLFileLoader::saveTo(const std::string &  url, const std::filesystem::path &  path){
 	saveAsync(url,path);
 	return ofHttpResponse();
 }
 
-int ofxEmscriptenURLFileLoader::saveAsync(const string &  url, const std::filesystem::path &  path){
+int ofxEmscriptenURLFileLoader::saveAsync(const std::string &  url, const std::filesystem::path &  path){
 	ofHttpRequest * req = new ofHttpRequest(url,url,true);
 #if __EMSCRIPTEN_major__>1 || (__EMSCRIPTEN_major__==1 && __EMSCRIPTEN_minor__>22)
 	emscripten_async_wget2(url.c_str(), path.c_str(), "GET", "", req, &onload_file_cb, &onerror_file_cb, NULL);

--- a/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenURLFileLoader.h
@@ -12,10 +12,10 @@ class ofxEmscriptenURLFileLoader: public ofBaseURLFileLoader {
 public:
 	ofxEmscriptenURLFileLoader();
 	virtual ~ofxEmscriptenURLFileLoader();
-	ofHttpResponse get(const string &  url);
-	int getAsync(const string &  url, const string &  name=""); // returns id
-	ofHttpResponse saveTo(const string &  url, const std::filesystem::path &  path);
-	int saveAsync(const string &  url, const std::filesystem::path &  path);
+	ofHttpResponse get(const std::string &  url);
+	int getAsync(const std::string &  url, const std::string &  name=""); // returns id
+	ofHttpResponse saveTo(const std::string &  url, const std::filesystem::path &  path);
+	int saveAsync(const std::string &  url, const std::filesystem::path &  path);
 	ofHttpResponse handleRequest(const ofHttpRequest & request);
 	int handleRequestAsync(const ofHttpRequest & request);
 	void remove(int id);

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -28,8 +28,8 @@ ofxEmscriptenVideoGrabber::~ofxEmscriptenVideoGrabber() {
 	// TODO Auto-generated destructor stub
 }
 
-vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{
-	return vector<ofVideoDevice>();
+std::vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{
+	return std::vector<ofVideoDevice>();
 }
 
 bool ofxEmscriptenVideoGrabber::setup(int w, int h){
@@ -134,7 +134,7 @@ bool ofxEmscriptenVideoGrabber::setPixelFormat(ofPixelFormat pixelFormat){
 }
 
 ofPixelFormat ofxEmscriptenVideoGrabber::getPixelFormat() const{
-	string format = html5video_grabber_pixel_format(id);
+	std::string format = html5video_grabber_pixel_format(id);
 	if(format == "RGB"){
 		return OF_PIXELS_RGB;
 	}else if(format == "RGBA"){

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.h
@@ -15,7 +15,7 @@ public:
 	ofxEmscriptenVideoGrabber();
 	~ofxEmscriptenVideoGrabber();
 
-	vector<ofVideoDevice>	listDevices() const;
+	std::vector<ofVideoDevice>	listDevices() const;
 	bool	setup(int w, int h);
 	bool	isInitialized() const;
 	void	update();

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
@@ -28,7 +28,7 @@ ofxEmscriptenVideoPlayer::~ofxEmscriptenVideoPlayer() {
 	html5video_player_delete(id);
 }
 
-bool ofxEmscriptenVideoPlayer::load(string name){
+bool ofxEmscriptenVideoPlayer::load(std::string name){
 	html5video_player_load(id,ofToDataPath(name).c_str());
 	return true;
 }
@@ -155,7 +155,7 @@ bool ofxEmscriptenVideoPlayer::setPixelFormat(ofPixelFormat pixelFormat){
 }
 
 ofPixelFormat ofxEmscriptenVideoPlayer::getPixelFormat() const{
-	string format = html5video_player_pixel_format(id);
+	std::string format = html5video_player_pixel_format(id);
 	if(format == "RGB"){
 		return OF_PIXELS_RGB;
 	}else if(format == "RGBA"){

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.h
@@ -16,7 +16,7 @@ public:
 	~ofxEmscriptenVideoPlayer();
 
 	//needs implementing
-	bool				load(string name);
+	bool				load(std::string name);
 	void				close();
 	void				update();
 

--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -3,10 +3,9 @@
 #include "ofBitmapFont.h"
 #include "ofXml.h"
 #include "ofJson.h"
-using namespace std;
 
 
-void ofxGuiSetFont(const string & fontPath, int fontsize, bool _bAntiAliased, bool _bFullCharacterSet, int dpi){
+void ofxGuiSetFont(const std::string & fontPath, int fontsize, bool _bAntiAliased, bool _bFullCharacterSet, int dpi){
 	ofxBaseGui::loadFont(fontPath, fontsize, _bAntiAliased, _bFullCharacterSet, dpi);
 }
 
@@ -164,7 +163,7 @@ void ofxBaseGui::unbindFontTexture(){
 }
 
 
-ofMesh ofxBaseGui::getTextMesh(const string & text, float x, float y){
+ofMesh ofxBaseGui::getTextMesh(const std::string & text, float x, float y){
 	if(useTTF){
 		return font.getStringMesh(text, x, y);
 	}else{
@@ -172,7 +171,7 @@ ofMesh ofxBaseGui::getTextMesh(const string & text, float x, float y){
 	}
 }
 
-ofRectangle ofxBaseGui::getTextBoundingBox(const string & text, float x, float y){
+ofRectangle ofxBaseGui::getTextBoundingBox(const std::string & text, float x, float y){
 	if(useTTF){
 		return font.getStringBoundingBox(text, x, y);
 	}else{
@@ -215,7 +214,7 @@ void ofxBaseGui::loadFromFile(const std::string& filename){
 	}
 }
 
-string ofxBaseGui::getName(){
+std::string ofxBaseGui::getName(){
 	return getParameter().getName();
 }
 
@@ -358,8 +357,8 @@ void ofxBaseGui::setNeedsRedraw(){
 	needsRedraw = true;
 }
 
-string ofxBaseGui::saveStencilToHex(const ofImage & img){
-	stringstream strm;
+std::string ofxBaseGui::saveStencilToHex(const ofImage & img){
+	std::stringstream strm;
 	int width = img.getWidth();
 	int height = img.getHeight();
 	int n = width * height;
@@ -372,7 +371,7 @@ string ofxBaseGui::saveStencilToHex(const ofImage & img){
 		}
 		i++;
 		if(i % 8 == 0){
-			strm << "0x" << hex << (unsigned int)cur;
+			strm << "0x" << std::hex << (unsigned int)cur;
 			cur = 0;
 			shift = 0;
 			if(i < n){

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -1,5 +1,4 @@
 #include "ofxButton.h"
-using namespace std;
 
 ofxButton::ofxButton(){
 	value.setSerializable(false);

--- a/addons/ofxGui/src/ofxGui.h
+++ b/addons/ofxGui/src/ofxGui.h
@@ -11,7 +11,7 @@
 #include "ofxColorPicker.h"
 #include "ofEvents.h"
 
-void ofxGuiSetFont(const string & fontPath,int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=true, int dpi=0);
+void ofxGuiSetFont(const std::string & fontPath,int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=true, int dpi=0);
 void ofxGuiSetFont(const ofTtfSettings & fontSettings);
 void ofxGuiSetBitmapFont();
 

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -5,8 +5,6 @@
 #include "ofxLabel.h"
 #include "ofxInputField.h"
 
-using namespace std;
-
 ofxGuiGroup::ofxGuiGroup(){
 	minimized = false;
 	spacing = 1;
@@ -42,7 +40,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	bGuiActive = false;
 
 	for(std::size_t i = 0; i < _parameters.size(); i++){
-		string type = _parameters.getType(i);
+		std::string type = _parameters.getType(i);
 		if(type == typeid(ofParameter <int32_t> ).name()){
 			auto p = _parameters.getInt(i);
 			add(p);
@@ -97,7 +95,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 		}else if(type == typeid(ofParameter <ofFloatColor> ).name()){
 			auto p = _parameters.getFloatColor(i);
 			add(p);
-		}else if(type == typeid(ofParameter <string> ).name()){
+		}else if(type == typeid(ofParameter <std::string> ).name()){
 			auto p = _parameters.getString(i);
 			add(p);
 		}else if(type == typeid(ofParameterGroup).name()){
@@ -171,7 +169,7 @@ void ofxGuiGroup::add(ofParameter <bool> & parameter){
 	add(new ofxToggle(parameter, b.width));
 }
 
-void ofxGuiGroup::add(ofParameter <string> & parameter){
+void ofxGuiGroup::add(ofParameter <std::string> & parameter){
 	add(new ofxInputField<std::string>(parameter, b.width));
 }
 
@@ -337,8 +335,8 @@ void ofxGuiGroup::render(){
 	}
 }
 
-vector <string> ofxGuiGroup::getControlNames() const{
-	vector <string> names;
+std::vector <std::string> ofxGuiGroup::getControlNames() const{
+	std::vector <std::string> names;
 	for(std::size_t i = 0; i < collection.size(); i++){
 		names.push_back(collection[i]->getName());
 	}

--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -442,7 +442,7 @@ bool ofxInputField<Type>::mouseScrolled(ofMouseEventArgs & mouse){
 
 //-----------------------------------------------------------
 template<>
-bool ofxInputField<string>::mouseScrolled(ofMouseEventArgs & mouse){
+bool ofxInputField<std::string>::mouseScrolled(ofMouseEventArgs & mouse){
 	if(b.inside(mouse)){
 		return true;
 	}else{
@@ -602,7 +602,7 @@ int ofxInputField<Type>::insertAlphabetic(uint32_t character){
 
 //-----------------------------------------------------------
 template<>
-int ofxInputField<string>::insertAlphabetic(uint32_t character){
+int ofxInputField<std::string>::insertAlphabetic(uint32_t character){
 	return insertKeystroke(character);
 }
 
@@ -765,7 +765,7 @@ void ofxInputField<Type>::parseInput(){
 
 //-----------------------------------------------------------
 template<>
-void ofxInputField<string>::parseInput(){
+void ofxInputField<std::string>::parseInput(){
 	value = input;
 }
 

--- a/addons/ofxGui/src/ofxInputField.h
+++ b/addons/ofxGui/src/ofxInputField.h
@@ -103,4 +103,4 @@ protected:
 
 typedef ofxInputField<float> ofxFloatField;
 typedef ofxInputField<int> ofxIntField;
-typedef ofxInputField<string> ofxTextField;
+typedef ofxInputField<std::string> ofxTextField;

--- a/addons/ofxGui/src/ofxLabel.cpp
+++ b/addons/ofxGui/src/ofxLabel.cpp
@@ -1,8 +1,7 @@
 #include "ofxLabel.h"
 #include "ofGraphics.h"
-using namespace std;
 
-ofxLabel::ofxLabel(ofParameter<string> _label, float width, float height){
+ofxLabel::ofxLabel(ofParameter<std::string> _label, float width, float height){
 	setup(_label,width,height);
 }
 
@@ -10,7 +9,7 @@ ofxLabel::~ofxLabel(){
     label.removeListener(this,&ofxLabel::valueChanged);
 }
 
-ofxLabel* ofxLabel::setup(ofParameter<string> _label, float width, float height) {
+ofxLabel* ofxLabel::setup(ofParameter<std::string> _label, float width, float height) {
     label.makeReferenceTo(_label);
     b.width  = width;
     b.height = height;
@@ -20,7 +19,7 @@ ofxLabel* ofxLabel::setup(ofParameter<string> _label, float width, float height)
     return this;
 }
 
-ofxLabel* ofxLabel::setup(const std::string& labelName, string _label, float width, float height) {
+ofxLabel* ofxLabel::setup(const std::string& labelName, std::string _label, float width, float height) {
     label.set(labelName,_label);
     return setup(label,width,height);
 }
@@ -32,11 +31,11 @@ void ofxLabel::generateDraw(){
 	bg.setFilled(true);
 	bg.rectangle(b);
 
-    string name;
+	std::string name;
     if(!getName().empty()){
     	name = getName() + ": ";
     }
-    name += (string)label;    
+    name += (std::string)label;    
     
     // resize the string inside the max width
     if(font.isLoaded()){ // using font
@@ -76,6 +75,6 @@ ofAbstractParameter & ofxLabel::getParameter(){
 	return label;
 }
 
-void ofxLabel::valueChanged(string & value){
+void ofxLabel::valueChanged(std::string & value){
     setNeedsRedraw();
 }

--- a/addons/ofxGui/src/ofxPanel.cpp
+++ b/addons/ofxGui/src/ofxPanel.cpp
@@ -8,7 +8,6 @@
 #include "ofxPanel.h"
 #include "ofGraphics.h"
 #include "ofImage.h"
-using namespace std;
 
 ofxPanel::ofxPanel()
 :bGrabbed(false){}

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -1,6 +1,5 @@
 #include "ofxSlider.h"
 #include "ofGraphics.h"
-using namespace std;
 
 namespace{
 	template<typename Type>
@@ -225,7 +224,7 @@ void ofxSlider<Type>::generateDraw(){
 
 template<typename Type>
 void ofxSlider<Type>::generateText(){	
-	string valStr = toString(value.get());
+	std::string valStr = toString(value.get());
 	auto inputWidth = getTextBoundingBox(valStr,0,0).width;
 	auto label = getTextBoundingBox(getName(), b.x + textPadding, b.y + b.height / 2 + 4);
 	auto value = getTextBoundingBox(valStr, b.x + b.width - textPadding - inputWidth, b.y + b.height / 2 + 4);

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -1,5 +1,4 @@
 #include "ofxSliderGroup.h"
-using namespace std;
 
 template<class VecType>
 ofxVecSlider_<VecType>::ofxVecSlider_(ofParameter<VecType> value, float width, float height){
@@ -13,7 +12,7 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     
     parameters.clear();
     
-    const string names[4] = {"x", "y", "z", "w"};
+    const std::string names[4] = {"x", "y", "z", "w"};
     
     this->value.makeReferenceTo(value);
     this->value.addListener(this, & ofxVecSlider_::changeValue);
@@ -130,7 +129,7 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
     ofxGuiGroup::setup(value.getName(), "", 0, 0);
     parameters.clear();
 
-	const string names[4] = {"r", "g", "b", "a"};
+	const std::string names[4] = {"r", "g", "b", "a"};
 
     ofColor_<ColorType> val = value;
     ofColor_<ColorType> min = value.getMin();

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -1,6 +1,5 @@
 #include "ofxToggle.h"
 #include "ofGraphics.h"
-using namespace std;
 
 ofxToggle::ofxToggle(ofParameter<bool> _bVal, float width, float height){
 	setup(_bVal,width,height);

--- a/addons/ofxKinect/src/ofxKinect.cpp
+++ b/addons/ofxKinect/src/ofxKinect.cpp
@@ -235,7 +235,7 @@ bool ofxKinect::open(int deviceIndex) {
 }
 
 //--------------------------------------------------------------------
-bool ofxKinect::open(string serial) {
+bool ofxKinect::open(std::string serial) {
 	if(!bGrabberInited) {
 		ofLogVerbose("ofxKinect") << "open(): cannot open, init not called";
 		return false;
@@ -382,7 +382,7 @@ void ofxKinect::update() {
 		tryCount = 0;
 		if(this->lock()) {
             if( videoPixels.getHeight() == videoPixelsIntra.getHeight() ){
-                swap(videoPixels,videoPixelsIntra);
+		std::swap(videoPixels,videoPixelsIntra);
             }else{
 				int minimumSize = MIN(videoPixels.size(), videoPixelsIntra.size());
 				memcpy(videoPixels.getData(), videoPixelsIntra.getData(), minimumSize);
@@ -402,7 +402,7 @@ void ofxKinect::update() {
 		bIsFrameNewDepth = true;
 		tryCount = 0;
 		if(this->lock()) {
-			swap(depthPixelsRaw, depthPixelsRawIntra);
+			std::swap(depthPixelsRaw, depthPixelsRawIntra);
 			bNeedsUpdateDepth = false;
 			this->unlock();
 
@@ -715,7 +715,7 @@ int ofxKinect::getDeviceId() const{
 }
 
 //---------------------------------------------------------------------------
-string ofxKinect::getSerial() const{
+std::string ofxKinect::getSerial() const{
 	return serial;
 }
 
@@ -755,7 +755,7 @@ bool ofxKinect::isDeviceConnected(int id) {
 }
 
 //---------------------------------------------------------------------------
-bool ofxKinect::isDeviceConnected(string serial) {
+bool ofxKinect::isDeviceConnected(std::string serial) {
 	return kinectContext.isConnected(serial);
 }
 
@@ -765,7 +765,7 @@ int ofxKinect::nextAvailableId() {
 }
 
 //---------------------------------------------------------------------------
-string ofxKinect::nextAvailableSerial() {
+std::string ofxKinect::nextAvailableSerial() {
 	return kinectContext.nextAvailableSerial();
 }
 
@@ -807,7 +807,7 @@ void ofxKinect::grabDepthFrame(freenect_device *dev, void *depth, uint32_t times
 
 	if(kinect->kinectDevice == dev) {
 		kinect->lock();
-		swap(kinect->depthPixelsRawBack,kinect->depthPixelsRawIntra);
+		std::swap(kinect->depthPixelsRawBack,kinect->depthPixelsRawIntra);
 		kinect->bNeedsUpdateDepth = true;
 		kinect->unlock();
 		freenect_set_depth_buffer(kinect->kinectDevice,kinect->depthPixelsRawBack.getData());
@@ -821,7 +821,7 @@ void ofxKinect::grabVideoFrame(freenect_device *dev, void *video, uint32_t times
 
 	if(kinect->kinectDevice == dev) {
 		kinect->lock();
-		swap(kinect->videoPixelsBack,kinect->videoPixelsIntra);
+		std::swap(kinect->videoPixelsBack,kinect->videoPixelsIntra);
 		kinect->bNeedsUpdateVideo = true;
 		kinect->unlock();
 		freenect_set_video_buffer(kinect->kinectDevice,kinect->videoPixelsBack.getData());
@@ -972,7 +972,7 @@ bool ofxKinectContext::open(ofxKinect& kinect, int id) {
 		ofLogError("ofxKinect") << "could not open device " <<  id;
 		return false;
 	}
-	kinects.insert(pair<int,ofxKinect*>(id, &kinect));
+	kinects.insert(std::pair<int,ofxKinect*>(id, &kinect));
 	
 	// set kinect id & serial from bus id
 	kinect.deviceId = id;
@@ -981,7 +981,7 @@ bool ofxKinectContext::open(ofxKinect& kinect, int id) {
 	return true;
 }
 
-bool ofxKinectContext::open(ofxKinect& kinect, string serial) {
+bool ofxKinectContext::open(ofxKinect& kinect, std::string serial) {
 	
 	// rebuild if necessary (aka new kinects plugged in)
 	buildDeviceList();
@@ -1003,7 +1003,7 @@ bool ofxKinectContext::open(ofxKinect& kinect, string serial) {
 		return false;
 	}
 	int index = getDeviceIndex(serial);
-	kinects.insert(pair<int,ofxKinect*>(deviceList[index].id, &kinect));
+	kinects.insert(std::pair<int,ofxKinect*>(deviceList[index].id, &kinect));
 	kinect.deviceId = deviceList[index].id;
 	kinect.serial = serial;
 	
@@ -1054,7 +1054,7 @@ void ofxKinectContext::buildDeviceList() {
 	for(int i = 0; i < numDevices; i++){
 		KinectPair kp;
 		kp.id = i;
-		kp.serial = (string) devAttrib->camera_serial; 
+		kp.serial = (std::string) devAttrib->camera_serial; 
 		deviceList.push_back(kp);
 		devAttrib = devAttrib->next;
 	}
@@ -1068,7 +1068,7 @@ void ofxKinectContext::listDevices(bool verbose) {
     if(!isInited())
 		init();
 	
-	stringstream stream;
+	std::stringstream stream;
 	
 	if(numTotal() == 0) {
 		stream << "no devices found";
@@ -1134,7 +1134,7 @@ int ofxKinectContext::getDeviceIndex(int id) {
 	return -1;
 }
 
-int ofxKinectContext::getDeviceIndex(string serial) {
+int ofxKinectContext::getDeviceIndex(std::string serial) {
 	for(unsigned int i = 0; i < deviceList.size(); ++i) {
 		if(deviceList[i].serial == serial)
 			return i;
@@ -1150,7 +1150,7 @@ int ofxKinectContext::getDeviceId(int index) {
 	return -1;
 }
 
-int ofxKinectContext::getDeviceId(string serial){
+int ofxKinectContext::getDeviceId(std::string serial){
 	for(unsigned int i = 0; i < deviceList.size(); ++i) {
 		if(deviceList[i].serial == serial){
 			return deviceList[i].id;
@@ -1164,7 +1164,7 @@ bool ofxKinectContext::isConnected(int id) {
 	return iter != kinects.end();
 }
 
-bool ofxKinectContext::isConnected(string serial) {
+bool ofxKinectContext::isConnected(std::string serial) {
 	std::map<int,ofxKinect*>::iterator iter;
 	for(iter = kinects.begin(); iter != kinects.end(); ++iter) {
 		if(iter->second->getSerial() == serial)
@@ -1187,7 +1187,7 @@ int ofxKinectContext::nextAvailableId() {
 	return -1;
 }
 
-string ofxKinectContext::nextAvailableSerial() {
+std::string ofxKinectContext::nextAvailableSerial() {
 	if(!isInited())
 		init();
 	

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -95,7 +95,7 @@ public:
 	///
 	/// NOTE: currently, libfreenect returns a serial number with all 0s for
 	/// kinect models > 1414, so this will only work with the original xbox kinect
-	bool open(string serial);
+	bool open(std::string serial);
 
 	/// close the connection and stop grabbing images
 	void close();
@@ -298,7 +298,7 @@ public:
 	///
 	/// NOTE: currently, libfreenect returns a serial number with all 0s for
 	/// kinect models > 1414, so this will only work with the original xbox kinect
-	string getSerial() const;
+	std::string getSerial() const;
 
 	/// static kinect image size
 	const static int width = 640;
@@ -322,7 +322,7 @@ public:
 
 	/// is a device already connected?
 	static bool isDeviceConnected(int id);
-	static bool isDeviceConnected(string serial);
+	static bool isDeviceConnected(std::string serial);
 
 	/// get the id of the next available device,
 	/// returns -1 if nothing found
@@ -330,7 +330,7 @@ public:
 	
 	/// get the serial number of the next available device,
 	/// returns an empty string "" if nothing found
-	static string nextAvailableSerial();
+	static std::string nextAvailableSerial();
 
 	/// set the time to wait when not getting data before attempting to re-open device.
     static void setReconnectWaitTime(float waitTime);
@@ -338,7 +338,7 @@ public:
 protected:
 
 	int deviceId;	///< -1 when not connected
-	string serial;	///< unique serial number, "" when not connected
+	std::string serial;	///< unique serial number, "" when not connected
 	
 	bool bUseTexture;
 	ofTexture depthTex; ///< the depth texture
@@ -386,7 +386,7 @@ private:
 	ofShortPixels depthPixelsRawBack;	///< depth back
 	ofPixels videoPixelsBack;			///< rgb back
 
-	vector<unsigned char> depthLookupTable;
+	std::vector<unsigned char> depthLookupTable;
 	void updateDepthLookupTable();
 	void updateDepthPixels();
 
@@ -440,7 +440,7 @@ public:
 	bool open(ofxKinect& kinect, int id=-1);
 	
 	/// open a kinect device by it's unique serial number
-	bool open(ofxKinect& kinect, string serial);
+	bool open(ofxKinect& kinect, std::string serial);
 
 	/// close a kinect device
 	void close(ofxKinect& kinect);
@@ -475,7 +475,7 @@ public:
 	
 	/// get the deviceList index from an id
 	/// returns -1 if not found
-	int getDeviceIndex(string serial);
+	int getDeviceIndex(std::string serial);
 
 	/// get the deviceList id from an index
 	/// returns -1 if not found
@@ -483,13 +483,13 @@ public:
 
 	/// get the deviceList id from a serial
 	/// returns -1 if not found
-    int getDeviceId(string serial);
+    int getDeviceId(std::string serial);
 
 	/// is a device with this id already connected?
 	bool isConnected(int id);
 	
 	/// is a device with this serial already connected?
-	bool isConnected(string serial);
+	bool isConnected(std::string serial);
 
 	/// get the id of the next available device,
 	/// returns -1 if nothing found
@@ -497,14 +497,14 @@ public:
 	
 	/// get the serial number of the next available device,
 	/// returns an empty string "" if nothing found
-	string nextAvailableSerial();
+	std::string nextAvailableSerial();
 
 	/// get the raw pointer
 	freenect_context* getContext() {return kinectContext;}
 
 	// for auto-enumeration
     struct KinectPair{
-		string serial;	///< unique serial number
+	std::string serial;	///< unique serial number
 		int id;			///< freenect bus id
     };
 	

--- a/addons/ofxNetwork/docs/Instructions.txt
+++ b/addons/ofxNetwork/docs/Instructions.txt
@@ -77,7 +77,7 @@ To:
 +++++ Step 5 ++++++
 To run the demo app make sure in ofConstants.h you have 
 
-using namespace std;
+using namespace std; // TODO: shouldn't be needed anymore
 #include <string>   
 #include <sstream>  //for ostringsream
 #include <iomanip>  //for setprecision

--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -29,7 +29,7 @@ void ofxTCPClient::setVerbose(bool _verbose){
 }
 
 //--------------------------
-bool ofxTCPClient::setup(string ip, int _port, bool blocking){
+bool ofxTCPClient::setup(std::string ip, int _port, bool blocking){
 
 	ofxTCPSettings settings(ip, _port);
 
@@ -98,14 +98,14 @@ bool ofxTCPClient::close(){
 }
 
 //--------------------------
-void ofxTCPClient::setMessageDelimiter(string delim){
+void ofxTCPClient::setMessageDelimiter(std::string delim){
 	if(delim != ""){
 		messageDelimiter = delim; 
 	}
 }
 
 //--------------------------
-bool ofxTCPClient::send(string message){
+bool ofxTCPClient::send(std::string message){
 	// tcp is a stream oriented protocol
 	// so there's no way to be sure were
 	// a message ends without using a terminator
@@ -181,7 +181,7 @@ bool ofxTCPClient::sendRawMsg(const char * msg, int size){
 }
 
 //--------------------------
-bool ofxTCPClient::sendRaw(string message){
+bool ofxTCPClient::sendRaw(std::string message){
 	if( message.length() == 0) return false;
     int ret = TCPClient.SendAll(message.c_str(), message.length());
     int errorCode = 0;
@@ -236,11 +236,11 @@ bool ofxTCPClient::isClosingCondition(int messageSize, int errorCode){
 }
 
 //--------------------------
-string ofxTCPClient::receive(){
+std::string ofxTCPClient::receive(){
 	str    = "";
 	int length=0;
 	//only get data from the buffer if we don't have already some complete message
-	if(tmpStr.find(messageDelimiter)==string::npos){
+	if(tmpStr.find(messageDelimiter)==std::string::npos){
 		memset(tmpBuff,  0, TCP_MAX_MSG_SIZE+1); //one more so there's always a \0 at the end for string concat
 		length = TCPClient.Receive(tmpBuff, TCP_MAX_MSG_SIZE);
 		if(length>0){ // don't copy the data if there was an error or disconnection
@@ -259,7 +259,7 @@ string ofxTCPClient::receive(){
 	}
 
 	// process any available data
-	if(tmpStr.find(messageDelimiter)!=string::npos){
+	if(tmpStr.find(messageDelimiter)!=std::string::npos){
 		str=tmpStr.substr(0,tmpStr.find(messageDelimiter));
 		tmpStr=tmpStr.substr(tmpStr.find(messageDelimiter)+messageDelimiter.size());
 	}
@@ -267,7 +267,7 @@ string ofxTCPClient::receive(){
 }
 
 //--------------------------
-static int findDelimiter(char * data, int size, string delimiter){
+static int findDelimiter(char * data, int size, std::string delimiter){
 	unsigned int posInDelimiter=0;
 	for(int i=0;i<size;i++){
 		if(data[i]==delimiter[posInDelimiter]){
@@ -335,7 +335,7 @@ int ofxTCPClient::peekReceiveRawBytes(char * receiveBuffer, int numBytes){
 }
 
 //--------------------------
-string ofxTCPClient::receiveRaw(){
+std::string ofxTCPClient::receiveRaw(){
     messageSize = TCPClient.Receive(tmpBuff, TCP_MAX_MSG_SIZE);
     int errorCode = 0;
     if(messageSize<0) errorCode = ofxNetworkCheckError();
@@ -365,6 +365,6 @@ int ofxTCPClient::getPort(){
 }
 
 //--------------------------
-string ofxTCPClient::getIP(){
+std::string ofxTCPClient::getIP(){
 	return ipAddr;
 }

--- a/addons/ofxNetwork/src/ofxTCPClient.h
+++ b/addons/ofxNetwork/src/ofxTCPClient.h
@@ -22,9 +22,9 @@ class ofxTCPClient{
 		void threadedFunction();
 
 		void setVerbose(bool _verbose);
-		bool setup(string ip, int _port, bool blocking = false);
+		bool setup(std::string ip, int _port, bool blocking = false);
 		bool setup(const ofxTCPSettings & settings);
-		void setMessageDelimiter(string delim);
+		void setMessageDelimiter(std::string delim);
 		bool close();
 
 	
@@ -32,10 +32,10 @@ class ofxTCPClient{
 		//is added to the end of the string which is
 		//used to indicate the end of the message to
 		//the receiver see: STR_END_MSG (ofxTCPClient.h)
-		bool send(string message);
+		bool send(std::string message);
 
 		//send data as a string without the end message
-		bool sendRaw(string message);
+		bool sendRaw(std::string message);
 
 		//same as send for binary messages
 		bool sendRawMsg(const char * msg, int size);
@@ -58,11 +58,11 @@ class ofxTCPClient{
 		//eg: if you want to send "Hello World" from other
 		//software and want to receive it as a string
 		//sender should send "Hello World[/TCP]"
-		string receive();
+		std::string receive();
 
 		//no terminating string you will need to be sure
 		//you are receiving all the data by using a loop
-		string receiveRaw();
+		std::string receiveRaw();
 
 		//pass in buffer to be filled - make sure the buffer
 		//is at least as big as numBytes
@@ -80,7 +80,7 @@ class ofxTCPClient{
 
 		bool isConnected();
 		int getPort();
-		string getIP();
+		std::string getIP();
 
 
 
@@ -102,9 +102,9 @@ private:
 		char			tmpBuff[TCP_MAX_MSG_SIZE+1];
 		ofBuffer 		tmpBuffReceive;
 		ofBuffer 		tmpBuffSend;
-		string			str, tmpStr, ipAddr;
+		std::string			str, tmpStr, ipAddr;
 		int				index, messageSize, port;
 		bool			connected;
-		string 			partialPrevMsg;
-		string			messageDelimiter;
+		std::string 			partialPrevMsg;
+		std::string			messageDelimiter;
 };

--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -441,7 +441,7 @@ int	ofxUDPManager::GetTimeoutReceive()
 }
 
 //--------------------------------------------------------------------------------
-bool ofxUDPManager::GetRemoteAddr(string& address,int& port) const
+bool ofxUDPManager::GetRemoteAddr(std::string& address,int& port) const
 {
 	if (m_hSocket == INVALID_SOCKET) return(false);
 	if ( canGetRemoteAddress ==	false) return (false);
@@ -457,7 +457,7 @@ bool ofxUDPManager::GetRemoteAddr(string& address,int& port) const
 }
 
 //--------------------------------------------------------------------------------
-bool ofxUDPManager::GetListenAddr(string& address,int& port) const
+bool ofxUDPManager::GetListenAddr(std::string& address,int& port) const
 {
 	if (m_hSocket == INVALID_SOCKET) return(false);
 

--- a/addons/ofxNetwork/src/ofxUDPManager.h
+++ b/addons/ofxNetwork/src/ofxUDPManager.h
@@ -138,8 +138,8 @@ public:
 	void SetTimeoutReceive(int timeoutInSeconds);
 	int  GetTimeoutSend();
 	int  GetTimeoutReceive();
-	bool GetRemoteAddr(string& address,int& port) const;	//	gets the IP and port of last received packet
-	bool GetListenAddr(string& address,int& port) const;	//	get our bound IP and port
+	bool GetRemoteAddr(std::string& address,int& port) const;	//	gets the IP and port of last received packet
+	bool GetListenAddr(std::string& address,int& port) const;	//	get our bound IP and port
 	bool SetReceiveBufferSize(int sizeInByte);
 	bool SetSendBufferSize(int sizeInByte);
 	int  GetReceiveBufferSize();

--- a/addons/ofxOpenCv/src/ofxCvBlob.h
+++ b/addons/ofxOpenCv/src/ofxCvBlob.h
@@ -24,7 +24,7 @@ class ofxCvBlob {
         ofPoint             centroid;
         bool                hole;
 
-        vector <ofPoint>    pts;    // the contour of the blob
+        std::vector <ofPoint>    pts;    // the contour of the blob
         int                 nPts;   // number of pts;
 
         //----------------------------------------

--- a/addons/ofxOpenCv/src/ofxCvContourFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.h
@@ -19,7 +19,7 @@ class ofxCvContourFinder : public ofBaseDraws {
 
   public:
   
-    vector<ofxCvBlob>  blobs;
+    std::vector<ofxCvBlob>  blobs;
     int                nBlobs;    // DEPRECATED: use blobs.size() instead
       
 
@@ -57,7 +57,7 @@ class ofxCvContourFinder : public ofBaseDraws {
     CvMemStorage*           contour_storage;
     CvMemStorage*           storage;
     CvMoments*              myMoments;
-    vector<CvSeq*>          cvSeqBlobs;  //these will become blobs
+    std::vector<CvSeq*>          cvSeqBlobs;  //these will become blobs
     
     ofPoint  anchor;
     bool  bAnchorIsPct;      

--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
@@ -43,7 +43,7 @@ void ofxCvHaarFinder::setNeighbors(unsigned neighbors) {
 	this->neighbors = neighbors;
 }
 
-void ofxCvHaarFinder::setup(string haarFile) {
+void ofxCvHaarFinder::setup(std::string haarFile) {
 	if(cascade != NULL)
 		cvReleaseHaarClassifierCascade(&cascade);
 

--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.h
@@ -19,13 +19,13 @@ http://www.comp.leeds.ac.uk/vision/opencv/opencvref_cv.html#decl_cvHaarDetectObj
 
 class ofxCvHaarFinder {
 public:
-	vector<ofxCvBlob> blobs;
+	std::vector<ofxCvBlob> blobs;
 
 	ofxCvHaarFinder();
 	ofxCvHaarFinder(const ofxCvHaarFinder& finder);
 	~ofxCvHaarFinder();
 	
-	void setup(string haarFile);
+	void setup(std::string haarFile);
 	
 	// The default value is 1.2. For accuracy, bring it closer but not equal to 1.0. To make it faster, use a larger value.
 	void setScaleHaar(float scaleHaar);
@@ -47,7 +47,7 @@ public:
 
 protected:
 	CvHaarClassifierCascade* cascade;
-	string haarFile;
+	std::string haarFile;
 	ofxCvGrayscaleImage img;
 	float scaleHaar;
 	unsigned neighbors;

--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -73,7 +73,7 @@ bool ofxOscReceiver::start() {
 		listenSocket = std::move(newPtr);
 	}
 	catch(std::exception &e){
-		string what = e.what();
+		std::string what = e.what();
 		// strip endline as ofLogError already adds one
 		if(!what.empty() && what.back() == '\n') {
 			what = what.substr(0, what.size()-1);

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -61,7 +61,7 @@ bool ofxOscSender::setup(const ofxOscSenderSettings &settings){
 		sendSocket.reset(socket);
 	}
 	catch(std::exception &e){
-		string what = e.what();
+		std::string what = e.what();
 		// strip endline as ofLogError already adds one
 		if(!what.empty() && what.back() == '\n') {
 			what = what.substr(0, what.size()-1);

--- a/addons/ofxPoco/src/ofxXmlPoco.cpp
+++ b/addons/ofxPoco/src/ofxXmlPoco.cpp
@@ -7,7 +7,7 @@ ofxXmlPoco::~ofxXmlPoco(){
 }
 
 
-ofxXmlPoco::ofxXmlPoco(const string & path){
+ofxXmlPoco::ofxXmlPoco(const std::string & path){
 	document = new Poco::XML::Document(); // we create this so that they can be merged later
 	element = document->documentElement();
 	load(path);
@@ -74,7 +74,7 @@ int ofxXmlPoco::getNumChildren() const{
     return numberOfChildren;
 }
 
-int ofxXmlPoco::getNumChildren(const string& path) const{
+int ofxXmlPoco::getNumChildren(const std::string& path) const{
 	if(!element){
 		return 0;
 	}
@@ -84,7 +84,7 @@ int ofxXmlPoco::getNumChildren(const string& path) const{
 
     for(unsigned long i=0; i < list->length(); i++){
         if(list->item(i) && list->item(i)->nodeType() == Poco::XML::Node::ELEMENT_NODE){
-            string nodeName = list->item(i)->localName();
+	    std::string nodeName = list->item(i)->localName();
             if(path.compare(nodeName) == 0){
                 numberOfChildren++;
             }
@@ -94,15 +94,15 @@ int ofxXmlPoco::getNumChildren(const string& path) const{
     return numberOfChildren;
 }
 
-string ofxXmlPoco::toString() const{
-    ostringstream stream;
+std::string ofxXmlPoco::toString() const{
+    std::ostringstream stream;
 
     Poco::XML::DOMWriter writer;
     writer.setOptions(Poco::XML::XMLWriter::PRETTY_PRINT);
     if(document){
         try{
             writer.writeNode( stream, getPocoDocument() );
-        }catch( exception & e ){
+        }catch( std::exception & e ){
             ofLogError("ofxXmlPoco") << "toString(): " << e.what();
         }
     } else if(element){
@@ -110,7 +110,7 @@ string ofxXmlPoco::toString() const{
         writer.writeNode( stream, element );
     }
 
-    string tmp = stream.str();
+    std::string tmp = stream.str();
 
     // don't know how else to get rid of the hidden <#text></#text> nodes :/
     ofStringReplace(tmp, "<#text>", "");
@@ -140,10 +140,10 @@ void ofxXmlPoco::addXml(ofxXmlPoco& xml, bool copyAll){
     }
 }
 
-bool ofxXmlPoco::addChild(const string& path){
-    vector<string> tokens;
+bool ofxXmlPoco::addChild(const std::string& path){
+    std::vector<std::string> tokens;
 
-    if(path.find('/') != string::npos){
+    if(path.find('/') != std::string::npos){
         tokens = tokenize(path, "/");
     }
     
@@ -152,7 +152,7 @@ bool ofxXmlPoco::addChild(const string& path){
         // don't 'push' down into the new nodes
         Poco::XML::Element *el = element;
 
-        vector<Poco::XML::Element*> toBeReleased;
+	std::vector<Poco::XML::Element*> toBeReleased;
 
 		for(std::size_t i = 0; i < tokens.size(); i++){
             Poco::XML::Element *pe = getPocoDocument()->createElement(tokens.at(i));
@@ -182,7 +182,7 @@ bool ofxXmlPoco::addChild(const string& path){
     return true;
 }
 
-string ofxXmlPoco::getValue() const{
+std::string ofxXmlPoco::getValue() const{
 	//if we don't have a DOM element, return the default value
 	if(!element){
 		return "";
@@ -200,8 +200,8 @@ string ofxXmlPoco::getValue() const{
 	return "";
 }
 
-string ofxXmlPoco::getValue(const string & path) const{
-	return getValue <string>(path, "");
+std::string ofxXmlPoco::getValue(const std::string & path) const{
+	return getValue <std::string>(path, "");
 }
 
 
@@ -210,7 +210,7 @@ int ofxXmlPoco::getIntValue() const {
 }
 
 
-int ofxXmlPoco::getIntValue(const string & path) const {
+int ofxXmlPoco::getIntValue(const std::string & path) const {
 	return getValue <int>(path, 0);
 }
 
@@ -220,7 +220,7 @@ float ofxXmlPoco::getFloatValue() const {
 }
 
 
-float ofxXmlPoco::getFloatValue(const string & path) const {
+float ofxXmlPoco::getFloatValue(const std::string & path) const {
 	return getValue <float>(path, 0.0);
 }
 
@@ -230,7 +230,7 @@ bool ofxXmlPoco::getBoolValue() const {
 }
 
 
-bool ofxXmlPoco::getBoolValue(const string & path) const {
+bool ofxXmlPoco::getBoolValue(const std::string & path) const {
 	return getValue <bool>(path, false);
 }
 
@@ -240,7 +240,7 @@ int64_t ofxXmlPoco::getInt64Value() const {
 }
 
 
-int64_t ofxXmlPoco::getInt64Value(const string & path) const {
+int64_t ofxXmlPoco::getInt64Value(const std::string & path) const {
 	return getValue <int64_t>(path, 0);
 }
 
@@ -365,7 +365,7 @@ bool ofxXmlPoco::setToPrevSibling(){
     return true;
 }
 
-bool ofxXmlPoco::setValue(const string& path, const string& value){
+bool ofxXmlPoco::setValue(const std::string& path, const std::string& value){
     Poco::XML::Element *e;
     if(element){
         e = (Poco::XML::Element*) element->getNodeByPath(path);
@@ -396,12 +396,12 @@ bool ofxXmlPoco::setValue(const string& path, const string& value){
     }
 }
 
-string ofxXmlPoco::getAttribute(const string& path) const{
+std::string ofxXmlPoco::getAttribute(const std::string& path) const{
     Poco::XML::Node *e;
     if(element){
-        if(path.find("[@") == string::npos){
+        if(path.find("[@") == std::string::npos){
             // we need to create a proper path
-            string attributePath = "[@" + path + "]";
+	    std::string attributePath = "[@" + path + "]";
             e = element->getNodeByPath(attributePath);
         }else{
             e = element->getNodeByPath(path);
@@ -417,14 +417,14 @@ string ofxXmlPoco::getAttribute(const string& path) const{
     return "";
 }
 
-bool ofxXmlPoco::removeAttribute(const string& path){
-    string attributeName, pathToAttribute;
+bool ofxXmlPoco::removeAttribute(const std::string& path){
+    std::string attributeName, pathToAttribute;
 
     Poco::XML::Element *e;
     if(element){
         bool hasPath = false;
         // you can pass either /node[@attr] or just attr
-        if(path.find("[@") != string::npos){
+        if(path.find("[@") != std::string::npos){
             int attrBegin = path.find("[@");
             int start = attrBegin + 2;
             int end = path.find("]", start);
@@ -461,12 +461,12 @@ bool ofxXmlPoco::removeAttribute(const string& path){
     return false;
 }
 
-bool ofxXmlPoco::removeAttributes(const string& path){
+bool ofxXmlPoco::removeAttributes(const std::string& path){
     Poco::XML::Element *e;
     if(element){
-        if(path.find("[@") == string::npos){
+        if(path.find("[@") == std::string::npos){
             // we need to create a proper path
-            string attributePath = "[@" + path + "]";
+	    std::string attributePath = "[@" + path + "]";
             e = (Poco::XML::Element*) element->getNodeByPath(attributePath);
         }else{
             e = (Poco::XML::Element*) element->getNodeByPath(path);
@@ -521,7 +521,7 @@ bool ofxXmlPoco::removeContents(){
     return false;
 }
 
-bool ofxXmlPoco::removeContents(const string& path){    
+bool ofxXmlPoco::removeContents(const std::string& path){    
     Poco::XML::Element *e;
     if(element){
         e = (Poco::XML::Element*) element->getNodeByPath(path);
@@ -558,7 +558,7 @@ void ofxXmlPoco::releaseAll(){
 }
 
 
-bool ofxXmlPoco::remove(const string & path){ // works for both attributes and tags
+bool ofxXmlPoco::remove(const std::string & path){ // works for both attributes and tags
 	Poco::XML::Node * node;
 	if(element){
 		node = element->getNodeByPath(path);
@@ -588,7 +588,7 @@ void ofxXmlPoco::remove(){
 }
 
 
-bool ofxXmlPoco::exists(const string & path) const{ // works for both attributes and tags
+bool ofxXmlPoco::exists(const std::string & path) const{ // works for both attributes and tags
 	Poco::XML::Node * node;
 	if(element){
 		node = element->getNodeByPath(path);
@@ -602,8 +602,8 @@ bool ofxXmlPoco::exists(const string & path) const{ // works for both attributes
 	return false;
 }
 
-map<string, string> ofxXmlPoco::getAttributes() const{ // works for both attributes and tags
-    map<string, string> attrMap;
+std::map<std::string, std::string> ofxXmlPoco::getAttributes() const{ // works for both attributes and tags
+    std::map<std::string, std::string> attrMap;
 
     if(element){
         Poco::AutoPtr<Poco::XML::NamedNodeMap> attr = element->attributes();
@@ -618,13 +618,13 @@ map<string, string> ofxXmlPoco::getAttributes() const{ // works for both attribu
 }
 
 
-bool ofxXmlPoco::setAttribute(const string& path, const string& value){
+bool ofxXmlPoco::setAttribute(const std::string& path, const std::string& value){
 
-    string attributeName, pathToAttribute;
+    std::string attributeName, pathToAttribute;
     bool hasPath = false;
 
     // you can pass either /node[@attr] or just attr
-    if(path.find("[@") != string::npos){
+    if(path.find("[@") != std::string::npos){
         size_t attrBegin = path.find("[@");
         size_t start = attrBegin + 2;
         size_t end = path.find("]", start);
@@ -649,9 +649,9 @@ bool ofxXmlPoco::setAttribute(const string& path, const string& value){
     Poco::XML::Element* curElement = getPocoElement(pathToAttribute);
 
     if(!curElement){ // if it doesn't exist
-        vector<string> tokens;
+	std::vector<std::string> tokens;
 
-        if(path.find('/') != string::npos){
+        if(path.find('/') != std::string::npos){
             tokens = tokenize(pathToAttribute, "/");
         }
 
@@ -664,9 +664,9 @@ bool ofxXmlPoco::setAttribute(const string& path, const string& value){
             size_t lastExistingTag = 0;
 
             // can't use reverse_iterator b/c accumulate doesn't like it
-            for(vector<string>::iterator it = tokens.end(); it != tokens.begin(); it--){
-                string empty = "";
-                string concat = accumulate(tokens.begin(), it, std::string());
+            for(std::vector<std::string>::iterator it = tokens.end(); it != tokens.begin(); it--){
+		std::string empty = "";
+		std::string concat = accumulate(tokens.begin(), it, std::string());
                 Poco::XML::Element* testElement = getPocoElement(concat);
                 if(testElement){
                     lastExistingTag++;
@@ -702,7 +702,7 @@ bool ofxXmlPoco::setAttribute(const string& path, const string& value){
 }
 
 
-bool ofxXmlPoco::loadFromBuffer(const string & buffer){
+bool ofxXmlPoco::loadFromBuffer(const std::string & buffer){
 	Poco::XML::DOMParser parser;
 
 	// release and null out if we already have a document
@@ -722,7 +722,7 @@ bool ofxXmlPoco::loadFromBuffer(const string & buffer){
 		element = document->documentElement();
 		return false;
 	}
-	catch(const exception & e){
+	catch(const std::exception & e){
 		short msg = atoi(e.what());
 		ofLogError("ofxXmlPoco") << "parse error: " << DOMErrorMessage(msg);
 		document = new Poco::XML::Document;
@@ -732,14 +732,14 @@ bool ofxXmlPoco::loadFromBuffer(const string & buffer){
 }
 
 
-string ofxXmlPoco::getName() const {
+std::string ofxXmlPoco::getName() const {
 	if(element){
 		return element->nodeName();
 	}
 	return "";
 }
 
-bool ofxXmlPoco::setTo(const string& path){
+bool ofxXmlPoco::setTo(const std::string& path){
     if(!element){
         if(document->documentElement()) {
             element = document->documentElement();
@@ -758,7 +758,7 @@ bool ofxXmlPoco::setTo(const string& path){
     //ofLogNotice("ofxXmlPoco") << path << " " << path.find("../");
 
     // another: let's go up a little
-    if(path.find("../") != string::npos){
+    if(path.find("../") != std::string::npos){
  
         Poco::XML::Element* prev = element;
         Poco::XML::Element* parent = nullptr;
@@ -782,7 +782,7 @@ bool ofxXmlPoco::setTo(const string& path){
             element = parent;
             return true;
         }else if (parent){
-            string remainingPath = path.substr((count * 3), path.size() - (count * 3));
+            std::string remainingPath = path.substr((count * 3), path.size() - (count * 3));
             element = (Poco::XML::Element*) parent->getNodeByPath(remainingPath);
 
              if(!element){
@@ -794,7 +794,7 @@ bool ofxXmlPoco::setTo(const string& path){
             ofLogWarning("ofxXmlPoco") << "setCurrentElement(): parent is nullptr.";
             return false;
         }
-    }else if(path.find("//") != string::npos){
+    }else if(path.find("//") != std::string::npos){
         // another: we're looking all over
         Poco::XML::Element* prev = element;
         element = (Poco::XML::Element*) document->getNodeByPath(path);
@@ -826,11 +826,11 @@ Poco::XML::Element * ofxXmlPoco::getPocoElement(){
 	return element;
 }
 
-Poco::XML::Element* ofxXmlPoco::getPocoElement(const string& path){
-    string copy = path;
+Poco::XML::Element* ofxXmlPoco::getPocoElement(const std::string& path){
+    std::string copy = path;
     // does it have an attribute? just in case
     std::size_t ind = copy.find("[@");
-    if(ind != string::npos){
+    if(ind != std::string::npos){
         copy = path.substr(0, ind);
     }
 
@@ -842,11 +842,11 @@ Poco::XML::Element* ofxXmlPoco::getPocoElement(const string& path){
     }
 }
 
-const Poco::XML::Element* ofxXmlPoco::getPocoElement(const string& path) const{
-    string copy = path;
+const Poco::XML::Element* ofxXmlPoco::getPocoElement(const std::string& path) const{
+    std::string copy = path;
     // does it have an attribute? just in case
 	std::size_t ind = copy.find("[@");
-    if(ind != string::npos){
+    if(ind != std::string::npos){
         copy = path.substr(0, ind);
     }
 
@@ -869,7 +869,7 @@ const Poco::XML::Document * ofxXmlPoco::getPocoDocument() const {
 }
 
 
-string ofxXmlPoco::DOMErrorMessage(short msg){
+std::string ofxXmlPoco::DOMErrorMessage(short msg){
 	switch(msg){
 	 case 1:
 		 return "INDEX_SIZE_ERR";
@@ -926,7 +926,7 @@ void ofSerialize(ofxXmlPoco & xml, const ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	if(name == ""){
 		name = "UnknownName";
 	}
@@ -944,7 +944,7 @@ void ofSerialize(ofxXmlPoco & xml, const ofAbstractParameter & parameter){
 		ofLogVerbose("ofxXmlPoco") << "end group " << name;
 		xml.setToParent();
 	}else{
-		string value = parameter.toString();
+		std::string value = parameter.toString();
 		if(!xml.exists(name)){
 			xml.addChild(name);
 			ofLogVerbose("ofxXmlPoco") << "creating tag " << name;
@@ -959,7 +959,7 @@ void ofDeserialize(const ofxXmlPoco & xml, ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	if(parameter.type() == typeid(ofParameterGroup).name()){
 		ofParameterGroup & group = static_cast <ofParameterGroup &>(parameter);
 		if(const_cast<ofxXmlPoco&>(xml).setTo(name)){
@@ -978,8 +978,8 @@ void ofDeserialize(const ofxXmlPoco & xml, ofAbstractParameter & parameter){
 				parameter.cast <bool>() = xml.getBoolValue(name);
 			}else if(parameter.type() == typeid(ofParameter <int64_t> ).name()){
 				parameter.cast <int64_t>() = xml.getInt64Value(name);
-			}else if(parameter.type() == typeid(ofParameter <string> ).name()){
-				parameter.cast <string>() = xml.getValue(name);
+			}else if(parameter.type() == typeid(ofParameter <std::string> ).name()){
+				parameter.cast <std::string>() = xml.getValue(name);
 			}else{
 				parameter.fromString(xml.getValue(name));
 			}

--- a/addons/ofxPoco/src/ofxXmlPoco.h
+++ b/addons/ofxPoco/src/ofxXmlPoco.h
@@ -34,62 +34,62 @@ public:
     ofxXmlPoco();
     ~ofxXmlPoco();
 
-    ofxXmlPoco( const string & path );
+    ofxXmlPoco( const std::string & path );
     ofxXmlPoco( const ofxXmlPoco& rhs );
     const ofxXmlPoco& operator =( const ofxXmlPoco& rhs );
 
     bool load(const std::filesystem::path & path);
     bool save(const std::filesystem::path & path);
 
-    bool            addChild( const string& path );
+    bool            addChild( const std::string& path );
     void            addXml( ofxXmlPoco& xml, bool copyAll = false);
 
-    string          getValue() const;
-    string          getValue(const string & path) const;
+    std::string          getValue() const;
+    std::string          getValue(const std::string & path) const;
     int				getIntValue() const;
-    int				getIntValue(const string & path) const;
+    int				getIntValue(const std::string & path) const;
     int64_t getInt64Value() const;
-    int64_t getInt64Value(const string& path) const;
+    int64_t getInt64Value(const std::string& path) const;
     float			getFloatValue() const;
-    float			getFloatValue(const string & path) const;
+    float			getFloatValue(const std::string & path) const;
     bool			getBoolValue() const;
-    bool			getBoolValue(const string & path) const;
+    bool			getBoolValue(const std::string & path) const;
 
-    bool            setValue(const string& path, const string& value);
+    bool            setValue(const std::string& path, const std::string& value);
     
-    string          getAttribute(const string& path) const;
-    bool            setAttribute(const string& path, const string& value);
-    map<string, string> getAttributes() const;
+    std::string          getAttribute(const std::string& path) const;
+    bool            setAttribute(const std::string& path, const std::string& value);
+    std::map<std::string, std::string> getAttributes() const;
     int             getNumChildren() const;
-    int             getNumChildren(const string& path) const;
+    int             getNumChildren(const std::string& path) const;
 
-    bool            removeAttribute(const string& path);
-    bool            removeAttributes(const string& path); // removes attributes for the passed path
+    bool            removeAttribute(const std::string& path);
+    bool            removeAttributes(const std::string& path); // removes attributes for the passed path
     bool            removeAttributes(); // removes attributes for the element ofxXmlPoco is pointing to
-    bool            removeContents(const string& path); // removes the path passed as parameter
+    bool            removeContents(const std::string& path); // removes the path passed as parameter
     bool            removeContents(); // removes the childs of the current element
-    bool            remove(const string& path); // removes both attributes and tags for the passed path
+    bool            remove(const std::string& path); // removes both attributes and tags for the passed path
     void            remove(); // removes the current element and all its children,
     						  // the current element will point to it's parent afterwards
     						  // if the current element is the document root this will act as clear()
 
-    bool            exists(const string& path) const; // works for both attributes and tags
+    bool            exists(const std::string& path) const; // works for both attributes and tags
     
     void			clear();  // clears the full document and points the current element to the root
 
-    string          getName() const;
+    std::string          getName() const;
     bool            reset();
 
     bool            setToChild(unsigned long index);
-    bool            setTo(const string& path);
+    bool            setTo(const std::string& path);
     bool            setToParent();
     bool            setToParent(int numLevelsUp);
     bool            setToSibling();
     bool            setToPrevSibling();
     
-    bool            loadFromBuffer( const string& buffer );
+    bool            loadFromBuffer( const std::string& buffer );
     
-	string          toString() const;
+    std::string          toString() const;
 
 
     //////////////////////////////////////////////////////////////////
@@ -97,14 +97,14 @@ public:
     //////////////////////////////////////////////////////////////////
     
     // a pretty useful tokenization system:
-    static vector<string> tokenize(const string & str, const string & delim){
-        vector<string> tokens;
+    static std::vector<std::string> tokenize(const std::string & str, const std::string & delim){
+	std::vector<std::string> tokens;
 
-        size_t p0 = 0, p1 = string::npos;
-        while(p0 != string::npos){
+        size_t p0 = 0, p1 = std::string::npos;
+        while(p0 != std::string::npos){
             p1 = str.find_first_of(delim, p0);
             if(p1 != p0){
-                string token = str.substr(p0, p1 - p0);
+		std::string token = str.substr(p0, p1 - p0);
                 tokens.push_back(token);
             }
             p0 = str.find_first_not_of(delim, p1);
@@ -113,11 +113,11 @@ public:
     }
     
     // templated to be anything
-    template <class T> bool addValue(const string& path, T data=T(), bool createEntirePath = false){
-        string value = ofToString(data);
-        vector<string> tokens;
+    template <class T> bool addValue(const std::string& path, T data=T(), bool createEntirePath = false){
+	std::string value = ofToString(data);
+	std::vector<std::string> tokens;
         
-        if(path.find('/') != string::npos){
+        if(path.find('/') != std::string::npos){
             tokens = tokenize(path, "/");
         }
 
@@ -188,7 +188,7 @@ public:
 
     
     // templated to be anything
-    template <class T> T getValue(const string& path, T returnVal=T()) const{
+    template <class T> T getValue(const std::string& path, T returnVal=T()) const{
     	if(element){
 			if(path == ""){
 				if(element->firstChild() && element->firstChild()->nodeType() == Poco::XML::Node::TEXT_NODE) {
@@ -211,9 +211,9 @@ public:
     // these are advanced, you probably don't want to use them
     
     Poco::XML::Element*        getPocoElement();
-    Poco::XML::Element*        getPocoElement(const string& path);
+    Poco::XML::Element*        getPocoElement(const std::string& path);
     const Poco::XML::Element*  getPocoElement() const;
-    const Poco::XML::Element*  getPocoElement(const string& path) const;
+    const Poco::XML::Element*  getPocoElement(const std::string& path) const;
 
     Poco::XML::Document*       getPocoDocument();
     const Poco::XML::Document* getPocoDocument() const;
@@ -221,7 +221,7 @@ public:
 
 protected:
     void releaseAll();
-    string DOMErrorMessage(short msg);
+    std::string DOMErrorMessage(short msg);
 
     Poco::XML::Document *document;
     Poco::XML::Element *element;

--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -8,7 +8,7 @@ ofxSVG::~ofxSVG(){
 	paths.clear();
 }
 
-void ofxSVG::load(string path){
+void ofxSVG::load(std::string path){
 	path = ofToDataPath(path);
 
 	if(path.compare("") == 0){
@@ -23,7 +23,7 @@ void ofxSVG::load(string path){
 	svgtiny_code code = svgtiny_parse(diagram, buffer.getText().c_str(), size, path.c_str(), 0, 0);
 
 	if(code != svgtiny_OK){
-		string msg;
+		std::string msg;
 		switch(code){
 		 case svgtiny_OUT_OF_MEMORY:
 			 msg = "svgtiny_OUT_OF_MEMORY";
@@ -120,6 +120,6 @@ void ofxSVG::setupShape(struct svgtiny_shape * shape, ofPath & path){
 	}
 }
 
-const vector <ofPath> & ofxSVG::getPaths() const{
+const std::vector <ofPath> & ofxSVG::getPaths() const{
     return paths;
 }

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -14,7 +14,7 @@ class ofxSVG {
 		float getHeight() const {
 			return height;
 		}
-		void load(string path);
+		void load(std::string path);
 		void draw();
 
 		int getNumPath(){
@@ -24,13 +24,13 @@ class ofxSVG {
 			return paths[n];
 		}
 
-		const vector <ofPath> & getPaths() const;
+		const std::vector <ofPath> & getPaths() const;
 
 	private:
 
 		float width, height;
 
-		vector <ofPath> paths;
+		std::vector <ofPath> paths;
 
 		void setupDiagram(struct svgtiny_diagram * diagram);
 		void setupShape(struct svgtiny_shape * shape, ofPath & path);

--- a/addons/ofxThreadedImageLoader/src/ofxThreadedImageLoader.cpp
+++ b/addons/ofxThreadedImageLoader/src/ofxThreadedImageLoader.cpp
@@ -19,7 +19,7 @@ ofxThreadedImageLoader::~ofxThreadedImageLoader(){
 
 // Load an image from disk.
 //--------------------------------------------------------------
-void ofxThreadedImageLoader::loadFromDisk(ofImage& image, string filename) {
+void ofxThreadedImageLoader::loadFromDisk(ofImage& image, std::string filename) {
 	nextID++;
 	ofImageLoaderEntry entry(image);
 	entry.filename = filename;
@@ -32,7 +32,7 @@ void ofxThreadedImageLoader::loadFromDisk(ofImage& image, string filename) {
 
 // Load an url asynchronously from an url.
 //--------------------------------------------------------------
-void ofxThreadedImageLoader::loadFromURL(ofImage& image, string url) {
+void ofxThreadedImageLoader::loadFromURL(ofImage& image, std::string url) {
 	nextID++;
 	ofImageLoaderEntry entry(image);
 	entry.url = url;

--- a/addons/ofxThreadedImageLoader/src/ofxThreadedImageLoader.h
+++ b/addons/ofxThreadedImageLoader/src/ofxThreadedImageLoader.h
@@ -7,15 +7,13 @@
 #include "ofThreadChannel.h"
 
 
-using namespace std;
-
 class ofxThreadedImageLoader : public ofThread {
 public:
     ofxThreadedImageLoader();
     ~ofxThreadedImageLoader();
 
-	void loadFromDisk(ofImage& image, string file);
-	void loadFromURL(ofImage& image, string url);
+	void loadFromDisk(ofImage& image, std::string file);
+	void loadFromURL(ofImage& image, std::string url);
 
 
 
@@ -34,18 +32,18 @@ private:
             image = &pImage;
         }
         ofImage* image;
-        string filename;
-        string url;
-        string name;
+	std::string filename;
+	std::string url;
+	std::string name;
     };
 
 
-    typedef map<string, ofImageLoaderEntry>::iterator entry_iterator;
+    typedef std::map<std::string, ofImageLoaderEntry>::iterator entry_iterator;
 
 	int                 nextID;
     int                 lastUpdate;
 
-	map<string,ofImageLoaderEntry> images_async_loading; // keeps track of images which are loading async
+	std::map<std::string,ofImageLoaderEntry> images_async_loading; // keeps track of images which are loading async
 	ofThreadChannel<ofImageLoaderEntry> images_to_load_from_disk;
 	ofThreadChannel<ofImageLoaderEntry> images_to_update;
 };

--- a/addons/ofxUnitTests/src/ofxUnitTests.h
+++ b/addons/ofxUnitTests/src/ofxUnitTests.h
@@ -282,9 +282,9 @@ private:
             if(res.status<200 || res.status>=300){
                 ofLogError() << "sending to " << req.url;
                 ofLogError() << res.status << ", " << res.error;
-                cout << res.data.getText() << endl;
+                std::cout << res.data.getText() << std::endl;
                 ofLogError() << "for body:";
-                cout << req.body << endl;
+                std::cout << req.body << std::endl;
                 return false;
             }else{
                 ofLogNotice() << "Test results sent correctly";

--- a/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
+++ b/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
@@ -150,7 +150,7 @@ ofxVectorGraphics::ofxVectorGraphics(){
 }
 
 //----------------------------------------------------------			
-void ofxVectorGraphics::beginEPS(string fileName, int x, int y, int w, int h){
+void ofxVectorGraphics::beginEPS(std::string fileName, int x, int y, int w, int h){
 	creeps.newFile(ofToDataPath(fileName).c_str(), x, y, x+w, y+h);
 	bRecord = true;
 	
@@ -561,7 +561,7 @@ void ofxVectorGraphics::endShape(bool bClose){
 
 //----------------------------------------------------------
 void ofxVectorGraphics::clearAllVertices(){
-	for(vector<double*>::iterator itr=curvePts.begin();
+	for(std::vector<double*>::iterator itr=curvePts.begin();
 		itr!=curvePts.end();
 		++itr){
 		delete [] (*itr);

--- a/addons/ofxVectorGraphics/src/ofxVectorGraphics.h
+++ b/addons/ofxVectorGraphics/src/ofxVectorGraphics.h
@@ -19,7 +19,7 @@ class ofxVectorGraphics{
 
 			//----------------------------------------------------------
 			//only call these two functions when you are ready to capture your graphics to disk!!!
-			void beginEPS(string fileName, int x = 0, int y = 0, int w = ofGetWidth(), int h = ofGetHeight() );
+			void beginEPS(std::string fileName, int x = -1, int y = 0, int w = ofGetWidth(), int h = ofGetHeight() );
 			void endEPS();
 
 			//----------------------------------------------------------
@@ -75,5 +75,5 @@ class ofxVectorGraphics{
 			bool bFirstPoint;
 			int  whichShapeMode;
 
-			vector<double *>curvePts;
+			std::vector<double *>curvePts;
 };

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -10,18 +10,18 @@ const float floatPrecision = 9;
 
 //----------------------------------------
 // a pretty useful tokenization system:
-static vector<string> tokenize(const string & str, const string & delim);
-static vector<string> tokenize(const string & str, const string & delim)
+static std::vector<std::string> tokenize(const std::string & str, const std::string & delim);
+static std::vector<std::string> tokenize(const std::string & str, const std::string & delim)
 {
-  vector<string> tokens;
+  std::vector<std::string> tokens;
 
-  size_t p0 = 0, p1 = string::npos;
-  while(p0 != string::npos)
+  size_t p0 = 0, p1 = std::string::npos;
+  while(p0 != std::string::npos)
   {
     p1 = str.find_first_of(delim, p0);
     if(p1 != p0)
     {
-      string token = str.substr(p0, p1 - p0);
+	std::string token = str.substr(p0, p1 - p0);
       tokens.push_back(token);
     }
     p0 = str.find_first_not_of(delim, p1);
@@ -41,7 +41,7 @@ ofxXmlSettings::ofxXmlSettings():
 }
 
 //----------------------------------------
-ofxXmlSettings::ofxXmlSettings(const string& xmlFile):
+ofxXmlSettings::ofxXmlSettings(const std::string& xmlFile):
     storedHandle(NULL)
 {
 	level			= 0;
@@ -72,9 +72,9 @@ void ofxXmlSettings::clear(){
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::loadFile(const string& xmlFile){
+bool ofxXmlSettings::loadFile(const std::string& xmlFile){
 
-	string fullXmlFile = ofToDataPath(xmlFile);
+    std::string fullXmlFile = ofToDataPath(xmlFile);
 
 	bool loadOkay = doc.LoadFile(fullXmlFile);
 
@@ -90,9 +90,9 @@ bool ofxXmlSettings::loadFile(const string& xmlFile){
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::saveFile(const string& xmlFile){
+bool ofxXmlSettings::saveFile(const std::string& xmlFile){
 
-	string fullXmlFile = ofToDataPath(xmlFile);
+	std::string fullXmlFile = ofToDataPath(xmlFile);
 	return doc.SaveFile(fullXmlFile);
 }
 
@@ -102,26 +102,26 @@ bool ofxXmlSettings::saveFile(){
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::load(const string & path){
+bool ofxXmlSettings::load(const std::string & path){
 	return loadFile(path);
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::save(const string & path){
+bool ofxXmlSettings::save(const std::string & path){
 	return saveFile(path);
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::clearTagContents(const string& tag, int which){
+void ofxXmlSettings::clearTagContents(const std::string& tag, int which){
 	//we check it first to see if it exists
 	//otherwise setValue will make a new empty tag
 	if( tagExists(tag, which) )setValue(tag, "", which);
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::removeTag(const string& tag, int which){
+void ofxXmlSettings::removeTag(const std::string& tag, int which){
 
-	vector<string> tokens = tokenize(tag,":");
+	std::vector<std::string> tokens = tokenize(tag,":");
 
 	//no tags so we return
 	if( tokens.size() == 0 ) return;
@@ -153,7 +153,7 @@ void ofxXmlSettings::removeTag(const string& tag, int which){
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::getValue(const string& tag, int defaultValue, int which) const{
+int ofxXmlSettings::getValue(const std::string& tag, int defaultValue, int which) const{
     TiXmlHandle valHandle(NULL);
 	if (readTag(tag, valHandle, which)){
 		return ofToInt(valHandle.ToText()->Value());
@@ -162,7 +162,7 @@ int ofxXmlSettings::getValue(const string& tag, int defaultValue, int which) con
 }
 
 //---------------------------------------------------------
-double ofxXmlSettings::getValue(const string& tag, double defaultValue, int which) const{
+double ofxXmlSettings::getValue(const std::string& tag, double defaultValue, int which) const{
     TiXmlHandle valHandle(NULL);
 	if (readTag(tag, valHandle, which)){
 		return ofToDouble(valHandle.ToText()->Value());
@@ -171,7 +171,7 @@ double ofxXmlSettings::getValue(const string& tag, double defaultValue, int whic
 }
 
 //---------------------------------------------------------
-string ofxXmlSettings::getValue(const string& tag, const string& defaultValue, int which) const{
+std::string ofxXmlSettings::getValue(const std::string& tag, const std::string& defaultValue, int which) const{
     TiXmlHandle valHandle(NULL);
 	if (readTag(tag, valHandle, which)){
 		return valHandle.ToText()->ValueStr();
@@ -180,9 +180,9 @@ string ofxXmlSettings::getValue(const string& tag, const string& defaultValue, i
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::readTag(const string&  tag, TiXmlHandle& valHandle, int which) const{
+bool ofxXmlSettings::readTag(const std::string&  tag, TiXmlHandle& valHandle, int which) const{
 
-	vector<string> tokens = tokenize(tag,":");
+	std::vector<std::string> tokens = tokenize(tag,":");
 
 	TiXmlHandle tagHandle = storedHandle;
 	for(int x=0;x<(int)tokens.size();x++){
@@ -197,12 +197,12 @@ bool ofxXmlSettings::readTag(const string&  tag, TiXmlHandle& valHandle, int whi
 
 
 //---------------------------------------------------------
-bool ofxXmlSettings::pushTag(const string&  tag, int which){
+bool ofxXmlSettings::pushTag(const std::string&  tag, int which){
 
 	int pos = tag.find(":");
 
     // Either find the tag specified, or the first tag if colon-seperated.
-    string tagToFind((pos > 0) ? tag.substr(0,pos) :tag);
+	std::string tagToFind((pos > 0) ? tag.substr(0,pos) :tag);
 
 	//we only allow to push one tag at a time.
 	TiXmlHandle isRealHandle = storedHandle.ChildElement(tagToFind, which);
@@ -239,9 +239,9 @@ int ofxXmlSettings::getPushLevel(){
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::tagExists(const string& tag, int which) const{
+bool ofxXmlSettings::tagExists(const std::string& tag, int which) const{
 
-	vector<string> tokens = tokenize(tag,":");
+	std::vector<std::string> tokens = tokenize(tag,":");
 
 	bool found = false;
 
@@ -276,13 +276,13 @@ bool ofxXmlSettings::tagExists(const string& tag, int which) const{
 
 
 //---------------------------------------------------------
-int ofxXmlSettings::getNumTags(const string&  tag) const{
+int ofxXmlSettings::getNumTags(const std::string&  tag) const{
 	//this only works for tags at the current root level
 
 	int pos = tag.find(":");
 
     // Either find the tag specified, or the first tag if colon-seperated.
-    string tagToFind((pos > 0) ? tag.substr(0,pos) :tag);
+	std::string tagToFind((pos > 0) ? tag.substr(0,pos) :tag);
 
 	//grab the handle from the level we are at
 	//normally this is the doc but could be a pushed node
@@ -304,12 +304,12 @@ int ofxXmlSettings::getNumTags(const string&  tag) const{
 
 
 //---------------------------------------------------------
-int ofxXmlSettings::writeTag(const string&  tag, const string& valueStr, int which){
+int ofxXmlSettings::writeTag(const std::string&  tag, const std::string& valueStr, int which){
 
-	vector<string> tokens = tokenize(tag,":");
+	std::vector<std::string> tokens = tokenize(tag,":");
 
 	// allocate on the stack
-    vector<TiXmlElement> elements;
+	std::vector<TiXmlElement> elements;
     elements.reserve(tokens.size());
 	for(int x=0;x<(int)tokens.size();x++)
         elements.push_back(tokens.at(x));
@@ -374,43 +374,43 @@ int ofxXmlSettings::writeTag(const string&  tag, const string& valueStr, int whi
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setValue(const string& tag, int value, int which){
+int ofxXmlSettings::setValue(const std::string& tag, int value, int which){
 	int tagID = writeTag(tag, ofToString(value).c_str(), which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setValue(const string& tag, double value, int which){
+int ofxXmlSettings::setValue(const std::string& tag, double value, int which){
 	int tagID = writeTag(tag, ofToString(value, floatPrecision).c_str(), which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setValue(const string& tag, const string& value, int which){
+int ofxXmlSettings::setValue(const std::string& tag, const std::string& value, int which){
 	int tagID = writeTag(tag, value, which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addValue(const string& tag, int value){
+int ofxXmlSettings::addValue(const std::string& tag, int value){
 	int tagID = writeTag(tag, ofToString(value).c_str(), -1) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addValue(const string&  tag, double value){
+int ofxXmlSettings::addValue(const std::string&  tag, double value){
 	int tagID = writeTag(tag, ofToString(value, floatPrecision).c_str(), -1) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addValue(const string& tag, const string& value){
+int ofxXmlSettings::addValue(const std::string& tag, const std::string& value){
 	int tagID = writeTag(tag, value, -1) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addTag(const string& tag){
+int ofxXmlSettings::addTag(const std::string& tag){
 	int tagID = writeTag(tag, "", -1) -1;
 	return tagID;
 }
@@ -421,41 +421,41 @@ int ofxXmlSettings::addTag(const string& tag){
 *******************/
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, int value, int which){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, int value, int which){
 	int tagID = writeAttribute(tag, attribute, ofToString(value).c_str(), which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, int value){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, int value){
 	return addAttribute(tag,attribute,value,-1);
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, double value, int which){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, double value, int which){
 	int tagID = writeAttribute(tag, attribute, ofToString(value, floatPrecision).c_str(), which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, double value){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, double value){
 	return addAttribute(tag,attribute,value,-1);
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, const string& value, int which){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which){
 	int tagID = writeAttribute(tag, attribute, value, which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::addAttribute(const string& tag, const string& attribute, const string& value){
+int ofxXmlSettings::addAttribute(const std::string& tag, const std::string& attribute, const std::string& value){
 	return addAttribute(tag,attribute,value,-1);
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::removeAttribute(const string& tag, const string& attribute, int which){
-	vector<string> tokens = tokenize(tag,":");
+void ofxXmlSettings::removeAttribute(const std::string& tag, const std::string& attribute, int which){
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -471,16 +471,16 @@ void ofxXmlSettings::removeAttribute(const string& tag, const string& attribute,
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::clearTagAttributes(const string& tag, int which){
-	vector<string> names;
-    getAttributeNames( tag, names, which );
-	for (vector<string>::iterator i = names.begin(); i != names.end(); i++)
+void ofxXmlSettings::clearTagAttributes(const std::string& tag, int which){
+	std::vector<std::string> names;
+	getAttributeNames( tag, names, which );
+	for (std::vector<std::string>::iterator i = names.begin(); i != names.end(); i++)
 		removeAttribute(tag, *i, which);
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::getNumAttributes(const string& tag, int which) const{
-	vector<string> tokens = tokenize(tag,":");
+int ofxXmlSettings::getNumAttributes(const std::string& tag, int which) const{
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -505,8 +505,8 @@ int ofxXmlSettings::getNumAttributes(const string& tag, int which) const{
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::attributeExists(const string& tag, const string& attribute, int which) const{
-	vector<string> tokens = tokenize(tag,":");
+bool ofxXmlSettings::attributeExists(const std::string& tag, const std::string& attribute, int which) const{
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -528,8 +528,8 @@ bool ofxXmlSettings::attributeExists(const string& tag, const string& attribute,
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::getAttributeNames(const string& tag, vector<string>& outNames, int which) const{
-	vector<string> tokens = tokenize(tag,":");
+bool ofxXmlSettings::getAttributeNames(const std::string& tag, std::vector<std::string>& outNames, int which) const{
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -543,34 +543,34 @@ bool ofxXmlSettings::getAttributeNames(const string& tag, vector<string>& outNam
 
 		// Do stuff with the element here
 		for (TiXmlAttribute* a = elem->FirstAttribute(); a; a = a->Next())
-			outNames.push_back( string(a->Name()) );
+			outNames.push_back( std::string(a->Name()) );
 	}
 	return !outNames.empty();
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::getAttribute(const string& tag, const string& attribute, int defaultValue, int which) const{
+int ofxXmlSettings::getAttribute(const std::string& tag, const std::string& attribute, int defaultValue, int which) const{
     int value = defaultValue;
 	readIntAttribute(tag, attribute, value, which);
 	return value;
 }
 
 //---------------------------------------------------------
-double ofxXmlSettings::getAttribute(const string& tag, const string& attribute, double defaultValue, int which) const{
+double ofxXmlSettings::getAttribute(const std::string& tag, const std::string& attribute, double defaultValue, int which) const{
     double value = defaultValue;
 	readDoubleAttribute(tag, attribute, value, which);
 	return value;
 }
 
 //---------------------------------------------------------
-string ofxXmlSettings::getAttribute(const string& tag, const string& attribute, const string& defaultValue, int which) const{
-    string value = defaultValue;
+std::string ofxXmlSettings::getAttribute(const std::string& tag, const std::string& attribute, const std::string& defaultValue, int which) const{
+	std::string value = defaultValue;
 	readStringAttribute(tag, attribute, value, which);
 	return value;
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setAttribute(const string& tag, const string& attribute, int value, int which){
+int ofxXmlSettings::setAttribute(const std::string& tag, const std::string& attribute, int value, int which){
 	char valueStr[255];
 	sprintf(valueStr, "%i", value);
 	int tagID = writeAttribute(tag, attribute, valueStr, which) -1;
@@ -578,7 +578,7 @@ int ofxXmlSettings::setAttribute(const string& tag, const string& attribute, int
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setAttribute(const string& tag, const string& attribute, double value, int which){
+int ofxXmlSettings::setAttribute(const std::string& tag, const std::string& attribute, double value, int which){
 	char valueStr[255];
 	sprintf(valueStr, "%lf", value);
 	int tagID = writeAttribute(tag, attribute, valueStr, which) -1;
@@ -586,14 +586,14 @@ int ofxXmlSettings::setAttribute(const string& tag, const string& attribute, dou
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::setAttribute(const string& tag, const string& attribute, const string& value, int which){
+int ofxXmlSettings::setAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which){
 	int tagID = writeAttribute(tag, attribute, value, which) -1;
 	return tagID;
 }
 
 //---------------------------------------------------------
-TiXmlElement* ofxXmlSettings::getElementForAttribute(const string& tag, int which) const{
-	vector<string> tokens = tokenize(tag,":");
+TiXmlElement* ofxXmlSettings::getElementForAttribute(const std::string& tag, int which) const{
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -605,7 +605,7 @@ TiXmlElement* ofxXmlSettings::getElementForAttribute(const string& tag, int whic
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::readIntAttribute(const string& tag, const string& attribute, int& outValue, int which) const{
+bool ofxXmlSettings::readIntAttribute(const std::string& tag, const std::string& attribute, int& outValue, int which) const{
 
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
@@ -614,7 +614,7 @@ bool ofxXmlSettings::readIntAttribute(const string& tag, const string& attribute
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::readDoubleAttribute(const string& tag, const string& attribute, double& outValue, int which) const{
+bool ofxXmlSettings::readDoubleAttribute(const std::string& tag, const std::string& attribute, double& outValue, int which) const{
 
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
@@ -623,12 +623,12 @@ bool ofxXmlSettings::readDoubleAttribute(const string& tag, const string& attrib
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::readStringAttribute(const string& tag, const string& attribute, string& outValue, int which) const{
+bool ofxXmlSettings::readStringAttribute(const std::string& tag, const std::string& attribute, std::string& outValue, int which) const{
 
     TiXmlElement* elem = getElementForAttribute(tag, which);
     if (elem)
     {
-        const string* value = elem->Attribute(attribute);
+        const std::string* value = elem->Attribute(attribute);
         if (value)
         {
             outValue = *value;
@@ -639,8 +639,8 @@ bool ofxXmlSettings::readStringAttribute(const string& tag, const string& attrib
 }
 
 //---------------------------------------------------------
-int ofxXmlSettings::writeAttribute(const string& tag, const string& attribute, const string& valueString, int which){
-	vector<string> tokens = tokenize(tag,":");
+int ofxXmlSettings::writeAttribute(const std::string& tag, const std::string& attribute, const std::string& valueString, int which){
+	std::vector<std::string> tokens = tokenize(tag,":");
 	TiXmlHandle tagHandle = storedHandle;
 	for (int x = 0; x < (int)tokens.size(); x++) {
 		if (x == 0)
@@ -667,7 +667,7 @@ int ofxXmlSettings::writeAttribute(const string& tag, const string& attribute, c
 }
 
 //---------------------------------------------------------
-bool ofxXmlSettings::loadFromBuffer( string buffer )
+bool ofxXmlSettings::loadFromBuffer( std::string buffer )
 {
     int size = buffer.size();
     bool loadOkay = doc.ReadFromMemory( buffer.c_str(), size);//, TiXmlEncoding encoding = TIXML_DEFAULT_ENCODING);
@@ -677,7 +677,7 @@ bool ofxXmlSettings::loadFromBuffer( string buffer )
 }
 
 //---------------------------------------------------------
-void ofxXmlSettings::copyXmlToString(string & str) const
+void ofxXmlSettings::copyXmlToString(std::string & str) const
 {
 	TiXmlPrinter printer;
 	doc.Accept(&printer);
@@ -688,7 +688,7 @@ void ofxXmlSettings::copyXmlToString(string & str) const
 //---------------------------------------------------------
 void ofSerialize(ofxXmlSettings & xml, const ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()) return;
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	if(name=="") name="UnknownName";
 	if(parameter.type()==typeid(ofParameterGroup).name()){
 		const ofParameterGroup & group = static_cast<const ofParameterGroup&>(parameter);
@@ -699,7 +699,7 @@ void ofSerialize(ofxXmlSettings & xml, const ofAbstractParameter & parameter){
 		}
 		xml.popTag();
 	}else{
-		string value = parameter.toString();
+		std::string value = parameter.toString();
 		if(!xml.tagExists(name))
 			xml.addValue(name,value);
 		else
@@ -710,7 +710,7 @@ void ofSerialize(ofxXmlSettings & xml, const ofAbstractParameter & parameter){
 //---------------------------------------------------------
 void ofDeserialize(const ofxXmlSettings & xml, ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()) return;
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	if(parameter.type()==typeid(ofParameterGroup).name()){
 		ofParameterGroup & group = static_cast<ofParameterGroup&>(parameter);
 		if(xml.tagExists(name)){
@@ -728,8 +728,8 @@ void ofDeserialize(const ofxXmlSettings & xml, ofAbstractParameter & parameter){
 				parameter.cast<float>() = xml.getValue(name,0.0f);
 			}else if(parameter.type()==typeid(ofParameter<bool>).name()){
 				parameter.cast<bool>() = xml.getValue(name,false);
-			}else if(parameter.type()==typeid(ofParameter<string>).name()){
-				parameter.cast<string>() = xml.getValue(name,"");
+			}else if(parameter.type()==typeid(ofParameter<std::string>).name()){
+				parameter.cast<std::string>() = xml.getValue(name,"");
 			}else{
 				parameter.fromString(xml.getValue(name,""));
 			}

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -8,8 +8,6 @@
 #include "tinyxml.h"
 #endif
 
-using namespace std;
-
 /*
 	Q: what is the which = 0 argument?
 
@@ -48,35 +46,35 @@ class ofxXmlSettings{
 
 	public:
         ofxXmlSettings();
-        ofxXmlSettings(const string& xmlFile);
+        ofxXmlSettings(const std::string& xmlFile);
 
         ~ofxXmlSettings();
 
 		void setVerbose(bool _verbose);
 
-		bool loadFile(const string& xmlFile);
-		bool saveFile(const string& xmlFile);
+		bool loadFile(const std::string& xmlFile);
+		bool saveFile(const std::string& xmlFile);
 		bool saveFile();
 
-		bool load(const string & path);
-		bool save(const string & path);
+		bool load(const std::string & path);
+		bool save(const std::string & path);
 
-		void clearTagContents(const string& tag, int which = 0);
-		void removeTag(const string& tag, int which = 0);
+		void clearTagContents(const std::string& tag, int which = 0);
+		void removeTag(const std::string& tag, int which = 0);
 
-		bool tagExists(const string& tag, int which = 0) const;
+		bool tagExists(const std::string& tag, int which = 0) const;
 
 		// removes all tags from within either the whole document
 		// or the tag you are currently at using pushTag
 		void	clear();
 
-		int 	getValue(const string&  tag, int            defaultValue, int which = 0) const;
-		double 	getValue(const string&  tag, double         defaultValue, int which = 0) const;
-		string 	getValue(const string&  tag, const string& 	defaultValue, int which = 0) const;
+		int 	getValue(const std::string&  tag, int            defaultValue, int which = 0) const;
+		double 	getValue(const std::string&  tag, double         defaultValue, int which = 0) const;
+		std::string 	getValue(const std::string&  tag, const std::string& 	defaultValue, int which = 0) const;
 
-		int 	setValue(const string&  tag, int            value, int which = 0);
-		int 	setValue(const string&  tag, double         value, int which = 0);
-		int 	setValue(const string&  tag, const string& 	value, int which = 0);
+		int 	setValue(const std::string&  tag, int            value, int which = 0);
+		int 	setValue(const std::string&  tag, double         value, int which = 0);
+		int 	setValue(const std::string&  tag, const std::string& 	value, int which = 0);
 
 		//advanced
 
@@ -88,7 +86,7 @@ class ofxXmlSettings{
 		//the pushed tag - normally addValue only lets you create multiple tags of the same
 		//at the top most level.
 
-		bool	pushTag(const string&  tag, int which = 0);
+		bool	pushTag(const std::string&  tag, int which = 0);
 		int		popTag();
 		int		getPushLevel();
 
@@ -97,7 +95,7 @@ class ofxXmlSettings{
 		//use pushTag and popTag to get number of tags whithin other tags
 		// both getNumTags("PT"); and getNumTags("PT:X"); will just return the
 		//number of <PT> tags at the current root level.
-		int		getNumTags(const string& tag) const;
+		int		getNumTags(const std::string& tag) const;
 
 		//-- addValue/addTag
 		//adds a tag to the document even if a tag with the same name
@@ -107,44 +105,44 @@ class ofxXmlSettings{
 		//-- important - this only works for top level tags
 		//   to put multiple tags inside other tags - use pushTag() and popTag()
 
-		int 	addValue(const string&  tag, int            value);
-		int 	addValue(const string&  tag, double         value);
-		int 	addValue(const string&  tag, const string& 	value);
+		int 	addValue(const std::string&  tag, int            value);
+		int 	addValue(const std::string&  tag, double         value);
+		int 	addValue(const std::string&  tag, const std::string& 	value);
 
-		int		addTag(const string& tag); //adds an empty tag at the current level
+		int		addTag(const std::string& tag); //adds an empty tag at the current level
 
         // Attribute-related methods
-		int		addAttribute(const string& tag, const string& attribute, int value, int which = 0);
-		int		addAttribute(const string& tag, const string& attribute, double value, int which = 0);
-		int		addAttribute(const string& tag, const string& attribute, const string& value, int which = 0);
+		int		addAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
+		int		addAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
+		int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
 
-		int		addAttribute(const string& tag, const string& attribute, int value);
-		int		addAttribute(const string& tag, const string& attribute, double value);
-		int		addAttribute(const string& tag, const string& attribute, const string& value);
+		int		addAttribute(const std::string& tag, const std::string& attribute, int value);
+		int		addAttribute(const std::string& tag, const std::string& attribute, double value);
+		int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
 
-		void	removeAttribute(const string& tag, const string& attribute, int which = 0);
-		void	clearTagAttributes(const string& tag, int which = 0);
+		void	removeAttribute(const std::string& tag, const std::string& attribute, int which = 0);
+		void	clearTagAttributes(const std::string& tag, int which = 0);
 
-		int		getNumAttributes(const string& tag, int which = 0) const;
+		int		getNumAttributes(const std::string& tag, int which = 0) const;
 
-		bool	attributeExists(const string& tag, const string& attribute, int which = 0) const;
+		bool	attributeExists(const std::string& tag, const std::string& attribute, int which = 0) const;
 
-		bool    getAttributeNames(const string& tag, vector<string>& outNames, int which = 0) const;
+		bool    getAttributeNames(const std::string& tag, std::vector<std::string>& outNames, int which = 0) const;
 
-		int		getAttribute(const string& tag, const string& attribute, int defaultValue, int which = 0) const;
-		double	getAttribute(const string& tag, const string& attribute, double defaultValue, int which = 0) const;
-		string	getAttribute(const string& tag, const string& attribute, const string& defaultValue, int which = 0) const;
+		int		getAttribute(const std::string& tag, const std::string& attribute, int defaultValue, int which = 0) const;
+		double	getAttribute(const std::string& tag, const std::string& attribute, double defaultValue, int which = 0) const;
+		std::string	getAttribute(const std::string& tag, const std::string& attribute, const std::string& defaultValue, int which = 0) const;
 
-		int		setAttribute(const string& tag, const string& attribute, int value, int which = 0);
-		int		setAttribute(const string& tag, const string& attribute, double value, int which = 0);
-		int		setAttribute(const string& tag, const string& attribute, const string& value, int which = 0);
+		int		setAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
+		int		setAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
+		int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
 
-		int		setAttribute(const string& tag, const string& attribute, int value);
-		int		setAttribute(const string& tag, const string& attribute, double value);
-		int		setAttribute(const string& tag, const string& attribute, const string& value);
+		int		setAttribute(const std::string& tag, const std::string& attribute, int value);
+		int		setAttribute(const std::string& tag, const std::string& attribute, double value);
+		int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
 
-		bool	loadFromBuffer( string buffer );
-		void	copyXmlToString(string & str) const;
+		bool	loadFromBuffer( std::string buffer );
+		void	copyXmlToString(std::string & str) const;
 
 		TiXmlDocument 	doc;
 		bool 			bDocLoaded;
@@ -155,16 +153,16 @@ class ofxXmlSettings{
 		int             level;
 
 
-		int 	writeTag(const string&  tag, const string& valueString, int which = 0);
-		bool 	readTag(const string&  tag, TiXmlHandle& valHandle, int which = 0) const;	// max 1024 chars...
+		int 	writeTag(const std::string&  tag, const std::string& valueString, int which = 0);
+		bool 	readTag(const std::string&  tag, TiXmlHandle& valHandle, int which = 0) const;	// max 1024 chars...
 
 
-		int		writeAttribute(const string& tag, const string& attribute, const string& valueString, int which = 0);
+		int		writeAttribute(const std::string& tag, const std::string& attribute, const std::string& valueString, int which = 0);
 
-		TiXmlElement* getElementForAttribute(const string& tag, int which) const;
-		bool readIntAttribute(const string& tag, const string& attribute, int& valueString, int which) const;
-		bool readDoubleAttribute(const string& tag, const string& attribute, double& outValue, int which) const;
-		bool readStringAttribute(const string& tag, const string& attribute, string& outValue, int which) const;
+		TiXmlElement* getElementForAttribute(const std::string& tag, int which) const;
+		bool readIntAttribute(const std::string& tag, const std::string& attribute, int& valueString, int which) const;
+		bool readDoubleAttribute(const std::string& tag, const std::string& attribute, double& outValue, int which) const;
+		bool readStringAttribute(const std::string& tag, const std::string& attribute, std::string& outValue, int which) const;
 };   
 
 void ofSerialize(ofxXmlSettings & settings, const ofAbstractParameter & parameter);

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -150,7 +150,7 @@ public:
     
     void run(ofBaseApp * appPtr);
     OF_DEPRECATED_MSG("Use setup(const ofiOSWindowSettings & settings); instead.", virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) );
-    static void startAppWithDelegate(string appDelegateClassName);
+    static void startAppWithDelegate(std::string appDelegateClassName);
     void update();
     void draw();
    
@@ -183,9 +183,9 @@ public:
     
     ofiOSWindowSettings & getSettings();
     ofCoreEvents & events();
-    shared_ptr<ofBaseRenderer> & renderer();
+    std::shared_ptr<ofBaseRenderer> & renderer();
 	
-	virtual void setWindowTitle(string title);
+	virtual void setWindowTitle(std::string title);
 	
 	virtual ofWindowMode getWindowMode();
 	
@@ -223,7 +223,7 @@ public:
 protected:
     
     ofCoreEvents coreEvents;
-    shared_ptr<ofBaseRenderer> currentRenderer;
+    std::shared_ptr<ofBaseRenderer> currentRenderer;
     ofiOSWindowSettings settings;
 
 	ofOrientation orientation;

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.mm
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.mm
@@ -35,11 +35,11 @@
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
     #include "ofxiOSAppDelegate.h"
     #include "ofxiOSViewController.h"
-    const string appDelegateName = "ofxiOSAppDelegate";
+    const std::string appDelegateName = "ofxiOSAppDelegate";
 #elif TARGET_OS_TV
     #include "ofxtvOSAppDelegate.h"
     #include "ofxtvOSViewController.h"
-    const string appDelegateName = "ofxtvOSAppDelegate";
+    const std::string appDelegateName = "ofxtvOSAppDelegate";
 #endif
 #include "ofxiOSEAGLView.h"
 
@@ -104,9 +104,9 @@ void ofAppiOSWindow::setup() {
 	}
 	setOrientation(settings.setupOrientation);
 	if(settings.glesVersion >= ESRendererVersion_20) {
-		currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+		currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
 	} else {
-		currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+		currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 	}
 	
 	hasExited = false;
@@ -126,7 +126,7 @@ void ofAppiOSWindow::run(ofBaseApp * appPtr){
     startAppWithDelegate(appDelegateName);
 }
 
-void ofAppiOSWindow::startAppWithDelegate(string appDelegateClassName) {
+void ofAppiOSWindow::startAppWithDelegate(std::string appDelegateClassName) {
     static bool bAppCreated = false;
     if(bAppCreated == true) {
         return;
@@ -275,7 +275,7 @@ bool ofAppiOSWindow::disableOrientationAnimation() {
 #endif
 
 //-----------------------------------------------------------------------------------
-void ofAppiOSWindow::setWindowTitle(string title) {
+void ofAppiOSWindow::setWindowTitle(std::string title) {
     // not supported on iOS.
 }
 
@@ -305,7 +305,7 @@ bool ofAppiOSWindow::enableRendererES2() {
     if(isRendererES2() == true) {
         return false;
     }
-    shared_ptr<ofBaseRenderer>renderer (new ofGLProgrammableRenderer(this));
+    std::shared_ptr<ofBaseRenderer>renderer (new ofGLProgrammableRenderer(this));
     ofSetCurrentRenderer(renderer);
     return true;
 }
@@ -314,7 +314,7 @@ bool ofAppiOSWindow::enableRendererES1() {
     if(isRendererES1() == true) {
         return false;
     }
-    shared_ptr<ofBaseRenderer> renderer(new ofGLRenderer(this));
+    std::shared_ptr<ofBaseRenderer> renderer(new ofGLRenderer(this));
     ofSetCurrentRenderer(renderer);
     return true;
 }
@@ -429,7 +429,7 @@ ofCoreEvents & ofAppiOSWindow::events(){
 }
 
 //-----------------------------------------------------------------------------------
-shared_ptr<ofBaseRenderer> & ofAppiOSWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppiOSWindow::renderer(){
     return currentRenderer;
 }
 

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -17,8 +17,8 @@ static ofxiOSEAGLView * _instanceRef = nil;
 
 @interface ofxiOSEAGLView() {
     BOOL bInit;
-	shared_ptr<ofAppiOSWindow> window;
-	shared_ptr<ofxiOSApp> app;
+	std::shared_ptr<ofAppiOSWindow> window;
+	std::shared_ptr<ofxiOSApp> app;
 }
 - (void)updateDimensions;
 @end
@@ -56,7 +56,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
         
         _instanceRef = self;
         
-        app = shared_ptr<ofxiOSApp>(appPtr);
+        app = std::shared_ptr<ofxiOSApp>(appPtr);
         activeTouches = [[NSMutableDictionary alloc] init];
                 
         screenSize = new glm::vec2();
@@ -79,7 +79,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 	
 	if(app.get() != ofGetAppPtr()) { // check if already running.
 		
-		ofSetMainLoop(shared_ptr<ofMainLoop>(NULL)); // destroy old main loop.
+		ofSetMainLoop(std::shared_ptr<ofMainLoop>(NULL)); // destroy old main loop.
 		auto mainLoop = std::make_shared<ofMainLoop>(); // make new main loop.
 		ofSetMainLoop(mainLoop);
 		

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -35,7 +35,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 
 - (id)initWithFrame:(CGRect)frame andApp:(ofxiOSApp *)appPtr {
 	
-	window = dynamic_pointer_cast<ofAppiOSWindow>(ofGetMainLoop()->getCurrentWindow());
+	window = std::dynamic_pointer_cast<ofAppiOSWindow>(ofGetMainLoop()->getCurrentWindow());
 	
     if(window.get() == NULL) {
         ofLog(OF_LOG_FATAL_ERROR, "ofxiOSEAGLView::initWithFrame - window is NULL");

--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -86,7 +86,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 		ofiOSWindowSettings windowSettings = window->getSettings();
 		window = NULL;
 
-		window = dynamic_pointer_cast<ofAppiOSWindow>(ofCreateWindow(windowSettings));
+		window = std::dynamic_pointer_cast<ofAppiOSWindow>(ofCreateWindow(windowSettings));
 
 		ofRunApp(app);
 	}

--- a/addons/ofxiOS/src/events/ofxiOSAlerts.h
+++ b/addons/ofxiOS/src/events/ofxiOSAlerts.h
@@ -33,8 +33,6 @@
 #include <list>
 #include "ofxiOSAlertsListener.h"
 
-using namespace std;
-
 class ofxiOSAlertsHandler : public ofxiOSAlertsListener {
 public:
 	void addListener(ofxiOSAlertsListener* o) {
@@ -82,7 +80,7 @@ public:
 	}
 	
 	//alerts engine will call this when the program is launched with a url
-	void launchedWithURL(string url)
+	void launchedWithURL(std::string url)
 	{
 		for(std::list<ofxiOSAlertsListener*>::iterator it=listeners.begin(); it!=listeners.end(); ++it) {
 			ofxiOSAlertsListener* o = *it;

--- a/addons/ofxiOS/src/events/ofxiOSAlertsListener.h
+++ b/addons/ofxiOS/src/events/ofxiOSAlertsListener.h
@@ -32,8 +32,6 @@
 
 #include <string>
 
-using namespace std;
-
 /****** protocol, delegate, interface, whatever you want to call it ******/
 class ofxiOSAlertsListener {
 public:

--- a/addons/ofxiOS/src/sound/SoundEngine.cpp
+++ b/addons/ofxiOS/src/sound/SoundEngine.cpp
@@ -86,7 +86,6 @@
 #include <pthread.h>
 #include <mach/mach.h>
 #include <iostream>
-using namespace std;
 
 // Local Includes
 #include "SoundEngine.h"
@@ -164,7 +163,7 @@ OSStatus OpenFile(const char *inFilePath, AudioFileID &outAFID)
 	OSStatus result = AudioFileOpenURL(theURL, fsRdPerm, 0, &outAFID);
 #endif
 	CFRelease(theURL);
-		//cout<<inFilePath<<endl;
+		//std::cout<<inFilePath<<std::endl;
 		AssertNoError("Error opening file", end);
 	end:
 		return result;
@@ -174,7 +173,7 @@ OSStatus LoadFileDataInfo(const char *inFilePath, AudioFileID &outAFID, AudioStr
 {
 	UInt32 thePropSize = sizeof(outFormat);				
 	OSStatus result = OpenFile(inFilePath, outAFID);
-		//cout<<inFilePath<<endl;
+		//std::cout<<inFilePath<<std::endl;
 		AssertNoError("Error opening file", end);
 
 	result = AudioFileGetProperty(outAFID, kAudioFilePropertyDataFormat, &thePropSize, &outFormat);
@@ -1125,7 +1124,7 @@ class OpenALObject
 					else
 					{
 						mSourcePrimed[i] = FALSE;
-						cout<<"priming error"<<endl;
+						std::cout<<"priming error"<<std::endl;
 					}
 				}
 				
@@ -1140,10 +1139,10 @@ class OpenALObject
 						return i;
 					}
 					else
-						cout<<"priming error"<<endl;
+						std::cout<<"priming error"<<std::endl;
 				}
 			}
-			cout<<"no sources!"<<endl;
+			std::cout<<"no sources!"<<std::endl;
 			// If we fell through the loop, then no available sources
 			return -1;
 		}

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.cpp
@@ -36,7 +36,7 @@ static std::mutex& soundPlayerLock() {
     return *m;
 }
 
-vector<ofxOpenALSoundPlayer *> soundPlayers;
+std::vector<ofxOpenALSoundPlayer *> soundPlayers;
 
 //--------------------------------------------------------------
 
@@ -110,7 +110,7 @@ bool ofxOpenALSoundPlayer::load(const std::filesystem::path& filePath, bool stre
 			length = SoundEngine_GetEffectLength(myId);
 		}
 		else {
-			cerr<<"faied to load sound "<<fileName<<endl;
+			std::cerr<<"faied to load sound "<<fileName<<std::endl;
 			bLoadedOk=false;
 		}
 		
@@ -194,7 +194,7 @@ void ofxOpenALSoundPlayer::setPan(float _pan) {
 		return;
 	
 	if(iAmAnMp3)
-		cerr<<"error, cannot set pan on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set pan on mp3s in openAL"<<std::endl;
 	else {
 		float locX = ofClamp(_pan, -1, 1);
 		setLocation(locX, location.y, location.z);
@@ -210,7 +210,7 @@ void ofxOpenALSoundPlayer::setPitch(float _pitch) {
 		return;
 
 	if(iAmAnMp3)
-		cerr<<"error, cannot set pitch on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set pitch on mp3s in openAL"<<std::endl;
 	else {
 		pitch = _pitch;
 		SoundEngine_SetEffectPitch(myPrimedId, (Float32)pitch);
@@ -225,7 +225,7 @@ void ofxOpenALSoundPlayer::setPaused(bool bP) {
 		return;
 	
 	if(iAmAnMp3)
-		cerr<<"error, cannot set pause on mp3s in openAL"<<endl; // TODO
+		std::cerr<<"error, cannot set pause on mp3s in openAL"<<std::endl; // TODO
 	else {
 		bool bPlaying = isPlaying();
 		bPaused = bP;
@@ -258,7 +258,7 @@ void ofxOpenALSoundPlayer::setMultiPlay(bool bMp) {
 		return;
 	
 	if(iAmAnMp3)
-		cerr<<"error, cannot set multiplay on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set multiplay on mp3s in openAL"<<std::endl;
 	else
 		bMultiPlay = bMp;
 }
@@ -270,7 +270,7 @@ void ofxOpenALSoundPlayer::setPosition(float pct) {
 		return;
 
 	if(iAmAnMp3)
-		cerr<<"error, cannot set position on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set position on mp3s in openAL"<<std::endl;
 	else
 		SoundEngine_SetEffectPosition(myPrimedId, pct*length);
 }
@@ -282,7 +282,7 @@ void ofxOpenALSoundPlayer::setPositionMS(int ms){
 		return;
 
 	if(iAmAnMp3)
-		cerr<<"error, cannot set position on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set position on mp3s in openAL"<<std::endl;
 	else
 		SoundEngine_SetEffectPosition(myPrimedId, float(ms)/1000.f);
 }
@@ -295,7 +295,7 @@ float ofxOpenALSoundPlayer::getPosition() const {
 
 	if(iAmAnMp3)
 	{
-		cerr<<"error, cannot get position on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot get position on mp3s in openAL"<<std::endl;
 	}
 	else
 		return (float)SoundEngine_GetEffectPosition(myPrimedId)/length;
@@ -311,7 +311,7 @@ int ofxOpenALSoundPlayer::getPositionMS()  const{
 
 	if(iAmAnMp3)
 	{
-		cerr<<"error, cannot get position on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot get position on mp3s in openAL"<<std::endl;
 	}
 	else
 		return SoundEngine_GetEffectPosition(myPrimedId)*1000.f;
@@ -371,7 +371,7 @@ void ofxOpenALSoundPlayer::initializeSoundEngine() {
 		OSStatus err = SoundEngine_Initialize(44100);
 				
 		if(err)
-			cerr<<"ERROR failed to initialize soundEngine."<<endl;
+			std::cerr<<"ERROR failed to initialize soundEngine."<<std::endl;
 		else {
 			numSounds=1;
 			mp3Loaded=false;
@@ -379,7 +379,7 @@ void ofxOpenALSoundPlayer::initializeSoundEngine() {
 			SoundEngineInitialized = true;
 			OSStatus err = SoundEngine_SetListenerPosition(0.0f, 0.0f, 0.0f);
 			if(err)
-				cerr<<"ERROR failed to set listener position in init..\n (if you are running in the simulator, this is normal, sounds won't work.)"<<endl;
+				std::cerr<<"ERROR failed to set listener position in init..\n (if you are running in the simulator, this is normal, sounds won't work.)"<<std::endl;
 		}
 	}
 }
@@ -407,7 +407,7 @@ void ofxALSoundStopAll(){
 //--------------------------------------------------------------
 
 float * ofxALSoundGetSpectrum(){
-	cerr<<"unfortunately there is no way to get the sound spectrum out of openAL"<<endl;
+	std::cerr<<"unfortunately there is no way to get the sound spectrum out of openAL"<<std::endl;
 	return NULL;
 }
 
@@ -475,7 +475,7 @@ bool ofxOpenALSoundPlayer::prime() {
 
 //--------------------------------------------------------------
 
-bool ofxOpenALSoundPlayer::loadBackgroundMusic(string fileName, bool queue, bool loadAtOnce) {
+bool ofxOpenALSoundPlayer::loadBackgroundMusic(std::string fileName, bool queue, bool loadAtOnce) {
 	myId = 0;
 	
 	if(!mp3Loaded) {
@@ -492,11 +492,11 @@ bool ofxOpenALSoundPlayer::loadBackgroundMusic(string fileName, bool queue, bool
 		else
 		{
 			bLoadedOk=false;
-			cerr<<"faied to load sound "<<fileName<<endl;
+			std::cerr<<"faied to load sound "<<fileName<<std::endl;
 		}
 	}
 	else {
-		cerr<<"more than one mp3 cannot be loaded at the same time"<<endl;
+		std::cerr<<"more than one mp3 cannot be loaded at the same time"<<std::endl;
 	}
 	
 	return bLoadedOk;
@@ -554,7 +554,7 @@ void ofxOpenALSoundPlayer::setLocation(float x, float y, float z) {
 		return;
 
 	if(iAmAnMp3)
-		cerr<<"error, cannot set location on mp3s in openAL"<<endl;
+		std::cerr<<"error, cannot set location on mp3s in openAL"<<std::endl;
 	else
 	{
 		location = {x,y,z};

--- a/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
+++ b/addons/ofxiOS/src/sound/ofxOpenALSoundPlayer.h
@@ -124,7 +124,7 @@ protected: //internal
 	
 	bool    prime();
 	void	updateInternalsForNewPrime();
-	bool	loadBackgroundMusic(string fileName, bool queue, bool loadAtOnce);
+	bool	loadBackgroundMusic(std::string fileName, bool queue, bool loadAtOnce);
 	void	unloadAllBackgroundMusic();
 	void	startBackgroundMusic();
 	void	stopBackgroundMusic(bool stopNow);
@@ -134,7 +134,7 @@ protected: //internal
 	ALuint  myPrimedId;
 	bool	stopped; 	
 	bool	iAmAnMp3;
-	vector <multiPlaySource *> retainedBuffers;
+	std::vector <multiPlaySource *> retainedBuffers;
 };
 
 #endif

--- a/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundPlayer.mm
@@ -21,7 +21,7 @@ bool ofxiOSSoundPlayer::load(const std::filesystem::path& fileName, bool stream)
         unload();
     }
 
-    string filePath = ofToDataPath(fileName);
+    std::string filePath = ofToDataPath(fileName);
     soundPlayer = [[AVSoundPlayer alloc] init];
     BOOL bOk = [(AVSoundPlayer *)soundPlayer loadWithPath:[NSString stringWithUTF8String:filePath.c_str()]];
     

--- a/addons/ofxiOS/src/sound/ofxiOSSoundStream.mm
+++ b/addons/ofxiOS/src/sound/ofxiOSSoundStream.mm
@@ -26,9 +26,9 @@ ofxiOSSoundStream::~ofxiOSSoundStream() {
 }
 
 //------------------------------------------------------------------------------
-vector<ofSoundDevice> ofxiOSSoundStream::getDeviceList(ofSoundDevice::Api api)  const{
+std::vector<ofSoundDevice> ofxiOSSoundStream::getDeviceList(ofSoundDevice::Api api)  const{
 	ofLogWarning("ofxiOSSoundStream") << "getDeviceList() isn't implemented on iOS";
-	return vector<ofSoundDevice>();
+	return std::vector<ofSoundDevice>();
 }
 
 //------------------------------------------------------------------------------

--- a/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.h
@@ -28,7 +28,7 @@ public:
     static void alertExternalDisplayChanged();
     
     //-------------------------------------------------------
-    static vector<ofxiOSExternalDisplayMode> getExternalDisplayModes();
+    static std::vector<ofxiOSExternalDisplayMode> getExternalDisplayModes();
     static bool displayOnExternalScreen(ofxiOSExternalDisplayMode externalDisplayMode);
     static bool displayOnExternalScreenWithPreferredDisplayMode();
     static bool displayOnDeviceScreen();

--- a/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSExternalDisplay.mm
@@ -13,7 +13,7 @@
 #include "ofxiOSAppDelegate.h"
 
 //-----------------------------------------------------------------------------------------
-static vector<ofxiOSExternalDisplay *> externalDisplayListeners;
+static std::vector<ofxiOSExternalDisplay *> externalDisplayListeners;
 
 void ofxiOSExternalDisplay::alertExternalDisplayConnected(){
     for(int i = 0; i < externalDisplayListeners.size(); i++){
@@ -34,8 +34,8 @@ void ofxiOSExternalDisplay::alertExternalDisplayChanged(){
 }
 
 //-----------------------------------------------------------------------------------------
-vector<ofxiOSExternalDisplayMode> ofxiOSExternalDisplay::getExternalDisplayModes(){
-    vector<ofxiOSExternalDisplayMode> externalDislayModes;
+std::vector<ofxiOSExternalDisplayMode> ofxiOSExternalDisplay::getExternalDisplayModes(){
+    std::vector<ofxiOSExternalDisplayMode> externalDislayModes;
     if([[UIScreen screens] count] == 1){ // no external displays connected.
         return externalDislayModes;
     }

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -58,7 +58,7 @@ class ofAppiOSWindow;
 class ofxiOSDeviceInfo{
 public:
     ofxiOSDeviceType deviceType;
-    string deviceString;
+    std::string deviceString;
     int versionMajor;
     int versionMinor;
 };
@@ -75,7 +75,7 @@ float ofxiOSGetMicAverageLevel();
 ofxiOSDeviceType ofxiOSGetDeviceType();
 
 // return device revision
-string ofxiOSGetDeviceRevision();
+std::string ofxiOSGetDeviceRevision();
 
 // return device revision and type parsd from string
 ofxiOSDeviceInfo ofxiOSGetDeviceInfo();
@@ -183,17 +183,17 @@ void ofxiOSScreenGrab(id delegate);
 
 
 // utility fuctions for converting strings and NSStrings back and forth
-string ofxiOSNSStringToString(NSString * s);
-NSString * ofxiOSStringToNSString(string s);
+std::string ofxiOSNSStringToString(NSString * s);
+NSString * ofxiOSStringToNSString(std::string s);
 
 // It returns the path to the folder which your app has read/write access to.
-string ofxiOSGetDocumentsDirectory();
+std::string ofxiOSGetDocumentsDirectory();
 
 // opens url in safari.
-void ofxiOSLaunchBrowser(string url);
+void ofxiOSLaunchBrowser(std::string url);
 
-void ofxiOSSetClipboardString(string clipboardString);
-string ofxiOSGetClipboardString();
+void ofxiOSSetClipboardString(std::string clipboardString);
+std::string ofxiOSGetClipboardString();
 
 // backwards compatibility < 0.8.0
 #define ofxiPhoneHasAudioIn ofxiOSHasAudioIn

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.mm
@@ -63,7 +63,7 @@ ofxiOSDeviceType ofxiOSGetDeviceType() {
 
 
 //--------------------------------------------------------------
-string ofxiOSGetDeviceRevision() {
+std::string ofxiOSGetDeviceRevision() {
 	size_t size;
     sysctlbyname("hw.machine", NULL, &size, NULL, 0);
 	
@@ -72,7 +72,7 @@ string ofxiOSGetDeviceRevision() {
 	machine = new char[size];
 	sysctlbyname("hw.machine", machine, &size, NULL, 0);
 	
-	string device(machine);
+	std::string device(machine);
 	
 		delete[] machine;
         
@@ -96,7 +96,7 @@ ofxiOSDeviceInfo ofxiOSGetDeviceInfo(){
     
     info.deviceType = ofxiOSGetDeviceType();
     info.deviceString = ofxiOSGetDeviceRevision();
-    vector <string> split = ofSplitString(info.deviceString, ",");
+    std::vector <std::string> split = ofSplitString(info.deviceString, ",");
     
     if( split.size() == 2 ){
         if( split[0].size() ){
@@ -480,19 +480,19 @@ bool ofxiOSCGImageToPixels(CGImageRef & ref, unsigned char * pixels){
 
 //--------------------------------------------------------------
 
-string ofxiOSNSStringToString(NSString * s) {
-	return string([s UTF8String]);
+std::string ofxiOSNSStringToString(NSString * s) {
+	return std::string([s UTF8String]);
 }
 
 //--------------------------------------------------------------
 
-NSString * ofxiOSStringToNSString(string s) {
+NSString * ofxiOSStringToNSString(std::string s) {
 	return [NSString stringWithUTF8String:s.c_str()];
 }
 
 //--------------------------------------------------------------
 
-string ofxiOSGetDocumentsDirectory()
+std::string ofxiOSGetDocumentsDirectory()
 {
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 	return ofxNSStringToString([paths objectAtIndex:0]) + "/";
@@ -500,17 +500,17 @@ string ofxiOSGetDocumentsDirectory()
 
 //--------------------------------------------------------------
 
-void ofxiOSLaunchBrowser(string url) {
+void ofxiOSLaunchBrowser(std::string url) {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:ofxStringToNSString(url)]];
 }
 
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
 //--------------------------------------------------------------
-void ofxiOSSetClipboardString(string clipboardString) {
+void ofxiOSSetClipboardString(std::string clipboardString) {
     [UIPasteboard generalPasteboard].string = [NSString stringWithUTF8String:clipboardString.c_str()];
 }
 
-string ofxiOSGetClipboardString() {
+std::string ofxiOSGetClipboardString() {
     return [[UIPasteboard generalPasteboard].string UTF8String];
 }
 #endif

--- a/addons/ofxiOS/src/utils/ofxiOSImagePicker.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSImagePicker.mm
@@ -121,7 +121,7 @@ void ofxiOSImagePicker::loadPixels()
 	
 	photo = [imagePicker getCGImage];
     if(!photo){
-        ofLogError("ofxiOSImagePicker::loadPixels") << " photo is NULL " << endl;
+        ofLogError("ofxiOSImagePicker::loadPixels") << " photo is NULL " << std::endl;
         return;
     }
     

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -60,15 +60,15 @@ public:
 	void setFontSize(int ptSize);
 	void setFontColor(int r, int g, int b, int a);
 	void setBgColor(int r, int g, int b, int a);
-	void setText(string _text);
-	void setPlaceholder(string _text);
+	void setText(std::string _text);
+	void setPlaceholder(std::string _text);
 	void openKeyboard();
 	void updateOrientation();
 	void makeSecure();
 	void setMaxChars(int max);
 	
-	string getText();
-    OF_DEPRECATED_MSG("Use getText() instead.", string getLabelText());
+	std::string getText();
+    OF_DEPRECATED_MSG("Use getText() instead.", std::string getLabelText());
 	bool isKeyboardShowing();
 	
     UITextField * getKeyboardTextField();

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.mm
@@ -100,21 +100,21 @@ void ofxiOSKeyboard::setBgColor(int r, int g, int b, int a)
 }
 
 //--------------------------------------------------------------
-void ofxiOSKeyboard::setText(string _text)
+void ofxiOSKeyboard::setText(std::string _text)
 {
 	NSString * text = [NSString stringWithUTF8String:_text.c_str()];
 	[keyboard setText:text];
 }
 
 //--------------------------------------------------------------
-void ofxiOSKeyboard::setPlaceholder(string _text)
+void ofxiOSKeyboard::setPlaceholder(std::string _text)
 {
 	NSString * text = [NSString stringWithUTF8String:_text.c_str()];
 	[keyboard setPlaceholder:text];
 }
 
 //--------------------------------------------------------------
-string ofxiOSKeyboard::getText()
+std::string ofxiOSKeyboard::getText()
 {
 	if([keyboard getText] == nil)
 	{
@@ -122,12 +122,12 @@ string ofxiOSKeyboard::getText()
 	}
 	else
 	{
-		return string([keyboard getText]);
+		return std::string([keyboard getText]);
 	}
 }
 
 //--------------------------------------------------------------
-string ofxiOSKeyboard::getLabelText()
+std::string ofxiOSKeyboard::getLabelText()
 {
 	if([keyboard getLabelText] == nil)
 	{
@@ -135,7 +135,7 @@ string ofxiOSKeyboard::getLabelText()
 	}
 	else
 	{
-		return string([keyboard getLabelText]);
+		return std::string([keyboard getLabelText]);
 	}
 }
 

--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.h
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.h
@@ -131,7 +131,7 @@ public:
 	void regionDidChange(bool animated);
 	void willStartLoadingMap();
 	void didFinishLoadingMap();
-	void errorLoadingMap(string errorDescription);
+	void errorLoadingMap(std::string errorDescription);
 	
 
 	// return instance to MKMapView

--- a/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKit.mm
@@ -259,7 +259,7 @@ void ofxiOSMapKit::didFinishLoadingMap() {
 }
 
 
-void ofxiOSMapKit::errorLoadingMap(string errorDescription) {
+void ofxiOSMapKit::errorLoadingMap(std::string errorDescription) {
 	for(std::list<ofxiOSMapKitListener*>::iterator it=listeners.begin(); it!=listeners.end(); ++it) {
 		ofxiOSMapKitListener* o = *it;
 		o->errorLoadingMap(errorDescription);

--- a/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.mm
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKitDelegate.mm
@@ -68,7 +68,7 @@
 
 - (void)mapViewDidFailLoadingMap:(MKMapView *)mapView withError:(NSError *)error {
 	ofLogVerbose("ofxiOSMapKitDelegate") << "mapViewDidFailLoadingMap";
-	string s = error != nil ? [[error localizedDescription] UTF8String] : "unknown error";
+	std::string s = error != nil ? [[error localizedDescription] UTF8String] : "unknown error";
 	mapKit->errorLoadingMap(s);
 }
 

--- a/addons/ofxiOS/src/utils/ofxiOSMapKitListener.h
+++ b/addons/ofxiOS/src/utils/ofxiOSMapKitListener.h
@@ -41,7 +41,7 @@ public:
 	virtual void regionDidChange(bool animated) {}
 	virtual void willStartLoadingMap() {}
 	virtual void didFinishLoadingMap() {}
-	virtual void errorLoadingMap(string errorDescription) {}
+	virtual void errorLoadingMap(std::string errorDescription) {}
 };
 
 #define ofxiPhoneMapKitListener ofxiOSMapKitListener

--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.h
@@ -34,7 +34,7 @@ class AVFoundationVideoGrabber;
 -(void)startCapture;
 -(void)stopCapture;
 -(void)lockExposureAndFocus;
--(vector <string>)listDevices;
+-(std::vector <std::string>)listDevices;
 -(void)setDevice:(int)_device;
 -(void)eraseGrabberPtr;
 
@@ -59,7 +59,7 @@ class AVFoundationVideoGrabber{
 	
 		bool isFrameNew();
 		
-		vector <ofVideoDevice> listDevices();
+		std::vector <ofVideoDevice> listDevices();
 		void setDevice(int deviceID);
 		bool setPixelFormat(ofPixelFormat PixelFormat);
 		ofPixelFormat getPixelFormat();

--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
@@ -240,8 +240,8 @@
 	return currentFrame;
 }
 
--(vector <string>)listDevices{
-    vector <string> deviceNames;
+-(std::vector <std::string>)listDevices{
+    std::vector <std::string> deviceNames;
 	NSArray * devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 	int i=0;
 	for (AVCaptureDevice * captureDevice in devices){
@@ -510,10 +510,10 @@ bool AVFoundationVideoGrabber::isFrameNew() {
 	return newFrame;
 }
 
-vector <ofVideoDevice> AVFoundationVideoGrabber::listDevices() {
-	vector <string> devList = [grabber listDevices];
+std::vector <ofVideoDevice> AVFoundationVideoGrabber::listDevices() {
+	std::vector <std::string> devList = [grabber listDevices];
     
-    vector <ofVideoDevice> devices; 
+    std::vector <ofVideoDevice> devices; 
     for(int i = 0; i < devList.size(); i++){
         ofVideoDevice vd; 
         vd.deviceName = devList[i]; 

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -17,7 +17,7 @@ public:
     // inherited from ofBaseVideoGrabber
     //---------------------------------------
     
-	vector<ofVideoDevice> listDevices() const;
+	std::vector<ofVideoDevice> listDevices() const;
     bool setup(int w, int h);
 
 	float getHeight() const;
@@ -65,7 +65,7 @@ public:
     
 protected:
     
-	shared_ptr<AVFoundationVideoGrabber> grabber;
+	std::shared_ptr<AVFoundationVideoGrabber> grabber;
     
     ofPixels pixels;
     

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.mm
@@ -5,7 +5,7 @@
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
 
 ofxiOSVideoGrabber::ofxiOSVideoGrabber() {
-	grabber = shared_ptr<AVFoundationVideoGrabber>(new AVFoundationVideoGrabber());
+	grabber = std::shared_ptr<AVFoundationVideoGrabber>(new AVFoundationVideoGrabber());
 }
 
 ofxiOSVideoGrabber::~ofxiOSVideoGrabber() {
@@ -13,7 +13,7 @@ ofxiOSVideoGrabber::~ofxiOSVideoGrabber() {
 }
 
 //--------------------------------------------------------------
-vector <ofVideoDevice> ofxiOSVideoGrabber::listDevices() const {
+std::vector <ofVideoDevice> ofxiOSVideoGrabber::listDevices() const {
 	return grabber->listDevices();
 }
 

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -13,7 +13,7 @@ public:
     void enableTextureCache();
     void disableTextureCache();
     
-    bool load(string name);
+    bool load(std::string name);
     void close();
     void update();
 	
@@ -59,7 +59,7 @@ public:
     
 	void * getAVFoundationVideoPlayer();
     
-    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(string name));
+    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(std::string name));
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels & getPixelsRef());
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels & getPixelsRef() const);
     OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.", ofTexture * getTexture());

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -34,7 +34,7 @@ void ofxiOSVideoPlayer::disableTextureCache() {
 }
 
 //----------------------------------------
-bool ofxiOSVideoPlayer::load(string name) {
+bool ofxiOSVideoPlayer::load(std::string name) {
 	
     if(!videoPlayer) {
         videoPlayer = [[AVFoundationVideoPlayer alloc] init];
@@ -590,7 +590,7 @@ void * ofxiOSVideoPlayer::getAVFoundationVideoPlayer() {
 }
 
 //---------------------------------------- DEPRECATED.
-bool ofxiOSVideoPlayer::loadMovie(string name) {
+bool ofxiOSVideoPlayer::loadMovie(std::string name) {
     return load(name);
 }
 

--- a/apps/devApps/explicitRendererExample/src/main.cpp
+++ b/apps/devApps/explicitRendererExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 	settings.setPosition(ofVec2f(300,0));
 	settings.resizable = true;
 	settings.numSamples = 8;
-	shared_ptr<ofAppBaseWindow> mainWindow = ofCreateWindow(settings);
+	std::shared_ptr<ofAppBaseWindow> mainWindow = ofCreateWindow(settings);
 
 	settings.width = 300;
 	settings.height = 300;
@@ -20,10 +20,10 @@ int main( ){
 	settings.resizable = false;
 	settings.numSamples = 4;
 	settings.shareContextWith = mainWindow;
-	shared_ptr<ofAppBaseWindow> guiWindow = ofCreateWindow(settings);
+	std::shared_ptr<ofAppBaseWindow> guiWindow = ofCreateWindow(settings);
 
-	shared_ptr<ofApp> mainApp(new ofApp);
-	shared_ptr<GuiApp> guiApp(new GuiApp);
+	std::shared_ptr<ofApp> mainApp(new ofApp);
+	std::shared_ptr<GuiApp> guiApp(new GuiApp);
 
 	mainApp->gui = guiApp;
 	mainApp->window = mainWindow;

--- a/apps/devApps/explicitRendererExample/src/ofApp.h
+++ b/apps/devApps/explicitRendererExample/src/ofApp.h
@@ -22,9 +22,9 @@ class ofApp : public ofBaseApp{
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
 		
-		shared_ptr<GuiApp> gui;
-		shared_ptr<ofAppBaseWindow> window;
-		shared_ptr<ofBaseGLRenderer> gl;
+		std::shared_ptr<GuiApp> gui;
+		std::shared_ptr<ofAppBaseWindow> window;
+		std::shared_ptr<ofBaseGLRenderer> gl;
 		ofSpherePrimitive sphere;
 		ofEasyCam camera;
 };

--- a/apps/devApps/ofPolyline resample tester/src/ofApp.cpp
+++ b/apps/devApps/ofPolyline resample tester/src/ofApp.cpp
@@ -143,52 +143,52 @@ void ofApp::draw(){
     ofPopMatrix();
     
     
-    stringstream s;
-    s << "Number of points: " << poly.size() << endl;
-    s << "totalLength: " << totalLength << endl;
+    std::stringstream s;
+    s << "Number of points: " << poly.size() << std::endl;
+    s << "totalLength: " << totalLength << std::endl;
     
-    s << endl;
-    s << "nearestIndex: " << nearestIndex << endl;
-    s << "nearestPoint: " << nearestPoint << endl;
-    s << "nearestDataPoint: " << nearestDataPoint << endl;
+    s << std::endl;
+    s << "nearestIndex: " << nearestIndex << std::endl;
+    s << "nearestPoint: " << nearestPoint << std::endl;
+    s << "nearestDataPoint: " << nearestDataPoint << std::endl;
     
-    s << endl;
-    s << "lengthAtIndex: " << lengthAtIndex << endl;
-    s << "pointAtIndex: " << pointAtIndex << endl;
+    s << std::endl;
+    s << "lengthAtIndex: " << lengthAtIndex << std::endl;
+    s << "pointAtIndex: " << pointAtIndex << std::endl;
     
-    s << endl;
-    s << "pointAtLength: " << pointAtLength << endl;
-    s << "pointAtPercent: " << pointAtPercent << endl;
+    s << std::endl;
+    s << "pointAtLength: " << pointAtLength << std::endl;
+    s << "pointAtPercent: " << pointAtPercent << std::endl;
     
-    s << endl;
-    s << "indexAtLength: " << indexAtLength << endl;
+    s << std::endl;
+    s << "indexAtLength: " << indexAtLength << std::endl;
     
     
-    s << endl;
-    s << "sinTime: " << sinTime << endl;
-    s << "sinIndex: " << sinIndex << endl;
-    s << "sinIndexLength: " << sinIndexLength << endl;
+    s << std::endl;
+    s << "sinTime: " << sinTime << std::endl;
+    s << "sinIndex: " << sinIndex << std::endl;
+    s << "sinIndexLength: " << sinIndexLength << std::endl;
     
-    s << endl;
-    s << "lengthAtIndexSin: " << lengthAtIndexSin << endl;
-    s << "pointAtIndexSin: " << pointAtIndexSin << endl;
-    s << "pointAtPercentSin: " << pointAtPercentSin << endl;
+    s << std::endl;
+    s << "lengthAtIndexSin: " << lengthAtIndexSin << std::endl;
+    s << "pointAtIndexSin: " << pointAtIndexSin << std::endl;
+    s << "pointAtPercentSin: " << pointAtPercentSin << std::endl;
     
-    s << endl;
-    s << "angleAtIndex: " << angleAtIndex << endl;
-    s << "angleAtIndexSin: " << angleAtIndexSin << endl;
+    s << std::endl;
+    s << "angleAtIndex: " << angleAtIndex << std::endl;
+    s << "angleAtIndexSin: " << angleAtIndexSin << std::endl;
     
-    s << endl;
-    s << "rotAtIndex: " << rotAtIndex << endl;
-    s << "rotAtIndexSin: " << rotAtIndexSin << endl;
+    s << std::endl;
+    s << "rotAtIndex: " << rotAtIndex << std::endl;
+    s << "rotAtIndexSin: " << rotAtIndexSin << std::endl;
     
-    s << endl;
-    s << "rotMagAtIndex: " << rotMagAtIndex << endl;
-    s << "rotMagAtIndexSin: " << rotMagAtIndexSin << endl;
+    s << std::endl;
+    s << "rotMagAtIndex: " << rotMagAtIndex << std::endl;
+    s << "rotMagAtIndexSin: " << rotMagAtIndexSin << std::endl;
     
-    s << endl;
-    s << "normalAtIndex: " << normalAtIndex << endl;
-    s << "normalAtIndexSin: " << normalAtIndexSin << endl;
+    s << std::endl;
+    s << "normalAtIndex: " << normalAtIndex << std::endl;
+    s << "normalAtIndexSin: " << normalAtIndexSin << std::endl;
     
     ofSetColor(255);
     ofDrawBitmapString(s.str(), 10, 30);

--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -26,9 +26,9 @@ of3dPrimitive::of3dPrimitive(const of3dPrimitive & mom):ofNode(mom){
     texCoords = mom.texCoords;
     usingVbo = mom.usingVbo;
 	if(usingVbo){
-		mesh = shared_ptr<ofMesh>(new ofVboMesh);
+		mesh = std::shared_ptr<ofMesh>(new ofVboMesh);
 	}else{
-		mesh = shared_ptr<ofMesh>(new ofMesh);
+		mesh = std::shared_ptr<ofMesh>(new ofMesh);
 	}
 	*mesh = *mom.mesh;
 }
@@ -93,8 +93,8 @@ const glm::vec4& of3dPrimitive::getTexCoords() const{
 }
 
 //----------------------------------------------------------
-vector<ofIndexType> of3dPrimitive::getIndices( int startIndex, int endIndex ) const {
-    vector<ofIndexType> indices;
+std::vector<ofIndexType> of3dPrimitive::getIndices( int startIndex, int endIndex ) const {
+    std::vector<ofIndexType> indices;
     indices.assign( getMesh().getIndices().begin()+startIndex, getMesh().getIndices().begin()+endIndex );
     return indices;
 }
@@ -266,11 +266,11 @@ void of3dPrimitive::drawAxes(float a_size)  const{
 //--------------------------------------------------------------
 void of3dPrimitive::setUseVbo(bool useVbo){
 	if(useVbo!=usingVbo){
-		shared_ptr<ofMesh> newMesh;
+		std::shared_ptr<ofMesh> newMesh;
 		if(useVbo){
-			newMesh = shared_ptr<ofMesh>(new ofVboMesh);
+			newMesh = std::shared_ptr<ofMesh>(new ofVboMesh);
 		}else{
-			newMesh = shared_ptr<ofMesh>(new ofMesh);
+			newMesh = std::shared_ptr<ofMesh>(new ofMesh);
 		}
 		*newMesh = *mesh;
 		mesh = newMesh;
@@ -652,7 +652,7 @@ void ofCylinderPrimitive::setBottomCapColor( ofColor color ) {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofCylinderPrimitive::getTopCapIndices() const {
+std::vector<ofIndexType> ofCylinderPrimitive::getTopCapIndices() const {
     return of3dPrimitive::getIndices( strides[0][0], strides[0][0] + strides[0][1] );
 }
 
@@ -667,7 +667,7 @@ ofMesh ofCylinderPrimitive::getTopCapMesh() const {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofCylinderPrimitive::getCylinderIndices() const {
+std::vector<ofIndexType> ofCylinderPrimitive::getCylinderIndices() const {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofCylinderPrimitive") << "getCylinderIndices(): must be in triangle strip mode";
     }
@@ -685,7 +685,7 @@ ofMesh ofCylinderPrimitive::getCylinderMesh() const {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofCylinderPrimitive::getBottomCapIndices() const {
+std::vector<ofIndexType> ofCylinderPrimitive::getBottomCapIndices() const {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofCylinderPrimitive") << "getBottomCapIndices(): must be in triangle strip mode";
     }
@@ -853,7 +853,7 @@ void ofConePrimitive::setCapColor( ofColor color ) {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofConePrimitive::getConeIndices() const {
+std::vector<ofIndexType> ofConePrimitive::getConeIndices() const {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofConePrimitive") << "getConeIndices(): must be in triangle strip mode";
     }
@@ -875,7 +875,7 @@ ofMesh ofConePrimitive::getConeMesh() const {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofConePrimitive::getCapIndices() const {
+std::vector<ofIndexType> ofConePrimitive::getCapIndices() const {
     if(getMesh().getMode() != OF_PRIMITIVE_TRIANGLE_STRIP) {
         ofLogWarning("ofConePrimitive") << "getCapIndices(): must be in triangle strip mode";
     }
@@ -1035,7 +1035,7 @@ void ofBoxPrimitive::resizeToTexture( ofTexture& inTexture ) {
 }
 
 //--------------------------------------------------------------
-vector<ofIndexType> ofBoxPrimitive::getSideIndices( int sideIndex ) const {
+std::vector<ofIndexType> ofBoxPrimitive::getSideIndices( int sideIndex ) const {
     
     if(sideIndex < 0 || sideIndex >= SIDES_TOTAL) {
         ofLogWarning("ofBoxPrimitive") << "getSideIndices(): faceIndex out of bounds, returning SIDE_FRONT";

--- a/libs/openFrameworks/3d/of3dPrimitives.h
+++ b/libs/openFrameworks/3d/of3dPrimitives.h
@@ -65,10 +65,10 @@ protected:
 
 	glm::vec4 texCoords;
     bool usingVbo;
-    shared_ptr<ofMesh>  mesh;
+    std::shared_ptr<ofMesh>  mesh;
     mutable ofMesh normalsMesh;
 
-    vector<ofIndexType> getIndices( int startIndex, int endIndex ) const;
+    std::vector<ofIndexType> getIndices( int startIndex, int endIndex ) const;
 
 };
 
@@ -177,7 +177,7 @@ protected:
 /// 
 ///     // get all the faces from the icoSphere, handy when you want to copy
 ///     // individual vertices or tweak them a little ;)
-///     vector<ofMeshFace> triangles = sphere.getMesh().getUniqueFaces();
+///     std::vector<ofMeshFace> triangles = sphere.getMesh().getUniqueFaces();
 /// 
 ///     // now draw
 ///     sphere.draw();
@@ -244,7 +244,7 @@ protected:
 /// 
 ///     // get all the faces from the icoSphere, handy when you want to copy
 ///     // individual vertices or tweak them a little ;)
-///     vector<ofMeshFace> triangles = icoSphere.getMesh().getUniqueFaces();
+///     std::vector<ofMeshFace> triangles = icoSphere.getMesh().getUniqueFaces();
 /// 
 ///     // now draw
 ///     icoSphere.draw();
@@ -293,7 +293,7 @@ protected:
 /// 
 ///     // get all the faces from the icoSphere, handy when you want to copy
 ///     // individual vertices or tweak them a little ;)
-///     vector<ofMeshFace> triangles = cylinder.getMesh().getUniqueFaces();
+///     std::vector<ofMeshFace> triangles = cylinder.getMesh().getUniqueFaces();
 /// 
 ///     // now draw
 ///     cylinder.draw();
@@ -337,11 +337,11 @@ public:
     void setCylinderColor( ofColor color );
     void setBottomCapColor( ofColor color );
 
-    vector<ofIndexType> getTopCapIndices() const;
+    std::vector<ofIndexType> getTopCapIndices() const;
     ofMesh getTopCapMesh() const;
-    vector<ofIndexType> getCylinderIndices() const;
+    std::vector<ofIndexType> getCylinderIndices() const;
     ofMesh getCylinderMesh() const;
-    vector<ofIndexType> getBottomCapIndices() const;
+    std::vector<ofIndexType> getBottomCapIndices() const;
     ofMesh getBottomCapMesh() const;
 
     int getResolutionRadius() const;
@@ -382,7 +382,7 @@ protected:
 /// 
 ///     // get all the faces from the cpme, handy when you want to copy
 ///     // individual vertices or tweak them a little ;)
-///     vector<ofMeshFace> triangles = cone.getMesh().getUniqueFaces();
+///     std::vector<ofMeshFace> triangles = cone.getMesh().getUniqueFaces();
 /// 
 ///     // now draw
 ///     cone.draw();
@@ -428,13 +428,13 @@ public:
     void setCapColor( ofColor color );
 
     /// \return a vector of the indices of vertices that make up the cone (as opposed to the cap indices).
-    vector<ofIndexType> getConeIndices() const;
+    std::vector<ofIndexType> getConeIndices() const;
 
     /// \return This returns an ofMesh made up of the cone (as opposed to the cap).
     ofMesh getConeMesh() const;
 
     /// \return a vector of the indices of vertices that make up the cap (as opposed to the cone indices).
-    vector<ofIndexType> getCapIndices() const;
+    std::vector<ofIndexType> getCapIndices() const;
 
     /// \return an ofMesh made up of the cap (as opposed to the cone).
     ofMesh getCapMesh() const;
@@ -488,7 +488,7 @@ protected:
 /// 
 ///     // get all the faces from the icoSphere, handy when you want to copy
 ///     // individual vertices or tweak them a little ;)
-///     vector<ofMeshFace> triangles = box.getMesh().getUniqueFaces();
+///     std::vector<ofMeshFace> triangles = box.getMesh().getUniqueFaces();
 /// 
 ///     // now draw
 ///     box.draw();
@@ -534,7 +534,7 @@ public:
 
     void resizeToTexture( ofTexture& inTexture );
 
-    vector<ofIndexType> getSideIndices( int sideIndex ) const;
+    std::vector<ofIndexType> getSideIndices( int sideIndex ) const;
     ofMesh getSideMesh( int sideIndex ) const;
 
     void setResolution( int res ); // same resolution for all sides //

--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -239,7 +239,7 @@ ofRectangle ofCamera::getViewport(const ofRectangle & viewport) const{
 	}
 }
 
-shared_ptr<ofBaseRenderer> ofCamera::getRenderer() const{
+std::shared_ptr<ofBaseRenderer> ofCamera::getRenderer() const{
 	if(!renderer){
 		return ofGetCurrentRenderer();
 	}else{
@@ -247,6 +247,6 @@ shared_ptr<ofBaseRenderer> ofCamera::getRenderer() const{
 	}
 }
 
-void ofCamera::setRenderer(shared_ptr<ofBaseRenderer> _renderer){
+void ofCamera::setRenderer(std::shared_ptr<ofBaseRenderer> _renderer){
 	renderer = _renderer;
 }

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -207,12 +207,12 @@ public:
 	/// \name Renderer
 	/// \{
     
-    void setRenderer(shared_ptr<ofBaseRenderer> renderer);
+    void setRenderer(std::shared_ptr<ofBaseRenderer> renderer);
 	
 	/// \}
 protected:
 	ofRectangle getViewport(const ofRectangle & _viewport) const;
-	shared_ptr<ofBaseRenderer> getRenderer() const;
+	std::shared_ptr<ofBaseRenderer> getRenderer() const;
 	void calcClipPlanes(const ofRectangle & viewport);
 	
 private:
@@ -224,6 +224,6 @@ private:
 	bool forceAspectRatio;
 	float aspectRatio; // only used when forceAspect=true, = w / h
 	bool vFlip;
-	shared_ptr<ofBaseRenderer> renderer;
+	std::shared_ptr<ofBaseRenderer> renderer;
 };
 

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -130,11 +130,11 @@ public:
 	/// OF_PRIMITIVE_TRIANGLE_FAN, OF_PRIMITIVE_LINES, OF_PRIMITIVE_LINE_STRIP,
 	/// OF_PRIMITIVE_LINE_LOOP, OF_PRIMITIVE_POINTS.
 	/// See [ofGLUtils](../gl/ofGLUtils.htm) for more information on these types.
-	ofMesh_(ofPrimitiveMode mode, const vector<V>& verts);
+	ofMesh_(ofPrimitiveMode mode, const std::vector<V>& verts);
 
 	virtual ~ofMesh_(){}
 
-	void setFromTriangles( const vector<ofMeshFace_<V,N,C,T>>& tris, bool bUseFaceNormal=false );
+	void setFromTriangles( const std::vector<ofMeshFace_<V,N,C,T>>& tris, bool bUseFaceNormal=false );
 
 	/// \}
 	/// \name Mesh Mode
@@ -221,7 +221,7 @@ public:
 	/// \brief Add a vector of vertices to a mesh, allowing you to push out
 	/// many at once rather than adding one at a time. The vector of vertices
 	/// is added after the end of the current vertices list.
-	void addVertices(const vector<V>& verts);
+	void addVertices(const std::vector<V>& verts);
 
 	/// \brief Add an array of vertices to the mesh.
 	/// Because you are using a pointer to the array you also have to define
@@ -255,10 +255,10 @@ public:
 	V getVertex(ofIndexType i) const;
 
 	/// \returns the vector that contains all of the vertices of the mesh.
-	vector<V> & getVertices();
+	std::vector<V> & getVertices();
 
 	/// \returns the vector that contains all of the vertices of the mesh.
-	const vector<V> & getVertices() const;
+	const std::vector<V> & getVertices() const;
 
 	/// \returns If the vertices of the mesh have changed, been added or removed.
 	bool haveVertsChanged();
@@ -300,7 +300,7 @@ public:
 	/// allowing you to push out many normals at once rather than
 	/// adding one at a time. The vector of normals is added after the end of
 	/// the current normals list.
-	void addNormals(const vector<N>& norms);
+	void addNormals(const std::vector<N>& norms);
 
 	/// \brief Add an array of normals to the mesh.
 	/// Because you are using a pointer to the array you also have to define
@@ -331,11 +331,11 @@ public:
 	/// will force a reset of the cache.
 	/// \returns the vector that contains all of the normals of the mesh,
 	/// if it has any.
-	vector<N> & getNormals();
+	std::vector<N> & getNormals();
 
 	/// \returns the vector that contains all of the normals of the mesh, if
 	/// it has any. (read only)
-	const vector<N> & getNormals() const;
+	const std::vector<N> & getNormals() const;
 
 	/// \returns If the normals of the mesh have changed, been added or removed.
 	bool haveNormalsChanged();
@@ -366,11 +366,11 @@ public:
 	/// by setting (perVertex = true) it will return the same normal value for
 	/// each of the three vertices making up a face.
 	/// \returns a vector containing the calculated normals of each face in the mesh.
-	vector<N> getFaceNormals( bool perVetex=false) const;
+	std::vector<N> getFaceNormals( bool perVetex=false) const;
 
 	/// \returns the mesh as a vector of unique ofMeshFace_s
 	/// a list of triangles that do not share vertices or indices
-	const vector<ofMeshFace_<V,N,C,T>> & getUniqueFaces() const;
+	const std::vector<ofMeshFace_<V,N,C,T>> & getUniqueFaces() const;
 
 	/// \}
 	/// \name Colors
@@ -386,7 +386,7 @@ public:
 
 	/// \brief This adds colors using a reference to a vector of ofColors.
 	/// For each color in the vector, this will put the colors at the corresponding vertex.
-	void addColors(const vector<C>& cols);
+	void addColors(const std::vector<C>& cols);
 
 	/// \brief This adds a pointer of colors to the ofMesh instance with the amount passed as the second parameter.
 	void addColors(const C* cols, std::size_t amt);
@@ -413,10 +413,10 @@ public:
 
 	/// Use this if you plan to change the colors as part of this call as it will force a reset of the cache.
 	/// \returns the vector that contains all of the colors of the mesh, if it has any.
-	vector<C> & getColors();
+	std::vector<C> & getColors();
 
 	/// \returns the vector that contains all of the colors of the mesh, if it has any. (read only)
-	const vector<C> & getColors() const;
+	const std::vector<C> & getColors() const;
 
 	/// \returns If the colors of the mesh have changed, been added or removed.
 	bool haveColorsChanged();
@@ -454,7 +454,7 @@ public:
 	/// allowing you to push out many at once rather than adding one at a time.
 	/// The vector of texture coordinates is added after the end of the current
 	/// texture coordinates list.
-	void addTexCoords(const vector<T>& tCoords);
+	void addTexCoords(const std::vector<T>& tCoords);
 
 	/// \brief  Add an array of texture coordinates to the mesh.
 	/// Because you are using a pointer to the array you also have to define
@@ -485,11 +485,11 @@ public:
 	/// Use this if you plan to change the texture coordinates as part of this
 	/// call as it will force a reset of the cache.
 	/// \returns a vector of Vec2f representing the texture coordinates for the whole mesh.
-	vector<T> & getTexCoords();
+	std::vector<T> & getTexCoords();
 
 	/// Because OF uses ARB textures these are in pixels rather than 0-1 normalized coordinates.
 	/// \returns a vector of Vec2f representing the texture coordinates for the whole mesh. (read only)
-	const vector<T> & getTexCoords() const;
+	const std::vector<T> & getTexCoords() const;
 
 	/// \returns If the texture coords of the mesh have changed, been added or removed.
 	bool haveTexCoordsChanged();
@@ -519,7 +519,7 @@ public:
 	/// \brief Use this if you plan to change the indices as part of this call as it
 	/// will force a reset of the cache.
 	/// \returns the vector that contains all of the indices of the mesh, if it has any.
-	vector<ofIndexType> & getIndices();
+	std::vector<ofIndexType> & getIndices();
 
 
 	/// \returns the index from the index vector. Each index represents the index of the vertex in the vertices vector. This determines the way that the vertices are connected into the polgoynon type set in the primitiveMode.
@@ -551,7 +551,7 @@ public:
 	void addIndex(ofIndexType i);
 
 	/// \brief This adds a vector of indices.
-	void addIndices(const vector<ofIndexType>& inds);
+	void addIndices(const std::vector<ofIndexType>& inds);
 
 	/// \brief This adds indices to the ofMesh by pointing to an array of indices.
 	/// The "amt" defines the length of the array.
@@ -579,7 +579,7 @@ public:
 
 
 	/// \returns the vector that contains all of the indices of the mesh, if it has any. (read only)
-	const vector<ofIndexType> & getIndices() const;
+	const std::vector<ofIndexType> & getIndices() const;
 
 	/// \returns If the indices of the mesh have changed, been added or removed.
 	bool haveIndicesChanged();
@@ -656,15 +656,15 @@ public:
 
 private:
 
-	vector<V> vertices;
-	vector<C> colors;
-	vector<N> normals;
-	vector<T> texCoords;
-	vector<ofIndexType> indices;
+	std::vector<V> vertices;
+	std::vector<C> colors;
+	std::vector<N> normals;
+	std::vector<T> texCoords;
+	std::vector<ofIndexType> indices;
 
 	// this variables are only caches and returned always as const
 	// mutable allows to change them from const methods
-	mutable vector<ofMeshFace_<V,N,C,T>> faces;
+	mutable std::vector<ofMeshFace_<V,N,C,T>> faces;
 	mutable bool bFacesDirty;
 
 	bool bVertsChanged, bColorsChanged, bNormalsChanged, bTexCoordsChanged,

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -23,7 +23,7 @@ ofMesh_<V,N,C,T>::ofMesh_(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-ofMesh_<V,N,C,T>::ofMesh_(ofPrimitiveMode mode, const vector<V>& verts){
+ofMesh_<V,N,C,T>::ofMesh_(ofPrimitiveMode mode, const std::vector<V>& verts){
 	bColorsChanged = false;
 	bNormalsChanged = false;
 	bTexCoordsChanged = false;
@@ -183,7 +183,7 @@ void ofMesh_<V,N,C,T>::addVertex(const V& v){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::addVertices(const vector<V>& verts){
+void ofMesh_<V,N,C,T>::addVertices(const std::vector<V>& verts){
 	vertices.insert(vertices.end(),verts.begin(),verts.end());
 	bVertsChanged = true;
 	bFacesDirty = true;
@@ -213,7 +213,7 @@ void ofMesh_<V,N,C,T>::addColor(const C& c){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::addColors(const vector<C>& cols){
+void ofMesh_<V,N,C,T>::addColors(const std::vector<C>& cols){
 	colors.insert(colors.end(),cols.begin(),cols.end());
 	bColorsChanged = true;
 	bFacesDirty = true;
@@ -243,7 +243,7 @@ void ofMesh_<V,N,C,T>::addNormal(const N& n){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::addNormals(const vector<N>& norms){
+void ofMesh_<V,N,C,T>::addNormals(const std::vector<N>& norms){
 	normals.insert(normals.end(),norms.begin(),norms.end());
 	bNormalsChanged = true;
 	bFacesDirty = true;
@@ -274,7 +274,7 @@ void ofMesh_<V,N,C,T>::addTexCoord(const T& t){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::addTexCoords(const vector<T>& tCoords){
+void ofMesh_<V,N,C,T>::addTexCoords(const std::vector<T>& tCoords){
 	texCoords.insert(texCoords.end(),tCoords.begin(),tCoords.end());
 	bTexCoordsChanged = true;
 	bFacesDirty = true;
@@ -312,7 +312,7 @@ void ofMesh_<V,N,C,T>::addIndex(ofIndexType i){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::addIndices(const vector<ofIndexType>& inds){
+void ofMesh_<V,N,C,T>::addIndices(const std::vector<ofIndexType>& inds){
 	indices.insert(indices.end(),inds.begin(),inds.end());
 	bIndicesChanged = true;
 	bFacesDirty = true;
@@ -592,7 +592,7 @@ const ofIndexType * ofMesh_<V,N,C,T>::getIndexPointer() const{
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<V> & ofMesh_<V,N,C,T>::getVertices(){
+std::vector<V> & ofMesh_<V,N,C,T>::getVertices(){
 	bVertsChanged = true;
 	bFacesDirty = true;
 	return vertices;
@@ -600,7 +600,7 @@ vector<V> & ofMesh_<V,N,C,T>::getVertices(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<C> & ofMesh_<V,N,C,T>::getColors(){
+std::vector<C> & ofMesh_<V,N,C,T>::getColors(){
 	bColorsChanged = true;
 	bFacesDirty = true;
 	return colors;
@@ -608,7 +608,7 @@ vector<C> & ofMesh_<V,N,C,T>::getColors(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<N> & ofMesh_<V,N,C,T>::getNormals(){
+std::vector<N> & ofMesh_<V,N,C,T>::getNormals(){
 	bNormalsChanged = true;
 	bFacesDirty = true;
 	return normals;
@@ -616,7 +616,7 @@ vector<N> & ofMesh_<V,N,C,T>::getNormals(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<T> & ofMesh_<V,N,C,T>::getTexCoords(){
+std::vector<T> & ofMesh_<V,N,C,T>::getTexCoords(){
 	bTexCoordsChanged = true;
 	bFacesDirty = true;
 	return texCoords;
@@ -624,7 +624,7 @@ vector<T> & ofMesh_<V,N,C,T>::getTexCoords(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<ofIndexType> & ofMesh_<V,N,C,T>::getIndices(){
+std::vector<ofIndexType> & ofMesh_<V,N,C,T>::getIndices(){
 	bIndicesChanged = true;
 	bFacesDirty = true;
 	return indices;
@@ -632,31 +632,31 @@ vector<ofIndexType> & ofMesh_<V,N,C,T>::getIndices(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<V> & ofMesh_<V,N,C,T>::getVertices() const{
+const std::vector<V> & ofMesh_<V,N,C,T>::getVertices() const{
 	return vertices;
 }
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<C> & ofMesh_<V,N,C,T>::getColors() const{
+const std::vector<C> & ofMesh_<V,N,C,T>::getColors() const{
 	return colors;
 }
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<N> & ofMesh_<V,N,C,T>::getNormals() const{
+const std::vector<N> & ofMesh_<V,N,C,T>::getNormals() const{
 	return normals;
 }
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<T> & ofMesh_<V,N,C,T>::getTexCoords() const{
+const std::vector<T> & ofMesh_<V,N,C,T>::getTexCoords() const{
 	return texCoords;
 }
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<ofIndexType> & ofMesh_<V,N,C,T>::getIndices() const{
+const std::vector<ofIndexType> & ofMesh_<V,N,C,T>::getIndices() const{
 	return indices;
 }
 
@@ -683,7 +683,7 @@ GLuint* ofPrimitive::getWireIndexPointer(){
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<int>& ofPrimitive::getFace(int faceNum){
+std::vector<int>& ofPrimitive::getFace(int faceNum){
 	switch(mode){
 		//GL_QUADS
 		indices[faceNum*4+0];
@@ -1029,7 +1029,7 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 	auto & data = *this;
 
 
-	string error;
+	std::string error;
 	ofBuffer buffer(is);
 	auto backup = data;
 
@@ -1063,7 +1063,7 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 		TexCoord,
 	};
 	
-	vector<Attribute> meshDefinition;
+	std::vector<Attribute> meshDefinition;
 	
 	data.clear();
 	State state = Header;
@@ -1086,7 +1086,7 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 
 	for(;line != lines.end(); ++line){
 		lineNum++;
-		string lineStr = *line;
+		std::string lineStr = *line;
 		if(lineStr.find("comment")==0 || lineStr.empty()){
 			continue;
 		}
@@ -1173,7 +1173,7 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 				error = "found more vertices: " + ofToString(currentVertex+1) + " than specified in header: " + ofToString(data.getNumVertices());
 				goto clean;
 			}
-			stringstream sline(lineStr);
+			std::stringstream sline(lineStr);
 			
 			// read in a line of vertex elements
 			// and split it into attributes,
@@ -1227,7 +1227,7 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 				error = "found more faces than specified in header";
 				goto clean;
 			}
-			stringstream sline(lineStr);
+			std::stringstream sline(lineStr);
 			int numV;
 			sline >> numV;
 			if(numV!=3){
@@ -1268,45 +1268,45 @@ void ofMesh_<V,N,C,T>::save(const std::filesystem::path& path, bool useBinary) c
 	ofFile os(path, ofFile::WriteOnly);
 	const auto & data = *this;
 
-	os << "ply" << endl;
+	os << "ply" << std::endl;
 	if(useBinary) {
-		os << "format binary_little_endian 1.0" << endl;
+		os << "format binary_little_endian 1.0" << std::endl;
 	} else {
-		os << "format ascii 1.0" << endl;
+		os << "format ascii 1.0" << std::endl;
 	}
 
 	if(data.getNumVertices()){
-		os << "element vertex " << data.getNumVertices() << endl;
-		os << "property float x" << endl;
-		os << "property float y" << endl;
-		os << "property float z" << endl;
+		os << "element vertex " << data.getNumVertices() << std::endl;
+		os << "property float x" << std::endl;
+		os << "property float y" << std::endl;
+		os << "property float z" << std::endl;
 		if(data.getNumColors()){
-			os << "property uchar red" << endl;
-			os << "property uchar green" << endl;
-			os << "property uchar blue" << endl;
-			os << "property uchar alpha" << endl;
+			os << "property uchar red" << std::endl;
+			os << "property uchar green" << std::endl;
+			os << "property uchar blue" << std::endl;
+			os << "property uchar alpha" << std::endl;
 		}
 		if(data.getNumTexCoords()){
-			os << "property float u" << endl;
-			os << "property float v" << endl;
+			os << "property float u" << std::endl;
+			os << "property float v" << std::endl;
 		}
 		if(data.getNumNormals()){
-			os << "property float nx" << endl;
-			os << "property float ny" << endl;
-			os << "property float nz" << endl;
+			os << "property float nx" << std::endl;
+			os << "property float ny" << std::endl;
+			os << "property float nz" << std::endl;
 		}
 	}
 
 	uint8_t faceSize = 3;
 	if(data.getNumIndices()){
-		os << "element face " << data.getNumIndices() / faceSize << endl;
-		os << "property list uchar int vertex_indices" << endl;
+		os << "element face " << data.getNumIndices() / faceSize << std::endl;
+		os << "property list uchar int vertex_indices" << std::endl;
 	} else if(data.getMode() == OF_PRIMITIVE_TRIANGLES) {
-		os << "element face " << data.getNumVertices() / faceSize << endl;
-		os << "property list uchar int vertex_indices" << endl;
+		os << "element face " << data.getNumVertices() / faceSize << std::endl;
+		os << "property list uchar int vertex_indices" << std::endl;
 	}
 
-	os << "end_header" << endl;
+	os << "end_header" << std::endl;
 
 	for(std::size_t i = 0; i < data.getNumVertices(); i++){
 		if(useBinary) {
@@ -1338,7 +1338,7 @@ void ofMesh_<V,N,C,T>::save(const std::filesystem::path& path, bool useBinary) c
 			}
 		}
 		if(!useBinary) {
-			os << endl;
+			os << std::endl;
 		}
 	}
 
@@ -1348,7 +1348,7 @@ void ofMesh_<V,N,C,T>::save(const std::filesystem::path& path, bool useBinary) c
 				os.write((char*) &faceSize, sizeof(unsigned char));
 				os.write((char*)&data.getIndices()[i], faceSize);
 			} else {
-				os << (std::size_t) faceSize << " " << data.getIndex(i) << " " << data.getIndex(i+1) << " " << data.getIndex(i+2) << endl;
+				os << (std::size_t) faceSize << " " << data.getIndex(i) << " " << data.getIndex(i+1) << " " << data.getIndex(i+2) << std::endl;
 			}
 		}
 	} else if(data.getMode() == OF_PRIMITIVE_TRIANGLES) {
@@ -1358,7 +1358,7 @@ void ofMesh_<V,N,C,T>::save(const std::filesystem::path& path, bool useBinary) c
 				os.write((char*) &faceSize, sizeof(unsigned char));
 				os.write((char*) indices, sizeof(indices));
 			} else {
-				os << (std::size_t) faceSize << " " << indices[0] << " " << indices[1] << " " << indices[2] << endl;
+				os << (std::size_t) faceSize << " " << indices[0] << " " << indices[1] << " " << indices[2] << std::endl;
 			}
 		}
 	}
@@ -1413,7 +1413,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::getMeshForIndices( ofIndexType startIndex, of
 	mesh.getVertices().assign( getVertices().begin()+startVertIndex, getVertices().begin()+endVertIndex );
 
 	if( hasColors() ) {
-		vector<ofFloatColor> colors;
+		std::vector<ofFloatColor> colors;
 		mesh.getColors().assign( getColors().begin()+startVertIndex, getColors().begin()+endVertIndex );
 		if( usingColors()) mesh.enableColors();
 		else mesh.disableColors();
@@ -1456,8 +1456,8 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::getMeshForIndices( ofIndexType startIndex, of
 template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::mergeDuplicateVertices() {
 
-	vector<V> verts = getVertices();
-	vector<ofIndexType> indices = getIndices();
+	std::vector<V> verts = getVertices();
+	std::vector<ofIndexType> indices = getIndices();
 
 	//get indexes to share single point - TODO: try j < i
 	for(ofIndexType i = 0; i < indices.size(); i++) {
@@ -1479,17 +1479,17 @@ void ofMesh_<V,N,C,T>::mergeDuplicateVertices() {
 	//indices array now has list of unique points we need
 	//but we need to delete the old points we're not using and that means the index values will change
 	//so we are going to create a new list of points and new indexes - we will use a map to map old index values to the new ones
-	vector <V> newPoints;
-	vector <ofIndexType> newIndexes;
-	map <ofIndexType, bool> ptCreated;
-	map <ofIndexType, ofIndexType> oldIndexNewIndex;
+	std::vector <V> newPoints;
+	std::vector <ofIndexType> newIndexes;
+	std::map <ofIndexType, bool> ptCreated;
+	std::map <ofIndexType, ofIndexType> oldIndexNewIndex;
 
-	vector<ofFloatColor> newColors;
-	vector<ofFloatColor>& colors = getColors();
-	vector<T> newTCoords;
-	vector<T>& tcoords = getTexCoords();
-	vector<N> newNormals;
-	vector<N>& normals = getNormals();
+	std::vector<ofFloatColor> newColors;
+	std::vector<ofFloatColor>& colors = getColors();
+	std::vector<T> newTCoords;
+	std::vector<T>& tcoords = getTexCoords();
+	std::vector<N> newNormals;
+	std::vector<N>& normals = getNormals();
 
 	for(ofIndexType i = 0; i < indices.size(); i++){
 		ptCreated[i] = false;
@@ -1551,7 +1551,7 @@ void ofMesh_<V,N,C,T>::mergeDuplicateVertices() {
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
 ofMeshFace_<V,N,C,T> ofMesh_<V,N,C,T>::getFace(ofIndexType faceId) const{
-	const vector<ofMeshFace_<V,N,C,T>> & faces = getUniqueFaces();
+	const std::vector<ofMeshFace_<V,N,C,T>> & faces = getUniqueFaces();
 	if(faces.size()>faceId){
 		return faces[faceId];
 	}else{
@@ -1563,7 +1563,7 @@ ofMeshFace_<V,N,C,T> ofMesh_<V,N,C,T>::getFace(ofIndexType faceId) const{
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-const vector<ofMeshFace_<V,N,C,T>> & ofMesh_<V,N,C,T>::getUniqueFaces() const{
+const std::vector<ofMeshFace_<V,N,C,T>> & ofMesh_<V,N,C,T>::getUniqueFaces() const{
 	if(bFacesDirty){
 		// if we are doing triangles, we have to use a vert and normal for each triangle
 		// that way we can calculate face normals and use getFaceNormal();
@@ -1606,9 +1606,9 @@ const vector<ofMeshFace_<V,N,C,T>> & ofMesh_<V,N,C,T>::getUniqueFaces() const{
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-vector<N> ofMesh_<V,N,C,T>::getFaceNormals( bool perVertex ) const{
+std::vector<N> ofMesh_<V,N,C,T>::getFaceNormals( bool perVertex ) const{
 	// default for ofPrimitiveBase is vertex normals //
-	vector<N> faceNormals;
+	std::vector<N> faceNormals;
 
 	if( hasVertices() ) {
 		if(vertices.size() > 3 && indices.size() > 3) {
@@ -1641,7 +1641,7 @@ vector<N> ofMesh_<V,N,C,T>::getFaceNormals( bool perVertex ) const{
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
-void ofMesh_<V,N,C,T>::setFromTriangles( const vector<ofMeshFace_<V,N,C,T>>& tris, bool bUseFaceNormal ) {
+void ofMesh_<V,N,C,T>::setFromTriangles( const std::vector<ofMeshFace_<V,N,C,T>>& tris, bool bUseFaceNormal ) {
 	if(tris.empty()) {
 		ofLogWarning("ofMesh") << "setFromTriangles(): ignoring empty tris vector";
 		return;
@@ -1701,15 +1701,15 @@ template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 
 	if( getMode() == OF_PRIMITIVE_TRIANGLES) {
-		vector<ofMeshFace_<V,N,C,T>> triangles = getUniqueFaces();
-		vector<V> verts;
+		std::vector<ofMeshFace_<V,N,C,T>> triangles = getUniqueFaces();
+		std::vector<V> verts;
 		for(ofIndexType i = 0; i < triangles.size(); i++) {
 			for(ofIndexType j = 0; j < 3; j++) {
 				verts.push_back( triangles[i].getVertex(j) );
 			}
 		}
 
-		map<int, int> removeIds;
+		std::map<int, int> removeIds;
 
 		float epsilon = .01f;
 		for(ofIndexType i = 0; i < verts.size()-1; i++) {
@@ -1728,17 +1728,17 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 		}
 
 		// string of vertex in 3d space to triangle index //
-		map<string, vector<int> > vertHash;
+		std::map<std::string, std::vector<int> > vertHash;
 
 		//ofLogNotice("ofMesh") << "smoothNormals(): num verts = " << verts.size() << " tris size = " << triangles.size();
 
-		string xStr, yStr, zStr;
+		std::string xStr, yStr, zStr;
 
 		for(ofIndexType i = 0; i < verts.size(); i++ ) {
 			xStr = "x"+ofToString(verts[i].x==-0?0:verts[i].x);
 			yStr = "y"+ofToString(verts[i].y==-0?0:verts[i].y);
 			zStr = "z"+ofToString(verts[i].z==-0?0:verts[i].z);
-			string vstring = xStr+yStr+zStr;
+			std::string vstring = xStr+yStr+zStr;
 			if(vertHash.find(vstring) == vertHash.end()) {
 				for(ofIndexType j = 0; j < triangles.size(); j++) {
 					for(ofIndexType k = 0; k < 3; k++) {
@@ -1754,8 +1754,8 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 			}
 		}
 
-//		for( map<string, vector<int> >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
-//			//for( map<string, int >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
+//		for( std::map<std::string, std::vector<int> >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
+//			//for( std::map<std::string, int >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
 //			ofLogNotice("ofMesh") << "smoothNormals(): " << it->first << "  num = " << it->second.size();
 //		}
 
@@ -1771,7 +1771,7 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 				yStr = "y"+ofToString(vert.y==-0?0:vert.y);
 				zStr = "z"+ofToString(vert.z==-0?0:vert.z);
 
-				string vstring = xStr+yStr+zStr;
+				std::string vstring = xStr+yStr+zStr;
 				numNormals=0;
 				normal = {0.f,0.f,0.f};
 				if(vertHash.find(vstring) != vertHash.end()) {
@@ -2071,7 +2071,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 	for (ofIndexType iteration = 0; iteration < iterations; iteration++)
 	{
 		size*=4;
-		vector<ofIndexType> newFaces;
+		std::vector<ofIndexType> newFaces;
 		for (ofIndexType i=0; i<size/12; i++)
 		{
 			auto i1 = faces[i*3];
@@ -2105,7 +2105,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 	}
 
 	/// Step 3 : generate texcoords
-	vector<T> texCoords;
+	std::vector<T> texCoords;
 	for (ofIndexType i=0;i<vertices.size();i++)
 	{
 		const auto& vec = vertices[i];

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2130,21 +2130,21 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 		T& t1 = texCoords[faces[i*3+1]];
 		T& t2 = texCoords[faces[i*3+2]];
 
-		if (abs(t2.x-t0.x)>0.5)
+		if (std::abs(t2.x-t0.x)>0.5)
 		{
 			if (t0.x<0.5)
 				indexToSplit.push_back(faces[i*3]);
 			else
 				indexToSplit.push_back(faces[i*3+2]);
 		}
-		if (abs(t1.x-t0.x)>0.5)
+		if (std::abs(t1.x-t0.x)>0.5)
 		{
 			if (t0.x<0.5)
 				indexToSplit.push_back(faces[i*3]);
 			else
 				indexToSplit.push_back(faces[i*3+1]);
 		}
-		if (abs(t2.x-t1.x)>0.5)
+		if (std::abs(t2.x-t1.x)>0.5)
 		{
 			if (t1.x<0.5)
 				indexToSplit.push_back(faces[i*3+1]);

--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -424,8 +424,8 @@ void ofNode::lookAt(const glm::vec3& lookAtPosition){
     auto relPosition = (getGlobalPosition() - lookAtPosition);
 	auto radius = glm::length(relPosition);
     if(radius>0){
-		auto latitude = acos(relPosition.y / radius) - glm::half_pi<float>();
-		auto longitude = atan2(relPosition.x , relPosition.z);
+		float latitude = acos(relPosition.y / radius) - glm::half_pi<float>();
+		float longitude = atan2(relPosition.x , relPosition.z);
 		glm::quat q = glm::angleAxis(latitude, glm::vec3(1,0,0)) * glm::angleAxis(longitude, glm::vec3(0,1,0)) * glm::angleAxis(0.f, glm::vec3(0,0,1));
         setGlobalOrientation(q);
     }

--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -34,7 +34,7 @@ public:
 	virtual void close(){
 	}
 	virtual ofCoreEvents & events() = 0;
-	virtual shared_ptr<ofBaseRenderer> & renderer() = 0;
+	virtual std::shared_ptr<ofBaseRenderer> & renderer() = 0;
 
 	virtual void hideCursor() {}
 	virtual void showCursor() {}
@@ -54,7 +54,7 @@ public:
 	virtual int		getWidth(){ return 0; }
 	virtual int		getHeight(){ return 0; }
 
-	virtual void	setWindowTitle(string title){}
+	virtual void	setWindowTitle(std::string title){}
 
 	virtual ofWindowMode	getWindowMode() {return OF_WINDOW ;}
 
@@ -65,8 +65,8 @@ public:
 	virtual void	disableSetupScreen(){}
 	
 	virtual void	setVerticalSync(bool enabled){};
-    virtual void    setClipboardString(const string& text) {}
-    virtual string  getClipboardString() { return ""; }
+    virtual void    setClipboardString(const std::string& text) {}
+    virtual std::string  getClipboardString() { return ""; }
 
     virtual void makeCurrent(){};
 	virtual void swapBuffers() {}

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -154,7 +154,7 @@ static const struct {
 #define CASE_STR(x,y) case x: str = y; break
 
 static const char* eglErrorString(EGLint err) {
-	string str;
+	std::string str;
 	switch (err) {
 	CASE_STR(EGL_SUCCESS, "no error");
 	CASE_STR(EGL_NOT_INITIALIZED, "EGL not, or could not be, initialized");
@@ -477,9 +477,9 @@ void ofAppEGLWindow::setup(const Settings & _settings) {
 	nFramesSinceWindowResized = 0;
 
 	if(settings.glesVersion>1){
-		currentRenderer = make_shared<ofGLProgrammableRenderer>(this);
+		currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 	}else{
-		currentRenderer = make_shared<ofGLRenderer>(this);
+		currentRenderer = std::make_shared<ofGLRenderer>(this);
 	}
 
 	makeCurrent();
@@ -903,7 +903,7 @@ ofCoreEvents & ofAppEGLWindow::events(){
 }
 
 //------------------------------------------------------------
-shared_ptr<ofBaseRenderer> & ofAppEGLWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppEGLWindow::renderer(){
 	return currentRenderer;
 }
 
@@ -1039,7 +1039,7 @@ void ofAppEGLWindow::pollEvents(){
 			}
 		}
 	} else {
-		queue<ofMouseEventArgs> mouseEventsCopy;
+		std::queue<ofMouseEventArgs> mouseEventsCopy;
 		instance->lock();
 		mouseEventsCopy = instance->mouseEvents;
 		while(!instance->mouseEvents.empty()){
@@ -1052,7 +1052,7 @@ void ofAppEGLWindow::pollEvents(){
 		}
 
 		// KEYBOARD EVENTS
-		queue<ofKeyEventArgs> keyEventsCopy;
+		std::queue<ofKeyEventArgs> keyEventsCopy;
 		instance->lock();
 		keyEventsCopy = instance->keyEvents;
 		while(!instance->keyEvents.empty()){
@@ -1077,7 +1077,7 @@ void ofAppEGLWindow::showCursor(){
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setWindowTitle(string title) {
+void ofAppEGLWindow::setWindowTitle(std::string title) {
 	ofLogNotice("ofAppEGLWindow") << "setWindowTitle(): not implemented";
 }
 
@@ -1350,14 +1350,14 @@ void ofAppEGLWindow::setupNativeMouse() {
 	// fallback to /dev/input/eventX since some vnc servers use uinput to handle mouse & keyboard
 	typedef int (*filter_ptr)(const struct dirent *d);
 	filter_ptr mouse_filters[2] = { filter_mouse, filter_event };
-	string devicePathBuffers[2] = { "/dev/input/by-path/", "/dev/input/" };
+	std::string devicePathBuffers[2] = { "/dev/input/by-path/", "/dev/input/" };
 
 	for(int i=0; i<2; i++){
 		int n = scandir(devicePathBuffers[i].c_str(), &eps, mouse_filters[i], dummy_sort);
 
 		// make sure that we found an appropriate entry
 		if(n >= 0 && eps != 0 && eps[0] != 0) {
-			string devicePathBuffer;
+			std::string devicePathBuffer;
 			devicePathBuffer.append(devicePathBuffers[i]);
 			devicePathBuffer.append(eps[0]->d_name);
 			mouse_fd = open(devicePathBuffer.c_str(), O_RDONLY | O_NONBLOCK);
@@ -1390,14 +1390,14 @@ void ofAppEGLWindow::setupNativeKeyboard() {
 	struct dirent **eps;
 	typedef int (*filter_ptr)(const struct dirent *d);
 	filter_ptr kbd_filters[2] = { filter_kbd, filter_event };
-	string devicePathBuffers[2] = { "/dev/input/by-path/", "/dev/input/" };
+	std::string devicePathBuffers[2] = { "/dev/input/by-path/", "/dev/input/" };
 
 	for(int i=0; i<2; i++){
 		int n = scandir(devicePathBuffers[i].c_str(), &eps, kbd_filters[i], dummy_sort);
 
 		// make sure that we found an appropriate entry
 		if(n >= 0 && eps != 0 && eps[0] != 0) {
-			string devicePathBuffer;
+			std::string devicePathBuffer;
 			devicePathBuffer.append(devicePathBuffers[i]);
 			devicePathBuffer.append(eps[0]->d_name);
 			keyboard_fd = open(devicePathBuffer.c_str(), O_RDONLY | O_NONBLOCK);
@@ -2141,7 +2141,7 @@ void ofAppEGLWindow::handleX11Event(const XEvent& event){
 		instance->coreEvents.notifyMouseEvent(mouseEvent);
 		break;
 	case MotionNotify:
-		//cout << "motion notify" << endl;
+		//cout << "motion notify" << std::endl;
 		mouseEvent.x = static_cast<float>(event.xmotion.x);
 		mouseEvent.y = static_cast<float>(event.xmotion.y);
 		mouseEvent.button = event.xbutton.button;

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -43,8 +43,8 @@ enum ofAppEGLWindowType {
 	OF_APP_WINDOW_X11
 };
 
-typedef map<EGLint,EGLint> ofEGLAttributeList;
-typedef map<EGLint,EGLint>::iterator ofEGLAttributeListIterator;
+typedef std::map<EGLint,EGLint> ofEGLAttributeList;
+typedef std::map<EGLint,EGLint>::iterator ofEGLAttributeListIterator;
 
 class ofAppEGLWindow : public ofAppBaseGLESWindow, public ofThread {
 public:
@@ -73,7 +73,7 @@ public:
 	void finishRender();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
 
 	void setThreadTimeout(long timeOut){ threadTimeout = timeOut; }
 
@@ -95,7 +95,7 @@ public:
 	virtual int	getWidth();
 	virtual int	getHeight();
 
-	virtual void setWindowTitle(string title); // TODO const correct
+	virtual void setWindowTitle(std::string title); // TODO const correct
 
 	virtual ofWindowMode getWindowMode();
 
@@ -159,14 +159,14 @@ protected:
 	bool bEnableSetupScreen;  ///< \brief This indicates the need/intent to draw a setup screen.
 	bool bShowCursor;  ///< \brief Indicate the visibility of the (mouse) cursor.
 
-	string eglDisplayString;
+	std::string eglDisplayString;
 	int nFramesSinceWindowResized;  ///< \brief The number of frames passed/shown since the window got resized.
 	ofOrientation orientation;
 
 
 	void threadedFunction();
-	queue<ofMouseEventArgs> mouseEvents;
-	queue<ofKeyEventArgs>   keyEvents;
+	std::queue<ofMouseEventArgs> mouseEvents;
+	std::queue<ofKeyEventArgs>   keyEvents;
 	void checkEvents();
 	ofImage mouseCursor;
 
@@ -283,6 +283,6 @@ private:
 	bool mouseDetected;
 	long threadTimeout;
 	ofCoreEvents coreEvents;
-	shared_ptr<ofBaseRenderer> currentRenderer;
+	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	static ofAppEGLWindow * instance;
 };

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -169,9 +169,9 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
 		if(settings.glesVersion>=2){
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+			currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
 		}else{
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+			currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 		}
 	#else
 		glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
@@ -182,9 +182,9 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		}
 		if(settings.glVersionMajor>=3){
 			glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
+			currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLProgrammableRenderer(this));
 		}else{
-			currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+			currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 		}
 	#endif
 
@@ -343,7 +343,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 
 #ifdef TARGET_LINUX
 //------------------------------------------------------------
-void ofAppGLFWWindow::setWindowIcon(const string & path){
+void ofAppGLFWWindow::setWindowIcon(const std::string & path){
     ofPixels iconPixels;
 	ofLoadImage(iconPixels,path);
 	setWindowIcon(iconPixels);
@@ -353,7 +353,7 @@ void ofAppGLFWWindow::setWindowIcon(const string & path){
 void ofAppGLFWWindow::setWindowIcon(const ofPixels & iconPixels){
 	iconSet = true;
 	int length = 2+iconPixels.getWidth()*iconPixels.getHeight();
-	vector<unsigned long> buffer(length);
+	std::vector<unsigned long> buffer(length);
 	buffer[0]=iconPixels.getWidth();
 	buffer[1]=iconPixels.getHeight();
 	for(size_t i=0;i<iconPixels.getWidth()*iconPixels.getHeight();i++){
@@ -375,7 +375,7 @@ ofCoreEvents & ofAppGLFWWindow::events(){
 }
 
 //--------------------------------------------
-shared_ptr<ofBaseRenderer> & ofAppGLFWWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppGLFWWindow::renderer(){
 	return currentRenderer;
 }
 
@@ -466,7 +466,7 @@ void ofAppGLFWWindow::setWindowShouldClose(){
 }
 
 //------------------------------------------------------------
-void ofAppGLFWWindow::setWindowTitle(string title){
+void ofAppGLFWWindow::setWindowTitle(std::string title){
 	settings.title = title;
 	glfwSetWindowTitle(windowP,settings.title.c_str());
 }
@@ -648,10 +648,10 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 		GLFWmonitor** monitors = glfwGetMonitors(&monitorCount);
 		if( settings.multiMonitorFullScreen && monitorCount > 1 ){
 			// find the monitors at the edges of the virtual desktop
-			int minx=numeric_limits<int>::max();
-			int miny=numeric_limits<int>::max();
-			int maxx=numeric_limits<int>::min();
-			int maxy=numeric_limits<int>::min();
+			int minx=std::numeric_limits<int>::max();
+			int miny=std::numeric_limits<int>::max();
+			int maxx=std::numeric_limits<int>::min();
+			int maxy=std::numeric_limits<int>::min();
 			int x,y,w,h;
 			int monitorLeft=0, monitorRight=0, monitorTop=0, monitorBottom=0;
 			for(int i = 0; i < monitorCount; i++){
@@ -990,7 +990,7 @@ static void rotateMouseXY(ofOrientation orientation, int w, int h, double &x, do
 //------------------------------------------------------------
 ofAppGLFWWindow * ofAppGLFWWindow::setCurrent(GLFWwindow* windowP){
 	ofAppGLFWWindow * instance = static_cast<ofAppGLFWWindow *>(glfwGetWindowUserPointer(windowP));
-	shared_ptr<ofMainLoop> mainLoop = ofGetMainLoop();
+	std::shared_ptr<ofMainLoop> mainLoop = ofGetMainLoop();
 	if(mainLoop){
 		mainLoop->setCurrentWindow(instance);
 	}
@@ -1501,12 +1501,12 @@ void ofAppGLFWWindow::setVerticalSync(bool bVerticalSync){
 }
 
 //------------------------------------------------------------
-void ofAppGLFWWindow::setClipboardString(const string& text) {
+void ofAppGLFWWindow::setClipboardString(const std::string& text) {
     glfwSetClipboardString(ofAppGLFWWindow::windowP, text.c_str());
 }
 
 //------------------------------------------------------------
-string ofAppGLFWWindow::getClipboardString() {
+std::string ofAppGLFWWindow::getClipboardString() {
 	const char* clipboard = glfwGetClipboardString(ofAppGLFWWindow::windowP);
 
 	if (clipboard) {

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -887,13 +887,13 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 			for(int i = 0; i < monitorCount; i++){
 				const GLFWvidmode * desktopMode = glfwGetVideoMode(monitors[i]);
 				glfwGetMonitorPos(monitors[i], &tempXPos, &tempYPos);
-				minX = min(tempXPos,minX);
-				minY = min(tempYPos,minY);
-				maxX = max(maxX,tempXPos + desktopMode->width);
-				maxY = max(maxY,tempYPos + desktopMode->height);
+				minX = std::min(tempXPos,minX);
+				minY = std::min(tempYPos,minY);
+				maxX = std::max(maxX,tempXPos + desktopMode->width);
+				maxY = std::max(maxY,tempYPos + desktopMode->height);
 
-				xpos = min(xpos,tempXPos);
-				ypos = min(ypos,tempYPos);
+				xpos = std::min(xpos,tempXPos);
+				ypos = std::min(ypos,tempYPos);
 			}
 
 			fullscreenW = maxX-minX;

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -48,7 +48,7 @@ public:
 	bool resizable = true;
 	int monitor = 0;
 	bool multiMonitorFullScreen = false;
-	shared_ptr<ofAppBaseWindow> shareContextWith;
+	std::shared_ptr<ofAppBaseWindow> shareContextWith;
 };
 
 #ifdef TARGET_OPENGLES
@@ -95,7 +95,7 @@ public:
 	int getWidth();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
     
     GLFWwindow* getGLFWWindow();
     void * getWindowContext(){return getGLFWWindow();}
@@ -105,7 +105,7 @@ public:
 	glm::vec2	getScreenSize();
 	glm::vec2 	getWindowPosition();
 
-	void setWindowTitle(string title);
+	void setWindowTitle(std::string title);
 	void setWindowPosition(int x, int y);
 	void setWindowShape(int w, int h);
 
@@ -122,8 +122,8 @@ public:
 
 	void		setVerticalSync(bool bSync);
 
-    void        setClipboardString(const string& text);
-    string      getClipboardString();
+    void        setClipboardString(const std::string& text);
+    std::string      getClipboardString();
 
     int         getPixelScreenCoordScale();
 
@@ -189,14 +189,14 @@ private:
 	static void		error_cb(int errorCode, const char* errorDescription);
 
 #ifdef TARGET_LINUX
-	void setWindowIcon(const string & path);
+	void setWindowIcon(const std::string & path);
 	void setWindowIcon(const ofPixels & iconPixels);
 	XIM xim;
 	XIC xic;
 #endif
 
 	ofCoreEvents coreEvents;
-	shared_ptr<ofBaseRenderer> currentRenderer;
+	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	ofGLFWWindowSettings settings;
 
 	ofWindowMode	windowMode;

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -100,7 +100,7 @@ void HandleFiles(WPARAM wParam)
 		while( *s != L'\0' ) {
 			stm << std::use_facet< std::ctype<wchar_t> >( loc ).narrow( *s++, dfault );
 		}
-		info.files.push_back(string(stm.str()));
+		info.files.push_back(std::string(stm.str()));
 
 			//toUTF8(udispName, dispName);
 
@@ -188,7 +188,7 @@ ofAppGlutWindow::ofAppGlutWindow(){
 // "rgba double samples>=4 depth" ( mac )
 // "rgb double depth alpha samples>=4" ( some pcs )
 //------------------------------------------------------------
- void ofAppGlutWindow::setGlutDisplayString(string displayStr){
+ void ofAppGlutWindow::setGlutDisplayString(std::string displayStr){
 	displayString = displayStr;
  }
 
@@ -262,7 +262,7 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 	windowW = glutGet(GLUT_WINDOW_WIDTH);
 	windowH = glutGet(GLUT_WINDOW_HEIGHT);
 
-	currentRenderer = shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
+	currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 
 
 #ifndef TARGET_OPENGLES
@@ -337,7 +337,7 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 
 #ifdef TARGET_LINUX
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowIcon(const string & path){
+void ofAppGlutWindow::setWindowIcon(const std::string & path){
     ofPixels iconPixels;
 	ofLoadImage(iconPixels,path);
 	setWindowIcon(iconPixels);
@@ -396,7 +396,7 @@ void ofAppGlutWindow::loop(){
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowTitle(string title){
+void ofAppGlutWindow::setWindowTitle(std::string title){
 	glutSetWindowTitle(title.c_str());
 }
 
@@ -582,7 +582,7 @@ ofCoreEvents & ofAppGlutWindow::events(){
 }
 
 //------------------------------------------------------------
-shared_ptr<ofBaseRenderer> & ofAppGlutWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppGlutWindow::renderer(){
 	return currentRenderer;
 }
 
@@ -779,7 +779,7 @@ void ofAppGlutWindow::dragEvent(char ** names, int howManyFiles, int dragX, int 
 	info.position.y = instance->getHeight()-dragY;
 
 	for (int i = 0; i < howManyFiles; i++){
-		string temp = string(names[i]);
+		std::string temp = std::string(names[i]);
 		info.files.push_back(temp);
 	}
 

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -31,7 +31,7 @@ public:
 	void setDoubleBuffering(bool _bDoubleBuffered); 
 	
 	//note if you fail to set a compatible string the app will not launch
-	void setGlutDisplayString(string str);
+	void setGlutDisplayString(std::string str);
 
 	void hideCursor();
 	void showCursor();
@@ -39,7 +39,7 @@ public:
 	void setFullscreen(bool fullScreen);
 	void toggleFullscreen();
 
-	void setWindowTitle(string title);
+	void setWindowTitle(std::string title);
 	void setWindowPosition(int x, int y);
 	void setWindowShape(int w, int h);
 
@@ -64,7 +64,7 @@ public:
 	void finishRender();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
 
 private:
 	static void display(void);
@@ -80,16 +80,16 @@ private:
 	static void entry_cb(int state);
 	static void exit_cb();
 	static void dragEvent(char ** fileNames, int howManyFiles, int dragX, int dragY);
-	string displayString;
+	std::string displayString;
 
 	bool iconSet;
 #ifdef TARGET_LINUX
-	void setWindowIcon(const string & path);
+	void setWindowIcon(const std::string & path);
 	void setWindowIcon(const ofPixels & iconPixels);
 #endif
 	
 	ofCoreEvents coreEvents;
-	shared_ptr<ofBaseRenderer> currentRenderer;
+	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	int windowId;
 };
 

--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -60,7 +60,7 @@ int getch()
 
 #endif
 
-const string ofNoopRenderer::TYPE="NOOP";
+const std::string ofNoopRenderer::TYPE="NOOP";
 
 //----------------------------------------------------------
 ofAppNoWindow::ofAppNoWindow(){
@@ -75,7 +75,7 @@ void ofAppNoWindow::setup(const ofWindowSettings & settings){
 	width = settings.width;
 	height = settings.height;
 
-	currentRenderer = shared_ptr<ofBaseRenderer>(new ofNoopRenderer);
+	currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofNoopRenderer);
 }
 
 //----------------------------------------------------------
@@ -97,7 +97,7 @@ void ofAppNoWindow::update(){
 		}
 		else if ( key == /* ctrl-c */ 3 )
 		{
-			ofLogNotice("ofAppNoWindow") << "Ctrl-C pressed" << endl;
+			ofLogNotice("ofAppNoWindow") << "Ctrl-C pressed" << std::endl;
 			break;
 		}
 		else
@@ -161,6 +161,6 @@ ofCoreEvents & ofAppNoWindow::events(){
 	return coreEvents;
 }
 
-shared_ptr<ofBaseRenderer> & ofAppNoWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppNoWindow::renderer(){
 	return currentRenderer;
 }

--- a/libs/openFrameworks/app/ofAppNoWindow.h
+++ b/libs/openFrameworks/app/ofAppNoWindow.h
@@ -35,22 +35,22 @@ public:
 	int			getHeight();
 
 	ofCoreEvents & events();
-	shared_ptr<ofBaseRenderer> & renderer();
+	std::shared_ptr<ofBaseRenderer> & renderer();
 
 private:
 	int width, height;
 
     ofBaseApp *		ofAppPtr;
     ofCoreEvents coreEvents;
-    shared_ptr<ofBaseRenderer> currentRenderer;
+    std::shared_ptr<ofBaseRenderer> currentRenderer;
 };
 
 class ofNoopRenderer: public ofBaseRenderer{
 public:
 	ofNoopRenderer():graphics3d(this){}
 private:
-	static const string TYPE;
-	const string & getType(){return TYPE;}
+	static const std::string TYPE;
+	const std::string & getType(){return TYPE;}
 
 	void startRender(){}
 	void finishRender(){}
@@ -166,8 +166,8 @@ private:
 	void drawCircle(float x, float y, float z, float radius) const{}
 	void drawSphere(float x, float y, float z, float radius) const{}
 	void drawEllipse(float x, float y, float z, float width, float height) const{}
-	void drawString(string text, float x, float y, float z) const{}
-	void drawString(const ofTrueTypeFont & font, string text, float x, float y) const{}
+	void drawString(std::string text, float x, float y, float z) const{}
+	void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const{}
 
 	void setBitmapTextMode(ofDrawBitmapMode mode){}
 	ofStyle getStyle() const{ return ofStyle(); }

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -26,7 +26,7 @@
 	//special case so we preserve supplied settngs
 	//TODO: remove me when we remove the ofAppGLFWWindow setters.
 	//--------------------------------------
-	void ofSetupOpenGL(shared_ptr<ofAppGLFWWindow> windowPtr, int w, int h, ofWindowMode screenMode){
+	void ofSetupOpenGL(std::shared_ptr<ofAppGLFWWindow> windowPtr, int w, int h, ofWindowMode screenMode){
 		ofInit();
 		auto settings = windowPtr->getSettings();
 		settings.width = w;
@@ -53,8 +53,8 @@
 
 //--------------------------------------
 namespace{
-    shared_ptr<ofMainLoop> & mainLoop(){
-        static shared_ptr<ofMainLoop> * mainLoop(new shared_ptr<ofMainLoop>(new ofMainLoop));
+    std::shared_ptr<ofMainLoop> & mainLoop(){
+        static std::shared_ptr<ofMainLoop> * mainLoop(new std::shared_ptr<ofMainLoop>(new ofMainLoop));
         return *mainLoop;
     }
 
@@ -156,18 +156,18 @@ void ofInit(){
 }
 
 //--------------------------------------
-shared_ptr<ofMainLoop> ofGetMainLoop(){
+std::shared_ptr<ofMainLoop> ofGetMainLoop(){
 	return mainLoop();
 }
 
 //--------------------------------------
-void ofSetMainLoop(shared_ptr<ofMainLoop> newMainLoop) {
+void ofSetMainLoop(std::shared_ptr<ofMainLoop> newMainLoop) {
 	mainLoop() = newMainLoop;
 }
 
 //--------------------------------------
 int ofRunApp(ofBaseApp * OFSA){
-	mainLoop()->run(std::move(shared_ptr<ofBaseApp>(OFSA)));
+	mainLoop()->run(std::move(std::shared_ptr<ofBaseApp>(OFSA)));
 	auto ret = ofRunMainLoop();
 #if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
 	ofExitCallback();
@@ -176,7 +176,7 @@ int ofRunApp(ofBaseApp * OFSA){
 }
 
 //--------------------------------------
-int ofRunApp(shared_ptr<ofBaseApp> && app){
+int ofRunApp(std::shared_ptr<ofBaseApp> && app){
 	mainLoop()->run(std::move(app));
 	auto ret = ofRunMainLoop();
 #if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
@@ -186,7 +186,7 @@ int ofRunApp(shared_ptr<ofBaseApp> && app){
 }
 
 //--------------------------------------
-void ofRunApp(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> && app){
+void ofRunApp(std::shared_ptr<ofAppBaseWindow> window, std::shared_ptr<ofBaseApp> && app){
 	mainLoop()->run(window, std::move(app));
 }
 
@@ -212,7 +212,7 @@ void ofSetupOpenGL(int w, int h, ofWindowMode screenMode){
 	ofCreateWindow(settings);
 }
 
-shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings){
+std::shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings){
 	ofInit();
 	return mainLoop()->createWindow(settings);
 }
@@ -298,7 +298,7 @@ void ofSetEscapeQuitsApp(bool bQuitOnEsc){
 }
 
 //--------------------------------------
-shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer(){
+std::shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer(){
 	return mainLoop()->getCurrentWindow()->renderer();
 }
 
@@ -431,7 +431,7 @@ ofRectangle	ofGetWindowRect() {
 }
 
 //--------------------------------------
-void ofSetWindowTitle(string title){
+void ofSetWindowTitle(std::string title){
 	mainLoop()->getCurrentWindow()->setWindowTitle(title);
 }
 

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -17,12 +17,12 @@ class ofCoreEvents;
 
 void ofInit();
 void ofSetupOpenGL(int w, int h, ofWindowMode screenMode);	// sets up the opengl context!
-shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings);	// sets up the opengl context!
-shared_ptr<ofMainLoop> ofGetMainLoop();
-void ofSetMainLoop(shared_ptr<ofMainLoop> mainLoop);
+std::shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings);	// sets up the opengl context!
+std::shared_ptr<ofMainLoop> ofGetMainLoop();
+void ofSetMainLoop(std::shared_ptr<ofMainLoop> mainLoop);
 
 template<typename Window>
-void ofSetupOpenGL(shared_ptr<Window> windowPtr, int w, int h, ofWindowMode screenMode){
+void ofSetupOpenGL(std::shared_ptr<Window> windowPtr, int w, int h, ofWindowMode screenMode){
 	ofInit();
 	ofWindowSettings settings;
 	settings.width = w;
@@ -34,21 +34,21 @@ void ofSetupOpenGL(shared_ptr<Window> windowPtr, int w, int h, ofWindowMode scre
 
 //special case so we preserve supplied settngs
 //TODO: remove me when we remove the ofSetupOpenGL legacy approach.
-void ofSetupOpenGL(shared_ptr<ofAppGLFWWindow> windowPtr, int w, int h, ofWindowMode screenMode);
+void ofSetupOpenGL(std::shared_ptr<ofAppGLFWWindow> windowPtr, int w, int h, ofWindowMode screenMode);
 
 template<typename Window>
 static void noopDeleter(Window*){}
 
 template<typename Window>
 void ofSetupOpenGL(Window * windowPtr, int w, int h, ofWindowMode screenMode){
-	shared_ptr<Window> window = shared_ptr<Window>(windowPtr,std::ptr_fun(noopDeleter<Window>));
+	std::shared_ptr<Window> window = std::shared_ptr<Window>(windowPtr,std::ptr_fun(noopDeleter<Window>));
 	ofSetupOpenGL(window,w,h,screenMode);
 }
 
 
-int ofRunApp(shared_ptr<ofBaseApp> && OFSA);
+int ofRunApp(std::shared_ptr<ofBaseApp> && OFSA);
 int ofRunApp(ofBaseApp * OFSA = nullptr); // will be deprecated
-void ofRunApp(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> && app);
+void ofRunApp(std::shared_ptr<ofAppBaseWindow> window, std::shared_ptr<ofBaseApp> && app);
 int ofRunMainLoop();
 
 
@@ -100,7 +100,7 @@ std::shared_ptr<ofAppBaseWindow> ofGetCurrentWindow();
 
 void 		ofSetWindowPosition(int x, int y);
 void 		ofSetWindowShape(int width, int height);
-void 		ofSetWindowTitle(string title);
+void 		ofSetWindowTitle(std::string title);
 void		ofEnableSetupScreen();
 void		ofDisableSetupScreen();
 void		ofSetFullscreen(bool fullscreen);
@@ -109,8 +109,8 @@ void		ofToggleFullscreen();
 void 		ofSetVerticalSync(bool bSync);
 
 ofCoreEvents & ofEvents();
-void ofSetCurrentRenderer(shared_ptr<ofBaseRenderer> renderer,bool setDefaults=false);
-shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer();
+void ofSetCurrentRenderer(std::shared_ptr<ofBaseRenderer> renderer,bool setDefaults=false);
+std::shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer();
 void ofSetEscapeQuitsApp(bool bQuitOnEsc);
 
 //-------------------------- native window handles

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -40,22 +40,22 @@ ofMainLoop::~ofMainLoop() {
 	exit();
 }
 
-shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & settings){
+std::shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & settings){
 #ifdef TARGET_NODISPLAY
-	shared_ptr<ofAppNoWindow> window = shared_ptr<ofAppNoWindow>(new ofAppNoWindow());
+	std::shared_ptr<ofAppNoWindow> window = std::shared_ptr<ofAppNoWindow>(new ofAppNoWindow());
 #else
 	#if defined(TARGET_OF_IOS)
-	shared_ptr<ofAppiOSWindow> window = shared_ptr<ofAppiOSWindow>(new ofAppiOSWindow());
+	std::shared_ptr<ofAppiOSWindow> window = std::shared_ptr<ofAppiOSWindow>(new ofAppiOSWindow());
 	#elif defined(TARGET_ANDROID)
-	shared_ptr<ofAppAndroidWindow> window = shared_ptr<ofAppAndroidWindow>(new ofAppAndroidWindow());
+	std::shared_ptr<ofAppAndroidWindow> window = std::shared_ptr<ofAppAndroidWindow>(new ofAppAndroidWindow());
 	#elif defined(TARGET_RASPBERRY_PI)
-	shared_ptr<ofAppEGLWindow> window = shared_ptr<ofAppEGLWindow>(new ofAppEGLWindow());
+	std::shared_ptr<ofAppEGLWindow> window = std::shared_ptr<ofAppEGLWindow>(new ofAppEGLWindow());
 	#elif defined(TARGET_EMSCRIPTEN)
-	shared_ptr<ofxAppEmscriptenWindow> window = shared_ptr<ofxAppEmscriptenWindow>(new ofxAppEmscriptenWindow);
+	std::shared_ptr<ofxAppEmscriptenWindow> window = std::shared_ptr<ofxAppEmscriptenWindow>(new ofxAppEmscriptenWindow);
 	#elif defined(TARGET_OPENGLES)
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+	std::shared_ptr<ofAppGLFWWindow> window = std::shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
 	#else
-	shared_ptr<ofAppGLFWWindow> window = shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
+	std::shared_ptr<ofAppGLFWWindow> window = std::shared_ptr<ofAppGLFWWindow>(new ofAppGLFWWindow());
 	#endif
 #endif
 	addWindow(window);
@@ -63,7 +63,7 @@ shared_ptr<ofAppBaseWindow> ofMainLoop::createWindow(const ofWindowSettings & se
 	return window;
 }
 
-void ofMainLoop::run(shared_ptr<ofAppBaseWindow> window, shared_ptr<ofBaseApp> && app){
+void ofMainLoop::run(std::shared_ptr<ofAppBaseWindow> window, std::shared_ptr<ofBaseApp> && app){
 	windowsApps[window] = app;
 	if(app){
 		ofAddListener(window->events().setup,app.get(),&ofBaseApp::setup,OF_EVENT_ORDER_APP);
@@ -155,8 +155,8 @@ void ofMainLoop::exit(){
 	exitEvent.notify(this);
 
 	for(auto i: windowsApps){
-		shared_ptr<ofAppBaseWindow> window = i.first;
-		shared_ptr<ofBaseApp> app = i.second;
+		std::shared_ptr<ofAppBaseWindow> window = i.first;
+		std::shared_ptr<ofBaseApp> app = i.second;
 		
 		if(window == nullptr) {
 			continue;
@@ -216,11 +216,11 @@ void ofMainLoop::exit(){
 	windowsApps.clear();
 }
 
-shared_ptr<ofAppBaseWindow> ofMainLoop::getCurrentWindow(){
+std::shared_ptr<ofAppBaseWindow> ofMainLoop::getCurrentWindow(){
 	return currentWindow.lock();
 }
 
-void ofMainLoop::setCurrentWindow(shared_ptr<ofAppBaseWindow> window){
+void ofMainLoop::setCurrentWindow(std::shared_ptr<ofAppBaseWindow> window){
 	currentWindow = window;
 }
 
@@ -236,7 +236,7 @@ void ofMainLoop::setCurrentWindow(ofAppBaseWindow * window){
 	}
 }
 
-shared_ptr<ofBaseApp> ofMainLoop::getCurrentApp(){
+std::shared_ptr<ofBaseApp> ofMainLoop::getCurrentApp(){
 	return windowsApps[currentWindow.lock()];
 }
 

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -45,7 +45,7 @@ public:
 	ofEvent<void> loopEvent;
 private:
 	void keyPressed(ofKeyEventArgs & key);
-	map<std::shared_ptr<ofAppBaseWindow>,std::shared_ptr<ofBaseApp> > windowsApps;
+	std::map<std::shared_ptr<ofAppBaseWindow>,std::shared_ptr<ofBaseApp> > windowsApps;
 	bool bShouldClose;
 	std::weak_ptr<ofAppBaseWindow> currentWindow;
 	int status;

--- a/libs/openFrameworks/communication/ofArduino.cpp
+++ b/libs/openFrameworks/communication/ofArduino.cpp
@@ -197,7 +197,7 @@ void ofArduino::disconnect(){
 }
 
 void ofArduino::update(){
-	vector <unsigned char> bytesToProcess;
+	std::vector <unsigned char> bytesToProcess;
 	int bytesToRead = _port.available();
 	if(bytesToRead > 0){
 		bytesToProcess.resize(bytesToRead);
@@ -234,11 +234,11 @@ int ofArduino::getPwm(int pin) const {
 	}
 }
 
-vector <unsigned char> ofArduino::getSysEx() const {
+std::vector <unsigned char> ofArduino::getSysEx() const {
 	return _sysExHistory.front();
 }
 
-string ofArduino::getString() const {
+std::string ofArduino::getString() const {
 	return _stringHistory.front();
 }
 
@@ -301,10 +301,10 @@ void ofArduino::sendPwm(int pin, int value, bool force){
 	}
 }
 
-void ofArduino::sendSysEx(int command, vector <unsigned char> data){
+void ofArduino::sendSysEx(int command, std::vector <unsigned char> data){
 	sendByte(FIRMATA_START_SYSEX);
 	sendByte(command);
-	vector <unsigned char>::iterator it = data.begin();
+	std::vector <unsigned char>::iterator it = data.begin();
 	while(it != data.end()){
 		//sendByte(*it);	// need to split data into 2 bytes before sending
 		sendValueAsTwo7bitBytes(*it);
@@ -321,10 +321,10 @@ void ofArduino::sendSysExEnd(){
 	sendByte(FIRMATA_END_SYSEX);
 }
 
-void ofArduino::sendString(string str){
+void ofArduino::sendString(std::string str){
 	sendByte(FIRMATA_START_SYSEX);
 	sendByte(FIRMATA_SYSEX_FIRMATA_STRING);
-	string::iterator it = str.begin();
+	std::string::iterator it = str.begin();
 	while(it != str.end()){
 		sendValueAsTwo7bitBytes(*it);
 		it++;
@@ -387,19 +387,19 @@ int ofArduino::getAnalogPinReporting(int pin) const {
 	return _analogPinReporting[pin];
 }
 
-list <int> * ofArduino::getAnalogHistory(int pin){
+std::list <int> * ofArduino::getAnalogHistory(int pin){
 	return &_analogHistory[pin];
 }
 
-list <int> * ofArduino::getDigitalHistory(int pin){
+std::list <int> * ofArduino::getDigitalHistory(int pin){
 	return &_digitalHistory[pin];
 }
 
-list <vector <unsigned char> > * ofArduino::getSysExHistory(){
+std::list <std::vector <unsigned char> > * ofArduino::getSysExHistory(){
 	return &_sysExHistory;
 }
 
-list <string> * ofArduino::getStringHistory(){
+std::list <std::string> * ofArduino::getStringHistory(){
 	return &_stringHistory;
 }
 
@@ -419,7 +419,7 @@ int ofArduino::getMinorFirmwareVersion() const {
 	return _minorFirmwareVersion;
 }
 
-string ofArduino::getFirmwareName() const {
+std::string ofArduino::getFirmwareName() const {
 	return _firmwareName;
 }
 
@@ -526,11 +526,11 @@ void ofArduino::processData(unsigned char inputData){
 }
 
 // sysex data is assumed to be 8-bit bytes split into two 7-bit bytes.
-void ofArduino::processSysExData(vector <unsigned char> data){
+void ofArduino::processSysExData(std::vector <unsigned char> data){
 
-	string str;
+	std::string str;
 
-	vector <unsigned char>::iterator it;
+	std::vector <unsigned char>::iterator it;
 	unsigned char buffer;
 	//int i = 1;
 

--- a/libs/openFrameworks/communication/ofArduino.h
+++ b/libs/openFrameworks/communication/ofArduino.h
@@ -227,11 +227,11 @@ class ofArduino {
 
 		void sendPwm(int pin, int value, bool force = false);
 
-		void sendSysEx(int command, vector <unsigned char> data);
+		void sendSysEx(int command, std::vector <unsigned char> data);
 
 		/// \brief Send a string to the Arduino
 		/// \note Firmata can not handle strings longer than 12 characters.
-		void sendString(string str);
+		void sendString(std::string str);
 
 		void sendProtocolVersionRequest();
 
@@ -297,10 +297,10 @@ class ofArduino {
 		int getAnalog(int pin) const;
 
 		/// \returns the last received SysEx message.
-		vector <unsigned char> getSysEx() const;
+		std::vector <unsigned char> getSysEx() const;
 
 		/// \returns the last received string.
-		string getString() const;
+		std::string getString() const;
 
 		/// \brief Returns the major firmware version
 		int getMajorProtocolVersion() const;
@@ -315,24 +315,24 @@ class ofArduino {
 		int getMinorFirmwareVersion() const;
 
 		/// \returns the name of the firmware.
-		string getFirmwareName() const;
+		std::string getFirmwareName() const;
 
 		/// \brief Returns a pointer to the digital data history list for the
 		/// given pin
 		/// \note Pin 16-21 can also be used if analog inputs 0-5 are used as
 		/// digital pins
 		/// \param pin The pin number (2-13)
-		list <int> * getDigitalHistory(int pin);
+		std::list <int> * getDigitalHistory(int pin);
 
 		/// \brief Returns a pointer to the analog data history list for the given pin.
 		/// \param pin The Arduino Uno pin: 0-5
-		list <int> * getAnalogHistory(int pin);
+		std::list <int> * getAnalogHistory(int pin);
 
 		/// \returns a pointer to the SysEx history.
-		list <vector <unsigned char> > * getSysExHistory();
+		std::list <std::vector <unsigned char> > * getSysExHistory();
 
 		/// \returns a pointer to the string history.
-		list <string> * getStringHistory();
+		std::list <std::string> * getStringHistory();
 
 		/// \brief Get the pin mode of the given pin
 		///
@@ -359,7 +359,7 @@ class ofArduino {
 
 		/// \brief Triggered when a SysEx message that isn't in the extended
 		/// command set is received, the SysEx message is passed as an argument
-		ofEvent <const vector <unsigned char> > ESysExReceived;
+		ofEvent <const std::vector <unsigned char> > ESysExReceived;
 
 		/// \brief Triggered when a protocol version is received, the major version
 		/// is passed as an argument.
@@ -376,7 +376,7 @@ class ofArduino {
 
 		/// \brief Triggered when a string is received, the string is passed as an
 		/// argument
-		ofEvent <const string> EStringReceived;
+		ofEvent <const std::string> EStringReceived;
 
 		/// \}
 		/// \name Servos
@@ -420,7 +420,7 @@ class ofArduino {
 
 		void processData(unsigned char inputData);
 		void processDigitalPort(int port, unsigned char value);
-		virtual void processSysExData(vector <unsigned char> data);
+		virtual void processSysExData(std::vector <unsigned char> data);
 
 		ofSerial _port;
 		int _portStatus;
@@ -438,26 +438,26 @@ class ofArduino {
 
 		// --- data holders
 		unsigned char _storedInputData[FIRMATA_MAX_DATA_BYTES];
-		vector <unsigned char> _sysExData;
+		std::vector <unsigned char> _sysExData;
 		int _majorProtocolVersion;
 		int _minorProtocolVersion;
 		int _majorFirmwareVersion;
 		int _minorFirmwareVersion;
-		string _firmwareName;
+		std::string _firmwareName;
 
 		// sum of majorFirmwareVersion * 10 + minorFirmwareVersion -> Firmata (?)
 		int _firmwareVersionSum;
 
-		list <vector <unsigned char> > _sysExHistory;
+		std::list <std::vector <unsigned char> > _sysExHistory;
 		// maintains a history of received sysEx messages (excluding SysEx messages in the extended command set)
 
-		list <string> _stringHistory;
+		std::list <std::string> _stringHistory;
 		// maintains a history of received strings
 
-		mutable list <int> _analogHistory[ARD_TOTAL_ANALOG_PINS];
+		mutable std::list <int> _analogHistory[ARD_TOTAL_ANALOG_PINS];
 		// a history of received data for each analog pin
 
-		mutable list <int> _digitalHistory[ARD_TOTAL_DIGITAL_PINS];
+		mutable std::list <int> _digitalHistory[ARD_TOTAL_DIGITAL_PINS];
 		// a history of received data for each digital pin
 
 		mutable int _digitalPinMode[ARD_TOTAL_DIGITAL_PINS];

--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -150,7 +150,7 @@ static bool isDeviceArduino( ofSerialDeviceInfo & A ){
 void ofSerial::buildDeviceList(){
 	deviceType = "serial";
 	devices.clear();
-	vector <string> prefixMatch;
+	std::vector <std::string> prefixMatch;
 
 	#ifdef TARGET_OSX
 
@@ -196,7 +196,7 @@ void ofSerial::buildDeviceList(){
 		ofLogNotice("ofSerial") << "found " << nPorts << " devices";
 		for(int i = 0; i < nPorts; i++){
 			//NOTE: we give the short port name for both as that is what the user should pass and the short name is more friendly
-			devices.push_back(ofSerialDeviceInfo(string(portNamesShort[i]), string(portNamesFriendly[i]), i));
+			devices.push_back(ofSerialDeviceInfo(std::string(portNamesShort[i]), std::string(portNamesFriendly[i]), i));
 		}
 
 	#endif
@@ -224,7 +224,7 @@ void ofSerial::listDevices(){
 }
 
 //----------------------------------------------------------------
-vector <ofSerialDeviceInfo> ofSerial::getDeviceList(){
+std::vector <ofSerialDeviceInfo> ofSerial::getDeviceList(){
 	buildDeviceList();
 	return devices;
 }
@@ -276,7 +276,7 @@ bool ofSerial::setup(int deviceNumber, int baud){
 }
 
 //----------------------------------------------------------------
-bool ofSerial::setup(string portName, int baud){
+bool ofSerial::setup(std::string portName, int baud){
 	bInited = false;
 
 	#if defined( TARGET_OSX ) || defined( TARGET_LINUX )

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -86,7 +86,7 @@ public:
 
 	/// \brief Returns a vector of ofSerialDeviceInfo instances with the
 	/// devicePath, deviceName, deviceID set.
-	vector <ofSerialDeviceInfo> getDeviceList();
+	std::vector <ofSerialDeviceInfo> getDeviceList();
 
 	/// \}
 	/// \name Serial Connection
@@ -114,7 +114,7 @@ public:
 	/// ofSerial mySerial;
 	/// mySerial.setup("COM4", 57600);
 	/// ~~~~
-	bool setup(string portName, int baudrate);
+	bool setup(std::string portName, int baudrate);
 
 	/// \brief Opens the serial port based on the order in which is listed and
 	/// sets the baud rate.
@@ -272,8 +272,8 @@ protected:
 	/// \see enumerateWin32Ports()
 	void buildDeviceList();
 
-	string deviceType;  ///\< \brief Name of the device on the other end of the serial connection.
-	vector <ofSerialDeviceInfo> devices;  ///\< This vector stores information about all serial devices found.
+	std::string deviceType;  ///\< \brief Name of the device on the other end of the serial connection.
+	std::vector <ofSerialDeviceInfo> devices;  ///\< This vector stores information about all serial devices found.
 	bool bHaveEnumeratedDevices;  ///\< \brief Indicate having enumerated devices (serial ports) available.
 	bool bInited;  ///\< \brief Indicate the successful initialization of the serial connection.
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -615,7 +615,7 @@ bool ofSendMessage(ofMessage msg){
 }
 
 //------------------------------------------
-bool ofSendMessage(string messageString){
+bool ofSendMessage(std::string messageString){
 	ofMessage msg(messageString);
 	return ofSendMessage(msg);
 }

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -19,7 +19,7 @@ int	ofGetPreviousMouseY();
 //-----------------------------------------------
 class ofDragInfo{
 	public:
-		vector <string> files;
+		std::vector <std::string> files;
 		glm::vec2 position;
 };
 
@@ -223,10 +223,10 @@ public:
 
 class ofMessage : public ofEventArgs{
 	public:
-		ofMessage( string msg ){
+		ofMessage( std::string msg ){
 			message = msg;
 		}
-		string message;
+		std::string message;
 };
 		
 enum ofTimeMode{
@@ -328,8 +328,8 @@ private:
 	int	currentMouseX, currentMouseY;
 	int	previousMouseX, previousMouseY;
 	bool bPreMouseNotSet;
-	set<int> pressedMouseButtons;
-	set<int> pressedKeys;
+	std::set<int> pressedMouseButtons;
+	std::set<int> pressedKeys;
 	int modifiers = 0;
 
 	enum TimeMode{
@@ -341,7 +341,7 @@ private:
 };
 
 bool ofSendMessage(ofMessage msg);
-bool ofSendMessage(string messageString);
+bool ofSendMessage(std::string messageString);
 
 ofCoreEvents & ofEvents();
 

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -42,7 +42,7 @@ ofBufferObject::ofBufferObject()
 }
 
 void ofBufferObject::allocate(){
-	data = shared_ptr<Data>(new Data());
+	data = std::shared_ptr<Data>(new Data());
 }
 
 void ofBufferObject::allocate(GLsizeiptr bytes, GLenum usage){

--- a/libs/openFrameworks/gl/ofBufferObject.h
+++ b/libs/openFrameworks/gl/ofBufferObject.h
@@ -20,7 +20,7 @@ public:
 	void allocate(GLsizeiptr bytes, const void * data, GLenum usage);
 
 	template<typename T>
-	void allocate(const vector<T> & data, GLenum usage){
+	void allocate(const std::vector<T> & data, GLenum usage){
 		allocate(data.size()*sizeof(T),&data[0],usage);
 	}
 
@@ -70,7 +70,7 @@ public:
 	/// typed version of setData, same functionality but guesses the size from the size
 	/// of the passed vector and size of the type
 	template<typename T>
-	void setData(const vector<T> & data, GLenum usage){
+	void setData(const std::vector<T> & data, GLenum usage){
 		setData(data.size()*sizeof(T),&data[0],usage);
 	}
 
@@ -82,14 +82,14 @@ public:
 	/// typed version of updateData, same functionality but guesses the size from the size
 	/// of the passed vector and size of the type
 	template<typename T>
-	void updateData(GLintptr offset, const vector<T> & data){
+	void updateData(GLintptr offset, const std::vector<T> & data){
 		updateData(offset,data.size()*sizeof(T),&data[0]);
 	}
 
     /// typed version of updateData, same functionality but guesses the size from the size
     /// of the passed vector and size of the type
     template<typename T>
-    void updateData(const vector<T> & data){
+    void updateData(const std::vector<T> & data){
         updateData(0,data.size()*sizeof(T),&data[0]);
     }
 
@@ -143,5 +143,5 @@ private:
 		GLenum lastTarget;
 		bool isBound;
 	};
-	shared_ptr<Data> data;
+	std::shared_ptr<Data> data;
 };

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -163,8 +163,8 @@ bool ofFbo::Settings::operator!=(const Settings & other){
 }
 
 //--------------------------------------------------------------
-static map<GLuint,int> & getIdsFB(){
-	static map<GLuint,int> * idsFB = new map<GLuint,int>;
+static std::map<GLuint,int> & getIdsFB(){
+	static std::map<GLuint,int> * idsFB = new std::map<GLuint,int>;
 	return *idsFB;
 }
 
@@ -192,8 +192,8 @@ static void releaseFB(GLuint id){
 }
 
 //--------------------------------------------------------------
-static map<GLuint,int> & getIdsRB(){
-	static map<GLuint,int> * idsRB = new map<GLuint,int>;
+static std::map<GLuint,int> & getIdsRB(){
+	static std::map<GLuint,int> * idsRB = new std::map<GLuint,int>;
 	return *idsRB;
 }
 
@@ -917,7 +917,7 @@ void ofFbo::flagDirty() const{
 		// flagged dirty at activation, so we can be sure all buffers which have 
 		// been rendered to are flagged dirty.
 		// 
-		int numBuffersToFlag = min(dirty.size(), activeDrawBuffers.size());
+		int numBuffersToFlag = std::min(dirty.size(), activeDrawBuffers.size());
 		for(int i=0; i < numBuffersToFlag; i++){
 			dirty[i] = true;
 		}
@@ -933,13 +933,13 @@ int ofFbo::getNumTextures() const {
 void ofFbo::setActiveDrawBuffer(int i){
 	if(!bIsAllocated) return;
 #ifndef TARGET_OPENGLES
-	vector<int> activebuffers(1, i);
+	std::vector<int> activebuffers(1, i);
 	setActiveDrawBuffers(activebuffers);
 #endif
 }
 
 //----------------------------------------------------------
-void ofFbo::setActiveDrawBuffers(const vector<int>& ids){
+void ofFbo::setActiveDrawBuffers(const std::vector<int>& ids){
 	if(!bIsAllocated) return;
 #ifndef TARGET_OPENGLES
     int numBuffers = activeDrawBuffers.size();
@@ -963,7 +963,7 @@ void ofFbo::setActiveDrawBuffers(const vector<int>& ids){
 void ofFbo::activateAllDrawBuffers(){
 	if(!bIsAllocated) return;
 #ifndef TARGET_OPENGLES
-    vector<int> activeBuffers(getNumTextures(),0);
+	std::vector<int> activeBuffers(getNumTextures(),0);
     for(int i=0; i < getNumTextures(); i++){
     	activeBuffers[i] = i;
     }

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -185,7 +185,7 @@ public:
 	int	getNumTextures() const;
 
 	void setActiveDrawBuffer(int i);
-	void setActiveDrawBuffers(const vector<int>& i);
+	void setActiveDrawBuffers(const std::vector<int>& i);
 	void activateAllDrawBuffers();
 
 	OF_DEPRECATED_MSG("Use getId()", GLuint getFbo() const);
@@ -209,7 +209,7 @@ public:
 		int		width;					// width of images attached to fbo
 		int		height;					// height of images attached to fbo
 		int		numColorbuffers;		// how many color buffers to create
-		vector<GLint> colorFormats;		// format of the color attachments for MRT.
+		std::vector<GLint> colorFormats;		// format of the color attachments for MRT.
 		bool	useDepth;				// whether to use depth buffer or not
 		bool	useStencil;				// whether to use stencil buffer or not
 		bool	depthStencilAsTexture;			// use a texture instead of a renderbuffer for depth (useful to draw it or use it in a shader later)
@@ -235,8 +235,8 @@ private:
 	GLuint				depthBuffer;
 	GLuint				stencilBuffer;
 
-	vector<GLuint>		colorBuffers;
-	vector<ofTexture>	textures;			
+	std::vector<GLuint>		colorBuffers;
+	std::vector<ofTexture>	textures;			
 
 	ofTexture			depthBufferTex;
 
@@ -244,7 +244,7 @@ private:
 	static int			_maxDrawBuffers;
 	static int			_maxSamples;
 
-	vector<GLenum>		activeDrawBuffers;  ///< table of currently active color draw buffers, allocate() defaults it to size(textures), with GL_COLOR_ATTACHMENT0..n as members, in order of allocation
+	std::vector<GLenum>		activeDrawBuffers;  ///< table of currently active color draw buffers, allocate() defaults it to size(textures), with GL_COLOR_ATTACHMENT0..n as members, in order of allocation
 
 	/// \brief  Flags used internally to keep track of MSAA renderbuffers / textures
 	/// \note   The dirty flags are only used when dealing if the framebuffer has MSAA 
@@ -254,7 +254,7 @@ private:
 	///         The flags are read whenever an attached texture is accessed. If the texture
 	///         is dirty, i.e. it has not yet been resolved from its associated renderbuffer
 	///         the texture will be resolved through blitting the renderbuffer into it.
-	mutable vector<bool> dirty;
+	mutable std::vector<bool> dirty;
 
 	int 				defaultTextureIndex; //used for getTextureReference
 	bool				bIsAllocated;

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -2703,8 +2703,8 @@ void ofGLProgrammableRenderer::saveScreen(int x, int y, int w, int h, ofPixels &
 		pixels.mirror(false,true);
 		break;
 	case OF_ORIENTATION_90_RIGHT:
-		swap(w,h);
-		swap(x,y);
+		std::swap(w,h);
+		std::swap(x,y);
 		if(!isVFlipped()){
 			x = sw - x;   // screen is flipped horizontally.
 			x -= w;
@@ -2718,8 +2718,8 @@ void ofGLProgrammableRenderer::saveScreen(int x, int y, int w, int h, ofPixels &
 		pixels.mirror(true,true);
 		break;
 	case OF_ORIENTATION_90_LEFT:
-		swap(w, h);
-		swap(x, y);
+		std::swap(w, h);
+		std::swap(x, y);
 		if(isVFlipped()){
 			x = sw - x;   // screen is flipped horizontally.
 			x -= w;

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -15,19 +15,19 @@
 #include "ofNode.h"
 
 
-static const string VIEW_MATRIX_UNIFORM="viewMatrix";
-static const string MODELVIEW_MATRIX_UNIFORM="modelViewMatrix";
-static const string PROJECTION_MATRIX_UNIFORM="projectionMatrix";
-static const string MODELVIEW_PROJECTION_MATRIX_UNIFORM="modelViewProjectionMatrix";
-static const string TEXTURE_MATRIX_UNIFORM="textureMatrix";
-static const string COLOR_UNIFORM="globalColor";
+static const std::string VIEW_MATRIX_UNIFORM="viewMatrix";
+static const std::string MODELVIEW_MATRIX_UNIFORM="modelViewMatrix";
+static const std::string PROJECTION_MATRIX_UNIFORM="projectionMatrix";
+static const std::string MODELVIEW_PROJECTION_MATRIX_UNIFORM="modelViewProjectionMatrix";
+static const std::string TEXTURE_MATRIX_UNIFORM="textureMatrix";
+static const std::string COLOR_UNIFORM="globalColor";
 
-static const string USE_TEXTURE_UNIFORM="usingTexture";
-static const string USE_COLORS_UNIFORM="usingColors";
-static const string BITMAP_STRING_UNIFORM="bitmapText";
+static const std::string USE_TEXTURE_UNIFORM="usingTexture";
+static const std::string USE_COLORS_UNIFORM="usingColors";
+static const std::string BITMAP_STRING_UNIFORM="bitmapText";
 
 
-const string ofGLProgrammableRenderer::TYPE="ProgrammableGL";
+const std::string ofGLProgrammableRenderer::TYPE="ProgrammableGL";
 static bool programmableRendererCreated = false;
 
 bool ofIsGLProgrammableRenderer(){
@@ -338,7 +338,7 @@ void ofGLProgrammableRenderer::draw(const ofPath & shape) const{
 			mut_this->setColor( shape.getStrokeColor(), shape.getStrokeColor().a);
 		}
 		mut_this->setLineWidth( shape.getStrokeWidth() );
-		const vector<ofPolyline> & outlines = shape.getOutline();
+		const std::vector<ofPolyline> & outlines = shape.getOutline();
 		for(int i=0; i<(int)outlines.size(); i++)
 			draw(outlines[i]);
 		mut_this->setLineWidth(lineWidth);
@@ -1682,7 +1682,7 @@ void ofGLProgrammableRenderer::drawEllipse(float x, float y, float z, float widt
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::drawString(string textString, float x, float y, float z) const{
+void ofGLProgrammableRenderer::drawString(std::string textString, float x, float y, float z) const{
 	ofGLProgrammableRenderer * mutThis = const_cast<ofGLProgrammableRenderer*>(this);
 	float sx = 0;
 	float sy = 0;
@@ -1835,7 +1835,7 @@ void ofGLProgrammableRenderer::drawString(string textString, float x, float y, f
 
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::drawString(const ofTrueTypeFont & font, string text, float x, float y) const{
+void ofGLProgrammableRenderer::drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const{
 	ofGLProgrammableRenderer * mutThis = const_cast<ofGLProgrammableRenderer*>(this);
 	ofBlendMode blendMode = currentStyle.blendingMode;
 
@@ -1856,14 +1856,14 @@ void ofGLProgrammableRenderer::drawString(const ofTrueTypeFont & font, string te
 // http://www.opengl.org/registry/doc/GLSLangSpec.1.50.09.pdf
 
 #ifdef TARGET_OPENGLES
-static const string vertex_shader_header =
+static const std::string vertex_shader_header =
 		"%extensions%\n"
 		"precision mediump float;\n"
 		"#define IN attribute\n"
 		"#define OUT varying\n"
 		"#define TEXTURE texture2D\n"
 		"#define TARGET_OPENGLES\n";
-static const string fragment_shader_header =
+static const std::string fragment_shader_header =
 		"%extensions%\n"
 		"precision mediump float;\n"
 		"#define IN varying\n"
@@ -1872,13 +1872,13 @@ static const string fragment_shader_header =
 		"#define FRAG_COLOR gl_FragColor\n"
 		"#define TARGET_OPENGLES\n";
 #else
-static const string vertex_shader_header =
+static const std::string vertex_shader_header =
 		"#version %glsl_version%\n"
 		"%extensions%\n"
 		"#define IN in\n"
 		"#define OUT out\n"
 		"#define TEXTURE texture\n";
-static const string fragment_shader_header =
+static const std::string fragment_shader_header =
 		"#version %glsl_version%\n"
 		"%extensions%\n"
 		"#define IN in\n"
@@ -1888,7 +1888,7 @@ static const string fragment_shader_header =
 		"out vec4 fragColor;\n";
 #endif
 
-static const string defaultVertexShader = vertex_shader_header + STRINGIFY(
+static const std::string defaultVertexShader = vertex_shader_header + STRINGIFY(
 	uniform mat4 projectionMatrix;
 	uniform mat4 modelViewMatrix;
 	uniform mat4 textureMatrix;
@@ -1913,7 +1913,7 @@ static const string defaultVertexShader = vertex_shader_header + STRINGIFY(
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderTexRectColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderTexRectColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2DRect src_tex_unit0;
 	uniform float usingTexture;
@@ -1932,7 +1932,7 @@ static const string defaultFragmentShaderTexRectColor = fragment_shader_header +
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderTexRectNoColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderTexRectNoColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2DRect src_tex_unit0;
 	uniform float usingTexture;
@@ -1950,7 +1950,7 @@ static const string defaultFragmentShaderTexRectNoColor = fragment_shader_header
 
 // ----------------------------------------------------------------------
 
-static const string alphaMaskFragmentShaderTexRectNoColor = fragment_shader_header + STRINGIFY(
+static const std::string alphaMaskFragmentShaderTexRectNoColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2DRect src_tex_unit0;
 	uniform sampler2DRect src_tex_unit1;
@@ -1969,7 +1969,7 @@ static const string alphaMaskFragmentShaderTexRectNoColor = fragment_shader_head
 
 // ----------------------------------------------------------------------
 
-static const string alphaMaskFragmentShaderTex2DNoColor = fragment_shader_header + STRINGIFY(
+static const std::string alphaMaskFragmentShaderTex2DNoColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2D src_tex_unit0;
 	uniform sampler2D src_tex_unit1;
@@ -1988,7 +1988,7 @@ static const string alphaMaskFragmentShaderTex2DNoColor = fragment_shader_header
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderTex2DColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderTex2DColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2D src_tex_unit0;
 	uniform float usingTexture;
@@ -2006,7 +2006,7 @@ static const string defaultFragmentShaderTex2DColor = fragment_shader_header + S
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderTex2DNoColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderTex2DNoColor = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2D src_tex_unit0;
 	uniform float usingTexture;
@@ -2023,7 +2023,7 @@ static const string defaultFragmentShaderTex2DNoColor = fragment_shader_header +
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderOESTexNoColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderOESTexNoColor = fragment_shader_header + STRINGIFY(
     
     uniform samplerExternalOES src_tex_unit0;
     uniform float usingTexture;
@@ -2041,7 +2041,7 @@ static const string defaultFragmentShaderOESTexNoColor = fragment_shader_header 
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderOESTexColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderOESTexColor = fragment_shader_header + STRINGIFY(
 																							
 	uniform samplerExternalOES src_tex_unit0;
 	uniform float usingTexture;
@@ -2059,7 +2059,7 @@ static const string defaultFragmentShaderOESTexColor = fragment_shader_header + 
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderNoTexColor = fragment_shader_header + STRINGIFY (
+static const std::string defaultFragmentShaderNoTexColor = fragment_shader_header + STRINGIFY (
 
 	uniform float usingTexture;
 	uniform float usingColors;
@@ -2076,7 +2076,7 @@ static const string defaultFragmentShaderNoTexColor = fragment_shader_header + S
 
 // ----------------------------------------------------------------------
 
-static const string defaultFragmentShaderNoTexNoColor = fragment_shader_header + STRINGIFY(
+static const std::string defaultFragmentShaderNoTexNoColor = fragment_shader_header + STRINGIFY(
 
 	uniform float usingTexture;
 	uniform float usingColors;
@@ -2093,7 +2093,7 @@ static const string defaultFragmentShaderNoTexNoColor = fragment_shader_header +
 
 // ----------------------------------------------------------------------
 
-static const string bitmapStringVertexShader = vertex_shader_header + STRINGIFY(
+static const std::string bitmapStringVertexShader = vertex_shader_header + STRINGIFY(
 
 	uniform mat4 projectionMatrix;
 	uniform mat4 modelViewMatrix;
@@ -2115,7 +2115,7 @@ static const string bitmapStringVertexShader = vertex_shader_header + STRINGIFY(
 
 // ----------------------------------------------------------------------
 
-static const string bitmapStringFragmentShader = fragment_shader_header + STRINGIFY(
+static const std::string bitmapStringFragmentShader = fragment_shader_header + STRINGIFY(
 
 	uniform sampler2D src_tex_unit0;
 	uniform vec4 globalColor;
@@ -2137,7 +2137,7 @@ static const string bitmapStringFragmentShader = fragment_shader_header + STRING
 // changing shaders in raspberry pi is very expensive so we use only one shader there
 // in desktop openGL these are not used but we declare it to avoid more ifdefs
 
-static const string uniqueVertexShader = vertex_shader_header + STRINGIFY(
+static const std::string uniqueVertexShader = vertex_shader_header + STRINGIFY(
         
 	uniform mat4 modelViewMatrix;
 	uniform mat4 projectionMatrix;
@@ -2164,7 +2164,7 @@ static const string uniqueVertexShader = vertex_shader_header + STRINGIFY(
 );
 
 // ----------------------------------------------------------------------
-static const string uniqueFragmentShader = fragment_shader_header + STRINGIFY(
+static const std::string uniqueFragmentShader = fragment_shader_header + STRINGIFY(
         
 	uniform sampler2D src_tex_unit0;
 	uniform float usingTexture;
@@ -2190,7 +2190,7 @@ static const string uniqueFragmentShader = fragment_shader_header + STRINGIFY(
 
 // ----------------------------------------------------------------------
 // video color space conversion shaders
-static const string FRAGMENT_SHADER_YUY2 = STRINGIFY(
+static const std::string FRAGMENT_SHADER_YUY2 = STRINGIFY(
 	uniform SAMPLER src_tex_unit0;\n
 	uniform vec4 globalColor;\n
 
@@ -2225,7 +2225,7 @@ static const string FRAGMENT_SHADER_YUY2 = STRINGIFY(
 );
 
 // ----------------------------------------------------------------------
-static const string FRAGMENT_SHADER_NV12_NV21 = STRINGIFY(
+static const std::string FRAGMENT_SHADER_NV12_NV21 = STRINGIFY(
 	uniform SAMPLER Ytex;\n
 	uniform SAMPLER UVtex;\n
 	uniform vec4 globalColor;\n
@@ -2253,7 +2253,7 @@ static const string FRAGMENT_SHADER_NV12_NV21 = STRINGIFY(
 );
 
 // ----------------------------------------------------------------------
-static const string FRAGMENT_SHADER_PLANAR_YUV = STRINGIFY(
+static const std::string FRAGMENT_SHADER_PLANAR_YUV = STRINGIFY(
 	uniform SAMPLER Ytex;\n
 	uniform SAMPLER Utex;\n
 	uniform SAMPLER Vtex;\n
@@ -2284,7 +2284,7 @@ static const string FRAGMENT_SHADER_PLANAR_YUV = STRINGIFY(
 	}\n
 );
 
-static string defaultShaderHeader(string header, GLenum textureTarget, int major, int minor){
+static std::string defaultShaderHeader(std::string header, GLenum textureTarget, int major, int minor){
 	ofStringReplace(header,"%glsl_version%",ofGLSLVersionFromGL(major,minor));
 #ifndef TARGET_OPENGLES
 	if(major<4 && minor<2){
@@ -2304,8 +2304,8 @@ static string defaultShaderHeader(string header, GLenum textureTarget, int major
 }
 
 
-static string shaderSource(const string & src, int major, int minor){
-	string shaderSrc = src;
+static std::string shaderSource(const std::string & src, int major, int minor){
+	std::string shaderSrc = src;
 	ofStringReplace(shaderSrc,"%glsl_version%",ofGLSLVersionFromGL(major,minor));
 #ifndef TARGET_OPENGLES
 	if(major<4 && minor<2){
@@ -2320,16 +2320,16 @@ static string shaderSource(const string & src, int major, int minor){
 }
 
 #ifdef TARGET_ANDROID
-static string shaderOESSource(const string & src, int major, int minor){
-	string shaderSrc = src;
+static std::string shaderOESSource(const std::string & src, int major, int minor){
+	std::string shaderSrc = src;
 	ofStringReplace(shaderSrc,"%glsl_version%",ofGLSLVersionFromGL(major,minor));
 	ofStringReplace(shaderSrc,"%extensions%","#extension GL_OES_EGL_image_external : require");
 	return shaderSrc;
 }
 #endif
 
-static string videoFragmentShaderSource(const ofBaseVideoDraws & video, int major, int minor){
-	string src;
+static std::string videoFragmentShaderSource(const ofBaseVideoDraws & video, int major, int minor){
+	std::string src;
 	switch(video.getPixelFormat()){
 		case OF_PIXELS_YUY2:
 			src = FRAGMENT_SHADER_YUY2;
@@ -2369,7 +2369,7 @@ static string videoFragmentShaderSource(const ofBaseVideoDraws & video, int majo
 			break;
 	}
 
-	string header = fragment_shader_header;
+	std::string header = fragment_shader_header;
 	GLenum textureTarget = video.getTexture().getTextureData().textureTarget;
 	if(textureTarget==GL_TEXTURE_2D){
 		header += "#define SAMPLER sampler2D\n";
@@ -2382,11 +2382,11 @@ static string videoFragmentShaderSource(const ofBaseVideoDraws & video, int majo
 	return shaderSource(header + src, major, minor);
 }
 
-string ofGLProgrammableRenderer::defaultVertexShaderHeader(GLenum textureTarget){
+std::string ofGLProgrammableRenderer::defaultVertexShaderHeader(GLenum textureTarget){
 	return defaultShaderHeader(vertex_shader_header,textureTarget,major,minor);
 }
 
-string ofGLProgrammableRenderer::defaultFragmentShaderHeader(GLenum textureTarget){
+std::string ofGLProgrammableRenderer::defaultFragmentShaderHeader(GLenum textureTarget){
 	return defaultShaderHeader(fragment_shader_header,textureTarget,major,minor);
 }
 

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -21,8 +21,8 @@ public:
 
 	void setup(int glVersionMajor, int glVersionMinor);
 
-    static const string TYPE;
-	const string & getType(){ return TYPE; }
+    static const std::string TYPE;
+	const std::string & getType(){ return TYPE; }
     
     void startRender();
     void finishRender();
@@ -163,8 +163,8 @@ public:
 	void drawTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3) const;
 	void drawCircle(float x, float y, float z, float radius) const;
 	void drawEllipse(float x, float y, float z, float width, float height) const;
-	void drawString(string text, float x, float y, float z) const;
-	void drawString(const ofTrueTypeFont & font, string text, float x, float y) const;
+	void drawString(std::string text, float x, float y, float z) const;
+	void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const;
 
 
 	void enableTextureTarget(const ofTexture & tex, int textureLocation);
@@ -223,8 +223,8 @@ public:
 	void setLightPosition(int lightIndex, const glm::vec4 & position){}
 	void setLightSpotDirection(int lightIndex, const glm::vec4 & direction){}
 
-	string defaultVertexShaderHeader(GLenum textureTarget);
-	string defaultFragmentShaderHeader(GLenum textureTarget);
+	std::string defaultVertexShaderHeader(GLenum textureTarget);
+	std::string defaultFragmentShaderHeader(GLenum textureTarget);
 
 	int getGLVersionMajor();
 	int getGLVersionMinor();
@@ -277,7 +277,7 @@ private:
 	int alphaMaskTextureTarget;
 
 	ofStyle currentStyle;
-	deque <ofStyle> styleHistory;
+	std::deque <ofStyle> styleHistory;
 	of3dGraphics graphics3d;
 	ofBitmapFont bitmapFont;
 	ofPath path;
@@ -317,7 +317,7 @@ private:
 	//void setFramebufferId(const GLuint& fboId_); // sets the current framebuffer id
 
 	// framebuffer binding state
-	deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
+	std::deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
     GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
 };

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -13,7 +13,7 @@
 #include "ofTrueTypeFont.h"
 #include "ofNode.h"
 
-const string ofGLRenderer::TYPE="GL";
+const std::string ofGLRenderer::TYPE="GL";
 
 //----------------------------------------------------------
 ofGLRenderer::ofGLRenderer(const ofAppBaseWindow * _window)
@@ -98,7 +98,7 @@ void ofGLRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode renderType, 
 					glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 					glTexCoordPointer(2, GL_FLOAT, sizeof(glm::vec2), &vertexData.getTexCoordsPointer()->x);
 			}else{
-				set<int>::iterator textureLocation = textureLocationsEnabled.begin();
+				std::set<int>::iterator textureLocation = textureLocationsEnabled.begin();
 				for(;textureLocation!=textureLocationsEnabled.end();textureLocation++){
 					glActiveTexture(GL_TEXTURE0+*textureLocation);
 					glClientActiveTexture(GL_TEXTURE0+*textureLocation);
@@ -150,7 +150,7 @@ void ofGLRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode renderType, 
 					glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 					glTexCoordPointer(2, GL_FLOAT, sizeof(ofVec2f), &vertexData.getTexCoordsPointer()->x);
 			}else{
-				set<int>::iterator textureLocation = textureLocationsEnabled.begin();
+					std::set<int>::iterator textureLocation = textureLocationsEnabled.begin();
 				for(;textureLocation!=textureLocationsEnabled.end();textureLocation++){
 					glActiveTexture(GL_TEXTURE0+*textureLocation);
 					glClientActiveTexture(GL_TEXTURE0+*textureLocation);
@@ -295,7 +295,7 @@ void ofGLRenderer::draw(const ofPath & shape) const{
 			mut_this->setColor( shape.getStrokeColor(), shape.getStrokeColor().a);
 		}
 		mut_this->setLineWidth( shape.getStrokeWidth() );
-		const vector<ofPolyline> & outlines = shape.getOutline();
+		const std::vector<ofPolyline> & outlines = shape.getOutline();
 		for(int i=0; i<(int)outlines.size(); i++)
 			draw(outlines[i]);
 		mut_this->setLineWidth(lineWidth);
@@ -997,7 +997,7 @@ void ofGLRenderer::loadViewMatrix(const glm::mat4 & m){
 
 	if(lightingEnabled){
 		for(size_t i=0;i<ofLightsData().size();i++){
-			shared_ptr<ofLight::Data> lightData = ofLightsData()[i].lock();
+			std::shared_ptr<ofLight::Data> lightData = ofLightsData()[i].lock();
 			if(lightData && lightData->isEnabled){
 				glLightfv(GL_LIGHT0 + lightData->glIndex, GL_POSITION, &lightData->position.x);
 				if(lightData->lightType == OF_LIGHT_SPOT || lightData->lightType == OF_LIGHT_AREA) {
@@ -1502,7 +1502,7 @@ void ofGLRenderer::drawEllipse(float x, float y, float z, float width, float hei
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::drawString(string textString, float x, float y, float z) const{
+void ofGLRenderer::drawString(std::string textString, float x, float y, float z) const{
 
 	ofGLRenderer * mutThis = const_cast<ofGLRenderer*>(this);
 	float sx = 0;
@@ -1678,7 +1678,7 @@ void ofGLRenderer::drawString(string textString, float x, float y, float z) cons
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::drawString(const ofTrueTypeFont & font, string text, float x, float y) const{
+void ofGLRenderer::drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const{
 	ofGLRenderer * mutThis = const_cast<ofGLRenderer*>(this);
 	bool blendEnabled = glIsEnabled(GL_BLEND);
 	GLint blend_src, blend_dst;

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -1960,8 +1960,8 @@ void ofGLRenderer::saveScreen(int x, int y, int w, int h, ofPixels & pixels){
 		pixels.mirror(false,true);
 		break;
 	case OF_ORIENTATION_90_RIGHT:
-		swap(w,h);
-		swap(x,y);
+		std::swap(w,h);
+		std::swap(x,y);
 		if(!isVFlipped()){
 			x = sw - x;   // screen is flipped horizontally.
 			x -= w;
@@ -1975,8 +1975,8 @@ void ofGLRenderer::saveScreen(int x, int y, int w, int h, ofPixels & pixels){
 		pixels.mirror(true,true);
 		break;
 	case OF_ORIENTATION_90_LEFT:
-		swap(w, h);
-		swap(x, y);
+		std::swap(w, h);
+		std::swap(x, y);
 		if(isVFlipped()){
 			x = sw - x;   // screen is flipped horizontally.
 			x -= w;

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -17,8 +17,8 @@ public:
 	ofGLRenderer(const ofAppBaseWindow * window);
 	~ofGLRenderer(){}
 
-    static const string TYPE;
-    const string & getType(){ return TYPE; }
+    static const std::string TYPE;
+    const std::string & getType(){ return TYPE; }
 
     void setup();
 
@@ -159,8 +159,8 @@ public:
 	void drawTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3) const;
 	void drawCircle(float x, float y, float z, float radius) const;
 	void drawEllipse(float x, float y, float z, float width, float height) const;
-	void drawString(string text, float x, float y, float z) const;
-	void drawString(const ofTrueTypeFont & font, string text, float x, float y) const;
+	void drawString(std::string text, float x, float y, float z) const;
+	void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const;
 
 
 	// gl specifics
@@ -226,28 +226,28 @@ private:
 
 	bool bBackgroundAuto;
 
-	mutable vector<glm::vec3> linePoints;
-	mutable vector<glm::vec3> rectPoints;
-	mutable vector<glm::vec3> triPoints;
-	mutable vector<glm::vec3> circlePoints;
+	mutable std::vector<glm::vec3> linePoints;
+	mutable std::vector<glm::vec3> rectPoints;
+	mutable std::vector<glm::vec3> triPoints;
+	mutable std::vector<glm::vec3> circlePoints;
 	ofPolyline circlePolyline;
 
 	ofMatrixStack matrixStack;
 	bool normalsEnabled;
 	bool lightingEnabled;
         bool materialBound;
-	set<int> textureLocationsEnabled;
+	std::set<int> textureLocationsEnabled;
 
 	int alphaMaskTextureTarget;
 
 	ofStyle currentStyle;
-	deque <ofStyle> styleHistory;
+	std::deque <ofStyle> styleHistory;
 	of3dGraphics graphics3d;
 	ofBitmapFont bitmapFont;
 	ofPath path;
 	const ofAppBaseWindow * window;
 
-	deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
+	std::deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
 	GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
 

--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -79,7 +79,7 @@ int ofGetGlInternalFormat(const ofFloatPixels& pix) {
 
 //---------------------------------
 // this is helpful for debugging ofTexture
-string ofGetGlInternalFormatName(int glInternalFormat) {
+std::string ofGetGlInternalFormatName(int glInternalFormat) {
 	switch(glInternalFormat) {
 		case GL_RGBA: return "GL_RGBA";
 #ifndef TARGET_OPENGLES
@@ -720,14 +720,14 @@ void ofSetPixelStoreiAlignment(GLenum pname, int stride){
     }
 }
 
-vector<string> ofGLSupportedExtensions(){
+std::vector<std::string> ofGLSupportedExtensions(){
 #ifdef TARGET_OPENGLES
 	char* extensions = (char*)glGetString(GL_EXTENSIONS);
 	if(extensions){
-		string extensions_str = extensions;
+		std::string extensions_str = extensions;
 		return ofSplitString(extensions_str," ");
 	}else{
-		return vector<string>();
+		return std::vector<std::string>();
 	}
 #else
 	int numExtensions=0;
@@ -743,10 +743,10 @@ vector<string> ofGLSupportedExtensions(){
 #endif
 }
 
-bool ofGLCheckExtension(string searchName){
+bool ofGLCheckExtension(std::string searchName){
 #if defined( TARGET_OPENGLES )
-	vector<string> extensionsList = ofGLSupportedExtensions();
-	set<string> extensionsSet;
+	std::vector<std::string> extensionsList = ofGLSupportedExtensions();
+	std::set<std::string> extensionsSet;
 	extensionsSet.insert(extensionsList.begin(),extensionsList.end());
 	return extensionsSet.find(searchName)!=extensionsSet.end();
 #else
@@ -761,8 +761,8 @@ bool ofGLSupportsNPOTTextures(){
 	static bool npotChecked = false;
 	static bool npotSupported = false;
 	if(!npotChecked){
-		vector<string> extensionsList = ofGLSupportedExtensions();
-		set<string> extensionsSet;
+		std::vector<std::string> extensionsList = ofGLSupportedExtensions();
+		std::set<std::string> extensionsSet;
 		extensionsSet.insert(extensionsList.begin(),extensionsList.end());
 
 		npotSupported = extensionsSet.find("GL_OES_texture_npot")!=extensionsSet.end() ||
@@ -779,7 +779,7 @@ bool ofGLSupportsNPOTTextures(){
 #endif
 }
 
-string ofGLSLVersionFromGL(int major, int minor){
+std::string ofGLSLVersionFromGL(int major, int minor){
 #ifdef TARGET_OPENGLES
 	return "ES1";
 #else
@@ -803,23 +803,23 @@ string ofGLSLVersionFromGL(int major, int minor){
 }
 
 #ifndef TARGET_PROGRAMMABLE_GL
-shared_ptr<ofBaseGLRenderer> ofGetGLRenderer(){
+std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer(){
 	if(ofGetCurrentRenderer()->getType()==ofGLRenderer::TYPE || ofGetCurrentRenderer()->getType()==ofGLProgrammableRenderer::TYPE){
-		return (shared_ptr<ofBaseGLRenderer>&)ofGetCurrentRenderer();
+		return (std::shared_ptr<ofBaseGLRenderer>&)ofGetCurrentRenderer();
 	}else if(ofGetCurrentRenderer()->getType()==ofRendererCollection::TYPE){
-		return ((shared_ptr<ofRendererCollection>&)ofGetCurrentRenderer())->getGLRenderer();
+		return ((std::shared_ptr<ofRendererCollection>&)ofGetCurrentRenderer())->getGLRenderer();
 	}else{
-		return shared_ptr<ofGLRenderer>();
+		return std::shared_ptr<ofGLRenderer>();
 	}
 }
 #else
-shared_ptr<ofBaseGLRenderer> ofGetGLRenderer(){
+std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer(){
 	if(ofGetCurrentRenderer()->getType()==ofGLProgrammableRenderer::TYPE){
-		return (shared_ptr<ofBaseGLRenderer>&)ofGetCurrentRenderer();
+		return (std::shared_ptr<ofBaseGLRenderer>&)ofGetCurrentRenderer();
 	}else if(ofGetCurrentRenderer()->getType()==ofRendererCollection::TYPE){
-		return ((shared_ptr<ofRendererCollection>&)ofGetCurrentRenderer())->getGLRenderer();
+		return ((std::shared_ptr<ofRendererCollection>&)ofGetCurrentRenderer())->getGLRenderer();
 	}else{
-		return shared_ptr<ofGLProgrammableRenderer>();
+		return std::shared_ptr<ofGLProgrammableRenderer>();
 	}
 }
 #endif
@@ -841,7 +841,7 @@ void ofReloadGLResources(){
 #ifndef TARGET_OPENGLES
 namespace{
 	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, void * user){
-		ostringstream oss;
+		std::ostringstream oss;
 		oss << "GL Debug: ";
 		
 		ofLogLevel level;

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -46,11 +46,11 @@ int ofGetGlInternalFormat(const ofFloatPixels& pix);
 
 //---------------------------------
 // this is helpful for debugging ofTexture
-string ofGetGlInternalFormatName(int glInternalFormat);
+std::string ofGetGlInternalFormatName(int glInternalFormat);
 int ofGetGLFormatFromInternal(int glInternalFormat);
 int ofGetGlTypeFromInternal(int glInternalFormat);
 
-shared_ptr<ofBaseGLRenderer> ofGetGLRenderer();
+std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer();
 
 
 int ofGetGlType(const ofPixels & pixels);
@@ -75,8 +75,8 @@ int ofGetNumChannelsFromGLFormat(int glFormat);
 void ofSetPixelStoreiAlignment(GLenum pname, int w, int bpc, int numChannels);
 void ofSetPixelStoreiAlignment(GLenum panme, int stride);
 
-vector<string> ofGLSupportedExtensions();
-bool ofGLCheckExtension(string searchName);
+std::vector<std::string> ofGLSupportedExtensions();
+bool ofGLCheckExtension(std::string searchName);
 bool ofGLSupportsNPOTTextures();
 
 bool ofIsGLProgrammableRenderer();
@@ -86,7 +86,7 @@ int ofGetGlFormat(const ofPixels_<T> & pixels) {
 	return ofGetGLFormatFromPixelFormat(pixels.getPixelFormat());
 }
 
-string ofGLSLVersionFromGL(int major, int minor);
+std::string ofGLSLVersionFromGL(int major, int minor);
 
 #ifndef TARGET_OPENGLES
 void ofEnableGLDebugLog();

--- a/libs/openFrameworks/gl/ofLight.cpp
+++ b/libs/openFrameworks/gl/ofLight.cpp
@@ -57,8 +57,8 @@ const ofFloatColor & ofGetGlobalAmbientColor(){
 }
 
 //----------------------------------------
-vector<weak_ptr<ofLight::Data> > & ofLightsData(){
-	static vector<weak_ptr<ofLight::Data> > * lightsActive = ofIsGLProgrammableRenderer()?new vector<weak_ptr<ofLight::Data> >:new vector<weak_ptr<ofLight::Data> >(8);
+std::vector<std::weak_ptr<ofLight::Data> > & ofLightsData(){
+	static std::vector<std::weak_ptr<ofLight::Data> > * lightsActive = ofIsGLProgrammableRenderer()?new std::vector<std::weak_ptr<ofLight::Data> >:new std::vector<std::weak_ptr<ofLight::Data> >(8);
 	return *lightsActive;
 }
 

--- a/libs/openFrameworks/gl/ofLight.h
+++ b/libs/openFrameworks/gl/ofLight.h
@@ -108,7 +108,7 @@ public:
 	
 private:
 	void customDraw(const ofBaseRenderer * renderer) const;
-	shared_ptr<Data> data;
+	std::shared_ptr<Data> data;
 	// update opengl light 
 	// this method overrides ofNode to catch the changes and update glLightv(GL_POSITION)
 	virtual void onPositionChanged();
@@ -116,4 +116,4 @@ private:
 };
 
 
-vector<weak_ptr<ofLight::Data> > & ofLightsData();
+std::vector<std::weak_ptr<ofLight::Data> > & ofLightsData();

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -8,8 +8,8 @@
 std::map<ofGLProgrammableRenderer*, std::map<std::string, std::weak_ptr<ofMaterial::Shaders>>> ofMaterial::shadersMap;
 
 namespace{
-string vertexSource(string defaultHeader, int maxLights, bool hasTexture, bool hasColor);
-string fragmentSource(string defaultHeader, string customUniforms, string postFragment, int maxLights, bool hasTexture, bool hasColor);
+    std::string vertexSource(std::string defaultHeader, int maxLights, bool hasTexture, bool hasColor);
+    std::string fragmentSource(std::string defaultHeader, std::string customUniforms, std::string postFragment, int maxLights, bool hasTexture, bool hasColor);
 }
 
 
@@ -115,11 +115,11 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
 
     if(shaders[&renderer] == nullptr){
         #ifndef TARGET_OPENGLES
-            string vertexRectHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_RECTANGLE);
-            string fragmentRectHeader = renderer.defaultFragmentShaderHeader(GL_TEXTURE_RECTANGLE);
+	std::string vertexRectHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_RECTANGLE);
+	std::string fragmentRectHeader = renderer.defaultFragmentShaderHeader(GL_TEXTURE_RECTANGLE);
         #endif
-        string vertex2DHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_2D);
-        string fragment2DHeader = renderer.defaultFragmentShaderHeader(GL_TEXTURE_2D);
+	std::string vertex2DHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_2D);
+	std::string fragment2DHeader = renderer.defaultFragmentShaderHeader(GL_TEXTURE_2D);
         auto numLights = ofLightsData().size();
         shaders[&renderer].reset(new Shaders);
         shaders[&renderer]->numLights = numLights;
@@ -237,8 +237,8 @@ void ofMaterial::updateMaterial(const ofShader & shader,ofGLProgrammableRenderer
 
 void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer & renderer) const{
 	for(size_t i=0;i<ofLightsData().size();i++){
-		string idx = ofToString(i);
-		shared_ptr<ofLight::Data> light = ofLightsData()[i].lock();
+		std::string idx = ofToString(i);
+		std::shared_ptr<ofLight::Data> light = ofLightsData()[i].lock();
 		if(!light || !light->isEnabled){
 			shader.setUniform1f("lights["+idx+"].enabled",0);
 			continue;
@@ -332,7 +332,7 @@ void ofMaterial::setCustomUniformTexture(const std::string & name, const ofTextu
 	uniformstex[name] = {value.getTextureData().textureTarget, int(value.getTextureData().textureID), textureLocation};
 }
 
-void ofMaterial::setCustomUniformTexture(const string & name, int textureTarget, GLint textureID, int textureLocation){
+void ofMaterial::setCustomUniformTexture(const std::string & name, int textureTarget, GLint textureID, int textureLocation){
 	uniformstex[name] = {textureTarget, textureID, textureLocation};
 }
 
@@ -340,8 +340,8 @@ void ofMaterial::setCustomUniformTexture(const string & name, int textureTarget,
 #include "shaders/phong.frag"
 
 namespace{
-    string shaderHeader(string header, int maxLights, bool hasTexture, bool hasColor){
-        header += "#define MAX_LIGHTS " + ofToString(max(1,maxLights)) + "\n";
+    std::string shaderHeader(std::string header, int maxLights, bool hasTexture, bool hasColor){
+        header += "#define MAX_LIGHTS " + ofToString(std::max(1,maxLights)) + "\n";
         if(hasTexture){
             header += "#define HAS_TEXTURE 1\n";
 		} else {
@@ -355,11 +355,11 @@ namespace{
         return header;
     }
 
-    string vertexSource(string defaultHeader, int maxLights, bool hasTexture, bool hasColor){
+    std::string vertexSource(std::string defaultHeader, int maxLights, bool hasTexture, bool hasColor){
         return shaderHeader(defaultHeader, maxLights, hasTexture, hasColor) + vertexShader;
     }
 
-    string fragmentSource(string defaultHeader, string customUniforms,  string postFragment, int maxLights, bool hasTexture, bool hasColor){
+    std::string fragmentSource(std::string defaultHeader, std::string customUniforms, std::string postFragment, int maxLights, bool hasTexture, bool hasColor){
         auto source = fragmentShader;
         if(postFragment.empty()){
             postFragment = "vec4 postFragment(vec4 localColor){ return localColor; }";

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -170,7 +170,7 @@ public:
 	void setCustomUniform3i(const std::string & name, glm::tvec3<int> value);
 	void setCustomUniform4i(const std::string & name, glm::tvec4<int> value);
 	void setCustomUniformTexture(const std::string & name, const ofTexture & value, int textureLocation);
-	void setCustomUniformTexture(const string & name, int textureTarget, GLint textureID, int textureLocation);
+	void setCustomUniformTexture(const std::string & name, int textureTarget, GLint textureID, int textureLocation);
 
 
 
@@ -199,8 +199,8 @@ private:
 
 	mutable std::map<ofGLProgrammableRenderer*,std::shared_ptr<Shaders>> shaders;
 	static std::map<ofGLProgrammableRenderer*, std::map<std::string,std::weak_ptr<Shaders>>> shadersMap;
-	static string vertexShader;
-	static string fragmentShader;
+	static std::string vertexShader;
+	static std::string fragmentShader;
 	std::map<std::string, float> uniforms1f;
 	std::map<std::string, glm::vec2> uniforms2f;
 	std::map<std::string, glm::vec3> uniforms3f;

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -18,18 +18,18 @@
 #endif
 
 
-static const string COLOR_ATTRIBUTE="color";
-static const string POSITION_ATTRIBUTE="position";
-static const string NORMAL_ATTRIBUTE="normal";
-static const string TEXCOORD_ATTRIBUTE="texcoord";
+static const std::string COLOR_ATTRIBUTE="color";
+static const std::string POSITION_ATTRIBUTE="position";
+static const std::string NORMAL_ATTRIBUTE="normal";
+static const std::string TEXCOORD_ATTRIBUTE="texcoord";
 
-static map<GLuint,int> & getShaderIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static std::map<GLuint,int> & getShaderIds(){
+	static std::map<GLuint,int> * ids = new std::map<GLuint,int>;
 	return *ids;
 }
 
-static map<GLuint,int> & getProgramIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static std::map<GLuint,int> & getProgramIds(){
+	static std::map<GLuint,int> * ids = new std::map<GLuint,int>;
 	return *ids;
 }
 
@@ -292,8 +292,8 @@ bool ofShader::setupShaderFromFile(GLenum type, const std::filesystem::path& fil
 	ofBuffer buffer = ofBufferFromFile(filename);
 	// we need to make absolutely sure to have an absolute path here, so that any #includes
 	// within the shader files have a root directory to traverse from.
-	string absoluteFilePath = ofFilePath::getAbsolutePath(filename, true);
-	string sourceDirectoryPath = ofFilePath::getEnclosingDirectory(absoluteFilePath,false);
+	std::string absoluteFilePath = ofFilePath::getAbsolutePath(filename, true);
+	std::string sourceDirectoryPath = ofFilePath::getEnclosingDirectory(absoluteFilePath,false);
 	if(buffer.size()) {
 		return setupShaderFromSource(type, buffer.getText(), sourceDirectoryPath);
 	} else {
@@ -307,8 +307,8 @@ ofShader::Source ofShader::sourceFromFile(GLenum type, const std::filesystem::pa
 	ofBuffer buffer = ofBufferFromFile(filename);
 	// we need to make absolutely sure to have an absolute path here, so that any #includes
 	// within the shader files have a root directory to traverse from.
-	string absoluteFilePath = ofFilePath::getAbsolutePath(filename, true);
-	string sourceDirectoryPath = ofFilePath::getEnclosingDirectory(absoluteFilePath,false);
+	std::string absoluteFilePath = ofFilePath::getAbsolutePath(filename, true);
+	std::string sourceDirectoryPath = ofFilePath::getEnclosingDirectory(absoluteFilePath,false);
 	if(buffer.size()) {
 		return Source{type, buffer.getText(), sourceDirectoryPath};
 	} else {
@@ -318,7 +318,7 @@ ofShader::Source ofShader::sourceFromFile(GLenum type, const std::filesystem::pa
 }
 
 //--------------------------------------------------------------
-bool ofShader::setupShaderFromSource(GLenum type, string source, string sourceDirectoryPath) {
+bool ofShader::setupShaderFromSource(GLenum type, std::string source, std::string sourceDirectoryPath) {
 	return setupShaderFromSource({type, source, sourceDirectoryPath});
 }
 
@@ -409,21 +409,21 @@ bool ofShader::setupShaderFromSource(ofShader::Source && source){
  */
 
 //--------------------------------------------------------------
-string ofShader::parseForIncludes( const string& source, const std::filesystem::path& sourceDirectoryPath) {
-	vector<string> included;
+std::string ofShader::parseForIncludes( const std::string& source, const std::filesystem::path& sourceDirectoryPath) {
+	std::vector<std::string> included;
 	return parseForIncludes( source, included, 0, sourceDirectoryPath);
 }
 
 //--------------------------------------------------------------
-string ofShader::parseForIncludes( const string& source, vector<string>& included, int level, const std::filesystem::path& sourceDirectoryPath) {
+std::string ofShader::parseForIncludes( const std::string& source, std::vector<std::string>& included, int level, const std::filesystem::path& sourceDirectoryPath) {
 
 	if ( level > 32 ) {
 		ofLogError( "ofShader", "glsl header inclusion depth limit reached, might be caused by cyclic header inclusion" );
 		return "";
 	}
 
-	stringstream output;
-	stringstream input;
+	std::stringstream output;
+	std::stringstream input;
 	input << source;
 
 	auto match_pragma_include = [](const std::string& s_, std::string& filename_) -> bool {
@@ -463,13 +463,13 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 	// once std::regex is available across the board, use this regex in favour of the above lambda:
 	// std::regex re("^\\s*#\\s*pragma\\s+include\\s+[\"<](.*)[\">].*");
 
-	string line;
+	std::string line;
 	while( std::getline( input, line ) ) {
 
-		string include;
+		std::string include;
 
 		if (!match_pragma_include(line, include)){
-			output << line << endl;
+			output << line << std::endl;
 			continue;
 		};
 
@@ -491,15 +491,15 @@ string ofShader::parseForIncludes( const string& source, vector<string>& include
 			continue;
 		}
 
-		string currentDir = ofFile(include).getEnclosingDirectory();
-		output << parseForIncludes( buffer.getText(), included, level + 1, currentDir ) << endl;
+		std::string currentDir = ofFile(include).getEnclosingDirectory();
+		output << parseForIncludes( buffer.getText(), included, level + 1, currentDir ) << std::endl;
 	}
 
 	return output.str();
 }
 
 //--------------------------------------------------------------
-string ofShader::getShaderSource(GLenum type)  const{
+std::string ofShader::getShaderSource(GLenum type)  const{
 	auto source = shaders.find(type);
 	if ( source != shaders.end()) {
 		return source->second.source.expandedSource;
@@ -579,18 +579,18 @@ void ofShader::checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLeve
 			std::regex nvidia_ati("^.*[(:]{1}(\\d+)[:)]{1}.*");
 			std::regex intel("^[0-9]+:([0-9]+)\\([0-9]+\\):.*$");
 			std::smatch matches;
-			string infoString = ofTrim(infoBuffer);
+			std::string infoString = ofTrim(infoBuffer);
 			if (std::regex_search(infoString, matches, intel) || std::regex_search(infoString, matches, nvidia_ati)){
 				ofBuffer buf;
 				buf.set(shaders[type].source.expandedSource);
 				ofBuffer::Line line = buf.getLines().begin();
 				int  offendingLineNumber = ofToInt(matches[1]);
-				ostringstream msg;
-				msg << "ofShader: " + nameForType(type) + ", offending line " << offendingLineNumber << " :"<< endl;
+				std::ostringstream msg;
+				msg << "ofShader: " + nameForType(type) + ", offending line " << offendingLineNumber << " :"<< std::endl;
 				for(int i=0; line != buf.getLines().end(); line++, i++ ){
-					string s = *line;
+					std::string s = *line;
 					if ( i >= offendingLineNumber -3 && i < offendingLineNumber + 2 ){
-						msg << "\t" << setw(5) << (i+1) << "\t" << s << endl;
+						msg << "\t" << std::setw(5) << (i+1) << "\t" << s << std::endl;
 					}
 				}
 				ofLog(logLevel) << msg.str();
@@ -616,7 +616,7 @@ void ofShader::checkProgramInfoLog() {
 		// We need to find a robust way of extracing this information from
 		// the log, and unfortunately can't use regex whilst gcc on RPi is assumed to
 		// be < 4.9, which is the first version fully supporting this c++11 feature.
-		string msg = "ofShader: program reports:\n";
+		std::string msg = "ofShader: program reports:\n";
 		ofLogError("ofShader") << msg + infoBuffer.getText();
 #ifdef TARGET_RAPSBERRY_PI
 		for(auto it: shaders){
@@ -677,10 +677,10 @@ bool ofShader::linkProgram() {
 		GLenum type = 0;
 		GLsizei length;
 		GLint location;
-		vector<GLchar> uniformName(uniformMaxLength);
+		std::vector<GLchar> uniformName(uniformMaxLength);
 		for(GLint i = 0; i < numUniforms; i++) {
 			glGetActiveUniform(program, i, uniformMaxLength, &length, &count, &type, uniformName.data());
-			string name(uniformName.begin(), uniformName.begin()+length);
+			std::string name(uniformName.begin(), uniformName.begin()+length);
 			// some drivers return uniform_name[0] for array uniforms
 			// instead of the real uniform name
 			location = glGetUniformLocation(program, name.c_str());
@@ -703,10 +703,10 @@ bool ofShader::linkProgram() {
 
 			count = -1;
 			type = 0;
-			vector<GLchar> uniformBlockName(uniformMaxLength);
+			std::vector<GLchar> uniformBlockName(uniformMaxLength);
 			for(GLint i = 0; i < numUniformBlocks; i++) {
 				glGetActiveUniformBlockName(program, i, uniformMaxLength, &length, uniformBlockName.data() );
-				string name(uniformBlockName.begin(), uniformBlockName.begin()+length);
+				std::string name(uniformBlockName.begin(), uniformBlockName.begin()+length);
 				uniformBlocksCache[name] = glGetUniformBlockIndex(program, name.c_str());
 			}
 		}
@@ -766,7 +766,7 @@ void ofShader::reloadGL(){
 #endif
 
 //--------------------------------------------------------------
-void ofShader::bindAttribute(GLuint location, const string & name) const{
+void ofShader::bindAttribute(GLuint location, const std::string & name) const{
 	attributesBindingsCache[name] = location;
 	glBindAttribLocation(program,location,name.c_str());
 }
@@ -911,12 +911,12 @@ void ofShader::dispatchCompute(GLuint x, GLuint y, GLuint z) const{
 #endif
 
 //--------------------------------------------------------------
-void ofShader::setUniformTexture(const string & name, const ofBaseHasTexture& img, int textureLocation)  const{
+void ofShader::setUniformTexture(const std::string & name, const ofBaseHasTexture& img, int textureLocation)  const{
 	setUniformTexture(name, img.getTexture(), textureLocation);
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniformTexture(const string & name, int textureTarget, GLint textureID, int textureLocation) const{
+void ofShader::setUniformTexture(const std::string & name, int textureTarget, GLint textureID, int textureLocation) const{
 	if(bLoaded) {
 		glActiveTexture(GL_TEXTURE0 + textureLocation);
 		if (!ofIsGLProgrammableRenderer()){
@@ -932,7 +932,7 @@ void ofShader::setUniformTexture(const string & name, int textureTarget, GLint t
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniformTexture(const string & name, const ofTexture& tex, int textureLocation)  const{
+void ofShader::setUniformTexture(const std::string & name, const ofTexture& tex, int textureLocation)  const{
 	if(bLoaded) {
 		ofTextureData texData = tex.getTextureData();
 		glActiveTexture(GL_TEXTURE0 + textureLocation);
@@ -959,7 +959,7 @@ void ofShader::setUniformTexture(const string & name, const ofTexture& tex, int 
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform1i(const string & name, int v1)  const{
+void ofShader::setUniform1i(const std::string & name, int v1)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform1i(loc, v1);
@@ -967,7 +967,7 @@ void ofShader::setUniform1i(const string & name, int v1)  const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform2i(const string & name, int v1, int v2)  const{
+void ofShader::setUniform2i(const std::string & name, int v1, int v2)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform2i(loc, v1, v2);
@@ -975,7 +975,7 @@ void ofShader::setUniform2i(const string & name, int v1, int v2)  const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform3i(const string & name, int v1, int v2, int v3)  const{
+void ofShader::setUniform3i(const std::string & name, int v1, int v2, int v3)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform3i(loc, v1, v2, v3);
@@ -983,7 +983,7 @@ void ofShader::setUniform3i(const string & name, int v1, int v2, int v3)  const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4i(const string & name, int v1, int v2, int v3, int v4)  const{
+void ofShader::setUniform4i(const std::string & name, int v1, int v2, int v3, int v4)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) 	glUniform4i(loc, v1, v2, v3, v4);
@@ -991,7 +991,7 @@ void ofShader::setUniform4i(const string & name, int v1, int v2, int v3, int v4)
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform1f(const string & name, float v1)  const{
+void ofShader::setUniform1f(const std::string & name, float v1)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform1f(loc, v1);
@@ -999,7 +999,7 @@ void ofShader::setUniform1f(const string & name, float v1)  const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform2f(const string & name, float v1, float v2)  const{
+void ofShader::setUniform2f(const std::string & name, float v1, float v2)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform2f(loc, v1, v2);
@@ -1007,7 +1007,7 @@ void ofShader::setUniform2f(const string & name, float v1, float v2)  const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform3f(const string & name, float v1, float v2, float v3)  const{
+void ofShader::setUniform3f(const std::string & name, float v1, float v2, float v3)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform3f(loc, v1, v2, v3);
@@ -1015,7 +1015,7 @@ void ofShader::setUniform3f(const string & name, float v1, float v2, float v3)  
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4f(const string & name, float v1, float v2, float v3, float v4)  const{
+void ofShader::setUniform4f(const std::string & name, float v1, float v2, float v3, float v4)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform4f(loc, v1, v2, v3, v4);
@@ -1024,27 +1024,27 @@ void ofShader::setUniform4f(const string & name, float v1, float v2, float v3, f
 
 
 //--------------------------------------------------------------
-void ofShader::setUniform2f(const string & name, const glm::vec2 & v) const{
+void ofShader::setUniform2f(const std::string & name, const glm::vec2 & v) const{
 	setUniform2f(name,v.x,v.y);
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform3f(const string & name, const glm::vec3 & v) const{
+void ofShader::setUniform3f(const std::string & name, const glm::vec3 & v) const{
 	setUniform3f(name,v.x,v.y,v.z);
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4f(const string & name, const glm::vec4 & v) const{
+void ofShader::setUniform4f(const std::string & name, const glm::vec4 & v) const{
 	setUniform4f(name,v.x,v.y,v.z,v.w);
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4f(const string & name, const ofFloatColor & v) const{
+void ofShader::setUniform4f(const std::string & name, const ofFloatColor & v) const{
 	setUniform4f(name,v.r,v.g,v.b,v.a);
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform1iv(const string & name, const int* v, int count)  const{
+void ofShader::setUniform1iv(const std::string & name, const int* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform1iv(loc, count, v);
@@ -1052,7 +1052,7 @@ void ofShader::setUniform1iv(const string & name, const int* v, int count)  cons
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform2iv(const string & name, const int* v, int count)  const{
+void ofShader::setUniform2iv(const std::string & name, const int* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform2iv(loc, count, v);
@@ -1060,7 +1060,7 @@ void ofShader::setUniform2iv(const string & name, const int* v, int count)  cons
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform3iv(const string & name, const int* v, int count)  const{
+void ofShader::setUniform3iv(const std::string & name, const int* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform3iv(loc, count, v);
@@ -1068,7 +1068,7 @@ void ofShader::setUniform3iv(const string & name, const int* v, int count)  cons
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4iv(const string & name, const int* v, int count)  const{
+void ofShader::setUniform4iv(const std::string & name, const int* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform4iv(loc, count, v);
@@ -1076,7 +1076,7 @@ void ofShader::setUniform4iv(const string & name, const int* v, int count)  cons
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform1fv(const string & name, const float* v, int count)  const{
+void ofShader::setUniform1fv(const std::string & name, const float* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform1fv(loc, count, v);
@@ -1084,7 +1084,7 @@ void ofShader::setUniform1fv(const string & name, const float* v, int count)  co
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform2fv(const string & name, const float* v, int count)  const{
+void ofShader::setUniform2fv(const std::string & name, const float* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform2fv(loc, count, v);
@@ -1092,7 +1092,7 @@ void ofShader::setUniform2fv(const string & name, const float* v, int count)  co
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform3fv(const string & name, const float* v, int count)  const{
+void ofShader::setUniform3fv(const std::string & name, const float* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform3fv(loc, count, v);
@@ -1100,7 +1100,7 @@ void ofShader::setUniform3fv(const string & name, const float* v, int count)  co
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniform4fv(const string & name, const float* v, int count)  const{
+void ofShader::setUniform4fv(const std::string & name, const float* v, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniform4fv(loc, count, v);
@@ -1133,7 +1133,7 @@ void ofShader::setUniforms(const ofParameterGroup & parameters) const{
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniformMatrix3f(const string & name, const glm::mat3 & m, int count)  const{
+void ofShader::setUniformMatrix3f(const std::string & name, const glm::mat3 & m, int count)  const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniformMatrix3fv(loc, count, GL_FALSE, glm::value_ptr(m));
@@ -1141,7 +1141,7 @@ void ofShader::setUniformMatrix3f(const string & name, const glm::mat3 & m, int 
 }
 
 //--------------------------------------------------------------
-void ofShader::setUniformMatrix4f(const string & name, const glm::mat4 & m, int count) const{
+void ofShader::setUniformMatrix4f(const std::string & name, const glm::mat4 & m, int count) const{
 	if(bLoaded) {
 		int loc = getUniformLocation(name);
 		if (loc != -1) glUniformMatrix4fv(loc, count, GL_FALSE, glm::value_ptr(m));
@@ -1199,7 +1199,7 @@ void ofShader::setAttribute4f(GLint location, float v1, float v2, float v3, floa
 }
 
 //--------------------------------------------------------------
-void ofShader::setAttribute1fv(const string & name, const float* v, GLsizei stride) const{
+void ofShader::setAttribute1fv(const std::string & name, const float* v, GLsizei stride) const{
 	if(bLoaded){
 		GLint location = getAttributeLocation(name);
 		if (location != -1) {
@@ -1210,7 +1210,7 @@ void ofShader::setAttribute1fv(const string & name, const float* v, GLsizei stri
 }
 
 //--------------------------------------------------------------
-void ofShader::setAttribute2fv(const string & name, const float* v, GLsizei stride) const{
+void ofShader::setAttribute2fv(const std::string & name, const float* v, GLsizei stride) const{
 	if(bLoaded){
 		GLint location = getAttributeLocation(name);
 		if (location != -1) {
@@ -1222,7 +1222,7 @@ void ofShader::setAttribute2fv(const string & name, const float* v, GLsizei stri
 }
 
 //--------------------------------------------------------------
-void ofShader::setAttribute3fv(const string & name, const float* v, GLsizei stride) const{
+void ofShader::setAttribute3fv(const std::string & name, const float* v, GLsizei stride) const{
 	if(bLoaded){
 		GLint location = getAttributeLocation(name);
 		if (location != -1) {
@@ -1233,7 +1233,7 @@ void ofShader::setAttribute3fv(const string & name, const float* v, GLsizei stri
 }
 
 //--------------------------------------------------------------
-void ofShader::setAttribute4fv(const string & name, const float* v, GLsizei stride) const{
+void ofShader::setAttribute4fv(const std::string & name, const float* v, GLsizei stride) const{
 	if(bLoaded){
 		GLint location = getAttributeLocation(name);
 		if (location != -1) {
@@ -1270,12 +1270,12 @@ void ofShader::setAttribute4d(GLint location, double v1, double v2, double v3, d
 #endif
 
 //--------------------------------------------------------------
-GLint ofShader::getAttributeLocation(const string & name)  const{
+GLint ofShader::getAttributeLocation(const std::string & name)  const{
 	return glGetAttribLocation(program, name.c_str());
 }
 
 //--------------------------------------------------------------
-GLint ofShader::getUniformLocation(const string & name)  const{
+GLint ofShader::getUniformLocation(const std::string & name)  const{
 	if(!bLoaded) return -1;
 	auto it = uniformsCache.find(name);
 	if (it == uniformsCache.end()){
@@ -1288,7 +1288,7 @@ GLint ofShader::getUniformLocation(const string & name)  const{
 #ifndef TARGET_OPENGLES
 #ifdef GLEW_ARB_uniform_buffer_object
 //--------------------------------------------------------------
-GLint ofShader::getUniformBlockIndex(const string & name)  const{
+GLint ofShader::getUniformBlockIndex(const std::string & name)  const{
 	if(!bLoaded) return -1;
 
 	if(GLEW_ARB_uniform_buffer_object) {
@@ -1305,7 +1305,7 @@ GLint ofShader::getUniformBlockIndex(const string & name)  const{
 }
 
 //--------------------------------------------------------------
-GLint ofShader::getUniformBlockBinding( const string & name ) const{
+GLint ofShader::getUniformBlockBinding( const std::string & name ) const{
 	if(!bLoaded) return -1;
 
 	if(GLEW_ARB_uniform_buffer_object) {
@@ -1332,7 +1332,7 @@ void ofShader::printActiveUniformBlocks()  const{
 		glGetProgramiv(program, GL_ACTIVE_UNIFORM_MAX_LENGTH, &uniformBlockMaxLength);
 
 		GLchar* uniformBlockName = new GLchar[uniformBlockMaxLength];
-		stringstream line;
+		std::stringstream line;
 		for(GLint i = 0; i < numUniformBlocks; i++) {
 			GLsizei length;
 			GLint blockBinding;
@@ -1356,7 +1356,7 @@ void ofShader::printActiveUniformBlocks()  const{
 }
 
 
-void ofShader::bindUniformBlock(GLuint binding, const string & name) const{
+void ofShader::bindUniformBlock(GLuint binding, const std::string & name) const{
 	if(bLoaded){
 		if(GLEW_ARB_uniform_buffer_object) {
 			GLint index = getUniformBlockIndex(name);
@@ -1384,7 +1384,7 @@ void ofShader::printActiveUniforms()  const{
 	GLenum type = 0;
 	GLchar* uniformName = new GLchar[uniformMaxLength];
 	for(GLint i = 0; i < numUniforms; i++) {
-		stringstream line;
+		std::stringstream line;
 		GLsizei length;
 		GLint location;
 		glGetActiveUniform(program, i, uniformMaxLength, &length, &count, &type, uniformName);
@@ -1412,7 +1412,7 @@ void ofShader::printActiveAttributes()  const{
 	GLint count = -1;
 	GLenum type = 0;
 	GLchar* attributeName = new GLchar[attributeMaxLength];
-	stringstream line;
+	std::stringstream line;
 	for(GLint i = 0; i < numAttributes; i++) {
 		GLsizei length;
 		glGetActiveAttrib(program, i, attributeMaxLength, &length, &count, &type, attributeName);
@@ -1453,7 +1453,7 @@ bool ofShader::operator!=(const ofShader & other) const{
 }
 
 //--------------------------------------------------------------
-string ofShader::nameForType(GLenum type){
+std::string ofShader::nameForType(GLenum type){
 	switch(type) {
 		case GL_VERTEX_SHADER: return "GL_VERTEX_SHADER";
 		case GL_FRAGMENT_SHADER: return "GL_FRAGMENT_SHADER";

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -134,53 +134,53 @@ public:
 #endif
 
 	// set a texture reference
-	void setUniformTexture(const string & name, const ofBaseHasTexture& img, int textureLocation) const;
-	void setUniformTexture(const string & name, const ofTexture& img, int textureLocation) const;
-	void setUniformTexture(const string & name, int textureTarget, GLint textureID, int textureLocation) const;
+	void setUniformTexture(const std::string & name, const ofBaseHasTexture& img, int textureLocation) const;
+	void setUniformTexture(const std::string & name, const ofTexture& img, int textureLocation) const;
+	void setUniformTexture(const std::string & name, int textureTarget, GLint textureID, int textureLocation) const;
 
 	// set a single uniform value
-	void setUniform1i(const string & name, int v1) const;
-	void setUniform2i(const string & name, int v1, int v2) const;
-	void setUniform3i(const string & name, int v1, int v2, int v3) const;
-	void setUniform4i(const string & name, int v1, int v2, int v3, int v4) const;
+	void setUniform1i(const std::string & name, int v1) const;
+	void setUniform2i(const std::string & name, int v0, int v2) const;
+	void setUniform3i(const std::string & name, int v1, int v2, int v3) const;
+	void setUniform4i(const std::string & name, int v1, int v2, int v3, int v4) const;
 
-	void setUniform1f(const string & name, float v1) const;
-	void setUniform2f(const string & name, float v1, float v2) const;
-	void setUniform3f(const string & name, float v1, float v2, float v3) const;
-	void setUniform4f(const string & name, float v1, float v2, float v3, float v4) const;
+	void setUniform1f(const std::string & name, float v0) const;
+	void setUniform2f(const std::string & name, float v1, float v2) const;
+	void setUniform3f(const std::string & name, float v1, float v2, float v3) const;
+	void setUniform4f(const std::string & name, float v1, float v2, float v3, float v4) const;
 
-	void setUniform2f(const string & name, const glm::vec2 & v) const;
-	void setUniform3f(const string & name, const glm::vec3 & v) const;
-	void setUniform4f(const string & name, const glm::vec4 & v) const;
-	void setUniform4f(const string & name, const ofFloatColor & v) const;
+	void setUniform2f(const std::string & name, const glm::vec2 & v) const;
+	void setUniform3f(const std::string & name, const glm::vec3 & v) const;
+	void setUniform4f(const std::string & name, const glm::vec4 & v) const;
+	void setUniform4f(const std::string & name, const ofFloatColor & v) const;
 
 	// set an array of uniform values
-	void setUniform1iv(const string & name, const int* v, int count = 1) const;
-	void setUniform2iv(const string & name, const int* v, int count = 1) const;
-	void setUniform3iv(const string & name, const int* v, int count = 1) const;
-	void setUniform4iv(const string & name, const int* v, int count = 1) const;
+	void setUniform1iv(const std::string & name, const int* v, int count = 1) const;
+	void setUniform2iv(const std::string & name, const int* v, int count = 1) const;
+	void setUniform3iv(const std::string & name, const int* v, int count = 1) const;
+	void setUniform4iv(const std::string & name, const int* v, int count = 1) const;
 
-	void setUniform1fv(const string & name, const float* v, int count = 1) const;
-	void setUniform2fv(const string & name, const float* v, int count = 1) const;
-	void setUniform3fv(const string & name, const float* v, int count = 1) const;
-	void setUniform4fv(const string & name, const float* v, int count = 1) const;
+	void setUniform1fv(const std::string & name, const float* v, int count = 1) const;
+	void setUniform2fv(const std::string & name, const float* v, int count = 1) const;
+	void setUniform3fv(const std::string & name, const float* v, int count = 1) const;
+	void setUniform4fv(const std::string & name, const float* v, int count = 1) const;
 
 	void setUniforms(const ofParameterGroup & parameters) const;
 
 	// note: it may be more optimal to use a 4x4 matrix than a 3x3 matrix, if possible
-	void setUniformMatrix3f(const string & name, const glm::mat3 & m, int count = 1) const;
-	void setUniformMatrix4f(const string & name, const glm::mat4 & m, int count = 1) const;
+	void setUniformMatrix3f(const std::string & name, const glm::mat3 & m, int count = 1) const;
+	void setUniformMatrix4f(const std::string & name, const glm::mat4 & m, int count = 1) const;
 
-	GLint getUniformLocation(const string & name) const;
+	GLint getUniformLocation(const std::string & name) const;
 
 	// set attributes that vary per vertex (look up the location before glBegin)
-	GLint getAttributeLocation(const string & name) const;
+	GLint getAttributeLocation(const std::string & name) const;
 
 #ifndef TARGET_OPENGLES
 #ifdef GLEW_ARB_uniform_buffer_object
-	GLint getUniformBlockIndex(const string & name) const;
-	GLint getUniformBlockBinding(const string & name) const;
-	void bindUniformBlock(GLuint bindind, const string & name) const;
+	GLint getUniformBlockIndex(const std::string & name) const;
+	GLint getUniformBlockBinding(const std::string & name) const;
+	void bindUniformBlock(GLuint bindind, const std::string & name) const;
 	void printActiveUniformBlocks() const;
 #endif
 #endif
@@ -204,12 +204,12 @@ public:
 	void setAttribute4d(GLint location, double v1, double v2, double v3, double v4) const;
 #endif
 
-	void setAttribute1fv(const string & name, const float* v, GLsizei stride=sizeof(float)) const;
-	void setAttribute2fv(const string & name, const float* v, GLsizei stride=sizeof(float)*2) const;
-	void setAttribute3fv(const string & name, const float* v, GLsizei stride=sizeof(float)*3) const;
-	void setAttribute4fv(const string & name, const float* v, GLsizei stride=sizeof(float)*4) const;
+	void setAttribute1fv(const std::string & name, const float* v, GLsizei stride=sizeof(float)) const;
+	void setAttribute2fv(const std::string & name, const float* v, GLsizei stride=sizeof(float)*2) const;
+	void setAttribute3fv(const std::string & name, const float* v, GLsizei stride=sizeof(float)*3) const;
+	void setAttribute4fv(const std::string & name, const float* v, GLsizei stride=sizeof(float)*4) const;
 
-	void bindAttribute(GLuint location, const string & name) const;
+	void bindAttribute(GLuint location, const std::string & name) const;
 
 	void printActiveUniforms() const;
 	void printActiveAttributes() const;
@@ -219,7 +219,7 @@ public:
 
 	// these methods create and compile a shader from source or file
 	// type: GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, GL_GEOMETRY_SHADER_EXT etc.
-	bool setupShaderFromSource(GLenum type, string source, string sourceDirectoryPath = "");
+	bool setupShaderFromSource(GLenum type, std::string source, std::string sourceDirectoryPath = "");
 	bool setupShaderFromFile(GLenum type, const std::filesystem::path& filename);
 
 	// links program with all compiled shaders
@@ -248,7 +248,7 @@ public:
 
 	/// @brief returns the shader source as it was passed to the GLSL compiler
 	/// @param type (GL_VERTEX_SHADER | GL_FRAGMENT_SHADER | GL_GEOMETRY_SHADER_EXT) the shader source you'd like to inspect.
-	string getShaderSource(GLenum type) const;
+	std::string getShaderSource(GLenum type) const;
 
 
 private:
@@ -260,12 +260,12 @@ private:
 		Source source;
 	};
 
-	unordered_map<GLenum, Shader> shaders;
-	unordered_map<string, GLint> uniformsCache;
-	mutable unordered_map<string, GLint> attributesBindingsCache;
+	std::unordered_map<GLenum, Shader> shaders;
+	std::unordered_map<std::string, GLint> uniformsCache;
+	mutable std::unordered_map<std::string, GLint> attributesBindingsCache;
 
 #ifndef TARGET_OPENGLES
-	unordered_map<string, GLint> uniformBlocksCache;
+	std::unordered_map<std::string, GLint> uniformBlocksCache;
 #endif
 
 	bool setupShaderFromSource(Source && source);
@@ -274,11 +274,11 @@ private:
 	bool checkProgramLinkStatus();
 	void checkShaderInfoLog(GLuint shader, GLenum type, ofLogLevel logLevel);
 	template<typename T>
-	void setDefineConstantTemp(const string & name, T value);
+	void setDefineConstantTemp(const std::string & name, T value);
 	template<typename T>
-	void setConstantTemp(const string & name, const std::string & type, T value);
+	void setConstantTemp(const std::string & name, const std::string & type, T value);
 	
-	static string nameForType(GLenum type);
+	static std::string nameForType(GLenum type);
 
 	/// @brief			Mimics the #include behaviour of the c preprocessor
 	/// @description	Includes files specified using the
@@ -286,8 +286,8 @@ private:
 	/// @note			Include paths are always specified _relative to the including file's current path_
 	///	@note			Recursive #pragma include statements are possible
 	/// @note			Includes will be processed up to 32 levels deep
-	static string parseForIncludes( const string& source, const std::filesystem::path& sourceDirectoryPath = "");
-	static string parseForIncludes( const string& source, vector<string>& included, int level = 0, const std::filesystem::path& sourceDirectoryPath = "");
+	static std::string parseForIncludes( const std::string& source, const std::filesystem::path& sourceDirectoryPath = "");
+	static std::string parseForIncludes( const std::string& source, std::vector<std::string>& included, int level = 0, const std::filesystem::path& sourceDirectoryPath = "");
 
 	void checkAndCreateProgram();
 #ifdef TARGET_ANDROID

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -161,8 +161,8 @@ static void release(GLuint id){
 }
 
 #ifdef TARGET_ANDROID
-static set<ofTexture*> & allTextures(){
-	static set<ofTexture*> * allTextures = new set<ofTexture*>;
+static std::set<ofTexture*> & allTextures(){
+	static std::set<ofTexture*> * allTextures = new std::set<ofTexture*>;
 	return *allTextures;
 }
 

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -119,8 +119,8 @@ void ofDisableArbTex(){
 }
 
 
-static map<GLuint,int> & getTexturesIndex(){
-	static map<GLuint,int> * textureReferences = new map<GLuint,int>;
+static std::map<GLuint,int> & getTexturesIndex(){
+	static std::map<GLuint,int> * textureReferences = new std::map<GLuint,int>;
 	return *textureReferences;
 }
 
@@ -739,8 +739,8 @@ void ofTexture::generateMipmap(){
 			static bool warningIssuedAlready = false;
 			
 			if (!warningIssuedAlready){
-				ofLogWarning() << "Mipmaps are not supported for textureTarget 0x" << hex << texData.textureTarget << endl
-				<< "Most probably you are trying to create mipmaps from a GL_TEXTURE_RECTANGLE texture." << endl
+				ofLogWarning() << "Mipmaps are not supported for textureTarget 0x" << std::hex << texData.textureTarget << std::endl
+				<< "Most probably you are trying to create mipmaps from a GL_TEXTURE_RECTANGLE texture." << std::endl
 				<< "Try ofDisableArbTex() before loading this texture.";
 				warningIssuedAlready = true;
 			}
@@ -842,7 +842,7 @@ void ofTexture::setAlphaMask(ofTexture & mask){
 	if(mask.texData.textureTarget!=this->texData.textureTarget){
 		ofLogError("ofTexture") << "Cannot set alpha mask with different texture target";
 	}else{
-		texData.alphaMask = shared_ptr<ofTexture>(new ofTexture(mask));
+		texData.alphaMask = std::shared_ptr<ofTexture>(new ofTexture(mask));
 	}
 }
 
@@ -963,8 +963,8 @@ void ofTexture::setTextureMinMagFilter(GLint minFilter, GLint magFilter){
 	if ( (minFilter > GL_LINEAR) && texData.hasMipmap == false ){
 		static bool hasWarnedNoMipmapsForMinFilter = false;
 		if(!hasWarnedNoMipmapsForMinFilter) {
-			ofLogWarning() << "Texture has no mipmaps - but minFilter 0x"<< hex << minFilter << " requires mipmaps."
-			<< endl << "Call ofTexture::generateMipmaps() first.";
+			ofLogWarning() << "Texture has no mipmaps - but minFilter 0x"<< std::hex << minFilter << " requires mipmaps."
+			<< std::endl << "Call ofTexture::generateMipmaps() first.";
 		}
 		hasWarnedNoMipmapsForMinFilter = true;
 		return;
@@ -1062,7 +1062,7 @@ void ofTexture::drawSubsection(float x, float y, float z, float w, float h, floa
 
 //----------------------------------------------------------
 void ofTexture::drawSubsection(float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		renderer->draw(*this,x,y,z,w,h,sx,sy,sw,sh);
 	}
@@ -1082,7 +1082,7 @@ ofMesh ofTexture::getMeshForSubsection(float x, float y, float z, float w, float
 	GLfloat py1 = h+y;
 
 	if (texData.bFlipTexture == vflipped){
-		swap(py0,py1);
+		std::swap(py0,py1);
 	}
 
 	// for rect mode center, let's do this:
@@ -1162,7 +1162,7 @@ void ofTexture::draw(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3
 	// before glEnable or else the shader gets confused
 	/// ps: maybe if bUsingArbTex is enabled we should use glActiveTextureARB?
 	//glActiveTexture(GL_TEXTURE0);
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		bind(0);
 		renderer->draw(getQuad(p1,p2,p3,p4),OF_MESH_FILL);

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -207,7 +207,7 @@ public:
 	
 	unsigned int bufferId; ///< Optionally if the texture is backed by a buffer so we can bind it
 private:
-	shared_ptr<ofTexture> alphaMask; ///< Optional alpha mask to bind
+	std::shared_ptr<ofTexture> alphaMask; ///< Optional alpha mask to bind
 	bool bUseExternalTextureID; ///< Are we using an external texture ID? 
 	glm::mat4 textureMatrix; ///< For required transformations.
 	bool useTextureMatrix; ///< Apply the transformation matrix?

--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -36,8 +36,8 @@ bool ofVbo::vaoChecked=false;
 	#define glBindVertexArray								glBindVertexArrayFunc
 #endif
 
-static map<GLuint,int> & getVAOIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static std::map<GLuint,int> & getVAOIds(){
+	static std::map<GLuint,int> * ids = new std::map<GLuint,int>;
 	return *ids;
 }
 
@@ -911,7 +911,7 @@ void ofVbo::bind() const{
             indexAttribute.bind();
         }
 
-		map<int,VertexAttribute>::const_iterator it;
+		std::map<int,VertexAttribute>::const_iterator it;
 		for(it = customAttributes.begin();it!=customAttributes.end();it++){
 			it->second.enable();
 		}

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -197,7 +197,7 @@ private:
 	VertexAttribute colorAttribute;
 	VertexAttribute texCoordAttribute;
 	VertexAttribute normalAttribute;
-	map<int,VertexAttribute> customAttributes;
+	std::map<int,VertexAttribute> customAttributes;
 	
 	static bool vaoChecked;
 	static bool vaoSupported;

--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -1,4 +1,4 @@
-static const string fragmentShader = R"(
+static const std::string fragmentShader = R"(
     IN vec2 v_texcoord; // pass the texCoord if needed
     IN vec3 v_normal;
     IN vec3 v_transformedNormal;

--- a/libs/openFrameworks/gl/shaders/phong.vert
+++ b/libs/openFrameworks/gl/shaders/phong.vert
@@ -1,4 +1,4 @@
-static const string vertexShader = R"(
+static const std::string vertexShader = R"(
 OUT vec2 v_texcoord; // pass the texCoord if needed
 OUT vec3 v_transformedNormal;
 OUT vec3 v_normal;

--- a/libs/openFrameworks/graphics/ofBitmapFont.cpp
+++ b/libs/openFrameworks/graphics/ofBitmapFont.cpp
@@ -390,7 +390,7 @@ static void addBitmapCharacter(ofMesh & charMesh, int & vertexCount, int charact
 	}	
 }
 
-ofMesh ofBitmapFont::getMesh(const string & text, int x, int y, ofDrawBitmapMode mode, bool vFlipped) const{
+ofMesh ofBitmapFont::getMesh(const std::string & text, int x, int y, ofDrawBitmapMode mode, bool vFlipped) const{
 	int len = (int)text.length();
 	float fontSize = 8.0f;
 
@@ -474,14 +474,14 @@ const ofTexture & ofBitmapFont::getTexture() const{
 }
 
 
-ofRectangle ofBitmapFont::getBoundingBox(const string & text, int x, int y) const{
+ofRectangle ofBitmapFont::getBoundingBox(const std::string & text, int x, int y) const{
     if(text.empty()){
         return ofRectangle(x,y,0,0);
     }
 
 	const ofMesh & mesh = getMesh(text,x,y);
-	glm::vec2 max(numeric_limits<float>::min(),numeric_limits<float>::min());
-	glm::vec2 min(numeric_limits<float>::max(),numeric_limits<float>::max());
+	glm::vec2 max(std::numeric_limits<float>::min(),std::numeric_limits<float>::min());
+	glm::vec2 min(std::numeric_limits<float>::max(),std::numeric_limits<float>::max());
 	for(std::size_t i=0;i< mesh.getNumVertices(); i++){
 		const auto & p = mesh.getVertex(i);
 		if(p.x<min.x) min.x = p.x;

--- a/libs/openFrameworks/graphics/ofBitmapFont.h
+++ b/libs/openFrameworks/graphics/ofBitmapFont.h
@@ -20,9 +20,9 @@ class ofBitmapFont{
 public:
 	ofBitmapFont();
 	~ofBitmapFont();
-	ofMesh getMesh(const string & text, int x, int y, ofDrawBitmapMode mode=OF_BITMAPMODE_MODEL_BILLBOARD, bool vFlipped=true) const;
+	ofMesh getMesh(const std::string & text, int x, int y, ofDrawBitmapMode mode=OF_BITMAPMODE_MODEL_BILLBOARD, bool vFlipped=true) const;
 	const ofTexture & getTexture() const;
-	ofRectangle getBoundingBox(const string & text, int x, int y) const;
+	ofRectangle getBoundingBox(const std::string & text, int x, int y) const;
 private:
 	static void init();
 	static ofPixels pixels;

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -8,7 +8,7 @@
 #include "ofNode.h"
 #include "ofGraphics.h"
 
-const string ofCairoRenderer::TYPE="cairo";
+const std::string ofCairoRenderer::TYPE="cairo";
 
 _cairo_status ofCairoRenderer::stream_function(void *closure,const unsigned char *data, unsigned int length){
 	((ofCairoRenderer*)closure)->streamBuffer.append((const char*)data,length);
@@ -31,7 +31,7 @@ ofCairoRenderer::~ofCairoRenderer(){
 	close();
 }
 
-void ofCairoRenderer::setup(string _filename, Type _type, bool multiPage_, bool b3D_, ofRectangle outputsize){
+void ofCairoRenderer::setup(std::string _filename, Type _type, bool multiPage_, bool b3D_, ofRectangle outputsize){
 	if( outputsize.width == 0 || outputsize.height == 0 ){
 		outputsize.set(0, 0, ofGetViewportWidth(), ofGetViewportHeight());
 	}
@@ -41,7 +41,7 @@ void ofCairoRenderer::setup(string _filename, Type _type, bool multiPage_, bool 
 	streamBuffer.clear();
 
 	if(type == FROM_FILE_EXTENSION){
-		string ext = ofFilePath::getFileExt(filename);
+		std::string ext = ofFilePath::getFileExt(filename);
 		if(ofToLower(ext)=="svg"){
 			type = SVG;
 		}else if(ofToLower(ext)=="pdf"){
@@ -190,7 +190,7 @@ void ofCairoRenderer::setCurveResolution(int resolution){
 
 void ofCairoRenderer::draw(const ofPath & shape) const{
 	cairo_new_path(cr);
-	const vector<ofPath::Command> & commands = shape.getCommands();
+	const std::vector<ofPath::Command> & commands = shape.getCommands();
 	for(int i=0;i<(int)commands.size();i++){
 		draw(commands[i]);
 	}
@@ -247,7 +247,7 @@ void ofCairoRenderer::draw(const ofPolyline & poly) const{
 	cairo_stroke( cr );
 }
 
-void ofCairoRenderer::draw(const vector<glm::vec3> & vertexData, ofPrimitiveMode drawMode) const{
+void ofCairoRenderer::draw(const std::vector<glm::vec3> & vertexData, ofPrimitiveMode drawMode) const{
 	if(vertexData.size()==0) return;
 	ofCairoRenderer * mut_this = const_cast<ofCairoRenderer*>(this);
 	mut_this->pushMatrix();
@@ -522,7 +522,7 @@ void ofCairoRenderer::draw(const ofPixels & raw, float x, float y, float z, floa
 	int picsize = pix.getWidth()* pix.getHeight();
 	const unsigned char *imgPix = pix.getData();
 
-	vector<unsigned char> swapPixels;
+	std::vector<unsigned char> swapPixels;
 
 	switch(pix.getImageType()){
 	case OF_IMAGE_COLOR:
@@ -914,7 +914,7 @@ void ofCairoRenderer::viewport(ofRectangle v){
 void ofCairoRenderer::viewport(float x, float y, float width, float height, bool invertY){
 	if(width < 0) width = originalViewport.width;
 	if(height < 0) height = originalViewport.height;
-	cout << "setting viewport to:" << width << ", " << height << endl;
+	std::cout << "setting viewport to:" << width << ", " << height << std::endl;
 
 	if (invertY){
 		y = -y;
@@ -1332,17 +1332,17 @@ void ofCairoRenderer::drawEllipse(float x, float y, float z, float width, float 
 	}
 }
 
-void ofCairoRenderer::drawString(string text, float x, float y, float z) const{
+void ofCairoRenderer::drawString(std::string text, float x, float y, float z) const{
 	cairo_select_font_face (cr, "Mono", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 	cairo_set_font_size (cr, 10);
-	vector<string> lines = ofSplitString(text, "\n");
+	std::vector<std::string> lines = ofSplitString(text, "\n");
 	for(int i=0;i<(int)lines.size();i++){
 		cairo_move_to (cr, x, y+i*14.3);
 		cairo_show_text (cr, lines[i].c_str() );
 	}
 }
 
-void ofCairoRenderer::drawString(const ofTrueTypeFont & font, string text, float x, float y) const{
+void ofCairoRenderer::drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const{
 	font.drawStringAsShapes(text,x,y);
 }
 

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -16,8 +16,8 @@ public:
 	ofCairoRenderer();
 	~ofCairoRenderer();
 
-	static const string TYPE;
-	const string & getType(){ return TYPE; }
+	static const std::string TYPE;
+	const std::string & getType(){ return TYPE; }
 
 	enum Type{
 		PDF,
@@ -25,7 +25,7 @@ public:
 		IMAGE,
 		FROM_FILE_EXTENSION
 	};
-	void setup(string filename, Type type=ofCairoRenderer::FROM_FILE_EXTENSION, bool multiPage=true, bool b3D=false, ofRectangle outputsize = ofRectangle(0,0,0,0));
+	void setup(std::string filename, Type type=ofCairoRenderer::FROM_FILE_EXTENSION, bool multiPage=true, bool b3D=false, ofRectangle outputsize = ofRectangle(0,0,0,0));
 	void setupMemoryOnly(Type _type, bool multiPage=true, bool b3D=false, ofRectangle viewport = ofRectangle(0,0,0,0));
 	void close();
 	void flush();
@@ -40,7 +40,7 @@ public:
 	void draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType ) const;
     void draw(const ofNode& node) const;
-	void draw(const vector<glm::vec3> & vertexData, ofPrimitiveMode drawMode) const;
+	void draw(const std::vector<glm::vec3> & vertexData, ofPrimitiveMode drawMode) const;
 	void draw(const ofImage & img, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofShortImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
@@ -151,8 +151,8 @@ public:
 	void drawTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3) const;
 	void drawCircle(float x, float y, float z, float radius) const;
 	void drawEllipse(float x, float y, float z, float width, float height) const;
-	void drawString(string text, float x, float y, float z) const;
-	void drawString(const ofTrueTypeFont & font, string text, float x, float y) const;
+	void drawString(std::string text, float x, float y, float z) const;
+	void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const;
 
 	// cairo specifics
 	cairo_t * getCairoContext();
@@ -172,12 +172,12 @@ private:
 	static _cairo_status stream_function(void *closure,const unsigned char *data, unsigned int length);
 	void draw(const ofPixels & img, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 
-	mutable deque<glm::vec3> curvePoints;
+	mutable std::deque<glm::vec3> curvePoints;
 	cairo_t * cr;
 	cairo_surface_t * surface;
 	bool bBackgroundAuto;
 
-	stack<cairo_matrix_t> matrixStack;
+	std::stack<cairo_matrix_t> matrixStack;
 
 	Type type;
 	int page;
@@ -189,21 +189,21 @@ private:
 	glm::mat4 modelView;
 	ofRectangle viewportRect, originalViewport;
 
-	stack<glm::mat4> projectionStack;
-	stack<glm::mat4> modelViewStack;
-	stack<ofRectangle> viewportStack;
+	std::stack<glm::mat4> projectionStack;
+	std::stack<glm::mat4> modelViewStack;
+	std::stack<ofRectangle> viewportStack;
 	
 	ofMatrixMode currentMatrixMode;
 
-	vector<glm::vec3> sphereVerts;
-	vector<glm::vec3> spherePoints;
+	std::vector<glm::vec3> sphereVerts;
+	std::vector<glm::vec3> spherePoints;
 
-	string filename;
+	std::string filename;
 	ofBuffer streamBuffer;
 	ofPixels imageBuffer;
 
 	ofStyle currentStyle;
-	deque <ofStyle> styleHistory;
+	std::deque <ofStyle> styleHistory;
 	of3dGraphics graphics3d;
 	ofPath path;
 };

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -18,7 +18,7 @@
 //style stuff - new in 006
 static ofVboMesh gradientMesh;
 
-void ofSetCurrentRenderer(shared_ptr<ofBaseRenderer> renderer,bool setDefaults){
+void ofSetCurrentRenderer(std::shared_ptr<ofBaseRenderer> renderer,bool setDefaults){
 	if(setDefaults){
 		ofStyle style = ofGetCurrentRenderer()->getStyle();
 		renderer->setupGraphicDefaults();
@@ -28,9 +28,9 @@ void ofSetCurrentRenderer(shared_ptr<ofBaseRenderer> renderer,bool setDefaults){
 }
 
 #if !defined(TARGET_OF_IOS) && !defined(TARGET_ANDROID) && !defined(TARGET_EMSCRIPTEN)
-static shared_ptr<ofCairoRenderer> cairoScreenshot;
-static shared_ptr<ofBaseRenderer> storedRenderer;
-static shared_ptr<ofRendererCollection> rendererCollection;
+static std::shared_ptr<ofCairoRenderer> cairoScreenshot;
+static std::shared_ptr<ofBaseRenderer> storedRenderer;
+static std::shared_ptr<ofRendererCollection> rendererCollection;
 static bool bScreenShotStarted = false;
 
 
@@ -52,15 +52,15 @@ static void ofEndSaveScreen(){
 
 }
 
-static void ofBeginSaveScreen(string filename, ofCairoRenderer::Type type, bool bMultipage, bool b3D, ofRectangle outputsize){
+static void ofBeginSaveScreen(std::string filename, ofCairoRenderer::Type type, bool bMultipage, bool b3D, ofRectangle outputsize){
 	if( bScreenShotStarted ) ofEndSaveScreen();
 	
 	storedRenderer = ofGetCurrentRenderer();
 	
-	cairoScreenshot = shared_ptr<ofCairoRenderer>(new ofCairoRenderer);
+	cairoScreenshot = std::shared_ptr<ofCairoRenderer>(new ofCairoRenderer);
 	cairoScreenshot->setup(filename, type, bMultipage, b3D, outputsize);
 
-	rendererCollection = make_shared<ofRendererCollection>();
+	rendererCollection = std::make_shared<ofRendererCollection>();
 	rendererCollection->renderers.push_back(storedRenderer);
 	rendererCollection->renderers.push_back(cairoScreenshot);
 	
@@ -70,7 +70,7 @@ static void ofBeginSaveScreen(string filename, ofCairoRenderer::Type type, bool 
 }
 
 //-----------------------------------------------------------------------------------
-void ofBeginSaveScreenAsPDF(string filename, bool bMultipage, bool b3D, ofRectangle outputsize){
+void ofBeginSaveScreenAsPDF(std::string filename, bool bMultipage, bool b3D, ofRectangle outputsize){
 	ofBeginSaveScreen(filename, ofCairoRenderer::PDF, bMultipage, b3D, outputsize);
 }
 
@@ -80,7 +80,7 @@ void ofEndSaveScreenAsPDF(){
 }
 
 //-----------------------------------------------------------------------------------
-void ofBeginSaveScreenAsSVG(string filename, bool bMultipage, bool b3D, ofRectangle outputsize){
+void ofBeginSaveScreenAsSVG(std::string filename, bool bMultipage, bool b3D, ofRectangle outputsize){
 	ofBeginSaveScreen(filename, ofCairoRenderer::SVG, bMultipage, b3D, outputsize);
 }
 
@@ -1122,28 +1122,28 @@ void ofVertex(const glm::vec2 & p){
 }
 
 //----------------------------------------------------------
-void ofVertices( const vector <glm::vec3> & polyPoints ){
+void ofVertices( const std::vector <glm::vec3> & polyPoints ){
 	for( const auto & p: polyPoints ){
 		ofGetCurrentRenderer()->getPath().lineTo(p);
 	}
 }
 
 //----------------------------------------------------------
-void ofVertices( const vector <glm::vec2> & polyPoints ){
+void ofVertices( const std::vector <glm::vec2> & polyPoints ){
 	for( const auto & p: polyPoints ){
 		ofGetCurrentRenderer()->getPath().lineTo(glm::vec3(p, 0.0));
 	}
 }
 
 //----------------------------------------------------------
-void ofVertices( const vector <ofVec3f> & polyPoints ){
+void ofVertices( const std::vector <ofVec3f> & polyPoints ){
 	for( const auto & p: polyPoints ){
 		ofGetCurrentRenderer()->getPath().lineTo(p);
 	}
 }
 
 //----------------------------------------------------------
-void ofVertices( const vector <ofVec2f> & polyPoints ){
+void ofVertices( const std::vector <ofVec2f> & polyPoints ){
 	for( const auto & p: polyPoints ){
 		ofGetCurrentRenderer()->getPath().lineTo(p);
 	}
@@ -1160,28 +1160,28 @@ void ofCurveVertex(float x, float y, float z){
 }
 
 //----------------------------------------------------------
-void ofCurveVertices( const vector <glm::vec3> & curvePoints){
+void ofCurveVertices( const std::vector <glm::vec3> & curvePoints){
 	for( const auto & p: curvePoints ){
 		ofGetCurrentRenderer()->getPath().curveTo(p);
 	}
 }
 
 //----------------------------------------------------------
-void ofCurveVertices( const vector <glm::vec2> & curvePoints){
+void ofCurveVertices( const std::vector <glm::vec2> & curvePoints){
 	for( const auto & p: curvePoints ){
 		ofGetCurrentRenderer()->getPath().curveTo(glm::vec3(p, 0.0));
 	}
 }
 
 //----------------------------------------------------------
-void ofCurveVertices( const vector <ofVec3f> & curvePoints){
+void ofCurveVertices( const std::vector <ofVec3f> & curvePoints){
 	for( const auto & p: curvePoints ){
 		ofGetCurrentRenderer()->getPath().curveTo(p);
 	}
 }
 
 //----------------------------------------------------------
-void ofCurveVertices( const vector <ofVec2f> & curvePoints){
+void ofCurveVertices( const std::vector <ofVec2f> & curvePoints){
 	for( const auto & p: curvePoints ){
 		ofGetCurrentRenderer()->getPath().curveTo(p);
 	}
@@ -1244,27 +1244,27 @@ void ofEndShape(bool bClose){
 // text
 //--------------------------------------------------
 template<>
-void ofDrawBitmapString(const string & textString, float x, float y, float z){
+void ofDrawBitmapString(const std::string & textString, float x, float y, float z){
 	ofGetCurrentRenderer()->drawString(textString,x,y,z);
 }
 
 //--------------------------------------------------
-void ofDrawBitmapStringHighlight(string text, const glm::vec3& position, const ofColor& background, const ofColor& foreground) {
+void ofDrawBitmapStringHighlight(std::string text, const glm::vec3& position, const ofColor& background, const ofColor& foreground) {
 	ofDrawBitmapStringHighlight(text, position.x, position.y, background, foreground);
 }
 
 //--------------------------------------------------
-void ofDrawBitmapStringHighlight(string text, const glm::vec2& position, const ofColor& background, const ofColor& foreground) {
+void ofDrawBitmapStringHighlight(std::string text, const glm::vec2& position, const ofColor& background, const ofColor& foreground) {
 	ofDrawBitmapStringHighlight(text, position.x, position.y, background, foreground);
 }
 
 //--------------------------------------------------
-void ofDrawBitmapStringHighlight(string text, int x, int y, const ofColor& background, const ofColor& foreground) {
-	vector<string> lines = ofSplitString(text, "\n");
+void ofDrawBitmapStringHighlight(std::string text, int x, int y, const ofColor& background, const ofColor& foreground) {
+	std::vector<std::string> lines = ofSplitString(text, "\n");
 	int maxLineLength = 0;
 	for(int i = 0; i < (int)lines.size(); i++) {
 		// tabs are not rendered
-		const string & line(lines[i]);
+		const std::string & line(lines[i]);
 		int currentLineLength = 0;
 		for(int j = 0; j < (int)line.size(); j++) {
 			if (line[j] == '\t') {

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -555,10 +555,10 @@ void ofVertex(float x, float y);
 void ofVertex(float x, float y, float z);
 void ofVertex(const glm::vec3 & p);
 void ofVertex(const glm::vec2 & p);
-void ofVertices(const vector <glm::vec3> & polyPoints);
-void ofVertices(const vector <glm::vec2> & polyPoints);
-void ofVertices(const vector <ofVec3f> & polyPoints);
-void ofVertices(const vector <ofVec2f> & polyPoints);
+void ofVertices(const std::vector <glm::vec3> & polyPoints);
+void ofVertices(const std::vector <glm::vec2> & polyPoints);
+void ofVertices(const std::vector <ofVec3f> & polyPoints);
+void ofVertices(const std::vector <ofVec2f> & polyPoints);
 
 /// \brief Specifies a single point of a shape. The difference from ofVertex is that
 /// the line describing the edge of the shape between two points will be a
@@ -573,10 +573,10 @@ void ofCurveVertex(const glm::vec2 & p);
 
 /// \brief Draws a curve through a series of vertices stored as a vector of
 /// ofPoints. Should be called between ofBeginShape() and ofEndShape().
-void ofCurveVertices(const vector <glm::vec3> & curvePoints);
-void ofCurveVertices(const vector <glm::vec2> & curvePoints);
-void ofCurveVertices(const vector <ofVec3f> & curvePoints);
-void ofCurveVertices(const vector <ofVec2f> & curvePoints);
+void ofCurveVertices(const std::vector <glm::vec3> & curvePoints);
+void ofCurveVertices(const std::vector <glm::vec2> & curvePoints);
+void ofCurveVertices(const std::vector <ofVec3f> & curvePoints);
+void ofCurveVertices(const std::vector <ofVec2f> & curvePoints);
 
 /// \brief Describes a bezier curve through three points of a shape. To be called
 /// between ofBeginShape() and ofEndShape().
@@ -664,10 +664,10 @@ void ofDrawBitmapString(const T & textString, const glm::vec3 & p);
 template<typename T>
 void ofDrawBitmapString(const T & textString, float x, float y, float z);
 template<>
-void ofDrawBitmapString(const string & textString, float x, float y, float z);
-void ofDrawBitmapStringHighlight(string text, const glm::vec3& position, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
-void ofDrawBitmapStringHighlight(string text, const glm::vec2& position, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
-void ofDrawBitmapStringHighlight(string text, int x, int y, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
+void ofDrawBitmapString(const std::string & textString, float x, float y, float z);
+void ofDrawBitmapStringHighlight(std::string text, const glm::vec3& position, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
+void ofDrawBitmapStringHighlight(std::string text, const glm::vec2& position, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
+void ofDrawBitmapStringHighlight(std::string text, int x, int y, const ofColor& background = ofColor::black, const ofColor& foreground = ofColor::white);
 
 
 /// \}
@@ -1217,7 +1217,7 @@ ofHandednessType ofGetCoordHandedness();
 /// }
 /// ~~~~
 /// \sa End drawing with ofEndSaveScreenAsPDF()
-void ofBeginSaveScreenAsPDF(string filename, bool bMultipage = false, bool b3D = false, ofRectangle outputsize = ofRectangle(0,0,0,0));
+void ofBeginSaveScreenAsPDF(std::string filename, bool bMultipage = false, bool b3D = false, ofRectangle outputsize = ofRectangle(0,0,0,0));
 
 /// \brief Terminates draw to PDF through ofCairoRenderer and outputs the file.
 /// \sa ofBeginSaveScreenAsPDF()
@@ -1225,7 +1225,7 @@ void ofEndSaveScreenAsPDF();
 
 /// \brief Begin rendering to a SVG file.
 /// \sa ofEndSaveScreenAsSVG(), ofBeginSaveScreenAsPDF()
-void ofBeginSaveScreenAsSVG(string filename, bool bMultipage = false, bool b3D = false, ofRectangle outputsize = ofRectangle(0,0,0,0));
+void ofBeginSaveScreenAsSVG(std::string filename, bool bMultipage = false, bool b3D = false, ofRectangle outputsize = ofRectangle(0,0,0,0));
 
 /// \brief Terminates draw to SVG and outputs the file.
 /// \sa ofBeginSaveScreenAsSVG()

--- a/libs/openFrameworks/graphics/ofPath.cpp
+++ b/libs/openFrameworks/graphics/ofPath.cpp
@@ -525,7 +525,7 @@ ofPolyline & ofPath::lastPolyline(){
 }
 
 //----------------------------------------------------------
-vector<ofPath::Command> & ofPath::getCommands(){
+std::vector<ofPath::Command> & ofPath::getCommands(){
 	if(mode==POLYLINES){
 		ofLogWarning("ofPath") << "getCommands(): trying to get path commands from shape with polylines only";
 	}else{
@@ -535,7 +535,7 @@ vector<ofPath::Command> & ofPath::getCommands(){
 }
 
 //----------------------------------------------------------
-const vector<ofPath::Command> & ofPath::getCommands() const{
+const std::vector<ofPath::Command> & ofPath::getCommands() const{
 	if(mode==POLYLINES){
 		ofLogWarning("ofPath") << "getCommands(): trying to get path commands from shape with polylines only";
 	}
@@ -628,7 +628,7 @@ void ofPath::tessellate(){
 }
 
 //----------------------------------------------------------
-const vector<ofPolyline> & ofPath::getOutline() const{
+const std::vector<ofPolyline> & ofPath::getOutline() const{
 	if(windingMode!=OF_POLY_WINDING_ODD){
 		const_cast<ofPath*>(this)->tessellate();
 		return tessellatedContour;

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -316,7 +316,7 @@ public:
 	/// \{
 
 	/// \brief Get an ofPolyline representing the outline of the ofPath.
-	const vector<ofPolyline> & getOutline() const;
+	const std::vector<ofPolyline> & getOutline() const;
 
 	void tessellate();
 
@@ -383,8 +383,8 @@ public:
 		float radiusX, radiusY, angleBegin, angleEnd;
 	};
 
-	vector<Command> & getCommands();
-	const vector<Command> & getCommands() const;
+	std::vector<Command> & getCommands();
+	const std::vector<Command> & getCommands() const;
 
 	/// \}
 	
@@ -399,8 +399,8 @@ private:
 	bool hasChanged();
 
 	// path description
-	//vector<ofSubPath>		paths;
-	vector<Command> 	commands;
+	//std::vector<ofSubPath>		paths;
+	std::vector<Command> 	commands;
 	ofPolyWindingMode 	windingMode;
 	ofColor 			fillColor;
 	ofColor				strokeColor;
@@ -409,8 +409,8 @@ private:
 	bool				bUseShapeColor;
 
 	// polyline / tessellation
-	vector<ofPolyline>  polylines;
-	vector<ofPolyline>  tessellatedContour; // if winding mode != ODD
+	std::vector<ofPolyline>  polylines;
+	std::vector<ofPolyline>  tessellatedContour; // if winding mode != ODD
 
 #ifdef TARGET_OPENGLES
 	ofMesh				cachedTessellation;

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -140,7 +140,7 @@ static ofImageType ofImageTypeFromPixelFormat(ofPixelFormat pixelFormat){
 	}
 }
 
-string ofToString(ofPixelFormat pixelFormat){
+std::string ofToString(ofPixelFormat pixelFormat){
 	switch(pixelFormat){
 		case OF_PIXELS_RGB:
 			return "RGB";

--- a/libs/openFrameworks/graphics/ofPixels.h
+++ b/libs/openFrameworks/graphics/ofPixels.h
@@ -597,8 +597,8 @@ void ofPixels_<PixelType>::copyFrom(const ofPixels_<SrcType> & mom){
 	if(mom.isAllocated()){
 		allocate(mom.getWidth(),mom.getHeight(),mom.getNumChannels());
 
-		const float srcMax = ( (sizeof(SrcType) == sizeof(float) ) ? 1.f : numeric_limits<SrcType>::max() );
-		const float dstMax = ( (sizeof(PixelType) == sizeof(float) ) ? 1.f : numeric_limits<PixelType>::max() );
+		const float srcMax = ( (sizeof(SrcType) == sizeof(float) ) ? 1.f : std::numeric_limits<SrcType>::max() );
+		const float dstMax = ( (sizeof(PixelType) == sizeof(float) ) ? 1.f : std::numeric_limits<PixelType>::max() );
 		const float factor = dstMax / srcMax;
 
 		if(sizeof(SrcType) == sizeof(float)) {

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -57,7 +57,7 @@ public:
 	ofPolyline_();
 
 	/// \brief Creates an ofPolyline from a vector of ofVec2f or T objects.
-	ofPolyline_(const vector<T>& verts);
+	ofPolyline_(const std::vector<T>& verts);
 
 	static ofPolyline_ fromRectangle(const ofRectangle& rect);
 
@@ -94,7 +94,7 @@ public:
 	/// 	ofPolyline p;
 	/// 	p.addVertices(verts);
 	/// ~~~~
-	void addVertices( const vector<T>& verts );
+	void addVertices( const std::vector<T>& verts );
 
 	/// \brief Adds multiple points at the end of the ofPolyline using a pointer to
 	/// an array of T objects.
@@ -131,17 +131,17 @@ public:
 	T& operator[] (int index);
     
 	/// \brief Gets a vector of vertices that the line contains
-	vector<T> & getVertices();
-	const vector<T> & getVertices() const;
+        std::vector<T> & getVertices();
+	const std::vector<T> & getVertices() const;
 
-	typename vector<T>::iterator begin();
-	typename vector<T>::const_iterator begin() const;
-	typename vector<T>::reverse_iterator rbegin();
-	typename vector<T>::const_reverse_iterator rbegin() const;
-	typename vector<T>::iterator end();
-	typename vector<T>::const_iterator end() const;
-	typename vector<T>::reverse_iterator rend();
-	typename vector<T>::const_reverse_iterator rend() const;
+	typename std::vector<T>::iterator begin();
+	typename std::vector<T>::const_iterator begin() const;
+	typename std::vector<T>::reverse_iterator rbegin();
+	typename std::vector<T>::const_reverse_iterator rbegin() const;
+	typename std::vector<T>::iterator end();
+	typename std::vector<T>::const_iterator end() const;
+	typename std::vector<T>::reverse_iterator rend();
+	typename std::vector<T>::const_reverse_iterator rend() const;
 
 	/// \}
     /// \name Lines and Curves
@@ -496,21 +496,21 @@ private:
 	void setCircleResolution(int res);
     float wrapAngle(float angleRad);
 
-	vector<T> points;
+        std::vector<T> points;
 	T rightVector;
     
     // cache
-    mutable vector<float> lengths;    // cumulative lengths, stored per point (lengths[n] is the distance to the n'th point, zero based)
-	mutable vector<T> tangents;       // tangent at vertex, stored per point
-	mutable vector<T> normals;        //
-	mutable vector<T> rotations;      // rotation axes between adjacent segments, stored per point (cross product)
-    mutable vector<float> angles;     // angle (rad) between adjacent segments, stored per point (asin(cross product))
+    mutable std::vector<float> lengths;    // cumulative lengths, stored per point (lengths[n] is the distance to the n'th point, zero based)
+	mutable std::vector<T> tangents;       // tangent at vertex, stored per point
+	mutable std::vector<T> normals;        //
+	mutable std::vector<T> rotations;      // rotation axes between adjacent segments, stored per point (cross product)
+    mutable std::vector<float> angles;     // angle (rad) between adjacent segments, stored per point (asin(cross product))
 	mutable T centroid2D;
     mutable float area;
     
     
-	deque<T> curveVertices;
-	vector<T> circlePoints;
+        std::deque<T> curveVertices;
+        std::vector<T> circlePoints;
 
 	bool bClosed;
 	bool bHasChanged;   // public API has access to this
@@ -534,7 +534,7 @@ using ofPolyline = ofPolyline_<ofDefaultVertexType>;
 /// \param poly a vector of glm::vec3s defining a polygon.
 /// \returns True if the point defined by the coordinates is enclosed, false otherwise.
 template<class T>
-bool ofInsidePoly(float x, float y, const vector<T>& polygon){
+bool ofInsidePoly(float x, float y, const std::vector<T>& polygon){
 	return ofPolyline_<T>::inside(x,y, ofPolyline_<T>(polygon));
 }
 
@@ -544,6 +544,6 @@ bool ofInsidePoly(float x, float y, const vector<T>& polygon){
 /// \param poly A vector of glm::vec3s defining a polygon.
 /// \returns True if the glm::vec3 is enclosed, false otherwise.
 template<class T>
-bool ofInsidePoly(const T& p, const vector<T>& poly){
+bool ofInsidePoly(const T& p, const std::vector<T>& poly){
 	return ofPolyline_<T>::inside(p.x,p.y, ofPolyline_<T>(poly));
 }

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -12,7 +12,7 @@ ofPolyline_<T>::ofPolyline_(){
 
 //----------------------------------------------------------
 template<class T>
-ofPolyline_<T>::ofPolyline_(const vector<T>& verts){
+ofPolyline_<T>::ofPolyline_(const std::vector<T>& verts){
     setRightVector();
 	clear();
 	addVertices(verts);
@@ -57,7 +57,7 @@ void ofPolyline_<T>::addVertex(float x, float y, float z) {
 
 //----------------------------------------------------------
 template<class T>
-void ofPolyline_<T>::addVertices(const vector<T>& verts) {
+void ofPolyline_<T>::addVertices(const std::vector<T>& verts) {
 	curveVertices.clear();
 	points.insert( points.end(), verts.begin(), verts.end() );
     flagHasChanged();
@@ -151,14 +151,14 @@ void ofPolyline_<T>::flagHasChanged() {
 
 //----------------------------------------------------------
 template<class T>
-vector<T> & ofPolyline_<T>::getVertices(){
+std::vector<T> & ofPolyline_<T>::getVertices(){
     flagHasChanged();
 	return points;
 }
 
 //----------------------------------------------------------
 template<class T>
-const vector<T> & ofPolyline_<T>::getVertices() const {
+const std::vector<T> & ofPolyline_<T>::getVertices() const {
 	return points;
 }
 
@@ -453,7 +453,7 @@ ofPolyline_<T> ofPolyline_<T>::getSmoothed(int smoothingSize, float smoothingSha
 	smoothingShape = ofClamp(smoothingShape, 0, 1);
 	
 	// precompute weights and normalization
-	vector<float> weights;
+	std::vector<float> weights;
 	weights.resize(smoothingSize);
 	// side weights
 	for(int i = 1; i < smoothingSize; i++) {
@@ -739,13 +739,13 @@ void ofPolyline_<T>::simplify(float tol){
 		return;
 	}
 
-	vector <T> sV;
+	std::vector <T> sV;
 	sV.resize(n);
     
     int    i, k, m, pv;            // misc counters
     float  tol2 = tol * tol;       // tolerance squared
-	vector<T> vt;
-    vector<int> mk;
+    std::vector<T> vt;
+    std::vector<int> mk;
     vt.resize(n);
 	mk.resize(n,0);
     
@@ -1119,49 +1119,49 @@ void ofPolyline_<T>::updateCache(bool bForceUpdate) const {
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::iterator ofPolyline_<T>::begin(){
+typename std::vector<T>::iterator ofPolyline_<T>::begin(){
 	return points.begin();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::iterator ofPolyline_<T>::end(){
+typename std::vector<T>::iterator ofPolyline_<T>::end(){
 	return points.end();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::const_iterator ofPolyline_<T>::begin() const{
+typename std::vector<T>::const_iterator ofPolyline_<T>::begin() const{
 	return points.begin();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::const_iterator ofPolyline_<T>::end() const{
+typename std::vector<T>::const_iterator ofPolyline_<T>::end() const{
 	return points.end();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::reverse_iterator ofPolyline_<T>::rbegin(){
+typename std::vector<T>::reverse_iterator ofPolyline_<T>::rbegin(){
 	return points.rbegin();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::reverse_iterator ofPolyline_<T>::rend(){
+typename std::vector<T>::reverse_iterator ofPolyline_<T>::rend(){
 	return points.rend();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::const_reverse_iterator ofPolyline_<T>::rbegin() const{
+typename std::vector<T>::const_reverse_iterator ofPolyline_<T>::rbegin() const{
 	return points.rbegin();
 }
 
 //--------------------------------------------------
 template<class T>
-typename vector<T>::const_reverse_iterator ofPolyline_<T>::rend() const{
+typename std::vector<T>::const_reverse_iterator ofPolyline_<T>::rend() const{
 	return points.rend();
 }
 

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -335,7 +335,7 @@ void ofPolyline_<T>::arc(const T & center, float radiusX, float radiusY, float a
     
     // if the delta angle is in the CCW direction OR the start and stop angles are
     // effectively the same adjust the remaining angle to be a be a full rotation
-    if(deltaAngle < 0 || abs(deltaAngle) < epsilon) remainingAngle += M_TWO_PI;
+    if(deltaAngle < 0 || std::abs(deltaAngle) < epsilon) remainingAngle += M_TWO_PI;
     
 	T radii(radiusX, radiusY, 0.f);
 	T point;
@@ -361,7 +361,7 @@ void ofPolyline_<T>::arc(const T & center, float radiusX, float radiusY, float a
             float firstPointDelta = atan2(sin(d),cos(d)); // negative is in the clockwise direction
             
             // if the are "equal", get the next one CCW
-            if(abs(firstPointDelta) < epsilon) {
+            if(std::abs(firstPointDelta) < epsilon) {
                 currentLUTIndex = clockwise ? (currentLUTIndex + 1) : (currentLUTIndex - 1);
                 firstPointDelta = segmentArcSize; // we start at the next lut point
             }

--- a/libs/openFrameworks/graphics/ofRendererCollection.cpp
+++ b/libs/openFrameworks/graphics/ofRendererCollection.cpp
@@ -6,5 +6,5 @@
  */
 
 #include "ofRendererCollection.h"
-const string ofRendererCollection::TYPE="collection";
+const std::string ofRendererCollection::TYPE="collection";
 

--- a/libs/openFrameworks/graphics/ofRendererCollection.h
+++ b/libs/openFrameworks/graphics/ofRendererCollection.h
@@ -11,19 +11,19 @@ public:
 	 ofRendererCollection():graphics3d(this){}
 	 ~ofRendererCollection(){}
 
-	 static const string TYPE;
-	 const string & getType(){ return TYPE; }
+	 static const std::string TYPE;
+	 const std::string & getType(){ return TYPE; }
 
-	 shared_ptr<ofBaseGLRenderer> getGLRenderer(){
+	 std::shared_ptr<ofBaseGLRenderer> getGLRenderer(){
 		for(auto renderer: renderers){
 			  if(renderer->getType()=="GL" || renderer->getType()=="ProgrammableGL"){
-				  return dynamic_pointer_cast<ofBaseGLRenderer>(renderer);
+				  return std::dynamic_pointer_cast<ofBaseGLRenderer>(renderer);
 			  }
 		}
 		#ifndef TARGET_PROGRAMMABLE_GL
-		 	 return shared_ptr<ofGLRenderer>();
+		 	 return std::shared_ptr<ofGLRenderer>();
 		#else
-		 	 return shared_ptr<ofGLProgrammableRenderer>();
+		 	 return std::shared_ptr<ofGLProgrammableRenderer>();
 		#endif
 	 }
 
@@ -574,14 +574,14 @@ public:
 	void enablePointSprites(){
 		for(auto renderer: renderers){
 			 if(renderer->getType()=="GL" || renderer->getType()=="ProgrammableGL"){
-				 dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->enablePointSprites();
+				 std::dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->enablePointSprites();
 			 }
 		 }
 	}
 	void disablePointSprites(){
 		for(auto renderer: renderers){
 			 if(renderer->getType()=="GL" || renderer->getType()=="ProgrammableGL"){
-				 dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->disablePointSprites();
+				 std::dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->disablePointSprites();
 			 }
 		 }
 	}
@@ -675,13 +675,13 @@ public:
 		 }
 	}
 
-	void drawString(string text, float x, float y, float z) const{
+	void drawString(std::string text, float x, float y, float z) const{
 		for(auto renderer: renderers){
 			renderer->drawString(text, x,y,z);
 		 }
 	}
 
-	void drawString(const ofTrueTypeFont & font, string text, float x, float y) const{
+	void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const{
 		for(auto renderer: renderers){
 			renderer->drawString(font, text, x,y);
 		 }
@@ -710,7 +710,7 @@ public:
 		return path;
 	}
 
-	vector<shared_ptr<ofBaseRenderer> > renderers;
+	std::vector<std::shared_ptr<ofBaseRenderer> > renderers;
 	of3dGraphics graphics3d;
 	ofPath path;
 };

--- a/libs/openFrameworks/graphics/ofTessellator.cpp
+++ b/libs/openFrameworks/graphics/ofTessellator.cpp
@@ -106,7 +106,7 @@ void ofTessellator::tessellateToMesh( const ofPolyline& src,  ofPolyWindingMode 
 
 	
 //----------------------------------------------------------
-void ofTessellator::tessellateToMesh( const vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, ofMesh & dstmesh, bool bIs2D ) {
+void ofTessellator::tessellateToMesh( const std::vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, ofMesh & dstmesh, bool bIs2D ) {
 
 
 	// pass vertex pointers to GLU tessellator
@@ -122,7 +122,7 @@ void ofTessellator::tessellateToMesh( const vector<ofPolyline>& src, ofPolyWindi
 }
 
 //----------------------------------------------------------
-void ofTessellator::tessellateToPolylines( const ofPolyline& src,  ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D){
+void ofTessellator::tessellateToPolylines( const ofPolyline& src,  ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D){
 
 	if (src.size() > 0) {
 		ofPolyline& polyline = const_cast<ofPolyline&>(src);
@@ -133,7 +133,7 @@ void ofTessellator::tessellateToPolylines( const ofPolyline& src,  ofPolyWinding
 
 
 //----------------------------------------------------------
-void ofTessellator::tessellateToPolylines( const vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D ) {
+void ofTessellator::tessellateToPolylines( const std::vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D ) {
 
 	// pass vertex pointers to GLU tessellator
 	for ( int i=0; i<(int)src.size(); ++i ) {
@@ -173,7 +173,7 @@ void ofTessellator::performTessellation(ofPolyWindingMode polyWindingMode, ofMes
 
 
 //----------------------------------------------------------
-void ofTessellator::performTessellation(ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D ) {
+void ofTessellator::performTessellation(ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D ) {
 	if (!tessTesselate(cacheTess, polyWindingMode, TESS_BOUNDARY_CONTOURS, 0, 3, 0)){
 		ofLogError("ofTessellator") << "performTesselation(): polyline boundary contours tessellation failed, winding mode " << polyWindingMode;
 		return;

--- a/libs/openFrameworks/graphics/ofTessellator.h
+++ b/libs/openFrameworks/graphics/ofTessellator.h
@@ -35,7 +35,7 @@ public:
 
 	/// \brief Tessellates a vector of ofPolyline instances into a single
 	/// ofMesh instance using the winding mode set in ofPolyWindingMode.
-	void tessellateToMesh( const vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, ofMesh & dstmesh, bool bIs2D=false );
+	void tessellateToMesh( const std::vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, ofMesh & dstmesh, bool bIs2D=false );
 	
 	/// \brief Tessellates a ofPolyline instance into a single ofMesh instance
 	/// using the winding mode set in ofPolyWindingMode.
@@ -43,15 +43,15 @@ public:
 
 	/// \brief Tessellates a vector of ofPolyline instances into vector of
 	/// ofPolyline instances using the winding mode set in ofPolyWindingMode.	
-	void tessellateToPolylines( const vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D=false );
+	void tessellateToPolylines( const std::vector<ofPolyline>& src, ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D=false );
 
 	/// \brief Tessellate multiple polylines into a single polyline.
-	void tessellateToPolylines( const ofPolyline & src, ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D=false );
+	void tessellateToPolylines( const ofPolyline & src, ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D=false );
 
 private:
 	
 	void performTessellation( ofPolyWindingMode polyWindingMode, ofMesh& dstmesh, bool bIs2D );
-	void performTessellation(ofPolyWindingMode polyWindingMode, vector<ofPolyline>& dstpoly, bool bIs2D );
+	void performTessellation(ofPolyWindingMode polyWindingMode, std::vector<ofPolyline>& dstpoly, bool bIs2D );
 	void init();
 
 	TESStesselator * cacheTess;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -304,7 +304,7 @@ static std::string osxFontPathByName(const std::string& fontname){
 	CFStringRef targetName = CFStringCreateWithCString(nullptr, fontname.c_str(), kCFStringEncodingUTF8);
 	CTFontDescriptorRef targetDescriptor = CTFontDescriptorCreateWithNameAndSize(targetName, 0.0);
 	CFURLRef targetURL = (CFURLRef) CTFontDescriptorCopyAttribute(targetDescriptor, kCTFontURLAttribute);
-	string fontPath = "";
+	std::string fontPath = "";
 
 	if(targetURL) {
 		UInt8 buffer[PATH_MAX];
@@ -323,7 +323,7 @@ static std::string osxFontPathByName(const std::string& fontname){
 #ifdef TARGET_WIN32
 #include <map>
 // font font face -> file name name mapping
-static map<std::string, std::string> fonts_table;
+static std::map<std::string, std::string> fonts_table;
 // read font linking information from registry, and store in std::map
 //------------------------------------------------------------------
 void initWindows(){
@@ -400,7 +400,7 @@ static std::string winFontPathByName(const std::string& fontname ){
 	if(fonts_table.find(fontname)!=fonts_table.end()){
 		return fonts_table[fontname];
 	}
-	for(map<std::string,std::string>::iterator it = fonts_table.begin(); it!=fonts_table.end(); it++){
+	for(std::map<std::string,std::string>::iterator it = fonts_table.begin(); it!=fonts_table.end(); it++){
 		if(ofIsStringInString(ofToLower(it->first),ofToLower(fontname))) return it->second;
 	}
 	return "";
@@ -482,7 +482,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
     err = FT_New_Face( library, filename.string().c_str(), fontID, &face );
 	if (err) {
 		// simple error table in lieu of full table (see fterrors.h)
-		string errorString = "unknown freetype";
+		std::string errorString = "unknown freetype";
 		if(err == 1) errorString = "INVALID FILENAME";
 		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << fontname << "\": FT_Error " << err << " " << errorString;
 		return false;
@@ -687,7 +687,7 @@ void ofTrueTypeFont::reloadTextures(){
 }
 
 //-----------------------------------------------------------
-bool ofTrueTypeFont::loadFont(string filename, int fontSize, bool bAntiAliased, bool bFullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
+bool ofTrueTypeFont::loadFont(std::string filename, int fontSize, bool bAntiAliased, bool bFullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
 	return load(filename, fontSize, bAntiAliased, bFullCharacterSet, makeContours, simplifyAmt, dpi);
 }
 
@@ -829,7 +829,7 @@ bool ofTrueTypeFont::load(const ofTtfSettings & _settings){
 		charOutlines.resize(1);
 	}
 
-	vector<ofTrueTypeFont::glyph> all_glyphs;
+	std::vector<ofTrueTypeFont::glyph> all_glyphs;
 
 	uint32_t areaSum=0;
 
@@ -874,8 +874,8 @@ bool ofTrueTypeFont::load(const ofTtfSettings & _settings){
 		}
 	}
 
-	vector<ofTrueTypeFont::glyphProps> sortedCopy = cps;
-	sort(sortedCopy.begin(),sortedCopy.end(),[](const ofTrueTypeFont::glyphProps & c1, const ofTrueTypeFont::glyphProps & c2){
+	std::vector<ofTrueTypeFont::glyphProps> sortedCopy = cps;
+	std::sort(sortedCopy.begin(),sortedCopy.end(),[](const ofTrueTypeFont::glyphProps & c1, const ofTrueTypeFont::glyphProps & c2){
 		if(c1.tH == c2.tH) return c1.tW > c2.tW;
 		else return c1.tH > c2.tH;
 	});
@@ -1103,7 +1103,7 @@ int ofTrueTypeFont::getKerning(uint32_t c, uint32_t prevC) const{
 	}
 }
 
-void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vFlipped, std::function<void(uint32_t, glm::vec2)> f) const{
+void ofTrueTypeFont::iterateString(const std::string & str, float x, float y, bool vFlipped, std::function<void(uint32_t, glm::vec2)> f) const{
 	glm::vec2 pos(x,y);
 
 	int newLineDirection		= 1;
@@ -1158,8 +1158,8 @@ void ofTrueTypeFont::setDirection(ofTtfSettings::Direction direction){
 }
 
 //-----------------------------------------------------------
-vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(const string &  str, bool vflip, bool filled) const{
-	vector<ofTTFCharacter> shapes;
+std::vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(const std::string &  str, bool vflip, bool filled) const{
+	std::vector<ofTTFCharacter> shapes;
 
 	if (!bLoadedOk){
 		ofLogError("ofxTrueTypeFont") << "getStringAsPoints(): font not allocated: line " << __LINE__ << " in " << __FILE__;
@@ -1241,14 +1241,14 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 		if ( c == '\t' ){
 			props.advance = getGlyphProperties( ' ' ).advance * letterSpacing * TAB_WIDTH;
 		}
-		maxX = max( maxX, pos.x + props.advance * letterSpacing );
-		minX = min( minX, pos.x );
+		maxX = std::max( maxX, pos.x + props.advance * letterSpacing );
+		minX = std::min( minX, pos.x );
 		if ( vflip ){
-			minY = min( minY, pos.y - ( props.ymax - props.ymin ) );
-			maxY = max( maxY, pos.y - ( props.bearingY - props.height ) );
+			minY = std::min( minY, pos.y - ( props.ymax - props.ymin ) );
+			maxY = std::max( maxY, pos.y - ( props.bearingY - props.height ) );
 		} else{
-			minY = min( minY, pos.y - ( props.ymax) );
-			maxY = max( maxY, pos.y - ( props.ymin ) );
+			minY = std::min( minY, pos.y - ( props.ymax) );
+			maxY = std::max( maxY, pos.y - ( props.ymin ) );
 		}
 	} );
 
@@ -1301,7 +1301,7 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 						if (c != '\n') {
 							auto g = loadGlyph(c);
 							lineWidth += g.props.advance * letterSpacing;
-							width = max(width, lineWidth);
+							width = std::max(width, lineWidth);
 						}else{
 							lineWidth = 0;
 						}
@@ -1323,8 +1323,8 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 
 //-----------------------------------------------------------
 ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) const{
-	vector<glyph> glyphs;
-	vector<glm::vec2> glyphPositions;
+	std::vector<glyph> glyphs;
+	std::vector<glm::vec2> glyphPositions;
 	long height = 0;
 	int width = 0;
 	int lineWidth = 0;
@@ -1337,8 +1337,8 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
 				int y = g.props.ymax + pos.y;
 				glyphPositions.emplace_back(x, y);
 				lineWidth += g.props.advance * letterSpacing;
-				width = max(width, lineWidth);
-				height = max(height, y + long(getLineHeight()));
+				width = std::max(width, lineWidth);
+				height = std::max(height, y + long(getLineHeight()));
 			}else{
 				lineWidth = 0;
 			}

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -117,7 +117,7 @@ public:
 
 class ofTtfSettings{
 	friend class ofTrueTypeFont;
-	vector<ofUnicode::range> ranges;
+	std::vector<ofUnicode::range> ranges;
 
 public:
     ofTtfSettings(const std::filesystem::path & name, int size)
@@ -191,7 +191,7 @@ public:
                   float simplifyAmt=0.3f,
 				  int dpi=0);
 
-	OF_DEPRECATED_MSG("Use load instead",bool loadFont(string filename,
+	OF_DEPRECATED_MSG("Use load instead",bool loadFont(std::string filename,
                   int fontsize,
                   bool _bAntiAliased=true,
                   bool _bFullCharacterSet=false,
@@ -347,7 +347,7 @@ public:
 	
 	/// \todo
 	ofTTFCharacter getCharacterAsPoints(uint32_t character, bool vflip=true, bool filled=true) const;
-	vector<ofTTFCharacter> getStringAsPoints(const std::string &  str, bool vflip=true, bool filled=true) const;
+	std::vector<ofTTFCharacter> getStringAsPoints(const std::string &  str, bool vflip=true, bool filled=true) const;
 	const ofMesh & getStringMesh(const std::string &  s, float x, float y, bool vflip=true) const;
 	const ofTexture & getFontTexture() const;
 	ofTexture getStringTexture(const std::string &  s, bool vflip=true) const;
@@ -361,10 +361,10 @@ protected:
 	
 	bool bLoadedOk;
 	
-	vector <ofTTFCharacter> charOutlines;
-	vector <ofTTFCharacter> charOutlinesNonVFlipped;
-	vector <ofTTFCharacter> charOutlinesContour;
-	vector <ofTTFCharacter> charOutlinesNonVFlippedContour;
+	std::vector <ofTTFCharacter> charOutlines;
+	std::vector <ofTTFCharacter> charOutlinesNonVFlipped;
+	std::vector <ofTTFCharacter> charOutlinesContour;
+	std::vector <ofTTFCharacter> charOutlinesNonVFlippedContour;
 
 	float lineHeight;
 	float ascenderHeight;
@@ -392,19 +392,19 @@ protected:
 		ofPixels pixels;
 	};
 
-	vector<glyphProps> cps; // properties for each character
+	std::vector<glyphProps> cps; // properties for each character
 
 	ofTtfSettings settings;
-	unordered_map<uint32_t,size_t> glyphIndexMap;
+	std::unordered_map<uint32_t,size_t> glyphIndexMap;
 
 
     int getKerning(uint32_t c, uint32_t prevC) const;
 	void drawChar(uint32_t c, float x, float y, bool vFlipped) const;
 	void drawCharAsShape(uint32_t c, float x, float y, bool vFlipped, bool filled) const;
-	void createStringMesh(const string & s, float x, float y, bool vFlipped) const;
+	void createStringMesh(const std::string & s, float x, float y, bool vFlipped) const;
 	glyph loadGlyph(uint32_t utf8) const;
 	const glyphProps & getGlyphProperties(uint32_t glyph) const;
-	void iterateString(const string & str, float x, float y, bool vFlipped, std::function<void(uint32_t, glm::vec2)> f) const;
+	void iterateString(const std::string & str, float x, float y, bool vFlipped, std::function<void(uint32_t, glm::vec2)> f) const;
 	size_t indexForGlyph(uint32_t glyph) const;
 
 	ofTexture texAtlas;
@@ -417,7 +417,7 @@ private:
 	friend void ofUnloadAllFontTextures();
 	friend void ofReloadAllFontTextures();
 #endif
-	shared_ptr<struct FT_FaceRec_>	face;
+	std::shared_ptr<struct FT_FaceRec_> face;
 	static const glyphProps invalidProps;
 	void		unloadTextures();
 	void		reloadTextures();

--- a/libs/openFrameworks/math/ofMath.cpp
+++ b/libs/openFrameworks/math/ofMath.cpp
@@ -53,7 +53,7 @@ float ofRandom(float max) {
 float ofRandom(float x, float y) {
 	float high = MAX(x, y);
 	float low = MIN(x, y);
-	return max(low, (low + ((high - low) * rand() / float(RAND_MAX))) * (1.0f - std::numeric_limits<float>::epsilon()));
+	return std::max(low, (low + ((high - low) * rand() / float(RAND_MAX))) * (1.0f - std::numeric_limits<float>::epsilon()));
 }
 
 //--------------------------------------------------
@@ -152,7 +152,7 @@ float ofLerp(float start, float stop, float amt) {
 float ofWrap(float value, float from, float to){
 	// algorithm from http://stackoverflow.com/a/5852628/599884
 	if(from > to){
-		swap(from, to);
+		std::swap(from, to);
 	}
 	float cycle = to - from;
 	if(ofIsFloatEqual(cycle, 0.0f)){

--- a/libs/openFrameworks/math/ofMatrix3x3.cpp
+++ b/libs/openFrameworks/math/ofMatrix3x3.cpp
@@ -300,26 +300,26 @@ void ofMatrix3x3::operator/=(float scalar) {
 }
 
 
-ostream& operator<<(ostream& os, const ofMatrix3x3& M) {
+std::ostream& operator<<(std::ostream& os, const ofMatrix3x3& M) {
 	int w = 8;
-	os	<< setw(w)
-		<< M.a << ", " << setw(w)
-		<< M.b << ", " << setw(w)
+	os	<< std::setw(w)
+		<< M.a << ", " << std::setw(w)
+		<< M.b << ", " << std::setw(w)
 		<< M.c << std::endl;
 
-	os	<< setw(w)
-		<< M.d << ", " << setw(w)
-		<< M.e << ", " << setw(w)
+	os	<< std::setw(w)
+		<< M.d << ", " << std::setw(w)
+		<< M.e << ", " << std::setw(w)
 		<< M.f << std::endl;
 
-	os	<< setw(w)
-		<< M.g << ", " << setw(w)
-		<< M.h << ", " << setw(w)
+	os	<< std::setw(w)
+		<< M.g << ", " << std::setw(w)
+		<< M.h << ", " << std::setw(w)
 		<< M.i;
 	return os;
 }
 
-istream& operator>>(istream& is, ofMatrix3x3& M) {
+std::istream& operator>>(std::istream& is, ofMatrix3x3& M) {
 	is >> M.a; is.ignore(2);
 	is >> M.b; is.ignore(2);
 	is >> M.c; is.ignore(1);

--- a/libs/openFrameworks/math/ofMatrix3x3.h
+++ b/libs/openFrameworks/math/ofMatrix3x3.h
@@ -152,8 +152,8 @@ public:
 	
 	void operator/=(float scalar);
 	
-	friend ostream& operator<<(ostream& os, const ofMatrix3x3& M);
-	friend istream& operator>>(istream& is, ofMatrix3x3& M);
+	friend std::ostream& operator<<(std::ostream& os, const ofMatrix3x3& M);
+	friend std::istream& operator>>(std::istream& is, ofMatrix3x3& M);
 	
 	/// \}
 };

--- a/libs/openFrameworks/math/ofMatrix4x4.h
+++ b/libs/openFrameworks/math/ofMatrix4x4.h
@@ -339,8 +339,8 @@ public:
 	}
 	
 	/// \cond INTERNAL
-	friend ostream& operator<<(ostream& os, const ofMatrix4x4& M);
-	friend istream& operator>>(istream& is, ofMatrix4x4& M);
+	friend std::ostream& operator<<(std::ostream& os, const ofMatrix4x4& M);
+	friend std::istream& operator>>(std::istream& is, ofMatrix4x4& M);
 	/// \endcond
 	
 	/// \brief Access the internal data in `float*` format
@@ -679,36 +679,36 @@ inline bool ofMatrix4x4::isNaN() const {
 
 
 
-inline ostream& operator<<(ostream& os, const ofMatrix4x4& M) {
+inline std::ostream& operator<<(std::ostream& os, const ofMatrix4x4& M) {
 	int w = 8;
-	os	<< setw(w)
-		<< M._mat[0][0] << ", " << setw(w)
-		<< M._mat[0][1] << ", " << setw(w)
-		<< M._mat[0][2] << ", " << setw(w) 
+	os	<< std::setw(w)
+		<< M._mat[0][0] << ", " << std::setw(w)
+		<< M._mat[0][1] << ", " << std::setw(w)
+		<< M._mat[0][2] << ", " << std::setw(w) 
 		<< M._mat[0][3] << std::endl;
 		
-	os	<< setw(w)
-		<< M._mat[1][0] << ", " << setw(w) 
-		<< M._mat[1][1] << ", " << setw(w)
-		<< M._mat[1][2] << ", " << setw(w) 
+	os	<< std::setw(w)
+		<< M._mat[1][0] << ", " << std::setw(w) 
+		<< M._mat[1][1] << ", " << std::setw(w)
+		<< M._mat[1][2] << ", " << std::setw(w) 
 		<< M._mat[1][3] << std::endl;
 	
-	os	<< setw(w)
-		<< M._mat[2][0] << ", " << setw(w) 
-		<< M._mat[2][1] << ", " << setw(w)
-		<< M._mat[2][2] << ", " << setw(w) 
+	os	<< std::setw(w)
+		<< M._mat[2][0] << ", " << std::setw(w) 
+		<< M._mat[2][1] << ", " << std::setw(w)
+		<< M._mat[2][2] << ", " << std::setw(w) 
 		<< M._mat[2][3] << std::endl;
 	
-	os	<< setw(w)
-		<< M._mat[3][0] << ", " << setw(w) 
-		<< M._mat[3][1] << ", " << setw(w)
-		<< M._mat[3][2] << ", " << setw(w) 
+	os	<< std::setw(w)
+		<< M._mat[3][0] << ", " << std::setw(w) 
+		<< M._mat[3][1] << ", " << std::setw(w)
+		<< M._mat[3][2] << ", " << std::setw(w) 
 		<< M._mat[3][3];
 	
 	return os;
 }
 
-inline istream& operator>>(istream& is, ofMatrix4x4& M) {
+inline std::istream& operator>>(std::istream& is, ofMatrix4x4& M) {
 	is >> M._mat[0][0]; is.ignore(2); 
 	is >> M._mat[0][1]; is.ignore(2);
 	is >> M._mat[0][2]; is.ignore(2);

--- a/libs/openFrameworks/math/ofQuaternion.h
+++ b/libs/openFrameworks/math/ofQuaternion.h
@@ -180,8 +180,8 @@ public:
     inline const ofQuaternion operator -(const ofQuaternion& rhs) const;    ///< Binary subtraction
     inline const ofQuaternion operator -() const;                           ///< returns the negative of the quaternion. calls operator -() on the Vec4
     
-    friend ostream& operator<<(ostream& os, const ofQuaternion &q);
-    friend istream& operator>>(istream& is, ofQuaternion &q);
+    friend std::ostream& operator<<(std::ostream& os, const ofQuaternion &q);
+    friend std::istream& operator>>(std::istream& is, ofQuaternion &q);
     
     /// \}
 };

--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -452,8 +452,8 @@ public:
 
 	
 	/// \cond INTERNAL
-	friend ostream& operator<<(ostream& os, const ofVec2f& vec);
-	friend istream& operator>>(istream& is, const ofVec2f& vec);
+	friend std::ostream& operator<<(std::ostream& os, const ofVec2f& vec);
+	friend std::istream& operator>>(std::istream& is, const ofVec2f& vec);
 	/// \endcond
 	
 	/// \}
@@ -1104,12 +1104,12 @@ inline ofVec2f& ofVec2f::operator/=( const ofVec2f& vec ) {
 	return *this;
 }
 
-inline ostream& operator<<(ostream& os, const ofVec2f& vec) {
+inline std::ostream& operator<<(std::ostream& os, const ofVec2f& vec) {
 	os << vec.x << ", " << vec.y;
 	return os;
 }
 
-inline istream& operator>>(istream& is, ofVec2f& vec) {
+inline std::istream& operator>>(std::istream& is, ofVec2f& vec) {
 	is >> vec.x;
 	is.ignore(2);
 	is >> vec.y;

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -451,8 +451,8 @@ public:
     ofVec3f& operator/=( const float f );
 	
     /// \cond INTERNAL
-	friend ostream& operator<<(ostream& os, const ofVec3f& vec);
-	friend istream& operator>>(istream& is, ofVec3f& vec);
+	friend std::ostream& operator<<(std::ostream& os, const ofVec3f& vec);
+	friend std::istream& operator>>(std::istream& is, ofVec3f& vec);
 	/// \endcond
 
     /// \}
@@ -1141,12 +1141,12 @@ inline bool ofVec3f::alignRad( const ofVec3f& vec, float tolerance ) const {
 //
 //
 
-inline ostream& operator<<(ostream& os, const ofVec3f& vec) {
+inline std::ostream& operator<<(std::ostream& os, const ofVec3f& vec) {
 	os << vec.x << ", " << vec.y << ", " << vec.z;
 	return os;
 }
 
-inline istream& operator>>(istream& is, ofVec3f& vec) {
+inline std::istream& operator>>(std::istream& is, ofVec3f& vec) {
 	is >> vec.x;
 	is.ignore(2);
 	is >> vec.y;

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -94,8 +94,8 @@ public:
     ofVec4f& operator/=( const float f );
 	    
 	/// \cond INTERNAL
-	friend ostream& operator<<(ostream& os, const ofVec4f& vec);
-	friend istream& operator>>(istream& is, const ofVec4f& vec);
+	friend std::ostream& operator<<(std::ostream& os, const ofVec4f& vec);
+	friend std::istream& operator>>(std::istream& is, const ofVec4f& vec);
 	/// \endcond
 
     /// \}
@@ -464,12 +464,12 @@ inline ofVec4f& ofVec4f::operator/=( const float f ) {
 }
 
 
-inline ostream& operator<<(ostream& os, const ofVec4f& vec) {
+inline std::ostream& operator<<(std::ostream& os, const ofVec4f& vec) {
 	os << vec.x << ", " << vec.y << ", " << vec.z << ", " << vec.w;
 	return os;
 }
 
-inline istream& operator>>(istream& is, ofVec4f& vec) {
+inline std::istream& operator>>(std::istream& is, ofVec4f& vec) {
 	is >> vec.x;
 	is.ignore(2);
 	is >> vec.y;

--- a/libs/openFrameworks/math/ofVectorMath.h
+++ b/libs/openFrameworks/math/ofVectorMath.h
@@ -142,19 +142,19 @@ namespace glm {
 	template <typename T, precision P>
 	inline std::ostream& operator<<(std::ostream& os, const tmat3x3<T, P>& mat) {
 		int w = 8;
-		os << setw(w)
-			<< mat[0][0] << ", " << setw(w)
-			<< mat[0][1] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[0][0] << ", " << std::setw(w)
+			<< mat[0][1] << ", " << std::setw(w)
 			<< mat[0][2] << std::endl;
 
-		os << setw(w)
-			<< mat[1][0] << ", " << setw(w)
-			<< mat[1][1] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[1][0] << ", " << std::setw(w)
+			<< mat[1][1] << ", " << std::setw(w)
 			<< mat[1][2] << std::endl;
 
-		os << setw(w)
-			<< mat[2][0] << ", " << setw(w)
-			<< mat[2][1] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[2][0] << ", " << std::setw(w)
+			<< mat[2][1] << ", " << std::setw(w)
 			<< mat[2][2];
 		return os;
 	}
@@ -180,28 +180,28 @@ namespace glm {
 	template <typename T, precision P>
 	inline std::ostream& operator<<(std::ostream& os, const tmat4x4<T, P>& mat) {
 		int w = 8;
-		os << setw(w)
-			<< mat[0][0] << ", " << setw(w)
-			<< mat[0][1] << ", " << setw(w)
-			<< mat[0][2] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[0][0] << ", " << std::setw(w)
+			<< mat[0][1] << ", " << std::setw(w)
+			<< mat[0][2] << ", " << std::setw(w)
 			<< mat[0][3] << std::endl;
 
-		os << setw(w)
-			<< mat[1][0] << ", " << setw(w)
-			<< mat[1][1] << ", " << setw(w)
-			<< mat[1][2] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[1][0] << ", " << std::setw(w)
+			<< mat[1][1] << ", " << std::setw(w)
+			<< mat[1][2] << ", " << std::setw(w)
 			<< mat[1][3] << std::endl;
 
-		os << setw(w)
-			<< mat[2][0] << ", " << setw(w)
-			<< mat[2][1] << ", " << setw(w)
-			<< mat[2][2] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[2][0] << ", " << std::setw(w)
+			<< mat[2][1] << ", " << std::setw(w)
+			<< mat[2][2] << ", " << std::setw(w)
 			<< mat[2][3] << std::endl;
 
-		os << setw(w)
-			<< mat[3][0] << ", " << setw(w)
-			<< mat[3][1] << ", " << setw(w)
-			<< mat[3][2] << ", " << setw(w)
+		os << std::setw(w)
+			<< mat[3][0] << ", " << std::setw(w)
+			<< mat[3][1] << ", " << std::setw(w)
+			<< mat[3][2] << ", " << std::setw(w)
 			<< mat[3][3];
 		return os;
 	}

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -10,17 +10,17 @@
 
 ALCdevice * ofOpenALSoundPlayer::alDevice = 0;
 ALCcontext * ofOpenALSoundPlayer::alContext = 0;
-vector<float> ofOpenALSoundPlayer::window;
+std::vector<float> ofOpenALSoundPlayer::window;
 float ofOpenALSoundPlayer::windowSum=0;
 
 
 kiss_fftr_cfg ofOpenALSoundPlayer::systemFftCfg=0;
-vector<float> ofOpenALSoundPlayer::systemWindowedSignal;
-vector<float> ofOpenALSoundPlayer::systemBins;
-vector<kiss_fft_cpx> ofOpenALSoundPlayer::systemCx_out;
+std::vector<float> ofOpenALSoundPlayer::systemWindowedSignal;
+std::vector<float> ofOpenALSoundPlayer::systemBins;
+std::vector<kiss_fft_cpx> ofOpenALSoundPlayer::systemCx_out;
 
-static set<ofOpenALSoundPlayer*> & players(){
-	static set<ofOpenALSoundPlayer*> * players = new set<ofOpenALSoundPlayer*>;
+static std::set<ofOpenALSoundPlayer*> & players(){
+	static std::set<ofOpenALSoundPlayer*> * players = new std::set<ofOpenALSoundPlayer*>;
 	return *players;
 }
 
@@ -30,7 +30,7 @@ void ofOpenALSoundUpdate(){
 
 // ----------------------------------------------------------------------------
 // from http://devmaster.net/posts/2893/openal-lesson-6-advanced-loading-and-error-handles
-static string getALErrorString(ALenum error) {
+static std::string getALErrorString(ALenum error) {
 	switch(error) {
         case AL_NO_ERROR:
             return "AL_NO_ERROR";
@@ -49,7 +49,7 @@ static string getALErrorString(ALenum error) {
 }
 
 #ifdef OF_USING_MPG123
-static string getMpg123EncodingString(int encoding) {
+static std::string getMpg123EncodingString(int encoding) {
 	switch(encoding) {
 		case MPG123_ENC_16:
 			return "MPG123_ENC_16";
@@ -171,7 +171,7 @@ void ofOpenALSoundPlayer::close(){
 }
 
 // ----------------------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfReadFile(const std::filesystem::path& path, vector<short> & buffer, vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfReadFile(const std::filesystem::path& path, std::vector<short> & buffer, std::vector<float> & fftAuxBuffer){
 	SF_INFO sfInfo;
 	SNDFILE* f = sf_open(path.c_str(),SFM_READ,&sfInfo);
 	if(!f){
@@ -225,7 +225,7 @@ bool ofOpenALSoundPlayer::sfReadFile(const std::filesystem::path& path, vector<s
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123ReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123ReadFile(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer){
 	int err = MPG123_OK;
 	mpg123_handle * f = mpg123_new(nullptr,&err);
 	if(mpg123_open(f,path.c_str())!=MPG123_OK){
@@ -263,7 +263,7 @@ bool ofOpenALSoundPlayer::mpg123ReadFile(const std::filesystem::path& path,vecto
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::sfStream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::sfStream(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer){
 	if(!streamf){
 		SF_INFO sfInfo;
 		streamf = sf_open(path.c_str(),SFM_READ,&sfInfo);
@@ -326,7 +326,7 @@ bool ofOpenALSoundPlayer::sfStream(const std::filesystem::path& path,vector<shor
 
 #ifdef OF_USING_MPG123
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::mpg123Stream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer){
+bool ofOpenALSoundPlayer::mpg123Stream(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer){
 	if(!mp3streamf){
 		int err = MPG123_OK;
 		mp3streamf = mpg123_new(nullptr,&err);
@@ -377,7 +377,7 @@ bool ofOpenALSoundPlayer::mpg123Stream(const std::filesystem::path& path,vector<
 #endif
 
 //------------------------------------------------------------
-bool ofOpenALSoundPlayer::stream(const std::filesystem::path& fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::stream(const std::filesystem::path& fileName, std::vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)=="mp3" || ofFilePath::getFileExt(fileName)=="MP3" || mp3streamf){
 		if(!mpg123Stream(fileName,buffer,fftAuxBuffer)) return false;
@@ -397,7 +397,7 @@ bool ofOpenALSoundPlayer::stream(const std::filesystem::path& fileName, vector<s
 	return true;
 }
 
-bool ofOpenALSoundPlayer::readFile(const std::filesystem::path& fileName, vector<short> & buffer){
+bool ofOpenALSoundPlayer::readFile(const std::filesystem::path& fileName, std::vector<short> & buffer){
 #ifdef OF_USING_MPG123
 	if(ofFilePath::getFileExt(fileName)!="mp3" && ofFilePath::getFileExt(fileName)!="MP3"){
 		if(!sfReadFile(fileName,buffer,fftAuxBuffer)) return false;
@@ -488,7 +488,7 @@ bool ofOpenALSoundPlayer::load(const std::filesystem::path& _fileName, bool is_s
 	    alSourcef (sources[0], AL_ROLLOFF_FACTOR,  0.0);
 	    alSourcei (sources[0], AL_SOURCE_RELATIVE, AL_TRUE);
 	}else{
-		vector<vector<short> > multibuffer;
+		std::vector<std::vector<short> > multibuffer;
 		multibuffer.resize(channels);
 		sources.resize(channels);
 		alGenSources(channels, &sources[0]);
@@ -562,7 +562,7 @@ bool ofOpenALSoundPlayer::isLoaded() const{
 
 //------------------------------------------------------------
 void ofOpenALSoundPlayer::threadedFunction(){
-	vector<vector<short> > multibuffer;
+	std::vector<std::vector<short> > multibuffer;
 	multibuffer.resize(channels);
 	while(isThreadRunning()){
 		std::unique_lock<std::mutex> lock(mutex);
@@ -987,7 +987,7 @@ float * ofOpenALSoundPlayer::getSystemSpectrum(int bands){
 	}
 	systemWindowedSignal.assign(systemWindowedSignal.size(),0);
 
-	set<ofOpenALSoundPlayer*>::iterator it;
+	std::set<ofOpenALSoundPlayer*>::iterator it;
 	for(it=players().begin();it!=players().end();it++){
 		if(!(*it)->isPlaying()) continue;
 		float * buffer = (*it)->getCurrentBufferSum(signalSize);
@@ -1006,7 +1006,7 @@ float * ofOpenALSoundPlayer::getSystemSpectrum(int bands){
 }
 
 // ----------------------------------------------------------------------------
-void ofOpenALSoundPlayer::runWindow(vector<float> & signal){
+void ofOpenALSoundPlayer::runWindow(std::vector<float> & signal){
 	for(int i = 0; i < (int)signal.size(); i++)
 		signal[i] *= window[i];
 }

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -92,18 +92,18 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		float * getCurrentBufferSum(int size);
 
 		static void createWindow(int size);
-		static void runWindow(vector<float> & signal);
+		static void runWindow(std::vector<float> & signal);
 		static void initSystemFFT(int bands);
 
-        bool sfReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-        bool sfStream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool sfReadFile(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer);
+        bool sfStream(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer);
 #ifdef OF_USING_MPG123
-        bool mpg123ReadFile(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
-        bool mpg123Stream(const std::filesystem::path& path,vector<short> & buffer,vector<float> & fftAuxBuffer);
+        bool mpg123ReadFile(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer);
+        bool mpg123Stream(const std::filesystem::path& path,std::vector<short> & buffer,std::vector<float> & fftAuxBuffer);
 #endif
 
-        bool readFile(const std::filesystem::path& fileName,vector<short> & buffer);
-        bool stream(const std::filesystem::path& fileName, vector<short> & buffer);
+        bool readFile(const std::filesystem::path& fileName,std::vector<short> & buffer);
+        bool stream(const std::filesystem::path& fileName, std::vector<short> & buffer);
 
 		bool isStreaming;
 		bool bMultiPlay;
@@ -118,27 +118,27 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 
 		static ALCdevice * alDevice;
 		static ALCcontext * alContext;
-		static vector<float> window;
+		static std::vector<float> window;
 		static float windowSum;
 
 		int channels;
 		float duration; //in secs
 		int samplerate;
-		vector<ALuint> buffers;
-		vector<ALuint> sources;
+		std::vector<ALuint> buffers;
+		std::vector<ALuint> sources;
 
 		// fft structures
-		vector<vector<float> > fftBuffers;
+		std::vector<std::vector<float> > fftBuffers;
 		kiss_fftr_cfg fftCfg;
-		vector<float> windowedSignal;
-		vector<float> bins;
-		vector<kiss_fft_cpx> cx_out;
+		std::vector<float> windowedSignal;
+		std::vector<float> bins;
+		std::vector<kiss_fft_cpx> cx_out;
 
 
 		static kiss_fftr_cfg systemFftCfg;
-		static vector<float> systemWindowedSignal;
-		static vector<float> systemBins;
-		static vector<kiss_fft_cpx> systemCx_out;
+		static std::vector<float> systemWindowedSignal;
+		static std::vector<float> systemBins;
+		static std::vector<kiss_fft_cpx> systemCx_out;
 
 		SNDFILE* streamf;
 		size_t stream_samples_read;
@@ -149,8 +149,8 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		int mp3_buffer_size;
 		int stream_subformat;
 		double stream_scale;
-		vector<short> buffer;
-		vector<float> fftAuxBuffer;
+		std::vector<short> buffer;
+		std::vector<float> fftAuxBuffer;
 
 		bool stream_end;
 };

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -69,7 +69,7 @@ ofRtAudioSoundStream::~ofRtAudioSoundStream() {
 
 //------------------------------------------------------------------------------
 std::vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList(ofSoundDevice::Api api) const{
-	vector<ofSoundDevice> deviceList;
+	std::vector<ofSoundDevice> deviceList;
 	try {
 		auto rtAudioApi = toRtAudio(api);
 		RtAudio audioTemp(toRtAudio(api));

--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -36,7 +36,7 @@ void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, s
 	setSampleRate(samplerate);
 	buffer.resize(numFrames * numChannels);
 	for(std::size_t i = 0; i < size(); i++){
-		buffer[i] = shortBuffer[i]/float(numeric_limits<short>::max());
+		buffer[i] = shortBuffer[i]/float(std::numeric_limits<short>::max());
 	}
 	checkSizeAndChannelsConsistency("copyFrom");
 }
@@ -48,32 +48,32 @@ void ofSoundBuffer::copyFrom(const float * floatBuffer, std::size_t numFrames, s
 	checkSizeAndChannelsConsistency("copyFrom");
 }
 
-void ofSoundBuffer::copyFrom(const vector<short> & shortBuffer, std::size_t numChannels, unsigned int sampleRate){
+void ofSoundBuffer::copyFrom(const std::vector<short> & shortBuffer, std::size_t numChannels, unsigned int sampleRate){
 	copyFrom(&shortBuffer[0],shortBuffer.size()/numChannels,numChannels,sampleRate);
 }
 
-void ofSoundBuffer::copyFrom(const vector<float> & floatBuffer, std::size_t numChannels, unsigned int sampleRate){
+void ofSoundBuffer::copyFrom(const std::vector<float> & floatBuffer, std::size_t numChannels, unsigned int sampleRate){
 	copyFrom(&floatBuffer[0],floatBuffer.size()/numChannels,numChannels,sampleRate);
 }
 
-void ofSoundBuffer::toShortPCM(vector<short> & dst) const{
+void ofSoundBuffer::toShortPCM(std::vector<short> & dst) const{
 	dst.resize(size());
 	for(std::size_t i = 0; i < size(); i++){
-		dst[i] = buffer[i]*float(numeric_limits<short>::max());
+		dst[i] = buffer[i]*float(std::numeric_limits<short>::max());
 	}
 }
 
 void ofSoundBuffer::toShortPCM(short * dst) const{
 	for(std::size_t i = 0; i < size(); i++){
-		dst[i] = buffer[i]*float(numeric_limits<short>::max());
+		dst[i] = buffer[i]*float(std::numeric_limits<short>::max());
 	}
 }
 
-vector<float> & ofSoundBuffer::getBuffer(){
+std::vector<float> & ofSoundBuffer::getBuffer(){
 	return buffer;
 }
 
-const vector<float> & ofSoundBuffer::getBuffer() const{
+const std::vector<float> & ofSoundBuffer::getBuffer() const{
 	return buffer;
 }
 
@@ -548,7 +548,7 @@ float ofSoundBuffer::getRMSAmplitudeChannel(std::size_t channel) const {
 void ofSoundBuffer::normalize(float level){
 	float maxAmplitude = 0;
 	for(std::size_t i = 0; i < size(); i++) {
-		maxAmplitude = max(maxAmplitude, abs(buffer[i]));
+		maxAmplitude = std::max(maxAmplitude, abs(buffer[i]));
 	}
 	float normalizationFactor = level/maxAmplitude;
 	for(std::size_t i = 0; i < size(); i++) {

--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -548,7 +548,7 @@ float ofSoundBuffer::getRMSAmplitudeChannel(std::size_t channel) const {
 void ofSoundBuffer::normalize(float level){
 	float maxAmplitude = 0;
 	for(std::size_t i = 0; i < size(); i++) {
-		maxAmplitude = std::max(maxAmplitude, abs(buffer[i]));
+		maxAmplitude = std::max<float>(maxAmplitude, abs(buffer[i]));
 	}
 	float normalizationFactor = level/maxAmplitude;
 	for(std::size_t i = 0; i < size(); i++) {

--- a/libs/openFrameworks/sound/ofSoundBuffer.h
+++ b/libs/openFrameworks/sound/ofSoundBuffer.h
@@ -144,11 +144,11 @@ public:
 
 	void copyFrom(const float * floatBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate);
 
-	void copyFrom(const vector<short> & shortBuffer, std::size_t numChannels, unsigned int sampleRate);
+	void copyFrom(const std::vector<short> & shortBuffer, std::size_t numChannels, unsigned int sampleRate);
 	
-	void copyFrom(const vector<float> & floatBuffer, std::size_t numChannels, unsigned int sampleRate);
+	void copyFrom(const std::vector<float> & floatBuffer, std::size_t numChannels, unsigned int sampleRate);
 
-	void toShortPCM(vector<short> & dst) const;
+	void toShortPCM(std::vector<short> & dst) const;
 	void toShortPCM(short * dst) const;
 
 	/// resize outBuffer to outNumFrames with outNumChannels, and then copy outNumFrames of data from us to outBuffer.
@@ -213,15 +213,15 @@ public:
 	void set(float value);
 	
 	/// return the underlying buffer. careful!
-	vector<float> & getBuffer();
-	const vector<float> & getBuffer() const;
+	std::vector<float> & getBuffer();
+	const std::vector<float> & getBuffer() const;
 
 protected:
 
 	// checks that size() and number of channels are consistent, logs a warning if not. returns consistency check result.
 	bool checkSizeAndChannelsConsistency(const std::string& function="" );
 
-	vector<float> buffer;
+	std::vector<float> buffer;
 	std::size_t channels;
 	unsigned int samplerate;
 

--- a/libs/openFrameworks/sound/ofSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofSoundPlayer.cpp
@@ -60,17 +60,17 @@ float * ofSoundGetSpectrum(int nBands){
 //---------------------------------------------------------------------------
 ofSoundPlayer::ofSoundPlayer (){
 #ifdef OF_SOUND_PLAYER_TYPE
-	player	= shared_ptr<OF_SOUND_PLAYER_TYPE>(new OF_SOUND_PLAYER_TYPE);
+	player	= std::shared_ptr<OF_SOUND_PLAYER_TYPE>(new OF_SOUND_PLAYER_TYPE);
 #endif
 }
 
 //---------------------------------------------------------------------------
-void ofSoundPlayer::setPlayer(shared_ptr<ofBaseSoundPlayer> newPlayer){
+void ofSoundPlayer::setPlayer(std::shared_ptr<ofBaseSoundPlayer> newPlayer){
 	player = newPlayer;
 }
 
 //--------------------------------------------------------------------
-shared_ptr<ofBaseSoundPlayer> ofSoundPlayer::getPlayer(){
+std::shared_ptr<ofBaseSoundPlayer> ofSoundPlayer::getPlayer(){
 	return player;
 }
 
@@ -83,7 +83,7 @@ bool ofSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
 }
 
 //--------------------------------------------------------------------
-bool ofSoundPlayer::loadSound(string fileName, bool stream){
+bool ofSoundPlayer::loadSound(std::string fileName, bool stream){
 	return load(fileName,stream);
 }
 

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -78,8 +78,8 @@ class ofSoundPlayer : public ofBaseSoundPlayer {
 public:
     ofSoundPlayer();
 
-    void setPlayer(shared_ptr<ofBaseSoundPlayer> newPlayer);
-    shared_ptr<ofBaseSoundPlayer> getPlayer();
+    void setPlayer(std::shared_ptr<ofBaseSoundPlayer> newPlayer);
+    std::shared_ptr<ofBaseSoundPlayer> getPlayer();
 
     /// \brief Tells the sound player which file to play.
     ///
@@ -88,7 +88,7 @@ public:
     /// \param fileName Path to the sound file, relative to your app's data folder.
     /// \param stream set "true" to enable streaming from disk (for large files).
     bool load(const std::filesystem::path& fileName, bool stream = false);
-    OF_DEPRECATED_MSG("Use load",bool loadSound(string fileName, bool stream = false));
+    OF_DEPRECATED_MSG("Use load",bool loadSound(std::string fileName, bool stream = false));
 
     /// \brief Stops and unloads the current sound.
     void unload();
@@ -162,6 +162,6 @@ public:
     bool isLoaded() const;
 
 protected:
-    shared_ptr<ofBaseSoundPlayer> player;
+    std::shared_ptr<ofBaseSoundPlayer> player;
 
 };

--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -133,8 +133,8 @@ void ofSoundStreamClose(){
 }
 
 //------------------------------------------------------------
-vector<ofSoundDevice> ofSoundStreamListDevices(){
-	vector<ofSoundDevice> deviceList = systemSoundStream.getDeviceList();
+std::vector<ofSoundDevice> ofSoundStreamListDevices(){
+	std::vector<ofSoundDevice> deviceList = systemSoundStream.getDeviceList();
 	ofLogNotice("ofSoundStreamListDevices") << std::endl << deviceList;
 	return deviceList;
 }
@@ -142,32 +142,32 @@ vector<ofSoundDevice> ofSoundStreamListDevices(){
 //------------------------------------------------------------
 ofSoundStream::ofSoundStream(){
 	#ifdef OF_SOUND_STREAM_TYPE
-		setSoundStream( shared_ptr<OF_SOUND_STREAM_TYPE>(new OF_SOUND_STREAM_TYPE) );
+		setSoundStream( std::shared_ptr<OF_SOUND_STREAM_TYPE>(new OF_SOUND_STREAM_TYPE) );
 	#endif
 }
 
 //------------------------------------------------------------
-void ofSoundStream::setSoundStream(shared_ptr<ofBaseSoundStream> soundStreamPtr){
+void ofSoundStream::setSoundStream(std::shared_ptr<ofBaseSoundStream> soundStreamPtr){
 	soundStream = soundStreamPtr;
 }
 
 //------------------------------------------------------------
-shared_ptr<ofBaseSoundStream> ofSoundStream::getSoundStream(){
+std::shared_ptr<ofBaseSoundStream> ofSoundStream::getSoundStream(){
 	return soundStream;
 }
 
 //------------------------------------------------------------
-vector<ofSoundDevice> ofSoundStream::getDeviceList(ofSoundDevice::Api api) const{
+std::vector<ofSoundDevice> ofSoundStream::getDeviceList(ofSoundDevice::Api api) const{
 	if( soundStream ){
 		return soundStream->getDeviceList(api);
 	} else {
-		return vector<ofSoundDevice>();
+		return std::vector<ofSoundDevice>();
 	}
 }
 
 //------------------------------------------------------------
-vector<ofSoundDevice> ofSoundStream::listDevices() const{
-	vector<ofSoundDevice> deviceList = getDeviceList();
+std::vector<ofSoundDevice> ofSoundStream::listDevices() const{
+	std::vector<ofSoundDevice> deviceList = getDeviceList();
 	ofLogNotice("ofSoundStream::listDevices") << std::endl << deviceList;
 	return deviceList;
 }
@@ -335,12 +335,12 @@ int ofSoundStream::getBufferSize() const{
 }
 
 //------------------------------------------------------------
-vector<ofSoundDevice> ofSoundStream::getMatchingDevices(const std::string& name, unsigned int inChannels, unsigned int outChannels) const {
-	vector<ofSoundDevice> devs = getDeviceList();
-	vector<ofSoundDevice> hits;
+std::vector<ofSoundDevice> ofSoundStream::getMatchingDevices(const std::string& name, unsigned int inChannels, unsigned int outChannels) const {
+	std::vector<ofSoundDevice> devs = getDeviceList();
+	std::vector<ofSoundDevice> hits;
 	
 	for(size_t i = 0; i < devs.size(); i++) {
-		bool nameMatch = devs[i].name.find(name) != string::npos;
+		bool nameMatch = devs[i].name.find(name) != std::string::npos;
 		bool inMatch = (inChannels == UINT_MAX) || (devs[i].inputChannels == inChannels);
 		bool outMatch = (outChannels == UINT_MAX) || (devs[i].outputChannels == outChannels);
 		

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -86,8 +86,8 @@ class ofSoundStream {
 public:
 	ofSoundStream();
 
-	void setSoundStream(shared_ptr<ofBaseSoundStream> soundStreamPtr);
-	shared_ptr<ofBaseSoundStream> getSoundStream();
+	void setSoundStream(std::shared_ptr<ofBaseSoundStream> soundStreamPtr);
+	std::shared_ptr<ofBaseSoundStream> getSoundStream();
 
 	/// \brief Prints a list of available audio devices to the console
 	void printDeviceList() const;
@@ -186,7 +186,7 @@ public:
 	OF_DEPRECATED_MSG("Use printDeviceList instead", std::vector<ofSoundDevice> listDevices() const);
 
 protected:
-	shared_ptr<ofBaseSoundStream> soundStream;
+	std::shared_ptr<ofBaseSoundStream> soundStream;
 	int tmpDeviceId = -1;
 
 };

--- a/libs/openFrameworks/types/ofBaseTypes.cpp
+++ b/libs/openFrameworks/types/ofBaseTypes.cpp
@@ -49,7 +49,7 @@ ofBaseVideoPlayer::~ofBaseVideoPlayer(){
 
 }
 
-void ofBaseVideoPlayer::loadAsync(string name){
+void ofBaseVideoPlayer::loadAsync(std::string name){
 	ofLogWarning("ofBaseVideoPlayer") << "loadAsync() not implemented, loading synchronously";
 	load(name);
 }

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -179,10 +179,10 @@ public:
 	virtual ~ofBaseHasTexturePlanes(){}
 
 	/// \returns a reference to a std::vector containing the ofTexture planes.
-	virtual vector<ofTexture> & getTexturePlanes()=0;
+	virtual std::vector<ofTexture> & getTexturePlanes()=0;
 
 	/// \returns a const reference to a std::vector containing the ofTexture planes.
-	virtual const vector<ofTexture> & getTexturePlanes() const=0;
+	virtual const std::vector<ofTexture> & getTexturePlanes() const=0;
 };
 
 
@@ -391,7 +391,7 @@ class ofBaseVideoGrabber: virtual public ofBaseVideo{
 	//needs implementing
 	/// \brief Get a list of available video grabber devices.
 	/// \returns a std::vector of ofVideoDevice objects.
-	virtual vector<ofVideoDevice>	listDevices() const = 0;
+	virtual std::vector<ofVideoDevice>	listDevices() const = 0;
 
 	/// \brief Set up the grabber with the requested width and height.
 	///
@@ -464,7 +464,7 @@ public:
 	/// \param name The name of the video resource to load.
 	/// \returns True if the video was loaded successfully.
 	/// \sa loadAsync()
-    virtual bool				load(string name) = 0;
+    virtual bool				load(std::string name) = 0;
 	/// \brief Asynchronously load a video resource by name.
 	///
 	/// The list of supported video types and sources (e.g. rtsp:// sources) is
@@ -475,7 +475,7 @@ public:
 	///
 	/// \param name The name of the video resource to load.
 	/// \sa isLoaded()
-    virtual void				loadAsync(string name);
+    virtual void				loadAsync(std::string name);
 	
 	/// \brief Play the video from the current playhead position.
 	/// \sa getPosition()
@@ -637,7 +637,7 @@ public:
 	/// type depending on the renderer being used.
 	///
 	/// \returns The string representation of the renderer type.
-	virtual const string & getType()=0;
+	virtual const std::string & getType()=0;
 
 	/// \brief Starts using this renderer as the rendering surface.
 	virtual void startRender() = 0;
@@ -1373,13 +1373,13 @@ public:
 	/// \param x The x position for the bottom of \p text.
 	/// \param y The y position for the left alignment of \p text.
 	/// \param z The z position of the text.
-	virtual void drawString(string text, float x, float y, float z) const=0;
+	virtual void drawString(std::string text, float x, float y, float z) const=0;
 	/// \brief Draw text with this renderer using an ofTrueType font.
 	/// \param font The font to use when drawing \p text.
 	/// \param text The text to draw with the renderer.
 	/// \param x The x position for the bottom of \p text.
 	/// \param y The y position for the left alignment of \p text.
-	virtual void drawString(const ofTrueTypeFont & font, string text, float x, float y) const=0;
+	virtual void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const=0;
 
 
 	// returns true an ofPath to draw with, this allows to keep
@@ -1940,28 +1940,28 @@ public:
 	/// blocks until a response is returned or the request times out
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \return HTTP response on success or failure
-	virtual ofHttpResponse get(const string& url)=0;
+	virtual ofHttpResponse get(const std::string& url)=0;
 
 	/// \brief make an asynchronous HTTP request
 	/// will not block, placed in a queue and run using a background thread
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \param name optional key to use when sorting requests
 	/// \return unique id for the active HTTP request
-	virtual int getAsync(const string& url, const string& name="")=0;
+	virtual int getAsync(const std::string& url, const std::string& name="")=0;
 
 	/// \brief make an HTTP request and save the response data to a file
 	/// blocks until a response is returned or the request times out
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \param path file path to save to
 	/// \return HTTP response on success or failure
-	virtual ofHttpResponse saveTo(const string& url, const std::filesystem::path& path)=0;
+	virtual ofHttpResponse saveTo(const std::string& url, const std::filesystem::path& path)=0;
 
 	/// \brief make an asynchronous HTTP request and save the response data to a file
 	/// will not block, placed in a queue and run using a background thread
 	/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 	/// \param path file path to save to
 	/// \returns unique id for the active HTTP request
-	virtual int saveAsync(const string& url, const std::filesystem::path& path)=0;
+	virtual int saveAsync(const std::string& url, const std::filesystem::path& path)=0;
 
 	/// \brief remove an active HTTP request from the queue
 	/// \param unique HTTP request id

--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -526,7 +526,7 @@ public:
     /// \param os An output stream reference.
     /// \param color The color to write to the output stream.
     /// \returns The passed output stream reference, useful for method chaining.
-    friend ostream& operator << (ostream& os, const ofColor_<PixelType>& color) {
+    friend std::ostream& operator << (std::ostream& os, const ofColor_<PixelType>& color) {
         if(sizeof(PixelType) == 1) {
             os << (int) color.r << ", " << (int) color.g << ", " << (int) color.b << ", " << (int) color.a;
         } else {
@@ -543,7 +543,7 @@ public:
     /// \param is An input stream reference.
     /// \param color The color to fill with the input stream.
     /// \returns The passed input stream reference, useful for method chaining.
-    friend istream& operator >> (istream& is, ofColor_<PixelType>& color) {
+    friend std::istream& operator >> (std::istream& is, ofColor_<PixelType>& color) {
         if(sizeof(PixelType) == 1) {
             int component;
             is >> std::skipws >> component;
@@ -677,7 +677,7 @@ ofColor_<PixelType> operator*(float val, const ofColor_<PixelType> &color) {
 
 template<typename PixelType>
 inline float ofColor_<PixelType>::limit() {
-	return numeric_limits<PixelType>::max();
+	return std::numeric_limits<PixelType>::max();
 }
 
 template<>

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -1,6 +1,5 @@
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
-//using namespace std;
 
 std::string ofAbstractParameter::getEscapedName() const{
 	return escape(getName());

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -1,13 +1,13 @@
 #include "ofParameter.h"
 #include "ofParameterGroup.h"
-using namespace std;
+//using namespace std;
 
-string ofAbstractParameter::getEscapedName() const{
+std::string ofAbstractParameter::getEscapedName() const{
 	return escape(getName());
 }
 
 
-string ofAbstractParameter::escape(const string& _str) const{
+std::string ofAbstractParameter::escape(const std::string& _str) const{
 
 	std::string str(_str);
 
@@ -29,12 +29,12 @@ string ofAbstractParameter::escape(const string& _str) const{
 }
 
 
-string ofAbstractParameter::type() const{
+std::string ofAbstractParameter::type() const{
 	return typeid(*this).name();
 }
 
-vector<string> ofAbstractParameter::getGroupHierarchyNames() const{
-	vector<string> hierarchy;
+std::vector<std::string> ofAbstractParameter::getGroupHierarchyNames() const{
+	std::vector<std::string> hierarchy;
 	auto p = getFirstParent();
 	if(p){
 		hierarchy = p.getGroupHierarchyNames();
@@ -47,13 +47,13 @@ bool ofAbstractParameter::isReferenceTo(const ofAbstractParameter &other) const{
 	return getInternalObject() == other.getInternalObject();
 }
 
-ostream& operator<<(ostream& os, const ofAbstractParameter& p){
+std::ostream& operator<<(std::ostream& os, const ofAbstractParameter& p){
 	os << p.toString();
 	return os;
 }
 
-istream& operator>>(istream& is, ofAbstractParameter& p){
-	string str;
+std::istream& operator>>(std::istream& is, ofAbstractParameter& p){
+	std::string str;
 	is >> str;
 	p.fromString(str);
 	return is;
@@ -73,16 +73,16 @@ ofParameter<void>::ofParameter()
 
 }
 
-ofParameter<void>::ofParameter(const string& name)
+ofParameter<void>::ofParameter(const std::string& name)
 :obj(new Value(name)){
 
 }
 
-void ofParameter<void>::setName(const string & name){
+void ofParameter<void>::setName(const std::string & name){
 	obj->name = name;
 }
 
-string ofParameter<void>::getName() const{
+std::string ofParameter<void>::getName() const{
 	return obj->name;
 }
 
@@ -131,7 +131,7 @@ void ofParameter<void>::setSerializable(bool serializable){
 	obj->serializable = serializable;
 }
 
-shared_ptr<ofAbstractParameter> ofParameter<void>::newReference() const{
+std::shared_ptr<ofAbstractParameter> ofParameter<void>::newReference() const{
 	return std::make_shared<ofParameter<void>>(*this);
 }
 

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -23,16 +23,16 @@ class ofParameterGroup;
 class ofAbstractParameter{
 public:
 	virtual ~ofAbstractParameter(){}
-	virtual string getName() const = 0;
-	virtual void setName(const string & name) = 0;
-	virtual string toString() const = 0;
-	virtual void fromString(const string & str) = 0;
+	virtual std::string getName() const = 0;
+	virtual void setName(const std::string & name) = 0;
+	virtual std::string toString() const = 0;
+	virtual void fromString(const std::string & str) = 0;
 
-	virtual string type() const;
-	virtual string getEscapedName() const;
+	virtual std::string type() const;
+	virtual std::string getEscapedName() const;
 
 	virtual void setParent(ofParameterGroup & _parent) = 0;
-	vector<string> getGroupHierarchyNames() const;
+	std::vector<std::string> getGroupHierarchyNames() const;
 
 	template<typename ParameterType>
 	ofParameter<ParameterType> & cast(){
@@ -47,19 +47,19 @@ public:
 	ofParameterGroup & castGroup();
 	const ofParameterGroup & castGroup() const;
 
-	friend ostream& operator<<(ostream& os, const ofAbstractParameter& p);
-	friend istream& operator>>(istream& is, ofAbstractParameter& p);
+	friend std::ostream& operator<<(std::ostream& os, const ofAbstractParameter& p);
+	friend std::istream& operator>>(std::istream& is, ofAbstractParameter& p);
 
 	virtual bool isSerializable() const = 0;
 	virtual bool isReadOnly() const = 0;
-	virtual shared_ptr<ofAbstractParameter> newReference() const = 0;
+	virtual std::shared_ptr<ofAbstractParameter> newReference() const = 0;
 
 	virtual bool isReferenceTo(const ofAbstractParameter& other) const;
 
 protected:
 	virtual const ofParameterGroup getFirstParent() const = 0;
 	virtual void setSerializable(bool serializable)=0;
-	virtual string escape(const string& str) const;
+	virtual std::string escape(const std::string& str) const;
 	virtual const void* getInternalObject() const = 0;
 };
 
@@ -74,13 +74,13 @@ public:
 	ofParameterGroup();
 
 	template<typename ...Args>
-	ofParameterGroup(const string & name)
+	ofParameterGroup(const std::string & name)
 	:obj(std::make_shared<Value>()){
 		setName(name);
 	}
 
 	template<typename ...Args>
-	ofParameterGroup(const string & name, Args&... p)
+	ofParameterGroup(const std::string & name, Args&... p)
 	:obj(std::make_shared<Value>()){
 		add(p...);
 		setName(name);
@@ -100,20 +100,20 @@ public:
 
 	void clear();
 
-	const ofParameter<void> & getVoid(const string& name) const;
-	const ofParameter<bool> & getBool(const string& name) const;
-	const ofParameter<int> & getInt(const string& name) const;
-	const ofParameter<float> & getFloat(const string& name) const;
-	const ofParameter<char> & getChar(const string& name) const;
-	const ofParameter<string> & getString(const string& name) const;
-	const ofParameter<ofPoint> & getPoint(const string& name) const;
-	const ofParameter<ofDefaultVec2> & getVec2f(const string& name) const;
-	const ofParameter<ofDefaultVec3> & getVec3f(const string& name) const;
-	const ofParameter<ofDefaultVec4> & getVec4f(const string& name) const;
-	const ofParameter<ofColor> & getColor(const string& name) const;
-	const ofParameter<ofShortColor> & getShortColor(const string& name) const;
-	const ofParameter<ofFloatColor> & getFloatColor(const string& name) const;
-	const ofParameterGroup & getGroup(const string& name) const;
+	const ofParameter<void> & getVoid(const std::string& name) const;
+	const ofParameter<bool> & getBool(const std::string& name) const;
+	const ofParameter<int> & getInt(const std::string& name) const;
+	const ofParameter<float> & getFloat(const std::string& name) const;
+	const ofParameter<char> & getChar(const std::string& name) const;
+	const ofParameter<std::string> & getString(const std::string& name) const;
+	const ofParameter<ofPoint> & getPoint(const std::string& name) const;
+	const ofParameter<ofDefaultVec2> & getVec2f(const std::string& name) const;
+	const ofParameter<ofDefaultVec3> & getVec3f(const std::string& name) const;
+	const ofParameter<ofDefaultVec4> & getVec4f(const std::string& name) const;
+	const ofParameter<ofColor> & getColor(const std::string& name) const;
+	const ofParameter<ofShortColor> & getShortColor(const std::string& name) const;
+	const ofParameter<ofFloatColor> & getFloatColor(const std::string& name) const;
+	const ofParameterGroup & getGroup(const std::string& name) const;
 
 
 	const ofParameter<void> & getVoid(std::size_t pos) const;
@@ -121,7 +121,7 @@ public:
 	const ofParameter<int> & getInt(std::size_t pos) const;
 	const ofParameter<float> & getFloat(std::size_t pos) const;
 	const ofParameter<char> & getChar(std::size_t pos) const;
-	const ofParameter<string> & getString(std::size_t pos) const;
+	const ofParameter<std::string> & getString(std::size_t pos) const;
 	const ofParameter<ofPoint> & getPoint(std::size_t pos) const;
 	const ofParameter<ofDefaultVec2> & getVec2f(std::size_t pos) const;
 	const ofParameter<ofDefaultVec3> & getVec3f(std::size_t pos) const;
@@ -131,20 +131,20 @@ public:
 	const ofParameter<ofFloatColor> & getFloatColor(std::size_t pos) const;
 	const ofParameterGroup & getGroup(std::size_t pos) const;
 
-	ofParameter<void> & getVoid(const string& name);
-	ofParameter<bool> & getBool(const string& name);
-	ofParameter<int> & getInt(const string& name);
-	ofParameter<float> & getFloat(const string& name);
-	ofParameter<char> & getChar(const string& name);
-	ofParameter<string> & getString(const string& name);
-	ofParameter<ofPoint> & getPoint(const string& name);
-	ofParameter<ofDefaultVec2> & getVec2f(const string& name);
-	ofParameter<ofDefaultVec3> & getVec3f(const string& name);
-	ofParameter<ofDefaultVec4> & getVec4f(const string& name);
-	ofParameter<ofColor> & getColor(const string& name);
-	ofParameter<ofShortColor> & getShortColor(const string& name);
-	ofParameter<ofFloatColor> & getFloatColor(const string& name);
-	ofParameterGroup & getGroup(const string& name);
+	ofParameter<void> & getVoid(const std::string& name);
+	ofParameter<bool> & getBool(const std::string& name);
+	ofParameter<int> & getInt(const std::string& name);
+	ofParameter<float> & getFloat(const std::string& name);
+	ofParameter<char> & getChar(const std::string& name);
+	ofParameter<std::string> & getString(const std::string& name);
+	ofParameter<ofPoint> & getPoint(const std::string& name);
+	ofParameter<ofDefaultVec2> & getVec2f(const std::string& name);
+	ofParameter<ofDefaultVec3> & getVec3f(const std::string& name);
+	ofParameter<ofDefaultVec4> & getVec4f(const std::string& name);
+	ofParameter<ofColor> & getColor(const std::string& name);
+	ofParameter<ofShortColor> & getShortColor(const std::string& name);
+	ofParameter<ofFloatColor> & getFloatColor(const std::string& name);
+	ofParameterGroup & getGroup(const std::string& name);
 
 
 	ofParameter<void> & getVoid(std::size_t pos);
@@ -152,7 +152,7 @@ public:
 	ofParameter<int> & getInt(std::size_t pos);
 	ofParameter<float> & getFloat(std::size_t pos);
 	ofParameter<char> & getChar(std::size_t pos);
-	ofParameter<string> & getString(std::size_t pos);
+	ofParameter<std::string> & getString(std::size_t pos);
 	ofParameter<ofPoint> & getPoint(std::size_t pos);
 	ofParameter<ofDefaultVec2> & getVec2f(std::size_t pos);
 	ofParameter<ofDefaultVec3> & getVec3f(std::size_t pos);
@@ -162,45 +162,45 @@ public:
 	ofParameter<ofFloatColor> & getFloatColor(std::size_t pos);
 	ofParameterGroup & getGroup(std::size_t pos);
 
-	const ofAbstractParameter & get(const string& name) const;
+	const ofAbstractParameter & get(const std::string& name) const;
 	const ofAbstractParameter & get(std::size_t pos) const;
 
-	const ofAbstractParameter & operator[](const string& name) const;
+	const ofAbstractParameter & operator[](const std::string& name) const;
 	const ofAbstractParameter & operator[](std::size_t pos) const;
 
-	ofAbstractParameter & get(const string& name);
+	ofAbstractParameter & get(const std::string& name);
 	ofAbstractParameter & get(std::size_t pos);
 
-	ofAbstractParameter & operator[](const string& name);
+	ofAbstractParameter & operator[](const std::string& name);
 	ofAbstractParameter & operator[](std::size_t pos);
 
 	template<typename ParameterType>
-	const ofParameter<ParameterType> & get(const string& name) const;
+	const ofParameter<ParameterType> & get(const std::string& name) const;
 
 	template<typename ParameterType>
 	const ofParameter<ParameterType> & get(std::size_t pos) const;
 
 	template<typename ParameterType>
-	ofParameter<ParameterType> & get(const string& name);
+	ofParameter<ParameterType> & get(const std::string& name);
 
 	template<typename ParameterType>
 	ofParameter<ParameterType> & get(std::size_t pos);
 
 	std::size_t size() const;
-	string getName(std::size_t position) const;
-	string getType(std::size_t position) const;
+	std::string getName(std::size_t position) const;
+	std::string getType(std::size_t position) const;
 	bool getIsReadOnly(int position) const;
-	int getPosition(const string& name) const;
+	int getPosition(const std::string& name) const;
 
-	friend ostream& operator<<(ostream& os, const ofParameterGroup& group);
+	friend std::ostream& operator<<(std::ostream& os, const ofParameterGroup& group);
 
-	string getName() const;
-	void setName(const string& name);
-	string getEscapedName() const;
-	string toString() const;
-	void fromString(const string& name);
+	std::string getName() const;
+	void setName(const std::string& name);
+	std::string getEscapedName() const;
+	std::string toString() const;
+	void fromString(const std::string& name);
 
-	bool contains(const string& name) const;
+	bool contains(const std::string& name) const;
 
 	ofAbstractParameter & back();
 	ofAbstractParameter & front();
@@ -210,7 +210,7 @@ public:
 	void setSerializable(bool serializable);
 	bool isSerializable() const;
 	bool isReadOnly() const;
-	shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> newReference() const;
 
 	void setParent(ofParameterGroup & parent);
 
@@ -218,14 +218,14 @@ public:
 
 	ofEvent<ofAbstractParameter> & parameterChangedE();
 
-	vector<shared_ptr<ofAbstractParameter> >::iterator begin();
-	vector<shared_ptr<ofAbstractParameter> >::iterator end();
-	vector<shared_ptr<ofAbstractParameter> >::const_iterator begin() const;
-	vector<shared_ptr<ofAbstractParameter> >::const_iterator end() const;
-	vector<shared_ptr<ofAbstractParameter> >::reverse_iterator rbegin();
-	vector<shared_ptr<ofAbstractParameter> >::reverse_iterator rend();
-	vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator rbegin() const;
-	vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator rend() const;
+	std::vector<std::shared_ptr<ofAbstractParameter> >::iterator begin();
+	std::vector<std::shared_ptr<ofAbstractParameter> >::iterator end();
+	std::vector<std::shared_ptr<ofAbstractParameter> >::const_iterator begin() const;
+	std::vector<std::shared_ptr<ofAbstractParameter> >::const_iterator end() const;
+	std::vector<std::shared_ptr<ofAbstractParameter> >::reverse_iterator rbegin();
+	std::vector<std::shared_ptr<ofAbstractParameter> >::reverse_iterator rend();
+	std::vector<std::shared_ptr<ofAbstractParameter> >::const_reverse_iterator rbegin() const;
+	std::vector<std::shared_ptr<ofAbstractParameter> >::const_reverse_iterator rend() const;
 
 protected:
 	const void* getInternalObject() const;
@@ -238,15 +238,15 @@ private:
 
 		void notifyParameterChanged(ofAbstractParameter & param);
 
-		map<string,std::size_t> parametersIndex;
-		vector<shared_ptr<ofAbstractParameter> > parameters;
-		string name;
+		std::map<std::string,std::size_t> parametersIndex;
+		std::vector<std::shared_ptr<ofAbstractParameter> > parameters;
+		std::string name;
 		bool serializable;
-		vector<weak_ptr<Value>> parents;
+		std::vector<std::weak_ptr<Value>> parents;
 		ofEvent<ofAbstractParameter> parameterChangedE;
 	};
-	shared_ptr<Value> obj;
-	ofParameterGroup(shared_ptr<Value> obj)
+	std::shared_ptr<Value> obj;
+	ofParameterGroup(std::shared_ptr<Value> obj)
 	:obj(obj){}
 
 	template<typename T>
@@ -259,7 +259,7 @@ private:
 };
 
 template<typename ParameterType>
-const ofParameter<ParameterType> & ofParameterGroup::get(const string& name) const{
+const ofParameter<ParameterType> & ofParameterGroup::get(const std::string& name) const{
 	return static_cast<const ofParameter<ParameterType>& >(get(name));
 }
 
@@ -269,7 +269,7 @@ const ofParameter<ParameterType> & ofParameterGroup::get(std::size_t pos) const{
 }
 
 template<typename ParameterType>
-ofParameter<ParameterType> & ofParameterGroup::get(const string& name){
+ofParameter<ParameterType> & ofParameterGroup::get(const std::string& name){
 	return static_cast<ofParameter<ParameterType>& >(get(name));
 }
 
@@ -379,14 +379,14 @@ namespace priv{
 
 	template <typename T>
 	struct has_loading_support {
-		static istream & stream;
+		static std::istream & stream;
 		static T & x;
 		static constexpr bool value = sizeof(check_op(stream >> x)) == sizeof(yes);
 	};
 
 	template <typename T>
 	struct has_saving_support {
-		static ostream & stream;
+		static std::ostream & stream;
 		static T & x;
 		static constexpr bool value = sizeof(check_op(stream << x)) == sizeof(yes);
 	};
@@ -440,15 +440,15 @@ public:
 	ofParameter();
 	ofParameter(const ofParameter<ParameterType> & v);
 	ofParameter(const ParameterType & v);
-	ofParameter(const string& name, const ParameterType & v);
-	ofParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+	ofParameter(const std::string& name, const ParameterType & v);
+	ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
 	const ParameterType & get() const;
 	const ParameterType * operator->() const;
 	operator const ParameterType & () const;
 
-	void setName(const string & name);
-	string getName() const;
+	void setName(const std::string & name);
+	std::string getName() const;
 
 	ParameterType getMin() const;
 
@@ -512,8 +512,8 @@ public:
 
 
 	ofParameter<ParameterType> & set(const ParameterType & v);
-	ofParameter<ParameterType> & set(const string& name, const ParameterType & v);
-	ofParameter<ParameterType> & set(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+	ofParameter<ParameterType> & set(const std::string& name, const ParameterType & v);
+	ofParameter<ParameterType> & set(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
 	ofParameter<ParameterType> & setWithoutEventNotifications(const ParameterType & v);
 
@@ -521,18 +521,18 @@ public:
 	void setMax(const ParameterType & max);
 
 	void setSerializable(bool serializable);
-	shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> newReference() const;
 
 	void setParent(ofParameterGroup & _parent);
 
 	const ofParameterGroup getFirstParent() const{
 		obj->parents.erase(std::remove_if(obj->parents.begin(),obj->parents.end(),
-						   [](weak_ptr<ofParameterGroup::Value> p){return p.lock()==nullptr;}),
+						   [](std::weak_ptr<ofParameterGroup::Value> p){return p.lock()==nullptr;}),
 						obj->parents.end());
 		if(!obj->parents.empty()){
 			return obj->parents.front().lock();
 		}else{
-			return shared_ptr<ofParameterGroup::Value>(nullptr);
+			return std::shared_ptr<ofParameterGroup::Value>(nullptr);
 		}
 	}
 
@@ -557,7 +557,7 @@ private:
 		,bInNotify(false)
 		,serializable(true){}
 
-		Value(string name, ParameterType v)
+		Value(std::string name, ParameterType v)
 		:name(name)
 		,value(v)
 		,min(of::priv::TypeInfo<ParameterType>::min())
@@ -565,7 +565,7 @@ private:
 		,bInNotify(false)
 		,serializable(true){}
 
-		Value(string name, ParameterType v, ParameterType min, ParameterType max)
+		Value(std::string name, ParameterType v, ParameterType min, ParameterType max)
 		:name(name)
 		,value(v)
 		,min(min)
@@ -573,16 +573,16 @@ private:
 		,bInNotify(false)
 		,serializable(true){}
 
-		string name;
+		std::string name;
 		ParameterType value;
 		ParameterType min, max;
 		ofEvent<ParameterType> changedE;
 		bool bInNotify;
 		bool serializable;
-		vector<weak_ptr<ofParameterGroup::Value>> parents;
+		std::vector<std::weak_ptr<ofParameterGroup::Value>> parents;
 	};
 
-	shared_ptr<Value> obj;
+	std::shared_ptr<Value> obj;
 	std::function<void(const ParameterType & v)> setMethod;
 
 	void eventsSetValue(const ParameterType & v);
@@ -609,12 +609,12 @@ ofParameter<ParameterType>::ofParameter(const ParameterType & v)
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)) {}
 
 template<typename ParameterType>
-ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v)
+ofParameter<ParameterType>::ofParameter(const std::string& name, const ParameterType & v)
 :obj(std::make_shared<Value>(name, v))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 template<typename ParameterType>
-ofParameter<ParameterType>::ofParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
+ofParameter<ParameterType>::ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
 :obj(std::make_shared<Value>(name, v, min, max))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
@@ -638,7 +638,7 @@ inline ofParameter<ParameterType> & ofParameter<ParameterType>::set(const Parame
 }
 
 template<typename ParameterType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::set(const string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max){
+ofParameter<ParameterType> & ofParameter<ParameterType>::set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max){
 	setName(name);
 	set(value);
 	setMin(min);
@@ -647,7 +647,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::set(const string& name,
 }
 
 template<typename ParameterType>
-ofParameter<ParameterType> & ofParameter<ParameterType>::set(const string& name, const ParameterType & value){
+ofParameter<ParameterType> & ofParameter<ParameterType>::set(const std::string& name, const ParameterType & value){
 	setName(name);
 	set(value);
 	return *this;
@@ -693,7 +693,7 @@ inline void ofParameter<ParameterType>::eventsSetValue(const ParameterType & v){
 			// Erase each invalid parent
 			obj->parents.erase(std::remove_if(obj->parents.begin(),
 											  obj->parents.end(),
-											  [this](const weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
+											  [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
 							   obj->parents.end());
 
 			// notify all leftover (valid) parents of this object's changed value.
@@ -758,12 +758,12 @@ inline ofParameter<ParameterType>::operator const ParameterType & () const{
 }
 
 template<typename ParameterType>
-void ofParameter<ParameterType>::setName(const string & name){
+void ofParameter<ParameterType>::setName(const std::string & name){
 	obj->name = name;
 }
 
 template<typename ParameterType>
-string ofParameter<ParameterType>::getName() const{
+std::string ofParameter<ParameterType>::getName() const{
 	return obj->name;
 }
 
@@ -912,7 +912,7 @@ void ofParameter<ParameterType>::makeReferenceTo(ofParameter<ParameterType> & mo
 }
 
 template<typename ParameterType>
-shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::newReference() const{
+std::shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::newReference() const{
 	return std::make_shared<ofParameter<ParameterType>>(*this);
 }
 
@@ -971,16 +971,16 @@ public:
 	void makeReferenceTo(ofParameter<void> & mom);
 
 	void setSerializable(bool serializable);
-	shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> newReference() const;
 
 	void setParent(ofParameterGroup & _parent);
 
 	const ofParameterGroup getFirstParent() const{
-		auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](weak_ptr<ofParameterGroup::Value> p){return p.lock()!=nullptr;});
+		auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](std::weak_ptr<ofParameterGroup::Value> p){return p.lock()!=nullptr;});
 		if(first!=obj->parents.end()){
 			return first->lock();
 		}else{
-			return shared_ptr<ofParameterGroup::Value>(nullptr);
+			return std::shared_ptr<ofParameterGroup::Value>(nullptr);
 		}
 	}
 	size_t getNumListeners() const;
@@ -996,16 +996,16 @@ private:
 		Value()
 		:serializable(false){}
 
-		Value(string name)
+		Value(std::string name)
 		:name(name)
 		,serializable(false){}
 
-		string name;
+		std::string name;
 		ofEvent<void> changedE;
 		bool serializable;
-		vector<weak_ptr<ofParameterGroup::Value>> parents;
+		std::vector<std::weak_ptr<ofParameterGroup::Value>> parents;
 	};
-	shared_ptr<Value> obj;
+	std::shared_ptr<Value> obj;
 };
 
 
@@ -1027,20 +1027,20 @@ public:
 	ofReadOnlyParameter(ofParameter<ParameterType> & p);
 	ofReadOnlyParameter(ofReadOnlyParameter<ParameterType,Friend> & p);
 	ofReadOnlyParameter(const ParameterType & v);
-	ofReadOnlyParameter(const string& name, const ParameterType & v);
-	ofReadOnlyParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+	ofReadOnlyParameter(const std::string& name, const ParameterType & v);
+	ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
 	const ParameterType & get() const;
 	const ParameterType * operator->() const;
 	operator const ParameterType & () const;
 
-	string getName() const;
+	std::string getName() const;
 
 	ParameterType getMin() const;
 
 	ParameterType getMax() const;
 
-	string toString() const;
+	std::string toString() const;
 
 	template<class ListenerClass, typename ListenerMethod>
 	void addListener(ListenerClass * listener, ListenerMethod method, int prio=OF_EVENT_ORDER_AFTER_APP);
@@ -1048,12 +1048,12 @@ public:
 	template<class ListenerClass, typename ListenerMethod>
 	void removeListener(ListenerClass * listener, ListenerMethod method, int prio=OF_EVENT_ORDER_AFTER_APP);
 
-	shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> newReference() const;
 	bool isSerializable() const;
 	bool isReadOnly() const;
 
 protected:
-	void setName(const string & name);
+	void setName(const std::string & name);
 	void enableEvents();
 	void disableEvents();
 	void setSerializable(bool s);
@@ -1095,13 +1095,13 @@ protected:
 
 	ofReadOnlyParameter<ParameterType,Friend>& set(const ParameterType & v);
 	
-	ofReadOnlyParameter<ParameterType,Friend>& set(const string& name, const ParameterType & value);
-	ofReadOnlyParameter<ParameterType,Friend>& set(const string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max);
+	ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value);
+	ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max);
 
 	void setMin(const ParameterType & min);
 	void setMax(const ParameterType & max);
 
-	void fromString(const string & str);
+	void fromString(const std::string & str);
 
 	void setParent(ofParameterGroup & _parent);
 
@@ -1138,11 +1138,11 @@ inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const Para
 :parameter(v){}
 
 template<typename ParameterType,typename Friend>
-inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const string& name, const ParameterType & v)
+inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v)
 :parameter(name,v){}
 
 template<typename ParameterType,typename Friend>
-inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
+inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
 :parameter(name,v,min,max){}
 
 
@@ -1163,7 +1163,7 @@ inline ofReadOnlyParameter<ParameterType,Friend>::operator const ParameterType &
 
 
 template<typename ParameterType,typename Friend>
-inline string ofReadOnlyParameter<ParameterType,Friend>::getName() const{
+inline std::string ofReadOnlyParameter<ParameterType,Friend>::getName() const{
 	return parameter.getName();
 }
 
@@ -1181,7 +1181,7 @@ inline ParameterType ofReadOnlyParameter<ParameterType,Friend>::getMax() const{
 
 
 template<typename ParameterType,typename Friend>
-inline string ofReadOnlyParameter<ParameterType,Friend>::toString() const{
+inline std::string ofReadOnlyParameter<ParameterType,Friend>::toString() const{
 	return parameter.toString();
 }
 
@@ -1201,7 +1201,7 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::removeListener(ListenerCl
 
 
 template<typename ParameterType,typename Friend>
-inline void ofReadOnlyParameter<ParameterType,Friend>::setName(const string & name){
+inline void ofReadOnlyParameter<ParameterType,Friend>::setName(const std::string & name){
 	parameter.setName(name);
 }
 
@@ -1360,13 +1360,13 @@ inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<Parameter
 }
 
 template<typename ParameterType,typename Friend>
-inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<ParameterType,Friend>::set(const string& name, const ParameterType & value){
+inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<ParameterType,Friend>::set(const std::string& name, const ParameterType & value){
 	parameter.set(name,value);
 	return *this;
 }
 
 template<typename ParameterType,typename Friend>
-inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<ParameterType,Friend>::set(const string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max){
+inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<ParameterType,Friend>::set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max){
 	parameter.set(name,value,min,max);
 	return *this;
 }
@@ -1384,12 +1384,12 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::setMax(const ParameterTyp
 
 
 template<typename ParameterType,typename Friend>
-inline void ofReadOnlyParameter<ParameterType,Friend>::fromString(const string & str){
+inline void ofReadOnlyParameter<ParameterType,Friend>::fromString(const std::string & str){
 	parameter.fromString(str);
 }
 
 template<typename ParameterType,typename Friend>
-shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType,Friend>::newReference() const{
+std::shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType,Friend>::newReference() const{
 	return std::make_shared<ofReadOnlyParameter<ParameterType,Friend>>(*this);
 }
 

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -8,7 +8,7 @@ ofParameterGroup::ofParameterGroup()
 }
 
 void ofParameterGroup::add(ofAbstractParameter & parameter){
-	shared_ptr<ofAbstractParameter> param = parameter.newReference();
+	std::shared_ptr<ofAbstractParameter> param = parameter.newReference();
 	const std::string name = param->getEscapedName();
 	if(obj->parametersIndex.find(name) != obj->parametersIndex.end()){
 		ofLogWarning() << "Adding another parameter with same name '" << param->getName() << "' to group '" << getName() << "'";
@@ -19,7 +19,7 @@ void ofParameterGroup::add(ofAbstractParameter & parameter){
 }
 
 void ofParameterGroup::remove(ofAbstractParameter &param){
-	std::for_each(obj->parameters.begin(), obj->parameters.end(), [&](shared_ptr<ofAbstractParameter>& p){
+	std::for_each(obj->parameters.begin(), obj->parameters.end(), [&](std::shared_ptr<ofAbstractParameter>& p){
 		if(p->isReferenceTo(param)){
 			remove(param.getName());
 		}
@@ -33,7 +33,7 @@ void ofParameterGroup::remove(size_t index){
 	remove(obj->parameters[index]->getName());
 }
 
-void ofParameterGroup::remove(const string &name){
+void ofParameterGroup::remove(const std::string &name){
 	if(!contains(name)){
 		return;
 	}
@@ -45,59 +45,59 @@ void ofParameterGroup::clear(){
 	obj.reset(new Value);
 }
 
-const ofParameter<void> & ofParameterGroup::getVoid(const string& name) const	{
+const ofParameter<void> & ofParameterGroup::getVoid(const std::string& name) const	{
 	return get<void>(name);
 }
 
-const ofParameter<bool> & ofParameterGroup::getBool(const string& name) const	{
+const ofParameter<bool> & ofParameterGroup::getBool(const std::string& name) const	{
 	return get<bool>(name);
 }
 
-const ofParameter<int> & ofParameterGroup::getInt(const string& name) const{
+const ofParameter<int> & ofParameterGroup::getInt(const std::string& name) const{
 	return get<int>(name);
 }
 
-const ofParameter<float> & ofParameterGroup::getFloat(const string& name) const{
+const ofParameter<float> & ofParameterGroup::getFloat(const std::string& name) const{
 	return get<float>(name);
 }
 
-const ofParameter<char> & ofParameterGroup::getChar(const string& name) const{
+const ofParameter<char> & ofParameterGroup::getChar(const std::string& name) const{
 	return get<char>(name);
 }
 
-const ofParameter<string> & ofParameterGroup::getString(const string& name) const{
-	return get<string>(name);
+const ofParameter<std::string> & ofParameterGroup::getString(const std::string& name) const{
+	return get<std::string>(name);
 }
 
-const ofParameter<ofPoint> & ofParameterGroup::getPoint(const string& name) const{
+const ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string& name) const{
 	return get<ofPoint>(name);
 }
 
-const ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const string& name) const{
+const ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const std::string& name) const{
 	return get<ofDefaultVec2>(name);
 }
 
-const ofParameter<ofDefaultVec3> & ofParameterGroup::getVec3f(const string& name) const{
+const ofParameter<ofDefaultVec3> & ofParameterGroup::getVec3f(const std::string& name) const{
 	return get<ofDefaultVec3>(name);
 }
 
-const ofParameter<ofDefaultVec4> & ofParameterGroup::getVec4f(const string& name) const{
+const ofParameter<ofDefaultVec4> & ofParameterGroup::getVec4f(const std::string& name) const{
 	return get<ofDefaultVec4>(name);
 }
 
-const ofParameter<ofColor> & ofParameterGroup::getColor(const string& name) const{
+const ofParameter<ofColor> & ofParameterGroup::getColor(const std::string& name) const{
 	return get<ofColor>(name);
 }
 
-const ofParameter<ofShortColor> & ofParameterGroup::getShortColor(const string& name) const{
+const ofParameter<ofShortColor> & ofParameterGroup::getShortColor(const std::string& name) const{
 	return get<ofShortColor>(name);
 }
 
-const ofParameter<ofFloatColor> & ofParameterGroup::getFloatColor(const string& name) const{
+const ofParameter<ofFloatColor> & ofParameterGroup::getFloatColor(const std::string& name) const{
 	return get<ofFloatColor>(name);
 }
 
-const ofParameterGroup & ofParameterGroup::getGroup(const string& name) const{
+const ofParameterGroup & ofParameterGroup::getGroup(const std::string& name) const{
 	return static_cast<const ofParameterGroup&>(get(name));
 }
 
@@ -121,8 +121,8 @@ const ofParameter<char> & ofParameterGroup::getChar(std::size_t pos) const{
 	return get<char>(pos);
 }
 
-const ofParameter<string> & ofParameterGroup::getString(std::size_t pos) const{
-	return get<string>(pos);
+const ofParameter<std::string> & ofParameterGroup::getString(std::size_t pos) const{
+	return get<std::string>(pos);
 }
 
 const ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos)	 const{
@@ -166,59 +166,59 @@ const ofParameterGroup & ofParameterGroup::getGroup(std::size_t pos) const{
 	}
 }
 
-ofParameter<void> & ofParameterGroup::getVoid(const string& name){
+ofParameter<void> & ofParameterGroup::getVoid(const std::string& name){
 	return get<void>(name);
 }
 
-ofParameter<bool> & ofParameterGroup::getBool(const string& name){
+ofParameter<bool> & ofParameterGroup::getBool(const std::string& name){
 	return get<bool>(name);
 }
 
-ofParameter<int> & ofParameterGroup::getInt(const string& name){
+ofParameter<int> & ofParameterGroup::getInt(const std::string& name){
 	return get<int>(name);
 }
 
-ofParameter<float> & ofParameterGroup::getFloat(const string& name){
+ofParameter<float> & ofParameterGroup::getFloat(const std::string& name){
 	return get<float>(name);
 }
 
-ofParameter<char> & ofParameterGroup::getChar(const string& name){
+ofParameter<char> & ofParameterGroup::getChar(const std::string& name){
 	return get<char>(name);
 }
 
-ofParameter<string> & ofParameterGroup::getString(const string& name){
-	return get<string>(name);
+ofParameter<std::string> & ofParameterGroup::getString(const std::string& name){
+	return get<std::string>(name);
 }
 
-ofParameter<ofPoint> & ofParameterGroup::getPoint(const string& name){
+ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string& name){
 	return get<ofPoint>(name);
 }
 
-ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const string& name){
+ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const std::string& name){
 	return get<ofDefaultVec2>(name);
 }
 
-ofParameter<ofDefaultVec3> & ofParameterGroup::getVec3f(const string& name){
+ofParameter<ofDefaultVec3> & ofParameterGroup::getVec3f(const std::string& name){
 	return get<ofDefaultVec3>(name);
 }
 
-ofParameter<ofDefaultVec4> & ofParameterGroup::getVec4f(const string& name){
+ofParameter<ofDefaultVec4> & ofParameterGroup::getVec4f(const std::string& name){
 	return get<ofDefaultVec4>(name);
 }
 
-ofParameter<ofColor> & ofParameterGroup::getColor(const string& name){
+ofParameter<ofColor> & ofParameterGroup::getColor(const std::string& name){
 	return get<ofColor>(name);
 }
 
-ofParameter<ofShortColor> & ofParameterGroup::getShortColor(const string& name){
+ofParameter<ofShortColor> & ofParameterGroup::getShortColor(const std::string& name){
 	return get<ofShortColor>(name);
 }
 
-ofParameter<ofFloatColor> & ofParameterGroup::getFloatColor(const string& name){
+ofParameter<ofFloatColor> & ofParameterGroup::getFloatColor(const std::string& name){
 	return get<ofFloatColor>(name);
 }
 
-ofParameterGroup & ofParameterGroup::getGroup(const string& name){
+ofParameterGroup & ofParameterGroup::getGroup(const std::string& name){
 	return static_cast<ofParameterGroup& >(get(name));
 }
 
@@ -242,8 +242,8 @@ ofParameter<char> & ofParameterGroup::getChar(std::size_t pos){
 	return get<char>(pos);
 }
 
-ofParameter<string> & ofParameterGroup::getString(std::size_t pos){
-	return get<string>(pos);
+ofParameter<std::string> & ofParameterGroup::getString(std::size_t pos){
+	return get<std::string>(pos);
 }
 
 ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos){
@@ -292,7 +292,7 @@ std::size_t ofParameterGroup::size() const{
 	return obj->parameters.size();
 }
 
-string ofParameterGroup::getName(std::size_t position) const{
+std::string ofParameterGroup::getName(std::size_t position) const{
 	if(position>=size()){
 		return "";
 	}else{
@@ -300,27 +300,27 @@ string ofParameterGroup::getName(std::size_t position) const{
 	}
 }
 
-string ofParameterGroup::getType(std::size_t position) const{
+std::string ofParameterGroup::getType(std::size_t position) const{
 	if(position>=size()) return "";
 	else return obj->parameters[position]->type();
 }
 
 
-int ofParameterGroup::getPosition(const string& name) const{
+int ofParameterGroup::getPosition(const std::string& name) const{
 	if(obj->parametersIndex.find(escape(name))!=obj->parametersIndex.end())
 		return obj->parametersIndex.find(escape(name))->second;
 	return -1;
 }
 
-string ofParameterGroup::getName() const{
+std::string ofParameterGroup::getName() const{
 	return obj->name;
 }
 
-void ofParameterGroup::setName(const string & name){
+void ofParameterGroup::setName(const std::string & name){
 	obj->name = name;
 }
 
-string ofParameterGroup::getEscapedName() const{
+std::string ofParameterGroup::getEscapedName() const{
 	if(getName()==""){
 		return "group";
 	}else{
@@ -328,19 +328,19 @@ string ofParameterGroup::getEscapedName() const{
 	}
 }
 
-string ofParameterGroup::toString() const{
-	stringstream out;
+std::string ofParameterGroup::toString() const{
+	std::stringstream out;
 	out << *this;
 	return out.str();
 }
 
-void ofParameterGroup::fromString(const string & name){
+void ofParameterGroup::fromString(const std::string & name){
 	ofLogWarning() << "ofParameterGroup doesn't implement fromString yet";
 }
 
 
-const ofAbstractParameter & ofParameterGroup::get(const string& name) const{
-	map<string,std::size_t>::const_iterator it = obj->parametersIndex.find(escape(name));
+const ofAbstractParameter & ofParameterGroup::get(const std::string& name) const{
+	std::map<std::string,std::size_t>::const_iterator it = obj->parametersIndex.find(escape(name));
 	std::size_t index = it->second;
 	return get(index);
 }
@@ -350,7 +350,7 @@ const ofAbstractParameter & ofParameterGroup::get(std::size_t pos) const{
 }
 
 
-const ofAbstractParameter & ofParameterGroup::operator[](const string& name) const{
+const ofAbstractParameter & ofParameterGroup::operator[](const std::string& name) const{
 	return get(name);
 }
 
@@ -358,8 +358,8 @@ const ofAbstractParameter & ofParameterGroup::operator[](std::size_t pos) const{
 	return get(pos);
 }
 
-ofAbstractParameter & ofParameterGroup::get(const string& name){
-	map<string,std::size_t>::const_iterator it = obj->parametersIndex.find(escape(name));
+ofAbstractParameter & ofParameterGroup::get(const std::string& name){
+	std::map<std::string,std::size_t>::const_iterator it = obj->parametersIndex.find(escape(name));
 	std::size_t index = it->second;
 	return get(index);
 }
@@ -369,7 +369,7 @@ ofAbstractParameter & ofParameterGroup::get(std::size_t pos){
 }
 
 
-ofAbstractParameter & ofParameterGroup::operator[](const string& name){
+ofAbstractParameter & ofParameterGroup::operator[](const std::string& name){
 	return get(name);
 }
 
@@ -377,28 +377,28 @@ ofAbstractParameter & ofParameterGroup::operator[](std::size_t pos){
 	return get(pos);
 }
 
-ostream& operator<<(ostream& os, const ofParameterGroup& group) {
+std::ostream& operator<<(std::ostream& os, const ofParameterGroup& group) {
 	std::streamsize width = os.width();
 	for(std::size_t i=0;i<group.size();i++){
 		if(group.getType(i)==typeid(ofParameterGroup).name()){
-			os << group.getName(i) << ":" << endl;
-			os << setw(width+4);
+			os << group.getName(i) << ":" << std::endl;
+			os << std::setw(width+4);
 			os << group.getGroup(i);
 		}else{
-			os << group.getName(i) << ":" << group.get(i) << endl;
-			os << setw(width);
+			os << group.getName(i) << ":" << group.get(i) << std::endl;
+			os << std::setw(width);
 		}
 	}
 	return os;
 }
 
-bool ofParameterGroup::contains(const string& name) const{
+bool ofParameterGroup::contains(const std::string& name) const{
 	return obj->parametersIndex.find(escape(name))!=obj->parametersIndex.end();
 }
 
 void ofParameterGroup::Value::notifyParameterChanged(ofAbstractParameter & param){
 	ofNotifyEvent(parameterChangedE,param);
-	parents.erase(std::remove_if(parents.begin(),parents.end(),[&param](const weak_ptr<Value> & p){
+	parents.erase(std::remove_if(parents.begin(),parents.end(),[&param](const std::weak_ptr<Value> & p){
 		auto parent = p.lock();
 		if(parent) parent->notifyParameterChanged(param);
 		return !parent;
@@ -406,11 +406,11 @@ void ofParameterGroup::Value::notifyParameterChanged(ofAbstractParameter & param
 }
 
 const ofParameterGroup ofParameterGroup::getFirstParent() const{
-	auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](const weak_ptr<Value> & p){return p.lock()!=nullptr;});
+	auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](const std::weak_ptr<Value> & p){return p.lock()!=nullptr;});
 	if(first!=obj->parents.end()){
 		return first->lock();
 	}else{
-		return shared_ptr<Value>(nullptr);
+		return std::shared_ptr<Value>(nullptr);
 	}
 }
 
@@ -450,7 +450,7 @@ const void* ofParameterGroup::getInternalObject() const{
 	return obj.get();
 }
 
-shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{
+std::shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{
 	return std::make_shared<ofParameterGroup>(*this);
 }
 
@@ -462,35 +462,35 @@ ofParameterGroup::operator bool() const{
 	return obj != nullptr;
 }
 
-vector<shared_ptr<ofAbstractParameter> >::iterator ofParameterGroup::begin(){
+std::vector<std::shared_ptr<ofAbstractParameter> >::iterator ofParameterGroup::begin(){
 	return obj->parameters.begin();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::iterator ofParameterGroup::end(){
+std::vector<std::shared_ptr<ofAbstractParameter> >::iterator ofParameterGroup::end(){
 	return obj->parameters.end();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::const_iterator ofParameterGroup::begin() const{
+std::vector<std::shared_ptr<ofAbstractParameter> >::const_iterator ofParameterGroup::begin() const{
 	return obj->parameters.begin();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::const_iterator ofParameterGroup::end() const{
+std::vector<std::shared_ptr<ofAbstractParameter> >::const_iterator ofParameterGroup::end() const{
 	return obj->parameters.end();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::reverse_iterator ofParameterGroup::rbegin(){
+std::vector<std::shared_ptr<ofAbstractParameter> >::reverse_iterator ofParameterGroup::rbegin(){
 	return obj->parameters.rbegin();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::reverse_iterator ofParameterGroup::rend(){
+std::vector<std::shared_ptr<ofAbstractParameter> >::reverse_iterator ofParameterGroup::rend(){
 	return obj->parameters.rend();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGroup::rbegin() const{
+std::vector<std::shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGroup::rbegin() const{
 	return obj->parameters.rbegin();
 }
 
-vector<shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGroup::rend() const{
+std::vector<std::shared_ptr<ofAbstractParameter> >::const_reverse_iterator ofParameterGroup::rend() const{
 	return obj->parameters.rend();
 }
 

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -825,13 +825,13 @@ bool ofRectangle::isZero() const{
 }
 
 //----------------------------------------------------------
-ostream& operator<<(ostream& os, const ofRectangle& rect){
+std::ostream& operator<<(std::ostream& os, const ofRectangle& rect){
 	os << rect.position << ", " << rect.width << ", " << rect.height;
 	return os;
 }
 
 //----------------------------------------------------------
-istream& operator>>(istream& is, ofRectangle& rect){
+std::istream& operator>>(std::istream& is, ofRectangle& rect){
 	is >> rect.position;
 	is.ignore(2);
 	is >> rect.width;

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -869,8 +869,8 @@ public:
 /// \cond INTERNAL
 /// \warning The internal z component of the glm::vec3 is preserved even though it
 /// is not used.
-ostream& operator<<(ostream& os, const ofRectangle& rect);
+std::ostream& operator<<(std::ostream& os, const ofRectangle& rect);
 /// \warning The internal z component of the glm::vec3 is preserved even though it
 /// is not used.
-istream& operator>>(istream& is, ofRectangle& rect);
+std::istream& operator>>(std::istream& is, ofRectangle& rect);
 /// \endcond

--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -14,7 +14,7 @@ class ofSerialDeviceInfo{
 		/// \param devicePathIn The path to the device.
 		/// \param deviceNameIn The name of the device.
 		/// \param deviceIDIn The ID of the device.
-		ofSerialDeviceInfo(string devicePathIn, string deviceNameIn, int deviceIDIn){
+		ofSerialDeviceInfo(std::string devicePathIn, std::string deviceNameIn, int deviceIDIn){
 			devicePath = devicePathIn;
 			deviceName = deviceNameIn;
 			deviceID = deviceIDIn;
@@ -31,7 +31,7 @@ class ofSerialDeviceInfo{
 		/// Example: `/dev/tty.cu/usbdevice-a440`.
 		///
 		/// \returns the device path.
-		string getDevicePath(){
+		std::string getDevicePath(){
 			return devicePath;
 		}
 
@@ -40,7 +40,7 @@ class ofSerialDeviceInfo{
 		/// Example: `usbdevice-a440` or `COM4`.
 		///
 		/// \returns the device name.
-		string getDeviceName(){
+		std::string getDeviceName(){
 			return deviceName;
 		}
 
@@ -57,10 +57,10 @@ class ofSerialDeviceInfo{
 		/// \cond INTERNAL
 
 		/// \brief The device path (e.g /dev/tty.cu/usbdevice-a440).
-		string devicePath;
+		std::string devicePath;
 
 		/// \brief The device name (e.g. usbdevice-a440 / COM4).
-		string deviceName;
+		std::string deviceName;
 
 		/// \brief The device ID (e.g. 0, 1, 2, 3, etc).
 		int deviceID;
@@ -250,7 +250,7 @@ public:
 	int height;
 
 	/// \brief A list of framerates for this video format in frames per second.
-	vector<float> framerates;
+	std::vector<float> framerates;
 };
 
 /// \brief A structure describing attributes of a video device.
@@ -262,17 +262,17 @@ public:
 	int id;
 
 	/// \brief The video device name.
-	string deviceName;
+	std::string deviceName;
 
 	/// \brief The video device hardware name.
-	string hardwareName;
+	std::string hardwareName;
 
 	/// \brief Unique identifier for the device if it has one. 
-	string serialID;
+	std::string serialID;
 
 	/// \brief A list of video device formats provided by the device.
 	/// \sa ofVideoFormat
-	vector<ofVideoFormat> formats;
+	std::vector<ofVideoFormat> formats;
 
 	/// \brief Is true if this video device is available.
 	bool bAvailable;

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -432,7 +432,7 @@ typedef ofBaseApp ofSimpleApp;
 
 
 
-using namespace std;
+//using namespace std;
 
 #ifndef PI
 	#define PI       3.14159265358979323846

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -432,8 +432,6 @@ typedef ofBaseApp ofSimpleApp;
 
 
 
-//using namespace std;
-
 #ifndef PI
 	#define PI       3.14159265358979323846
 #endif

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -31,13 +31,13 @@ ofBuffer::ofBuffer(const char * _buffer, std::size_t size)
 }
 
 //--------------------------------------------------
-ofBuffer::ofBuffer(istream & stream, size_t ioBlockSize)
+ofBuffer::ofBuffer(std::istream & stream, size_t ioBlockSize)
 :currentLine(end(),end()){
 	set(stream, ioBlockSize);
 }
 
 //--------------------------------------------------
-bool ofBuffer::set(istream & stream, size_t ioBlockSize){
+bool ofBuffer::set(std::istream & stream, size_t ioBlockSize){
 	if(stream.bad()){
 		clear();
 		return false;
@@ -45,7 +45,7 @@ bool ofBuffer::set(istream & stream, size_t ioBlockSize){
 		buffer.clear();
 	}
 
-	vector<char> aux_buffer(ioBlockSize);
+	std::vector<char> aux_buffer(ioBlockSize);
 	while(stream.good()){
 		stream.read(&aux_buffer[0], ioBlockSize);
 		append(aux_buffer.data(), stream.gcount());
@@ -59,7 +59,7 @@ void ofBuffer::setall(char mem){
 }
 
 //--------------------------------------------------
-bool ofBuffer::writeTo(ostream & stream) const {
+bool ofBuffer::writeTo(std::ostream & stream) const {
 	if(stream.bad()){
 		return false;
 	}
@@ -73,12 +73,12 @@ void ofBuffer::set(const char * _buffer, std::size_t _size){
 }
 
 //--------------------------------------------------
-void ofBuffer::set(const string & text){
+void ofBuffer::set(const std::string & text){
 	set(text.c_str(), text.size());
 }
 
 //--------------------------------------------------
-void ofBuffer::append(const string& _buffer){
+void ofBuffer::append(const std::string& _buffer){
 	append(_buffer.c_str(), _buffer.size());
 }
 
@@ -129,7 +129,7 @@ const char * ofBuffer::getBinaryBuffer() const {
 }
 
 //--------------------------------------------------
-string ofBuffer::getText() const {
+std::string ofBuffer::getText() const {
 	if(buffer.empty()){
 		return "";
 	}
@@ -137,12 +137,12 @@ string ofBuffer::getText() const {
 }
 
 //--------------------------------------------------
-ofBuffer::operator string() const {
+ofBuffer::operator std::string() const {
 	return getText();
 }
 
 //--------------------------------------------------
-ofBuffer & ofBuffer::operator=(const string & text){
+ofBuffer & ofBuffer::operator=(const std::string & text){
 	set(text);
 	return *this;
 }
@@ -153,7 +153,7 @@ std::size_t ofBuffer::size() const {
 }
 
 //--------------------------------------------------
-string ofBuffer::getNextLine(){
+std::string ofBuffer::getNextLine(){
 	if(currentLine.empty()){
 		currentLine = getLines().begin();
 	}else{
@@ -163,7 +163,7 @@ string ofBuffer::getNextLine(){
 }
 
 //--------------------------------------------------
-string ofBuffer::getFirstLine(){
+std::string ofBuffer::getFirstLine(){
 	currentLine = getLines().begin();
 	return currentLine.asString();
 }
@@ -179,47 +179,47 @@ void ofBuffer::resetLineReader(){
 }
 
 //--------------------------------------------------
-vector<char>::iterator ofBuffer::begin(){
+std::vector<char>::iterator ofBuffer::begin(){
 	return buffer.begin();
 }
 
 //--------------------------------------------------
-vector<char>::iterator ofBuffer::end(){
+std::vector<char>::iterator ofBuffer::end(){
 	return buffer.end();
 }
 
 //--------------------------------------------------
-vector<char>::const_iterator ofBuffer::begin() const{
+std::vector<char>::const_iterator ofBuffer::begin() const{
 	return buffer.begin();
 }
 
 //--------------------------------------------------
-vector<char>::const_iterator ofBuffer::end() const{
+std::vector<char>::const_iterator ofBuffer::end() const{
 	return buffer.end();
 }
 
 //--------------------------------------------------
-vector<char>::reverse_iterator ofBuffer::rbegin(){
+std::vector<char>::reverse_iterator ofBuffer::rbegin(){
 	return buffer.rbegin();
 }
 
 //--------------------------------------------------
-vector<char>::reverse_iterator ofBuffer::rend(){
+std::vector<char>::reverse_iterator ofBuffer::rend(){
 	return buffer.rend();
 }
 
 //--------------------------------------------------
-vector<char>::const_reverse_iterator ofBuffer::rbegin() const{
+std::vector<char>::const_reverse_iterator ofBuffer::rbegin() const{
 	return buffer.rbegin();
 }
 
 //--------------------------------------------------
-vector<char>::const_reverse_iterator ofBuffer::rend() const{
+std::vector<char>::const_reverse_iterator ofBuffer::rend() const{
 	return buffer.rend();
 }
 
 //--------------------------------------------------
-ofBuffer::Line::Line(vector<char>::iterator _begin, vector<char>::iterator _end)
+ofBuffer::Line::Line(std::vector<char>::iterator _begin, std::vector<char>::iterator _end)
 	:_current(_begin)
 	,_begin(_begin)
 	,_end(_end){
@@ -231,9 +231,9 @@ ofBuffer::Line::Line(vector<char>::iterator _begin, vector<char>::iterator _end)
 
 	_current = std::find(_begin, _end, '\n');
 	if(_current - 1 >= _begin && *(_current - 1) == '\r'){
-		line = string(_begin, _current - 1);
+		line = std::string(_begin, _current - 1);
 	}else{
-		line = string(_begin, _current);
+		line = std::string(_begin, _current);
 	}
 	if(_current != _end){
 		_current+=1;
@@ -241,17 +241,17 @@ ofBuffer::Line::Line(vector<char>::iterator _begin, vector<char>::iterator _end)
 }
 
 //--------------------------------------------------
-const string & ofBuffer::Line::operator*() const{
+const std::string & ofBuffer::Line::operator*() const{
 	return line;
 }
 
 //--------------------------------------------------
-const string * ofBuffer::Line::operator->() const{
+const std::string * ofBuffer::Line::operator->() const{
 	return &line;
 }
 
 //--------------------------------------------------
-const string & ofBuffer::Line::asString() const{
+const std::string & ofBuffer::Line::asString() const{
 	return line;
 }
 
@@ -285,7 +285,7 @@ bool ofBuffer::Line::empty() const{
 
 
 //--------------------------------------------------
-ofBuffer::RLine::RLine(vector<char>::reverse_iterator _rbegin, vector<char>::reverse_iterator _rend)
+ofBuffer::RLine::RLine(std::vector<char>::reverse_iterator _rbegin, std::vector<char>::reverse_iterator _rend)
 	:_current(_rbegin)
 	,_rbegin(_rbegin)
 	,_rend(_rend){
@@ -295,24 +295,24 @@ ofBuffer::RLine::RLine(vector<char>::reverse_iterator _rbegin, vector<char>::rev
 		return;
 	}
 	_current = std::find(_rbegin+1, _rend, '\n');
-	line = string(_current.base(), _rbegin.base() - 1);
+	line = std::string(_current.base(), _rbegin.base() - 1);
 	if(_current < _rend-1 && *(_current + 1) == '\r'){
 		_current+=1;
 	}
 }
 
 //--------------------------------------------------
-const string & ofBuffer::RLine::operator*() const{
+const std::string & ofBuffer::RLine::operator*() const{
 	return line;
 }
 
 //--------------------------------------------------
-const string * ofBuffer::RLine::operator->() const{
+const std::string * ofBuffer::RLine::operator->() const{
 	return &line;
 }
 
 //--------------------------------------------------
-const string & ofBuffer::RLine::asString() const{
+const std::string & ofBuffer::RLine::asString() const{
 	return line;
 }
 
@@ -344,7 +344,7 @@ bool ofBuffer::RLine::empty() const{
 }
 
 //--------------------------------------------------
-ofBuffer::Lines::Lines(vector<char>::iterator begin, vector<char>::iterator end)
+ofBuffer::Lines::Lines(std::vector<char>::iterator begin, std::vector<char>::iterator end)
 :_begin(begin)
 ,_end(end){}
 
@@ -360,7 +360,7 @@ ofBuffer::Line ofBuffer::Lines::end(){
 
 
 //--------------------------------------------------
-ofBuffer::RLines::RLines(vector<char>::reverse_iterator rbegin, vector<char>::reverse_iterator rend)
+ofBuffer::RLines::RLines(std::vector<char>::reverse_iterator rbegin, std::vector<char>::reverse_iterator rend)
 :_rbegin(rbegin)
 ,_rend(rend){}
 
@@ -385,13 +385,13 @@ ofBuffer::RLines ofBuffer::getReverseLines(){
 }
 
 //--------------------------------------------------
-ostream & operator<<(ostream & ostr, const ofBuffer & buf){
+std::ostream & operator<<(std::ostream & ostr, const ofBuffer & buf){
 	buf.writeTo(ostr);
 	return ostr;
 }
 
 //--------------------------------------------------
-istream & operator>>(istream & istr, ofBuffer & buf){
+std::istream & operator>>(std::istream & istr, ofBuffer & buf){
 	buf.set(istr);
 	return istr;
 }
@@ -434,7 +434,7 @@ ofFile::~ofFile(){
 //-------------------------------------------------------------------------------------------------------------
 ofFile::ofFile(const ofFile & mom)
 :basic_ios()
-,fstream()
+,std::fstream()
 ,mode(Reference)
 ,binary(true){
 	copyFrom(mom);
@@ -462,7 +462,7 @@ void ofFile::copyFrom(const ofFile & mom){
 bool ofFile::openStream(Mode _mode, bool _binary){
 	mode = _mode;
 	binary = _binary;
-	ios_base::openmode binary_mode = binary ? ios::binary : (ios_base::openmode)0;
+	std::ios_base::openmode binary_mode = binary ? std::ios::binary : (std::ios_base::openmode)0;
 	switch(_mode) {
 		case WriteOnly:
 		case ReadWrite:
@@ -482,23 +482,23 @@ bool ofFile::openStream(Mode _mode, bool _binary){
 
 		case ReadOnly:
 			if(exists() && isFile()){
-				fstream::open(path().c_str(), ios::in | binary_mode);
+				std::fstream::open(path().c_str(), std::ios::in | binary_mode);
 			}
 			break;
 
 		case WriteOnly:
-			fstream::open(path().c_str(), ios::out | binary_mode);
+				std::fstream::open(path().c_str(), std::ios::out | binary_mode);
 			break;
 
 		case ReadWrite:
-			fstream::open(path().c_str(), ios_base::in | ios_base::out | binary_mode);
+				std::fstream::open(path().c_str(), std::ios_base::in | std::ios_base::out | binary_mode);
 			break;
 
 		case Append:
-			fstream::open(path().c_str(), ios::out | ios::app | binary_mode);
+				std::fstream::open(path().c_str(), std::ios::out | std::ios::app | binary_mode);
 			break;
 	}
-	return fstream::good();
+	return std::fstream::good();
 }
 
 //------------------------------------------------------------------------------------------------------------
@@ -518,7 +518,7 @@ bool ofFile::openFromCWD(const std::filesystem::path & _path, Mode _mode, bool b
 //-------------------------------------------------------------------------------------------------------------
 bool ofFile::changeMode(Mode _mode, bool binary){
 	if(_mode != mode){
-		string _path = path();
+		std::string _path = path();
 		close();
 		myFile = std::filesystem::path(_path);
 		return openStream(_mode, binary);
@@ -536,7 +536,7 @@ bool ofFile::isWriteMode(){
 //-------------------------------------------------------------------------------------------------------------
 void ofFile::close(){
 	myFile = std::filesystem::path();
-	if(mode!=Reference) fstream::close();
+	if(mode!=Reference) std::fstream::close();
 }
 
 //------------------------------------------------------------------------------------------------------------
@@ -580,7 +580,7 @@ bool ofFile::writeFromBuffer(const ofBuffer & buffer){
 }
 
 //------------------------------------------------------------------------------------------------------------
-filebuf *ofFile::getFileBuffer() const {
+std::filebuf *ofFile::getFileBuffer() const {
 	return rdbuf();
 }
 
@@ -594,12 +594,12 @@ bool ofFile::exists() const {
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::path() const {
+std::string ofFile::path() const {
 	return myFile.string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::getExtension() const {
+std::string ofFile::getExtension() const {
 	auto dotext = myFile.extension().string();
 	if(!dotext.empty() && dotext.front()=='.'){
 		return std::string(dotext.begin()+1,dotext.end());
@@ -609,22 +609,22 @@ string ofFile::getExtension() const {
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::getFileName() const {
+std::string ofFile::getFileName() const {
 	return myFile.filename().string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::getBaseName() const {
+std::string ofFile::getBaseName() const {
 	return myFile.stem().string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::getEnclosingDirectory() const {
+std::string ofFile::getEnclosingDirectory() const {
 	return ofFilePath::getEnclosingDirectory(path());
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFile::getAbsolutePath() const {
+std::string ofFile::getAbsolutePath() const {
 	return ofFilePath::getAbsolutePath(path());
 }
 
@@ -771,7 +771,7 @@ void ofFile::setExecutable(bool flag){
 }
 
 //------------------------------------------------------------------------------------------------------------
-bool ofFile::copyTo(const filesystem::path& _path, bool bRelativeToData, bool overwrite) const{
+bool ofFile::copyTo(const std::filesystem::path& _path, bool bRelativeToData, bool overwrite) const{
 	auto path = _path;
 
 	if(path.empty()){
@@ -827,7 +827,7 @@ bool ofFile::copyTo(const filesystem::path& _path, bool bRelativeToData, bool ov
 }
 
 //------------------------------------------------------------------------------------------------------------
-bool ofFile::moveTo(const filesystem::path& _path, bool bRelativeToData, bool overwrite){
+bool ofFile::moveTo(const std::filesystem::path& _path, bool bRelativeToData, bool overwrite){
 	auto path = _path;
 
 	if(path.empty()){
@@ -885,7 +885,7 @@ bool ofFile::moveTo(const filesystem::path& _path, bool bRelativeToData, bool ov
 }
 
 //------------------------------------------------------------------------------------------------------------
-bool ofFile::renameTo(const filesystem::path& path, bool bRelativeToData, bool overwrite){
+bool ofFile::renameTo(const std::filesystem::path& path, bool bRelativeToData, bool overwrite){
 	return moveTo(path,bRelativeToData,overwrite);
 }
 
@@ -1068,12 +1068,12 @@ bool ofDirectory::exists() const {
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofDirectory::path() const {
+std::string ofDirectory::path() const {
 	return myDir.string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofDirectory::getAbsolutePath() const {
+std::string ofDirectory::getAbsolutePath() const {
 	try{
 		return std::filesystem::canonical(std::filesystem::absolute(myDir)).string();
 	}catch(...){
@@ -1264,7 +1264,7 @@ std::size_t ofDirectory::listDir(){
 	}
 
 
-	if(!extensions.empty() && !ofContains(extensions, (string)"*")){
+	if(!extensions.empty() && !ofContains(extensions, (std::string)"*")){
 		ofRemove(files, [&](ofFile & file){
 			return std::find(extensions.begin(), extensions.end(), ofToLower(file.getExtension())) == extensions.end();
 		});
@@ -1281,17 +1281,17 @@ std::size_t ofDirectory::listDir(){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofDirectory::getOriginalDirectory() const {
+std::string ofDirectory::getOriginalDirectory() const {
 	return originalDirectory;
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofDirectory::getName(std::size_t position) const{
+std::string ofDirectory::getName(std::size_t position) const{
 	return files.at(position).getFileName();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofDirectory::getPath(std::size_t position) const{
+std::string ofDirectory::getPath(std::size_t position) const{
 	return originalDirectory + getName(position);
 }
 
@@ -1307,7 +1307,7 @@ ofFile ofDirectory::operator[](std::size_t position) const {
 }
 
 //------------------------------------------------------------------------------------------------------------
-const vector<ofFile> & ofDirectory::getFiles() const{
+const std::vector<ofFile> & ofDirectory::getFiles() const{
 	if(files.empty() && !myDir.empty()){
 		const_cast<ofDirectory*>(this)->listDir();
 	}
@@ -1326,7 +1326,7 @@ void ofDirectory::reset(){
 
 //------------------------------------------------------------------------------------------------------------
 static bool natural(const ofFile& a, const ofFile& b) {
-	string aname = a.getBaseName(), bname = b.getBaseName();
+	std::string aname = a.getBaseName(), bname = b.getBaseName();
 	int aint = ofToInt(aname), bint = ofToInt(bname);
 	if(ofToString(aint) == aname && ofToString(bint) == bname) {
 		return aint < bint;
@@ -1438,7 +1438,7 @@ bool ofDirectory::doesDirectoryExist(const std::filesystem::path& _dirPath, bool
 		return std::filesystem::exists(dirPath) && std::filesystem::is_directory(dirPath);
 	}
 	catch (std::exception & except) {
-		ofLogError("ofDirectory") << "doesDirectoryExist(): couldn't find directory \"" << dirPath << "\": " << except.what() << endl;
+		ofLogError("ofDirectory") << "doesDirectoryExist(): couldn't find directory \"" << dirPath << "\": " << except.what() << std::endl;
 		return false;
 	}
 }
@@ -1487,22 +1487,22 @@ bool ofDirectory::operator>=(const ofDirectory & dir) const{
 }
 
 //------------------------------------------------------------------------------------------------------------
-vector<ofFile>::const_iterator ofDirectory::begin() const{
+std::vector<ofFile>::const_iterator ofDirectory::begin() const{
 	return getFiles().begin();
 }
 
 //------------------------------------------------------------------------------------------------------------
-vector<ofFile>::const_iterator ofDirectory::end() const{
+std::vector<ofFile>::const_iterator ofDirectory::end() const{
 	return files.end();
 }
 
 //------------------------------------------------------------------------------------------------------------
-vector<ofFile>::const_reverse_iterator ofDirectory::rbegin() const{
+std::vector<ofFile>::const_reverse_iterator ofDirectory::rbegin() const{
 	return getFiles().rbegin();
 }
 
 //------------------------------------------------------------------------------------------------------------
-vector<ofFile>::const_reverse_iterator ofDirectory::rend() const{
+std::vector<ofFile>::const_reverse_iterator ofDirectory::rend() const{
 	return files.rend();
 }
 
@@ -1515,7 +1515,7 @@ vector<ofFile>::const_reverse_iterator ofDirectory::rend() const{
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
+std::string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
     auto path = _path.string();
 	auto sep = std::filesystem::path("/").make_preferred();
 	if(!path.empty()){
@@ -1527,7 +1527,7 @@ string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
+std::string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
     auto path = std::filesystem::path(_path).make_preferred().string();
 	auto sep = std::filesystem::path("/").make_preferred();
 	if(!path.empty()){
@@ -1540,18 +1540,18 @@ string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getFileExt(const std::filesystem::path& filename){
+std::string ofFilePath::getFileExt(const std::filesystem::path& filename){
 	return ofFile(filename,ofFile::Reference).getExtension();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::removeExt(const std::filesystem::path& filename){
+std::string ofFilePath::removeExt(const std::filesystem::path& filename){
 	return ofFilePath::join(getEnclosingDirectory(filename,false), ofFile(filename,ofFile::Reference).getBaseName());
 }
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getPathForDirectory(const std::filesystem::path& path){
+std::string ofFilePath::getPathForDirectory(const std::filesystem::path& path){
 	// if a trailing slash is missing from a path, this will clean it up
 	// if it's a windows-style "\" path it will add a "\"
 	// if it's a unix-style "/" path it will add a "/"
@@ -1564,7 +1564,7 @@ string ofFilePath::getPathForDirectory(const std::filesystem::path& path){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::removeTrailingSlash(const std::filesystem::path& _path){
+std::string ofFilePath::removeTrailingSlash(const std::filesystem::path& _path){
     auto path = _path.string();
 	if(path.length() > 0 && (path[path.length() - 1] == '/' || path[path.length() - 1] == '\\')){
 		path = path.substr(0, path.length() - 1);
@@ -1574,7 +1574,7 @@ string ofFilePath::removeTrailingSlash(const std::filesystem::path& _path){
 
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getFileName(const std::filesystem::path& _filePath, bool bRelativeToData){
+std::string ofFilePath::getFileName(const std::filesystem::path& _filePath, bool bRelativeToData){
     std::string filePath = _filePath.string();
 
 	if(bRelativeToData){
@@ -1585,12 +1585,12 @@ string ofFilePath::getFileName(const std::filesystem::path& _filePath, bool bRel
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getBaseName(const std::filesystem::path& filePath){
+std::string ofFilePath::getBaseName(const std::filesystem::path& filePath){
 	return ofFile(filePath,ofFile::Reference).getBaseName();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getEnclosingDirectory(const std::filesystem::path& _filePath, bool bRelativeToData){
+std::string ofFilePath::getEnclosingDirectory(const std::filesystem::path& _filePath, bool bRelativeToData){
     std::string filePath = _filePath.string();
 	if(bRelativeToData){
 		filePath = ofToDataPath(filePath);
@@ -1604,7 +1604,7 @@ bool ofFilePath::createEnclosingDirectory(const std::filesystem::path& filePath,
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData){
+std::string ofFilePath::getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData){
 	if(bRelativeToData){
 		return ofToDataPath(path, true);
 	}else{
@@ -1623,17 +1623,17 @@ bool ofFilePath::isAbsolute(const std::filesystem::path& path){
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getCurrentWorkingDirectory(){
+std::string ofFilePath::getCurrentWorkingDirectory(){
 	return std::filesystem::current_path().string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::join(const std::filesystem::path& path1, const std::filesystem::path& path2){
+std::string ofFilePath::join(const std::filesystem::path& path1, const std::filesystem::path& path2){
 	return (std::filesystem::path(path1) / std::filesystem::path(path2)).string();
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getCurrentExePath(){
+std::string ofFilePath::getCurrentExePath(){
 	#if defined(TARGET_LINUX) || defined(TARGET_ANDROID)
 		char buff[FILENAME_MAX];
 		ssize_t size = readlink("/proc/self/exe", buff, sizeof(buff) - 1);
@@ -1652,24 +1652,24 @@ string ofFilePath::getCurrentExePath(){
 		}
 		return path;
 	#elif defined(TARGET_WIN32)
-		vector<char> executablePath(MAX_PATH);
+		std::vector<char> executablePath(MAX_PATH);
 		DWORD result = ::GetModuleFileNameA(nullptr, &executablePath[0], static_cast<DWORD>(executablePath.size()));
 		if(result == 0) {
 			ofLogError("ofFilePath") << "getCurrentExePath(): couldn't get path, GetModuleFileNameA failed";
 		}else{
-			return string(executablePath.begin(), executablePath.begin() + result);
+			return std::string(executablePath.begin(), executablePath.begin() + result);
 		}
 	#endif
 	return "";
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getCurrentExeDir(){
+std::string ofFilePath::getCurrentExeDir(){
 	return getEnclosingDirectory(getCurrentExePath(), false);
 }
 
 //------------------------------------------------------------------------------------------------------------
-string ofFilePath::getUserHomeDir(){
+std::string ofFilePath::getUserHomeDir(){
 	#ifdef TARGET_WIN32
 		// getenv will return any Environent Variable on Windows
 		// USERPROFILE is the key on Windows 7 but it might be HOME
@@ -1683,7 +1683,7 @@ string ofFilePath::getUserHomeDir(){
 	#endif
 }
 
-string ofFilePath::makeRelative(const std::filesystem::path & from, const std::filesystem::path & to){
+std::string ofFilePath::makeRelative(const std::filesystem::path & from, const std::filesystem::path & to){
 	auto pathFrom = std::filesystem::absolute( from );
 	auto pathTo = std::filesystem::absolute( to );
 	std::filesystem::path ret;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -34,7 +34,7 @@ public:
 	/// Create a buffer and set its contents from an input stream.
 	///
 	/// \param ioBlockSize the number of bytes to read from the stream in chunks
-	ofBuffer(istream & stream, size_t ioBlockSize = 1024);
+	ofBuffer(std::istream & stream, size_t ioBlockSize = 1024);
 
 	/// Set the contents of the buffer from a raw byte pointer.
 	///
@@ -47,13 +47,13 @@ public:
 	/// Set contents of the buffer from a string.
 	///
 	/// \param text string to copy data from
-	void set(const string & text);
+	void set(const std::string & text);
 	
 	/// Set contents of the buffer from an input stream.
 	///
 	/// \param stream input stream to copy data from
 	/// \param ioBlockSize the number of bytes to read from the stream in chunks
-	bool set(istream & stream, size_t ioBlockSize = 1024);
+	bool set(std::istream & stream, size_t ioBlockSize = 1024);
 	
 	/// Set all bytes in the buffer to a given value.
 	///
@@ -63,7 +63,7 @@ public:
 	/// Append bytes to the end of buffer from a string.
 	///
 	/// \param _buffer string to copy bytes from
-	void append(const string& _buffer);
+	void append(const std::string& _buffer);
 	
 	/// Append bytes to the end of the buffer from a raw byte pointer.
 	///
@@ -80,7 +80,7 @@ public:
 	void reserve(size_t size);
 
 	/// Write contents of the buffer to an output stream.
-	bool writeTo(ostream & stream) const;
+	bool writeTo(std::ostream & stream) const;
 
 	/// Remove all bytes from the buffer, leaving a size of 0.
 	void clear();
@@ -117,45 +117,45 @@ public:
 	/// get the contents of the buffer as a string.
 	///
 	/// \returns buffer contents as a string
-	string getText() const;
+	std::string getText() const;
 	
 	/// Use buffer as a string via cast.
 	///
 	/// \returns buffer contents as a string
-	operator string() const;
+	operator std::string() const;
 	
 	/// set contents of the buffer from a string
-	ofBuffer & operator=(const string & text);
+	ofBuffer & operator=(const std::string & text);
 
 	/// Check the buffer's size.
 	///
 	/// \returns the size of the buffer's content in bytes
 	std::size_t size() const;
 
-	OF_DEPRECATED_MSG("use a lines iterator instead",string getNextLine());
-	OF_DEPRECATED_MSG("use a lines iterator instead",string getFirstLine());
+	OF_DEPRECATED_MSG("use a lines iterator instead",std::string getNextLine());
+	OF_DEPRECATED_MSG("use a lines iterator instead",std::string getFirstLine());
 	OF_DEPRECATED_MSG("use a lines iterator instead",bool isLastLine());
 	OF_DEPRECATED_MSG("use a lines iterator instead",void resetLineReader());
 	
-	friend ostream & operator<<(ostream & ostr, const ofBuffer & buf);
-	friend istream & operator>>(istream & istr, ofBuffer & buf);
+	friend std::ostream & operator<<(std::ostream & ostr, const ofBuffer & buf);
+	friend std::istream & operator>>(std::istream & istr, ofBuffer & buf);
 
-	vector<char>::iterator begin();
-	vector<char>::iterator end();
-	vector<char>::const_iterator begin() const;
-	vector<char>::const_iterator end() const;
-	vector<char>::reverse_iterator rbegin();
-	vector<char>::reverse_iterator rend();
-	vector<char>::const_reverse_iterator rbegin() const;
-	vector<char>::const_reverse_iterator rend() const;
+	std::vector<char>::iterator begin();
+	std::vector<char>::iterator end();
+	std::vector<char>::const_iterator begin() const;
+	std::vector<char>::const_iterator end() const;
+	std::vector<char>::reverse_iterator rbegin();
+	std::vector<char>::reverse_iterator rend();
+	std::vector<char>::const_reverse_iterator rbegin() const;
+	std::vector<char>::const_reverse_iterator rend() const;
 
 	/// A line of text in the buffer.
 	///
 	struct Line: public std::iterator<std::forward_iterator_tag,Line>{
-		Line(vector<char>::iterator _begin, vector<char>::iterator _end);
-		const string & operator*() const;
-		const string * operator->() const;
-		const string & asString() const;
+		Line(std::vector<char>::iterator _begin, std::vector<char>::iterator _end);
+		const std::string & operator*() const;
+		const std::string * operator->() const;
+		const std::string & asString() const;
 		
 		/// Increment to the next line.
 		Line& operator++();
@@ -170,17 +170,17 @@ public:
 		bool empty() const;
 
 	private:
-		string line;
-		vector<char>::iterator _current, _begin, _end;
+		std::string line;
+		std::vector<char>::iterator _current, _begin, _end;
 	};
 
 	/// A line of text in the buffer.
 	///
 	struct RLine: public std::iterator<std::forward_iterator_tag,Line>{
-		RLine(vector<char>::reverse_iterator _begin, vector<char>::reverse_iterator _end);
-		const string & operator*() const;
-		const string * operator->() const;
-		const string & asString() const;
+		RLine(std::vector<char>::reverse_iterator _begin, std::vector<char>::reverse_iterator _end);
+		const std::string & operator*() const;
+		const std::string * operator->() const;
+		const std::string & asString() const;
 
 		/// Increment to the next line.
 		RLine& operator++();
@@ -195,14 +195,14 @@ public:
 		bool empty() const;
 
 	private:
-		string line;
-		vector<char>::reverse_iterator _current, _rbegin, _rend;
+		std::string line;
+		std::vector<char>::reverse_iterator _current, _rbegin, _rend;
 	};
 
 	/// A series of text lines in the buffer.
 	///
 	struct Lines{
-		Lines(vector<char>::iterator begin, vector<char>::iterator end);
+		Lines(std::vector<char>::iterator begin, std::vector<char>::iterator end);
 		
 		/// Get the first line in the buffer.
 		Line begin();
@@ -214,14 +214,14 @@ public:
 		RLine rend();
 
 	private:
-		vector<char>::iterator _begin, _end;
+		std::vector<char>::iterator _begin, _end;
 	};
 
 
 	/// A series of text lines in the buffer.
 	///
 	struct RLines{
-		RLines(vector<char>::reverse_iterator rbegin, vector<char>::reverse_iterator rend);
+		RLines(std::vector<char>::reverse_iterator rbegin, std::vector<char>::reverse_iterator rend);
 
 		/// Get the first line in the buffer.
 		RLine begin();
@@ -230,7 +230,7 @@ public:
 		RLine end();
 
 	private:
-		vector<char>::reverse_iterator _rbegin, _rend;
+		std::vector<char>::reverse_iterator _rbegin, _rend;
 	};
 
 	/// Access the contents of the buffer as a series of text lines.
@@ -251,7 +251,7 @@ public:
 	RLines getReverseLines();
 
 private:
-	vector<char> 	buffer;
+	std::vector<char> 	buffer;
 	Line			currentLine;
 };
 
@@ -288,32 +288,32 @@ public:
 	///
 	/// \param filename file path
 	/// \returns filename extension only
-    static string getFileExt(const std::filesystem::path& filename);
+    static std::string getFileExt(const std::filesystem::path& filename);
 	
 	/// Remove extension from a filename, ie. "duck.jpg" ->"duck".
 	///
 	/// \param filename file path
 	/// \returns filename without extension
-    static string removeExt(const std::filesystem::path& filename);
+    static std::string removeExt(const std::filesystem::path& filename);
 	
 	/// Prepend path with a slash, ie. "images" -> "/images".
 	///
 	/// \param path file or directory path
 	/// \returns slah + path
-    static string addLeadingSlash(const std::filesystem::path& path);
+    static std::string addLeadingSlash(const std::filesystem::path& path);
 	
 	/// Append path with a slash, ie. "images" -> "images/".
 	///
 	/// \param path directory path
 	/// \returns path + slash
-    static string addTrailingSlash(const std::filesystem::path& path);
+    static std::string addTrailingSlash(const std::filesystem::path& path);
 	
 	/// Remove a path's trailing slash (if found),
 	/// ie. "images/" -> "images".
 	///
 	/// \param path directory path
 	/// \returns path minus trailing slash
-    static string removeTrailingSlash(const std::filesystem::path& path);
+    static std::string removeTrailingSlash(const std::filesystem::path& path);
 	
 	/// Cleaned up a directory path by adding a trailing slash if needed.
 	///
@@ -322,7 +322,7 @@ public:
 	///
 	/// \param path directory path
 	/// \returns cleaned path + trailing slash (if needed)
-    static string getPathForDirectory(const std::filesystem::path& path);
+    static std::string getPathForDirectory(const std::filesystem::path& path);
 	
 	/// Get the absolute, full path for a given path,
 	/// ie. "images" -> "/Users/mickey/of/apps/myApps/Donald/bin/data/images".
@@ -332,7 +332,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	/// \returns absolute path
-    static string getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData = true);
+    static std::string getAbsolutePath(const std::filesystem::path& path, bool bRelativeToData = true);
 
 	/// Check if a path is an absolute (aka a full path),
 	/// ie. "images" -> false,
@@ -351,7 +351,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	/// \returns filename
-    static string getFileName(const std::filesystem::path& filePath, bool bRelativeToData = true);
+    static std::string getFileName(const std::filesystem::path& filePath, bool bRelativeToData = true);
 	
 	/// Get a file path without its last component,
 	/// ie. "images/duck.jpg" -> "images" and
@@ -359,7 +359,7 @@ public:
 	///
 	/// \param filePath file path
 	/// \returns basename
-    static string getBaseName(const std::filesystem::path& filePath);
+    static std::string getBaseName(const std::filesystem::path& filePath);
 
 	/// Get the enclosing parent directory of a path,
 	/// ie. "images/duck.jpg" -> "images", assumes the path is in the data
@@ -370,7 +370,7 @@ public:
 	/// are *not* in the data folder and want the direct path without relative
 	/// "../../"
 	///\returns enclosing directory
-    static string getEnclosingDirectory(const std::filesystem::path& filePath, bool bRelativeToData = true);
+    static std::string getEnclosingDirectory(const std::filesystem::path& filePath, bool bRelativeToData = true);
 	
 	/// Create the enclosing parent directory of a path, ie.
 	/// "images" is the enclosing directory of "duck.jpg" = "images/duck.jpg".
@@ -394,7 +394,7 @@ public:
 	/// \warning This location *may* change if you or a library calls the cd()
 	/// std C function.
 	/// \returns current working directory
-	static string getCurrentWorkingDirectory();
+	static std::string getCurrentWorkingDirectory();
 	
 	/// Create a single path by joining path1 & path2 using a slash,
 	/// ie. "/hello/world" + "foo/bar" -> "/hello/world/foo/bar".
@@ -402,7 +402,7 @@ public:
 	/// \param path1 left half of the path to join
 	/// \param path2 right half of the path to join
 	/// \returns joined path
-    static string join(const std::filesystem::path& path1, const std::filesystem::path& path2);
+    static std::string join(const std::filesystem::path& path1, const std::filesystem::path& path2);
 	
 	/// Get the full path to the application's executable file.
 	///
@@ -411,7 +411,7 @@ public:
 	/// Linux: the binary file itself
 	///
 	/// \returns current executable path
-	static string getCurrentExePath();
+	static std::string getCurrentExePath();
 	
 	/// Get the full path to the application's parent directory.
 	///
@@ -419,7 +419,7 @@ public:
 	/// Mac: the Contents/MacOS folder within the application's .app bundle
 	///
 	/// \returns current executable directory
-	static string getCurrentExeDir();
+	static std::string getCurrentExeDir();
 
 	/// Get the absolute path to the user's home directory.
 	///
@@ -428,7 +428,7 @@ public:
 	/// Linux: /home/<username>
 	///
 	/// \returns home directory path
-	static string getUserHomeDir();
+	static std::string getUserHomeDir();
 
 	/// Make one path relative to another,
 	/// ie. the relative path of "images/felines/lions" to
@@ -437,7 +437,7 @@ public:
 	/// \param from starting path
 	/// \param to destination path
 	/// \returns relative path
-    static string makeRelative(const std::filesystem::path & from, const std::filesystem::path & to);
+    static std::string makeRelative(const std::filesystem::path & from, const std::filesystem::path & to);
 };
 
 /// \class ofFile
@@ -446,7 +446,7 @@ public:
 ///
 /// inherits from an fstream so you can read/write using the stream operators
 /// once a file path has been opened
-class ofFile: public fstream{
+class ofFile: public std::fstream{
 
 public:
 	
@@ -549,39 +549,39 @@ public:
 	/// Get the current path.
 	///
 	/// \returns current path
-	string path() const;
+	std::string path() const;
 	
 	/// Get the current path without its extension,
 	/// ie. "duck.jpg" ->"duck".
 	///
 	/// \returns current path file extension
-	string getExtension() const;
+	std::string getExtension() const;
 	
 	/// Get the filename of the current path by stripping the parent
 	/// directories, ie. "images/duck.jpg"  -> "duck.jpg".
 	///
 	/// \returns current path filename
-	string getFileName() const;
+	std::string getFileName() const;
 	
 	/// \biref Get the current path without its last component,
 	/// ie. "images/duck.jpg" -> "images" and
 	/// "images/some/folder" -> "images/some".
 	///
 	/// \returns current path basename
-	string getBaseName() const;
+	std::string getBaseName() const;
 	
 	/// Get the enclosing parent directory of a path,
 	/// ie. "images/duck.jpg" -> "images", assumes the path is in the data
 	/// directory.
 	///
 	/// \returns current path's enclosing directory
-	string getEnclosingDirectory() const;
+	std::string getEnclosingDirectory() const;
 	
 	/// \biref Get the absolute, full path of the file,
 	/// ie. "images" -> "/Users/mickey/of/apps/myApps/Donald/bin/data/images".
 	///
 	/// \returns current path as an absolute path
-	string getAbsolutePath() const;
+	std::string getAbsolutePath() const;
 
 	/// Check if the current path is readable.
 	///
@@ -733,7 +733,7 @@ public:
 	///     write_file << file.getFileBuffer();
 	///
 	/// \return output stream
-	filebuf * getFileBuffer() const;
+	std::filebuf * getFileBuffer() const;
 	
 	operator std::filesystem::path(){
 		return myFile;
@@ -850,13 +850,13 @@ public:
 	/// Get the current path.
 	///
 	/// \returns current path
-	string path() const;
+	std::string path() const;
 	
 	/// Get the absolute, full path of the directory,
 	/// ie. "images" -> "/Users/mickey/of/apps/myApps/Donald/bin/data/images".
 	///
 	/// \return current path as an absolute path
-	string getAbsolutePath() const;
+	std::string getAbsolutePath() const;
 
 	/// Check if the current path is readable.
 	///
@@ -923,7 +923,7 @@ public:
 	/// \param overwrite set to true if you want to overwrite the file or
 	/// directory at the new path
 	/// \returns true if the copy was successful
-	bool copyTo(const filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
+	bool copyTo(const std::filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
 	
 	/// Move the current file or directory path to a new path.
 	///
@@ -937,7 +937,7 @@ public:
 	/// \param overwrite set to true if you want to overwrite the file or
 	/// directory at the new path
 	/// \returns true if the copy was successful
-	bool moveTo(const filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
+	bool moveTo(const std::filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
 	
 	/// Rename the current file or directory path to a new path.
 	///
@@ -951,7 +951,7 @@ public:
 	/// \param overwrite set to true if you want to overwrite the file or
 	/// directory at the new path
 	/// \returns true if the copy was successful
-	bool renameTo(const filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
+	bool renameTo(const std::filesystem::path& path, bool bRelativeToData = true, bool overwrite = false);
 	
 	/// Removes the file or directory at the current path.
 	///
@@ -974,7 +974,7 @@ public:
 	/// extensions which have been explicitly allowed.
 	///
 	/// \param extension file type extension ie. "jpg", "png", "txt", etc
-	void allowExt(const string& extension);
+	void allowExt(const std::string& extension);
 	
 	/// Open and read the contents of a directory.
 	///
@@ -983,7 +983,7 @@ public:
 	///
 	/// \param path directory path
 	/// \returns number of paths found
-	std::size_t listDir(const string& path);
+	std::size_t listDir(const std::string& path);
 	
 	/// Open and read the contents of the current directory.
 	///
@@ -994,7 +994,7 @@ public:
 	std::size_t listDir();
 
 	/// \returns the current path
-	string getOriginalDirectory() const;
+	std::string getOriginalDirectory() const;
 	
 	/// Get the filename at a given position in the directory contents
 	/// list, ie. "duck.jpg".
@@ -1005,7 +1005,7 @@ public:
 	/// listed directory contents.
 	/// \param position array index in the directory contents list
 	/// \returns file or directory name
-	string getName(std::size_t position) const;
+	std::string getName(std::size_t position) const;
 	
 	/// Get the full path of the file or directory at a given position in
 	/// the directory contents list.
@@ -1016,7 +1016,7 @@ public:
 	/// listed directory contents.
 	/// \param position array index in the directory contents list
 	/// \returns file or directory name including the current path
-	string getPath(std::size_t position) const;
+	std::string getPath(std::size_t position) const;
 	
 	/// Open an ofFile instance using the path a given position in the
 	/// directory contents list.
@@ -1040,7 +1040,7 @@ public:
 	/// Directory contents are automatically listed.
 	///
 	/// \returns vector of files in the directory
-	const vector<ofFile> & getFiles() const;
+	const std::vector<ofFile> & getFiles() const;
 
 	/// Access directory contents via th array operator.
 	///
@@ -1156,16 +1156,16 @@ public:
 	/// \returns true if the path was removed successfully
 	static bool removeDirectory(const std::filesystem::path& path, bool deleteIfNotEmpty,  bool bRelativeToData = true);
 
-	vector<ofFile>::const_iterator begin() const;
-	vector<ofFile>::const_iterator end() const;
-	vector<ofFile>::const_reverse_iterator rbegin() const;
-	vector<ofFile>::const_reverse_iterator rend() const;
+	std::vector<ofFile>::const_iterator begin() const;
+	std::vector<ofFile>::const_iterator end() const;
+	std::vector<ofFile>::const_reverse_iterator rbegin() const;
+	std::vector<ofFile>::const_reverse_iterator rend() const;
 
 private:
 	std::filesystem::path myDir;
-	string originalDirectory;
-	vector <string> extensions;
-	vector <ofFile> files;
+	std::string originalDirectory;
+	std::vector <std::string> extensions;
+	std::vector <ofFile> files;
 	bool showHidden;
 
 };

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -32,5 +32,5 @@ private:
 	std::chrono::nanoseconds lastFrameTime;
 	std::chrono::nanoseconds filteredTime;
 	double filterAlpha;
-	queue<double> timestamps;
+	std::queue<double> timestamps;
 };

--- a/libs/openFrameworks/utils/ofJson.h
+++ b/libs/openFrameworks/utils/ofJson.h
@@ -68,7 +68,7 @@ inline void ofSerialize(ofJson & js, ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+        std::string name = parameter.getEscapedName();
 	if(name == ""){
 		name = "UnknownName";
 	}
@@ -80,7 +80,7 @@ inline void ofSerialize(ofJson & js, ofAbstractParameter & parameter){
 		}
 		js[name] = jsonGroup;
 	}else{
-		string value = parameter.toString();
+		std::string value = parameter.toString();
 		js[name] = value;
 	}
 }
@@ -89,7 +89,7 @@ inline void ofDeserialize(const ofJson & json, ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+        std::string name = parameter.getEscapedName();
 	if(json.find(name) != json.end()){
 		if(parameter.type() == typeid(ofParameterGroup).name()){
 			ofParameterGroup & group = static_cast <ofParameterGroup &>(parameter);
@@ -105,7 +105,7 @@ inline void ofDeserialize(const ofJson & json, ofAbstractParameter & parameter){
 				parameter.cast <bool>() = json[name].get<bool>();
 			}else if(parameter.type() == typeid(ofParameter <int64_t> ).name() && json[name].is_number_integer()){
 				parameter.cast <int64_t>() = json[name].get<int64_t>();
-			}else if(parameter.type() == typeid(ofParameter <string> ).name()){
+			}else if(parameter.type() == typeid(ofParameter <std::string> ).name()){
 				parameter.cast <std::string>() = json[name].get<std::string>();
 			}else{
 				parameter.fromString(json[name]);

--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -6,24 +6,24 @@
 static ofLogLevel currentLogLevel =  OF_LOG_NOTICE;
 
 bool ofLog::bAutoSpace = false;
-string & ofLog::getPadding() {
-	static string * padding = new string;
+std::string & ofLog::getPadding() {
+	static std::string * padding = new std::string;
 	return *padding;
 }
 
-static map<string,ofLogLevel> & getModules(){
-	static map<string,ofLogLevel> * modules = new map<string,ofLogLevel>;
+static std::map<std::string,ofLogLevel> & getModules(){
+	static std::map<std::string,ofLogLevel> * modules = new std::map<std::string,ofLogLevel>;
 	return *modules;
 }
 
 static void noopDeleter(ofBaseLoggerChannel*){}
 #ifdef TARGET_ANDROID
 	#include "ofxAndroidLogChannel.h"
-	shared_ptr<ofBaseLoggerChannel> ofLog::channel = shared_ptr<ofxAndroidLogChannel>(new ofxAndroidLogChannel,std::ptr_fun(noopDeleter));
+	std::shared_ptr<ofBaseLoggerChannel> ofLog::channel = std::shared_ptr<ofxAndroidLogChannel>(new ofxAndroidLogChannel,std::ptr_fun(noopDeleter));
 #elif defined(TARGET_WIN32)
-	shared_ptr<ofBaseLoggerChannel> ofLog::channel = IsDebuggerPresent() ? shared_ptr<ofBaseLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)) : shared_ptr<ofBaseLoggerChannel>(new ofConsoleLoggerChannel, std::ptr_fun(noopDeleter));
+	std::shared_ptr<ofBaseLoggerChannel> ofLog::channel = IsDebuggerPresent() ? std::shared_ptr<ofBaseLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)) : std::shared_ptr<ofBaseLoggerChannel>(new ofConsoleLoggerChannel, std::ptr_fun(noopDeleter));
 #else
-	shared_ptr<ofBaseLoggerChannel> ofLog::channel = shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter));
+	std::shared_ptr<ofBaseLoggerChannel> ofLog::channel = std::shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter));
 #endif
 
 //--------------------------------------------------
@@ -32,7 +32,7 @@ void ofSetLogLevel(ofLogLevel level){
 }
 
 //--------------------------------------------------
-void ofSetLogLevel(string module, ofLogLevel level){
+void ofSetLogLevel(std::string module, ofLogLevel level){
 	getModules()[module] = level;
 }
 
@@ -42,7 +42,7 @@ ofLogLevel ofGetLogLevel(){
 }
 
 //--------------------------------------------------
-ofLogLevel ofGetLogLevel(string module){
+ofLogLevel ofGetLogLevel(std::string module){
 	if (getModules().find(module) == getModules().end()) {
 		return currentLogLevel;
 	} else {
@@ -52,17 +52,17 @@ ofLogLevel ofGetLogLevel(string module){
 
 //--------------------------------------------------
 void ofLogToFile(const std::filesystem::path & path, bool append){
-	ofLog::setChannel(shared_ptr<ofFileLoggerChannel>(new ofFileLoggerChannel(path,append)));
+	ofLog::setChannel(std::shared_ptr<ofFileLoggerChannel>(new ofFileLoggerChannel(path,append)));
 }
 
 //--------------------------------------------------
 void ofLogToConsole(){
-	ofLog::setChannel(shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter)));
+	ofLog::setChannel(std::shared_ptr<ofConsoleLoggerChannel>(new ofConsoleLoggerChannel,std::ptr_fun(noopDeleter)));
 }
 
 #ifdef TARGET_WIN32
 void ofLogToDebugView() {
-	ofLog::setChannel(shared_ptr<ofDebugViewLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)));
+	ofLog::setChannel(std::shared_ptr<ofDebugViewLoggerChannel>(new ofDebugViewLoggerChannel, std::ptr_fun(noopDeleter)));
 }
 #endif
 
@@ -81,7 +81,7 @@ ofLog::ofLog(ofLogLevel _level){
 }
 
 //--------------------------------------------------
-ofLog::ofLog(ofLogLevel level, const string & message){
+ofLog::ofLog(ofLogLevel level, const std::string & message){
 	_log(level,"",message);
 	bPrinted = true;
 }
@@ -116,7 +116,7 @@ ofLog::~ofLog(){
 	}
 }
 
-bool ofLog::checkLog(ofLogLevel level, const string & module){
+bool ofLog::checkLog(ofLogLevel level, const std::string & module){
 	if(getModules().find(module)==getModules().end()){
 		if(level >= currentLogLevel) return true;
 	}else{
@@ -126,25 +126,25 @@ bool ofLog::checkLog(ofLogLevel level, const string & module){
 }
 
 //-------------------------------------------------------
-void ofLog::_log(ofLogLevel level, const string & module, const string & message){
+void ofLog::_log(ofLogLevel level, const std::string & module, const std::string & message){
 	if(checkLog(level,module)){
 		channel->log(level,module, message);
 	}
 }
 
 //--------------------------------------------------
-ofLogVerbose::ofLogVerbose(const string & _module){
+ofLogVerbose::ofLogVerbose(const std::string & _module){
 	level = OF_LOG_VERBOSE;
 	module = _module;
 	bPrinted=false;
 }
 
-ofLogVerbose::ofLogVerbose(const string & _module, const string & _message){
+ofLogVerbose::ofLogVerbose(const std::string & _module, const std::string & _message){
 	_log(OF_LOG_VERBOSE,_module,_message);
 	bPrinted = true;
 }
 
-ofLogVerbose::ofLogVerbose(const string & module, const char* format, ...){
+ofLogVerbose::ofLogVerbose(const std::string & module, const char* format, ...){
 	if(checkLog(OF_LOG_VERBOSE, module)){
 		va_list args;
 		va_start(args, format);
@@ -155,18 +155,18 @@ ofLogVerbose::ofLogVerbose(const string & module, const char* format, ...){
 }
 
 //--------------------------------------------------
-ofLogNotice::ofLogNotice(const string & _module){
+ofLogNotice::ofLogNotice(const std::string & _module){
 	level = OF_LOG_NOTICE;
 	module = _module;
 	bPrinted=false;
 }
 
-ofLogNotice::ofLogNotice(const string & _module, const string & _message){
+ofLogNotice::ofLogNotice(const std::string & _module, const std::string & _message){
 	_log(OF_LOG_NOTICE,_module,_message);
 	bPrinted = true;
 }
 
-ofLogNotice::ofLogNotice(const string & module, const char* format, ...){
+ofLogNotice::ofLogNotice(const std::string & module, const char* format, ...){
 	if(checkLog(OF_LOG_NOTICE, module)){
 		va_list args;
 		va_start(args, format);
@@ -177,18 +177,18 @@ ofLogNotice::ofLogNotice(const string & module, const char* format, ...){
 }
 
 //--------------------------------------------------
-ofLogWarning::ofLogWarning(const string & _module){
+ofLogWarning::ofLogWarning(const std::string & _module){
 	level = OF_LOG_WARNING;
 	module = _module;
 	bPrinted=false;
 }
 
-ofLogWarning::ofLogWarning(const string & _module, const string & _message){
+ofLogWarning::ofLogWarning(const std::string & _module, const std::string & _message){
 	_log(OF_LOG_WARNING,_module,_message);
 	bPrinted = true;
 }
 
-ofLogWarning::ofLogWarning(const string & module, const char* format, ...){
+ofLogWarning::ofLogWarning(const std::string & module, const char* format, ...){
 	if(checkLog(OF_LOG_WARNING, module)){
 		va_list args;
 		va_start(args, format);
@@ -199,18 +199,18 @@ ofLogWarning::ofLogWarning(const string & module, const char* format, ...){
 }
 
 //--------------------------------------------------
-ofLogError::ofLogError(const string & _module){
+ofLogError::ofLogError(const std::string & _module){
 	level = OF_LOG_ERROR;
 	module = _module;
 	bPrinted=false;
 }
 
-ofLogError::ofLogError(const string & _module, const string & _message){
+ofLogError::ofLogError(const std::string & _module, const std::string & _message){
 	_log(OF_LOG_ERROR,_module,_message);
 	bPrinted = true;
 }
 
-ofLogError::ofLogError(const string & module, const char* format, ...){
+ofLogError::ofLogError(const std::string & module, const char* format, ...){
 	if(checkLog(OF_LOG_ERROR, module)){
 		va_list args;
 		va_start(args, format);
@@ -221,18 +221,18 @@ ofLogError::ofLogError(const string & module, const char* format, ...){
 }
 
 //--------------------------------------------------
-ofLogFatalError::ofLogFatalError(const string &  _module){
+ofLogFatalError::ofLogFatalError(const std::string &  _module){
 	level = OF_LOG_FATAL_ERROR;
 	module = _module;
 	bPrinted=false;
 }
 
-ofLogFatalError::ofLogFatalError(const string & _module, const string & _message){
+ofLogFatalError::ofLogFatalError(const std::string & _module, const std::string & _message){
 	_log(OF_LOG_FATAL_ERROR,_module,_message);
 	bPrinted = true;
 }
 
-ofLogFatalError::ofLogFatalError(const string & module, const char* format, ...){
+ofLogFatalError::ofLogFatalError(const std::string & module, const char* format, ...){
 	if(checkLog(OF_LOG_FATAL_ERROR, module)){
 		va_list args;
 		va_start(args, format);
@@ -243,15 +243,15 @@ ofLogFatalError::ofLogFatalError(const string & module, const char* format, ...)
 }
 
 //--------------------------------------------------
-void ofLog::setChannel(shared_ptr<ofBaseLoggerChannel> _channel){
+void ofLog::setChannel(std::shared_ptr<ofBaseLoggerChannel> _channel){
 	channel = _channel;
 }
 
-void ofSetLoggerChannel(shared_ptr<ofBaseLoggerChannel> loggerChannel){
+void ofSetLoggerChannel(std::shared_ptr<ofBaseLoggerChannel> loggerChannel){
 	ofLog::setChannel(loggerChannel);
 }
 
-string ofGetLogLevelName(ofLogLevel level, bool pad){
+std::string ofGetLogLevelName(ofLogLevel level, bool pad){
 	switch(level){
 		case OF_LOG_VERBOSE:
 			return "verbose";
@@ -271,25 +271,25 @@ string ofGetLogLevelName(ofLogLevel level, bool pad){
 }
 
 //--------------------------------------------------
-void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const string & message){
+void ofConsoleLoggerChannel::log(ofLogLevel level, const std::string & module, const std::string & message){
 	// print to cerr for OF_LOG_ERROR and OF_LOG_FATAL_ERROR, everything else to cout 
-	ostream& out = level < OF_LOG_ERROR ? cout : cerr;
+	std::ostream& out = level < OF_LOG_ERROR ? std::cout : std::cerr;
 	out << "[" << ofGetLogLevelName(level, true)  << "] ";
 	// only print the module name if it's not ""
 	if(module != ""){
 		out << module << ": ";
 	}
-	out << message << endl;
+	out << message << std::endl;
 }
 
-void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const char* format, ...){
+void ofConsoleLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, ...){
 	va_list args;
 	va_start(args, format);
 	log(level, module, format, args);
 	va_end(args);
 }
 
-void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const char* format, va_list args){
+void ofConsoleLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, va_list args){
 	//thanks stefan!
 	//http://www.ozzu.com/cpp-tutorials/tutorial-writing-custom-printf-wrapper-function-t89166.html
 	FILE* out = level < OF_LOG_ERROR ? stdout : stderr;
@@ -304,19 +304,19 @@ void ofConsoleLoggerChannel::log(ofLogLevel level, const string & module, const 
 
 #ifdef TARGET_WIN32
 #include <array>
-void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const string & message) {
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const std::string & module, const std::string & message) {
 	// print to cerr for OF_LOG_ERROR and OF_LOG_FATAL_ERROR, everything else to cout 
-	stringstream out;
+	std::stringstream out;
 	out << "[" << ofGetLogLevelName(level, true) << "] ";
 	// only print the module name if it's not ""
 	if (module != "") {
 		out << module << ": ";
 	}
-	out << message << endl;
+	out << message << std::endl;
 	OutputDebugStringA(out.str().c_str());
 }
 
-void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const char* format, ...) {
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, ...) {
 	va_list args;
 	va_start(args, format);
 	log(level, module, format, args);
@@ -324,7 +324,7 @@ void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, cons
 
 }
 
-void ofDebugViewLoggerChannel::log(ofLogLevel level, const string & module, const char* format, va_list args) {
+void ofDebugViewLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, va_list args) {
 	std::string buffer;;
 	buffer =  "[" + ofGetLogLevelName(level, true) + "] ";
 	if (module != "") {
@@ -354,30 +354,30 @@ void ofFileLoggerChannel::close(){
 
 void ofFileLoggerChannel::setFile(const std::filesystem::path & path,bool append){
 	file.open(path,append?ofFile::Append:ofFile::WriteOnly);
-	file << endl;
-	file << endl;
-	file << "--------------------------------------- " << ofGetTimestampString() << endl;
+	file << std::endl;
+	file << std::endl;
+	file << "--------------------------------------- " << ofGetTimestampString() << std::endl;
 }
 
-void ofFileLoggerChannel::log(ofLogLevel level, const string & module, const string & message){
+void ofFileLoggerChannel::log(ofLogLevel level, const std::string & module, const std::string & message){
 	file << "[" << ofGetLogLevelName(level, true) << "] ";
 	if(module != ""){
 		file << module << ": ";
 	}
-	file << message << endl;
+	file << message << std::endl;
 }
 
-void ofFileLoggerChannel::log(ofLogLevel level, const string & module, const char* format, ...){
+void ofFileLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, ...){
 	va_list args;
 	va_start(args, format);
 	log(level, module, format, args);
 	va_end(args);
 }
 
-void ofFileLoggerChannel::log(ofLogLevel level, const string & module, const char* format, va_list args){
+void ofFileLoggerChannel::log(ofLogLevel level, const std::string & module, const char* format, va_list args){
 	file << "[" << ofGetLogLevelName(level, true) << "] ";
 	if(module != ""){
 		file << module << ": ";
 	}
-	file << ofVAArgsToString(format,args) << endl;
+	file << ofVAArgsToString(format,args) << std::endl;
 }

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -178,7 +178,7 @@ void ofSetLogLevel(ofLogLevel level);
 /// // In this case, we will see the verbose message from "MyClass", but not
 /// // the message from "MyOtherClass".
 /// ~~~~
-void ofSetLogLevel(string module, ofLogLevel level);
+void ofSetLogLevel(std::string module, ofLogLevel level);
 
 /// \brief Get the currently set global logging level.
 /// \returns The currently set global logging level.
@@ -187,13 +187,13 @@ ofLogLevel ofGetLogLevel();
 /// \brief Get the logging level for a specific module.
 /// \param module specific module name.
 /// \returns The currently set specific module logging level.
-ofLogLevel ofGetLogLevel(string module);
+ofLogLevel ofGetLogLevel(std::string module);
 
 /// \brief Get log level name as a string.
 /// \param level The ofLogLevel you want as a string.
 /// \param pad True if you want all log level names to be the same length.
 /// \returns The log level name as a string.
-string ofGetLogLevelName(ofLogLevel level, bool pad=false);
+std::string ofGetLogLevelName(ofLogLevel level, bool pad=false);
 
 /// \}
 
@@ -229,7 +229,7 @@ void ofLogToDebugView();
 /// to email or even Twitter.
 ///
 /// \param loggerChannel A shared pointer to the logger channel.
-void ofSetLoggerChannel(shared_ptr<ofBaseLoggerChannel> loggerChannel);
+void ofSetLoggerChannel(std::shared_ptr<ofBaseLoggerChannel> loggerChannel);
 
 /// \}
 
@@ -340,7 +340,7 @@ class ofLog{
 		///
 		/// \param level The ofLogLevel for this log message.
 		/// \param message The log message.
-		ofLog(ofLogLevel level, const string & message);
+		ofLog(ofLogLevel level, const std::string & message);
 
 		/// \brief Logs a message at a specific log level using the printf interface.
 		///
@@ -420,7 +420,7 @@ class ofLog{
 		///
 		/// \sa ofFileLoggerChannel ofConsoleLoggerChannel
 		/// \param channel The channel to log to.
-		static void setChannel(shared_ptr<ofBaseLoggerChannel> channel);
+		static void setChannel(std::shared_ptr<ofBaseLoggerChannel> channel);
 	
 		/// \}
 
@@ -468,21 +468,21 @@ class ofLog{
 
 		ofLogLevel level; ///< Log level.
 		bool bPrinted;	  ///< Has the message been printed in the constructor?
-		string module;    ///< The destination module for this message.
+		std::string module;    ///< The destination module for this message.
 		
 		/// \brief Print a log line.
 		/// \param level The log level.
 		/// \param module The target module.
 		/// \param message The log message.
-		void _log(ofLogLevel level, const string & module, const string & message);
+		void _log(ofLogLevel level, const std::string & module, const std::string & message);
 	
 		/// \brief Determine if the given module is active at the given log level.
 		/// \param level The log level.
 		/// \param module The target module.
 		/// \returns true if the given module is active at the given log level.
-		bool checkLog(ofLogLevel level, const string & module);
+		bool checkLog(ofLogLevel level, const std::string & module);
 	
-		static shared_ptr<ofBaseLoggerChannel> channel;	///< The target channel.
+		static std::shared_ptr<ofBaseLoggerChannel> channel;	///< The target channel.
 	
 		/// \endcond
 	
@@ -494,7 +494,7 @@ class ofLog{
 		ofLog(ofLog const&) {}        					// not defined, not copyable
 		ofLog& operator=(ofLog& from) {return *this;}	// not defined, not assignable
 		
-		static string & getPadding(); ///< The padding between std::ostream calls.
+		static std::string & getPadding(); ///< The padding between std::ostream calls.
 };
 
 
@@ -505,17 +505,17 @@ class ofLogVerbose : public ofLog{
 	public:
 		/// \brief Create a verbose log message.
 		/// \param module The target module.
-		ofLogVerbose(const string &module="");
+		ofLogVerbose(const std::string &module="");
 
 		/// \brief Create a verbose log message.
 		/// \param module The target module.
 		/// \param message The log message.
-		ofLogVerbose(const string & module, const string & message);
+		ofLogVerbose(const std::string & module, const std::string & message);
 
 		/// \brief Create a verbose log message.
 		/// \param module The target module.
 		/// \param format The printf-style format string.
-		ofLogVerbose(const string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
+		ofLogVerbose(const std::string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 };
 
 /// \brief Derived log class for easy notice logging.
@@ -525,17 +525,17 @@ class ofLogNotice : public ofLog{
 	public:
 		/// \brief Create a notice log message.
 		/// \param module The target module.
-		ofLogNotice(const string & module="");
+		ofLogNotice(const std::string & module="");
 
 		/// \brief Create a notice log message.
 		/// \param module The target module.
 		/// \param message The log message.
-		ofLogNotice(const string & module, const string & message);
+		ofLogNotice(const std::string & module, const std::string & message);
 
 		/// \brief Create a notice log message.
 		/// \param module The target module.
 		/// \param format The printf-style format string.
-		ofLogNotice(const string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
+		ofLogNotice(const std::string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 };
 
 /// \brief Derived log class for easy warning logging.
@@ -545,16 +545,16 @@ class ofLogWarning : public ofLog{
 	public:
 	/// \brief Create a verbose log message.
 	/// \param module The target module.
-		ofLogWarning(const string & module="");
+		ofLogWarning(const std::string & module="");
 	/// \brief Create a verbose log message.
 	/// \param module The target module.
 	/// \param message The log message.
-		ofLogWarning(const string & module, const string & message);
+		ofLogWarning(const std::string & module, const std::string & message);
 	
 	/// \brief Create a verbose log message.
 	/// \param module The target module.
 	/// \param format The printf-style format string.
-		ofLogWarning(const string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
+		ofLogWarning(const std::string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 };
 
 /// \brief Derived log class for easy error logging.
@@ -564,17 +564,17 @@ class ofLogError : public ofLog{
 	public:
 		/// \brief Create a error log message.
 		/// \param module The target module.
-		ofLogError(const string & module="");
+		ofLogError(const std::string & module="");
 	
 		/// \brief Create a error log message.
 		/// \param module The target module.
 		/// \param message The log message.
-		ofLogError(const string & module, const string & message);
+		ofLogError(const std::string & module, const std::string & message);
 	
 		/// \brief Create a error log message.
 		/// \param module The target module.
 		/// \param format The printf-style format string.
-		ofLogError(const string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
+		ofLogError(const std::string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 };
 
 /// \brief Derived log class for easy fatal error logging.
@@ -584,17 +584,17 @@ class ofLogFatalError : public ofLog{
 	public:
 		/// \brief Create a fatal error log message.
 		/// \param module The target module.
-		ofLogFatalError(const string & module="");
+		ofLogFatalError(const std::string & module="");
 
 		/// \brief Create a fatal error log message.
 		/// \param module The target module.
 		/// \param message The log message.
-		ofLogFatalError(const string & module, const string & message);
+		ofLogFatalError(const std::string & module, const std::string & message);
 	
 		/// \brief Create a fatal error log message.
 		/// \param module The target module.
 		/// \param format The printf-style format string.
-		ofLogFatalError(const string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
+		ofLogFatalError(const std::string & module, const char* format, ...) OF_PRINTF_ATTR(3, 4);
 };
 
 
@@ -616,20 +616,20 @@ public:
 	/// \param level The log level.
 	/// \param module The target module.
 	/// \param message The log message.
-	virtual void log(ofLogLevel level, const string & module, const string & message)=0;
+	virtual void log(ofLogLevel level, const std::string & module, const std::string & message)=0;
 
 	/// \brief Log a message.
 	/// \param level The log level.
 	/// \param module The target module.
 	/// \param format The printf-style format string.
-	virtual void log(ofLogLevel level, const string & module, const char* format, ...)  OF_PRINTF_ATTR(4, 5) =0;
+	virtual void log(ofLogLevel level, const std::string & module, const char* format, ...)  OF_PRINTF_ATTR(4, 5) =0;
 
 	/// \brief Log a message.
 	/// \param level The log level.
 	/// \param module The target module.
 	/// \param format The printf-style format string.
 	/// \param args the list of printf-style arguments.
-	virtual void log(ofLogLevel level, const string & module, const char* format, va_list args)=0;
+	virtual void log(ofLogLevel level, const std::string & module, const char* format, va_list args)=0;
 };
 
 /// \brief A logger channel that logs its messages to the console.
@@ -637,9 +637,9 @@ class ofConsoleLoggerChannel: public ofBaseLoggerChannel{
 public:
 	/// \brief Destroy the console logger channel.
 	virtual ~ofConsoleLoggerChannel(){};
-	void log(ofLogLevel level, const string & module, const string & message);
-	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
-	void log(ofLogLevel level, const string & module, const char* format, va_list args);
+	void log(ofLogLevel level, const std::string & module, const std::string & message);
+	void log(ofLogLevel level, const std::string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
+	void log(ofLogLevel level, const std::string & module, const char* format, va_list args);
 };
 
 #ifdef TARGET_WIN32
@@ -648,9 +648,9 @@ class ofDebugViewLoggerChannel : public ofBaseLoggerChannel {
 public:
 	/// \brief Destroy the console logger channel.
 	virtual ~ofDebugViewLoggerChannel() {};
-	void log(ofLogLevel level, const string & module, const string & message);
-	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
-	void log(ofLogLevel level, const string & module, const char* format, va_list args);
+	void log(ofLogLevel level, const std::string & module, const std::string & message);
+	void log(ofLogLevel level, const std::string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
+	void log(ofLogLevel level, const std::string & module, const char* format, va_list args);
 };
 #endif
 
@@ -673,9 +673,9 @@ public:
 	/// \param append True if the log data should be added to an existing file.
     void setFile(const std::filesystem::path & path,bool append=false);
 
-	void log(ofLogLevel level, const string & module, const string & message);
-	void log(ofLogLevel level, const string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
-	void log(ofLogLevel level, const string & module, const char* format, va_list args);
+	void log(ofLogLevel level, const std::string & module, const std::string & message);
+	void log(ofLogLevel level, const std::string & module, const char* format, ...) OF_PRINTF_ATTR(4, 5);
+	void log(ofLogLevel level, const std::string & module, const char* format, va_list args);
 
 	/// \brief CLose the log file.
 	void close();

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -129,8 +129,8 @@ bool ofMatrixStack::doesHWOrientation() const{
 
 void ofMatrixStack::viewport(float x, float y, float width, float height, bool vflip){
 	if(!doesHWOrientation() && (orientation==OF_ORIENTATION_90_LEFT || orientation==OF_ORIENTATION_90_RIGHT)){
-		swap(width,height);
-		swap(x,y);
+		std::swap(width,height);
+		std::swap(x,y);
 	}
 
 	if(width < 0 || height < 0){
@@ -153,8 +153,8 @@ ofRectangle ofMatrixStack::getCurrentViewport() const{
 	}
 
 	if(!doesHWOrientation() && (orientation==OF_ORIENTATION_90_LEFT || orientation==OF_ORIENTATION_90_RIGHT)){
-		swap(tmpCurrentViewport.width,tmpCurrentViewport.height);
-		swap(tmpCurrentViewport.x,tmpCurrentViewport.y);
+		std::swap(tmpCurrentViewport.width,tmpCurrentViewport.height);
+		std::swap(tmpCurrentViewport.x,tmpCurrentViewport.y);
 	}
 	return tmpCurrentViewport;
 }
@@ -228,7 +228,7 @@ void ofMatrixStack::pushView(){
 
 	viewMatrixStack.push(viewMatrix);
 
-	orientationStack.push(make_pair(orientation,vFlipped));
+	orientationStack.push(std::make_pair(orientation,vFlipped));
 }
 
 void ofMatrixStack::popView(){
@@ -238,7 +238,7 @@ void ofMatrixStack::popView(){
 	}
 
 	if(!orientationStack.empty()){
-		pair<ofOrientation,bool> orientationFlip = orientationStack.top();
+		std::pair<ofOrientation,bool> orientationFlip = orientationStack.top();
 		setOrientation(orientationFlip.first,orientationFlip.second);
 		orientationStack.pop();
 	}

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -368,7 +368,7 @@ ofFileDialogResult ofSystemLoadDialog(std::string windowTitle, bool bFolderSelec
 	//------------------------------------------------------------------------------   windoze
 	//----------------------------------------------------------------------------------------
 #ifdef TARGET_WIN32
-	wstring windowTitleW;
+	std::wstring windowTitleW;
 	windowTitleW.assign(windowTitle.begin(), windowTitle.end());
 
 	if (bFolderSelection == false){

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -102,9 +102,9 @@ gboolean init_gtk(gpointer userdata){
 
 struct FileDialogData{
 	GtkFileChooserAction action;
-	string windowTitle;
-	string defaultName;
-	string results;
+	std::string windowTitle;
+	std::string defaultName;
+	std::string results;
 	bool done;
 	std::condition_variable condition;
 	std::mutex mutex;
@@ -154,8 +154,8 @@ gboolean file_dialog_gtk(gpointer userdata){
 }
 
 struct TextDialogData{
-	string text;
-	string question;
+	std::string text;
+	std::string question;
 	bool done;
 	std::condition_variable condition;
 	std::mutex mutex;
@@ -209,7 +209,7 @@ static void initGTK(){
 
 }
 
-static string gtkFileDialog(GtkFileChooserAction action,string windowTitle,string defaultName=""){
+static std::string gtkFileDialog(GtkFileChooserAction action,std::string windowTitle,std::string defaultName=""){
 	initGTK();
 	FileDialogData dialogData;
 	dialogData.action = action;
@@ -243,18 +243,18 @@ ofFileDialogResult::ofFileDialogResult(){
 }
 
 //------------------------------------------------------------------------------
-string ofFileDialogResult::getName(){
+std::string ofFileDialogResult::getName(){
 	return fileName;
 }
 
 //------------------------------------------------------------------------------
-string ofFileDialogResult::getPath(){
+std::string ofFileDialogResult::getPath(){
 	return filePath;
 }
 
 
 //------------------------------------------------------------------------------
-void ofSystemAlertDialog(string errorMessage){
+void ofSystemAlertDialog(std::string errorMessage){
 	#ifdef TARGET_WIN32
 		// we need to convert error message to a wide char message.
 		// first, figure out the length and allocate a wchar_t at that length + 1 (the +1 is for a terminating character)
@@ -296,7 +296,7 @@ void ofSystemAlertDialog(string errorMessage){
 	#endif
 
 	#ifdef TARGET_EMSCRIPTEN
-		emscripten_run_script((string("alert(")+errorMessage+");").c_str());
+		emscripten_run_script((std::string("alert(")+errorMessage+");").c_str());
 	#endif
 }
 
@@ -309,7 +309,7 @@ static int CALLBACK loadDialogBrowseCallback(
   LPARAM lParam,
   LPARAM lpData
 ){
-    string defaultPath = *(string*)lpData;
+    std::string defaultPath = *(std::string*)lpData;
     if(defaultPath!="" && uMsg==BFFM_INITIALIZED){
 		wchar_t         wideCharacterBuffer[MAX_PATH];
 		wcscpy(wideCharacterBuffer, convertNarrowToWide(ofToDataPath(defaultPath)).c_str());
@@ -323,7 +323,7 @@ static int CALLBACK loadDialogBrowseCallback(
 //---------------------------------------------------------------------
 
 // OS specific results here.  "" = cancel or something bad like can't load, can't save, etc...
-ofFileDialogResult ofSystemLoadDialog(string windowTitle, bool bFolderSelection, string defaultPath){
+ofFileDialogResult ofSystemLoadDialog(std::string windowTitle, bool bFolderSelection, std::string defaultPath){
 
 	ofFileDialogResult results;
 
@@ -356,7 +356,7 @@ ofFileDialogResult ofSystemLoadDialog(string windowTitle, bool bFolderSelection,
 
 		if(buttonClicked == NSFileHandlingPanelOKButton) {
 			NSURL * selectedFileURL = [[loadDialog URLs] objectAtIndex:0];
-			results.filePath = string([[selectedFileURL path] UTF8String]);
+			results.filePath = std::string([[selectedFileURL path] UTF8String]);
 		}
 	}
 #endif
@@ -484,7 +484,7 @@ ofFileDialogResult ofSystemLoadDialog(string windowTitle, bool bFolderSelection,
 
 
 
-ofFileDialogResult ofSystemSaveDialog(string defaultName, string messageName){
+ofFileDialogResult ofSystemSaveDialog(std::string defaultName, std::string messageName){
 
 	ofFileDialogResult results;
 
@@ -503,7 +503,7 @@ ofFileDialogResult ofSystemSaveDialog(string defaultName, string messageName){
 		[context makeCurrentContext];
 
 		if(buttonClicked == NSFileHandlingPanelOKButton){
-			results.filePath = string([[[saveDialog URL] path] UTF8String]);
+			results.filePath = std::string([[[saveDialog URL] path] UTF8String]);
 		}
 	}
 #endif
@@ -580,7 +580,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 #endif
 
 
-string ofSystemTextBoxDialog(string question, string text){
+std::string ofSystemTextBoxDialog(std::string question, std::string text){
 #if defined( TARGET_LINUX ) && defined (OF_USING_GTK)
 	initGTK();
 	TextDialogData dialogData;
@@ -751,7 +751,7 @@ string ofSystemTextBoxDialog(string question, string text){
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
-     text = emscripten_run_script_string((string("prompt('") + question + "','')").c_str());
+     text = emscripten_run_script_string((std::string("prompt('") + question + "','')").c_str());
 #endif
 	return text;
 }

--- a/libs/openFrameworks/utils/ofSystemUtils.h
+++ b/libs/openFrameworks/utils/ofSystemUtils.h
@@ -9,33 +9,33 @@ class ofFileDialogResult{
 		
 		/// \return the name of the selected file or directory, if set
 		/// currently returns only 1 file, this may change in the future
-		string getName();
+		std::string getName();
 	
 		/// \return the full path of the selected file or directory, if set
-		string getPath();
+		std::string getPath();
 	
-		string filePath; //< full path to selected file or directory
-		string fileName; //< selected file or directory name
+		std::string filePath; //< full path to selected file or directory
+		std::string fileName; //< selected file or directory name
 		bool bSuccess; //< true if the dialog action was successful, aka file select not cancel
 };
 
 /// \brief show an error message in an alert dialog box
-void ofSystemAlertDialog(string errorMessage);
+void ofSystemAlertDialog(std::string errorMessage);
 
 /// \brief show a file load dialog box
 /// \param windowTitle optional window title string, ie. "Load background image"
 /// \param bFolderSelection set to true to allow folder selection
 /// \param defaultPath optional default directory path to start the dialog in, ie. ofFilePath::getUserHomeDir()
 /// \return dialog result with selection (if any)
-ofFileDialogResult ofSystemLoadDialog(string windowTitle="", bool bFolderSelection = false, string defaultPath="");
+ofFileDialogResult ofSystemLoadDialog(std::string windowTitle="", bool bFolderSelection = false, std::string defaultPath="");
 
 /// \brief show a file save dialog box
 /// \param defaultName suggested filename to start dialog, ie "screenshot.png"
 /// \param messageName descriptive text for the save action, ie. "Saving screenshot as"
 /// \return dialog result with selection (if any)
-ofFileDialogResult ofSystemSaveDialog(string defaultName, string messageName);
+ofFileDialogResult ofSystemSaveDialog(std::string defaultName, std::string messageName);
 
 /// \brief show a text entry dialog box
 /// \param question descriptive text for the text entry, ie. "What's your favorite color?"
 /// \param text optional default text entry string, ie. "blue"
-string ofSystemTextBoxDialog(string question, string text="");
+std::string ofSystemTextBoxDialog(std::string question, std::string text="");

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -9,14 +9,14 @@ class ofHttpResponse;
 class ofHttpRequest{
 public:
 	ofHttpRequest();
-	ofHttpRequest(const string& url, const string& name,bool saveTo=false);
+	ofHttpRequest(const std::string& url, const std::string& name,bool saveTo=false);
 
-	string				url; //< request url
-	string				name; //< optional name key for sorting
+	std::string				url; //< request url
+	std::string				name; //< optional name key for sorting
 	bool				saveTo; //< save to a file once the request is finised?
-	map<string,string>	headers; //< HTTP header keys & values
-	string				body; //< POST body data
-	string				contentType; //< POST data mime type
+	std::map<std::string,std::string>	headers; //< HTTP header keys & values
+	std::string				body; //< POST body data
+	std::string				contentType; //< POST data mime type
 	std::function<void(const ofHttpResponse&)> done;
     size_t              timeoutSeconds = 0;
 
@@ -40,36 +40,36 @@ private:
 class ofHttpResponse{
 public:
 	ofHttpResponse();
-	ofHttpResponse(const ofHttpRequest& request, const ofBuffer& data, int status, const string& error);
-	ofHttpResponse(const ofHttpRequest& request, int status, const string& error);
+	ofHttpResponse(const ofHttpRequest& request, const ofBuffer& data, int status, const std::string& error);
+	ofHttpResponse(const ofHttpRequest& request, int status, const std::string& error);
 
 	operator ofBuffer&();
 
 	ofHttpRequest	    request; //< matching HTTP request for this response
 	ofBuffer		    data; //< response raw data
 	int					status; //< HTTP response status (200: OK, 404: Not Found, etc)
-	string				error; //< HTTP error string, if any (OK, Not Found, etc)
+	std::string				error; //< HTTP error string, if any (OK, Not Found, etc)
 };
 
 /// \brief make an HTTP GET request
 /// blocks until a response is returned or the request times out
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \returns HTTP response
-ofHttpResponse ofLoadURL(const string& url);
+ofHttpResponse ofLoadURL(const std::string& url);
 
 /// \brief make an asynchronous HTTP GET request
 /// will not block, placed in a queue and run using a background thread
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \param name optional key to use when sorting requests
 /// \return unique id for the active HTTP request
-int ofLoadURLAsync(const string& url, const string& name=""); // returns id
+int ofLoadURLAsync(const std::string& url, const std::string& name=""); // returns id
 
 /// \brief make an HTTP GET request and save the response data to a file
 /// blocks until a response is returned or the request times out
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \param path file path to save to
 /// \return HTTP response on success or failure
-ofHttpResponse ofSaveURLTo(const string& url, const std::filesystem::path& path);
+ofHttpResponse ofSaveURLTo(const std::string& url, const std::filesystem::path& path);
 
 /// make an asynchronous HTTP request for a url and save the response to a file at path
 /// \returns unique request id for the active HTTP request
@@ -79,7 +79,7 @@ ofHttpResponse ofSaveURLTo(const string& url, const std::filesystem::path& path)
 /// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 /// \param path file path to save to
 /// \returns unique id for the active HTTP request
-int ofSaveURLAsync(const string& url, const std::filesystem::path& path);
+int ofSaveURLAsync(const std::string& url, const std::filesystem::path& path);
 
 /// \brief remove an active HTTP request from the queue
 /// \param unique HTTP request id
@@ -116,28 +116,28 @@ class ofURLFileLoader  {
 		/// blocks until a response is returned or the request times out
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \return HTTP response on success or failure
-		ofHttpResponse get(const string& url);
+		ofHttpResponse get(const std::string& url);
 	
 		/// \brief make an asynchronous HTTP request
 		/// will not block, placed in a queue and run using a background thread
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \param name optional key to use when sorting requests
 		/// \return unique id for the active HTTP request
-        int getAsync(const string& url, const string& name="");
+        int getAsync(const std::string& url, const std::string& name="");
 	
 		/// \brief make an HTTP request and save the response data to a file
 		/// blocks until a response is returned or the request times out
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \param path file path to save to
 		/// \return HTTP response on success or failure
-        ofHttpResponse saveTo(const string& url, const std::filesystem::path& path);
+        ofHttpResponse saveTo(const std::string& url, const std::filesystem::path& path);
 	
 		/// \brief make an asynchronous HTTP request and save the response data to a file
 		/// will not block, placed in a queue and run using a background thread
 		/// \param url HTTP url to request, ie. "http://somewebsite.com/someapi/someimage.jpg"
 		/// \param path file path to save to
 		/// \returns unique id for the active HTTP request
-        int saveAsync(const string& url, const std::filesystem::path& path);
+        int saveAsync(const std::string& url, const std::filesystem::path& path);
 	
 		/// \brief remove an active HTTP request from the queue
 		/// \param unique HTTP request id
@@ -160,5 +160,5 @@ class ofURLFileLoader  {
         int handleRequestAsync(const ofHttpRequest& request);
 
     private:
-        shared_ptr<ofBaseURLFileLoader> impl;
+	std::shared_ptr<ofBaseURLFileLoader> impl;
 };

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -58,7 +58,7 @@ namespace{
 	bool enableDataPath = true;
 
     //--------------------------------------------------
-    string defaultDataPath(){
+    std::string defaultDataPath(){
     #if defined TARGET_OSX
         try{
             return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
@@ -66,7 +66,7 @@ namespace{
             return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
         }
     #elif defined TARGET_ANDROID
-            return string("sdcard/");
+            return std::string("sdcard/");
     #else
             try{
                 return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).string();
@@ -386,16 +386,16 @@ void ofSleepMillis(int millis){
 
 //default ofGetTimestampString returns in this format: 2011-01-15-18-29-35-299
 //--------------------------------------------------
-string ofGetTimestampString(){
+std::string ofGetTimestampString(){
 
-	string timeFormat = "%Y-%m-%d-%H-%M-%S-%i";
+	std::string timeFormat = "%Y-%m-%d-%H-%M-%S-%i";
 
 	return ofGetTimestampString(timeFormat);
 }
 
 //specify the string format - eg: %Y-%m-%d-%H-%M-%S-%i ( 2011-01-15-18-29-35-299 )
 //--------------------------------------------------
-string ofGetTimestampString(const string& timestampFormat){
+std::string ofGetTimestampString(const std::string& timestampFormat){
 	std::stringstream str;
 	auto now = std::chrono::system_clock::now();
 	auto t = std::chrono::system_clock::to_time_t(now);    std::chrono::duration<double> s = now - std::chrono::system_clock::from_time_t(t);
@@ -510,7 +510,7 @@ void ofSetDataPathRoot(const std::filesystem::path& newRoot){
 }
 
 //--------------------------------------------------
-string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
+std::string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
 	if (!enableDataPath)
         return path.string();
 
@@ -592,81 +592,81 @@ string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
 
 //----------------------------------------
 template<>
-string ofFromString(const string& value){
+std::string ofFromString(const std::string& value){
 	return value;
 }
 
 //----------------------------------------
 template<>
-const char * ofFromString(const string& value){
+const char * ofFromString(const std::string& value){
 	return value.c_str();
 }
 
 //----------------------------------------
 template <>
-string ofToHex(const string& value) {
-	ostringstream out;
+std::string ofToHex(const std::string& value) {
+	std::ostringstream out;
 	// how many bytes are in the string
 	std::size_t numBytes = value.size();
 	for(std::size_t i = 0; i < numBytes; i++) {
 		// print each byte as a 2-character wide hex value
-		out << setfill('0') << std::setw(2) << std::hex << (unsigned int) ((unsigned char)value[i]);
+		out << std::setfill('0') << std::setw(2) << std::hex << (unsigned int) ((unsigned char)value[i]);
 	}
 	return out.str();
 }
 
 //----------------------------------------
-string ofToHex(const char* value) {
+std::string ofToHex(const char* value) {
 	// this function is necessary if you want to print a string
 	// using a syntax like ofToHex("test")
-	return ofToHex((string) value);
+	return ofToHex((std::string) value);
 }
 
 //----------------------------------------
-int ofToInt(const string& intString) {
+int ofToInt(const std::string& intString) {
 	return ofTo<int>(intString);
 }
 
 //----------------------------------------
-int ofHexToInt(const string& intHexString) {
+int ofHexToInt(const std::string& intHexString) {
 	int x = 0;
-	istringstream cur(intHexString);
+	std::istringstream cur(intHexString);
 	cur >> std::hex >> x;
 	return x;
 }
 
 //----------------------------------------
-char ofHexToChar(const string& charHexString) {
+char ofHexToChar(const std::string& charHexString) {
 	int x = 0;
-	istringstream cur(charHexString);
+	std::istringstream cur(charHexString);
 	cur >> std::hex >> x;
 	return (char) x;
 }
 
 //----------------------------------------
-float ofHexToFloat(const string& floatHexString) {
+float ofHexToFloat(const std::string& floatHexString) {
 	union intFloatUnion {
 		uint32_t i;
 		float f;
 	} myUnion;
 	myUnion.i = 0;
-	istringstream cur(floatHexString);
+	std::istringstream cur(floatHexString);
 	cur >> std::hex >> myUnion.i;
 	return myUnion.f;
 }
 
 //----------------------------------------
-string ofHexToString(const string& stringHexString) {
-	stringstream out;
-	stringstream stream(stringHexString);
+std::string ofHexToString(const std::string& stringHexString) {
+	std::stringstream out;
+	std::stringstream stream(stringHexString);
 	// a hex string has two characters per byte
 	std::size_t numBytes = stringHexString.size() / 2;
 	for(std::size_t i = 0; i < numBytes; i++) {
-		string curByte;
+		std::string curByte;
 		// grab two characters from the hex string
-		stream >> setw(2) >> curByte;
+		stream >> std::setw(2) >> curByte;
 		// prepare to parse the two characters
-		stringstream curByteStream(curByte);
+		std::stringstream curByteStream(curByte);
 		int cur = 0;
 		// parse the two characters as a hex-encoded int
 		curByteStream >> std::hex >> cur;
@@ -677,22 +677,22 @@ string ofHexToString(const string& stringHexString) {
 }
 
 //----------------------------------------
-float ofToFloat(const string& floatString) {
+float ofToFloat(const std::string& floatString) {
 	return ofTo<float>(floatString);
 }
 
 //----------------------------------------
-double ofToDouble(const string& doubleString) {
+double ofToDouble(const std::string& doubleString) {
 	return ofTo<double>(doubleString);
 }
 
 //----------------------------------------
-int64_t ofToInt64(const string& intString) {
+int64_t ofToInt64(const std::string& intString) {
 	return ofTo<int64_t>(intString);
 }
 
 //----------------------------------------
-bool ofToBool(const string& boolString) {
+bool ofToBool(const std::string& boolString) {
 	auto lower = ofToLower(boolString);
 	if(lower == "true") {
 		return true;
@@ -701,19 +701,19 @@ bool ofToBool(const string& boolString) {
 		return false;
 	}
 	bool x = false;
-	istringstream cur(lower);
+	std::istringstream cur(lower);
 	cur >> x;
 	return x;
 }
 
 //----------------------------------------
-char ofToChar(const string& charString) {
+char ofToChar(const std::string& charString) {
 	return ofTo<char>(charString);
 }
 
 //----------------------------------------
-template <> string ofToBinary(const string& value) {
-	stringstream out;
+template <> std::string ofToBinary(const std::string& value) {
+	std::stringstream out;
 	std::size_t numBytes = value.size();
 	for(std::size_t i = 0; i < numBytes; i++) {
 		std::bitset<8> bitBuffer(value[i]);
@@ -723,28 +723,28 @@ template <> string ofToBinary(const string& value) {
 }
 
 //----------------------------------------
-string ofToBinary(const char* value) {
+std::string ofToBinary(const char* value) {
 	// this function is necessary if you want to print a string
 	// using a syntax like ofToBinary("test")
-	return ofToBinary((string) value);
+	return ofToBinary((std::string) value);
 }
 
 //----------------------------------------
-int ofBinaryToInt(const string& value) {
+int ofBinaryToInt(const std::string& value) {
 	const int intSize = sizeof(int) * 8;
 	std::bitset<intSize> binaryString(value);
 	return (int) binaryString.to_ulong();
 }
 
 //----------------------------------------
-char ofBinaryToChar(const string& value) {
+char ofBinaryToChar(const std::string& value) {
 	const int charSize = sizeof(char) * 8;
 	std::bitset<charSize> binaryString(value);
 	return (char) binaryString.to_ulong();
 }
 
 //----------------------------------------
-float ofBinaryToFloat(const string& value) {
+float ofBinaryToFloat(const std::string& value) {
 	const int floatSize = sizeof(float) * 8;
 	std::bitset<floatSize> binaryString(value);
 	union ulongFloatUnion {
@@ -755,9 +755,9 @@ float ofBinaryToFloat(const string& value) {
 	return myUFUnion.f;
 }
 //----------------------------------------
-string ofBinaryToString(const string& value) {
-	ostringstream out;
-	stringstream stream(value);
+std::string ofBinaryToString(const std::string& value) {
+	std::ostringstream out;
+	std::stringstream stream(value);
 	std::bitset<8> byteString;
 	std::size_t numBytes = value.size() / 8;
 	for(std::size_t i = 0; i < numBytes; i++) {
@@ -768,16 +768,16 @@ string ofBinaryToString(const string& value) {
 }
 
 //--------------------------------------------------
-vector <string> ofSplitString(const string & source, const string & delimiter, bool ignoreEmpty, bool trim) {
-	vector<string> result;
+std::vector <std::string> ofSplitString(const std::string & source, const std::string & delimiter, bool ignoreEmpty, bool trim) {
+	std::vector<std::string> result;
 	if (delimiter.empty()) {
 		result.push_back(source);
 		return result;
 	}
-	string::const_iterator substart = source.begin(), subend;
+	std::string::const_iterator substart = source.begin(), subend;
 	while (true) {
 		subend = search(substart, source.end(), delimiter.begin(), delimiter.end());
-		string sub(substart, subend);
+		std::string sub(substart, subend);
 		if(trim) {
 			sub = ofTrim(sub);
 		}
@@ -793,14 +793,14 @@ vector <string> ofSplitString(const string & source, const string & delimiter, b
 }
 
 //--------------------------------------------------
-string ofJoinString(const vector<string>& stringElements, const string& delimiter){
-	string str;
+std::string ofJoinString(const std::vector<std::string>& stringElements, const std::string& delimiter){
+	std::string str;
 	if(stringElements.empty()){
 		return str;
 	}
 	auto numStrings = stringElements.size();
-	string::size_type strSize = delimiter.size() * (numStrings - 1);
-	for (const string &s : stringElements) {
+	std::string::size_type strSize = delimiter.size() * (numStrings - 1);
+	for (const std::string &s : stringElements) {
 		strSize += s.size();
 	}
 	str.reserve(strSize);
@@ -813,7 +813,7 @@ string ofJoinString(const vector<string>& stringElements, const string& delimite
 }
 
 //--------------------------------------------------
-void ofStringReplace(string& input, const string& searchStr, const string& replaceStr){
+void ofStringReplace(std::string& input, const std::string& searchStr, const std::string& replaceStr){
 	auto pos = input.find(searchStr);
 	while(pos != std::string::npos){
 		input.replace(pos, searchStr.size(), replaceStr);
@@ -828,12 +828,12 @@ void ofStringReplace(string& input, const string& searchStr, const string& repla
 }
 
 //--------------------------------------------------
-bool ofIsStringInString(const string& haystack, const string& needle){
+bool ofIsStringInString(const std::string& haystack, const std::string& needle){
     return haystack.find(needle) != std::string::npos;
 }
 
 //--------------------------------------------------
-std::size_t ofStringTimesInString(const string& haystack, const string& needle){
+std::size_t ofStringTimesInString(const std::string& haystack, const std::string& needle){
 	const size_t step = needle.size();
 
 	size_t count(0);
@@ -848,7 +848,7 @@ std::size_t ofStringTimesInString(const string& haystack, const string& needle){
 }
 
 
-ofUTF8Iterator::ofUTF8Iterator(const string & str){
+ofUTF8Iterator::ofUTF8Iterator(const std::string & str){
 	try{
 		utf8::replace_invalid(str.begin(),str.end(),back_inserter(src_valid));
 	}catch(...){
@@ -894,7 +894,7 @@ utf8::iterator<std::string::const_reverse_iterator> ofUTF8Iterator::rend() const
 
 //--------------------------------------------------
 // helper method to get locale from name
-static std::locale getLocale(const string & locale) {
+static std::locale getLocale(const std::string & locale) {
 	std::locale loc;
 	try {
 		loc = std::locale(locale.c_str());
@@ -906,7 +906,7 @@ static std::locale getLocale(const string & locale) {
 }
 
 //--------------------------------------------------
-string ofToLower(const string & src, const string & locale){
+std::string ofToLower(const std::string & src, const std::string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
@@ -919,7 +919,7 @@ string ofToLower(const string & src, const string & locale){
 }
 
 //--------------------------------------------------
-string ofToUpper(const string & src, const string & locale){
+std::string ofToUpper(const std::string & src, const std::string & locale){
 	std::string dst;
 	std::locale loc = getLocale(locale);
 	try{
@@ -932,7 +932,7 @@ string ofToUpper(const string & src, const string & locale){
 }
 
 //--------------------------------------------------
-string ofTrimFront(const string & src, const string& locale){
+std::string ofTrimFront(const std::string & src, const std::string& locale){
     auto dst = src;
     std::locale loc = getLocale(locale);
     dst.erase(dst.begin(),std::find_if_not(dst.begin(),dst.end(),[&](char & c){return std::isspace<char>(c,loc);}));
@@ -940,7 +940,7 @@ string ofTrimFront(const string & src, const string& locale){
 }
 
 //--------------------------------------------------
-string ofTrimBack(const string & src, const string& locale){
+std::string ofTrimBack(const std::string & src, const std::string& locale){
     auto dst = src;
     std::locale loc = getLocale(locale);
 	dst.erase(std::find_if_not(dst.rbegin(),dst.rend(),[&](char & c){return std::isspace<char>(c,loc);}).base(), dst.end());
@@ -948,26 +948,26 @@ string ofTrimBack(const string & src, const string& locale){
 }
 
 //--------------------------------------------------
-string ofTrim(const string & src, const string& locale){
+std::string ofTrim(const std::string & src, const std::string& locale){
     return ofTrimFront(ofTrimBack(src));
 }
 
 //--------------------------------------------------
-void ofAppendUTF8(string & str, uint32_t utf8){
+void ofAppendUTF8(std::string & str, uint32_t utf8){
 	try{
 		utf8::append(utf8, back_inserter(str));
 	}catch(...){}
 }
 
 //--------------------------------------------------
-void ofUTF8Append(string & str, uint32_t utf8){
+void ofUTF8Append(std::string & str, uint32_t utf8){
 	try{
 		utf8::append(utf8, back_inserter(str));
 	}catch(...){}
 }
 
 //--------------------------------------------------
-void ofUTF8Insert(string & str, size_t pos, uint32_t utf8){
+void ofUTF8Insert(std::string & str, size_t pos, uint32_t utf8){
 	std::string newText;
 	size_t i = 0;
 	for(auto c: ofUTF8Iterator(str)){
@@ -984,7 +984,7 @@ void ofUTF8Insert(string & str, size_t pos, uint32_t utf8){
 }
 
 //--------------------------------------------------
-void ofUTF8Erase(string & str, size_t start, size_t len){
+void ofUTF8Erase(std::string & str, size_t start, size_t len){
 	std::string newText;
 	size_t i = 0;
 	for(auto c: ofUTF8Iterator(str)){
@@ -997,7 +997,7 @@ void ofUTF8Erase(string & str, size_t start, size_t len){
 }
 
 //--------------------------------------------------
-std::string ofUTF8Substring(const string & str, size_t start, size_t len){
+std::string ofUTF8Substring(const std::string & str, size_t start, size_t len){
 	size_t i=0;
 	std::string newText;
 	for(auto c: ofUTF8Iterator(str)){
@@ -1029,7 +1029,7 @@ size_t ofUTF8Length(const std::string & str){
 }
 
 //--------------------------------------------------
-string ofVAArgsToString(const char * format, ...){
+std::string ofVAArgsToString(const char * format, ...){
 	va_list args;
 	va_start(args, format);
 	char buf[256];
@@ -1050,7 +1050,7 @@ string ofVAArgsToString(const char * format, ...){
 	return s;
 }
 
-string ofVAArgsToString(const char * format, va_list args){
+std::string ofVAArgsToString(const char * format, va_list args){
 	char buf[256];
 	size_t n = std::vsnprintf(buf, sizeof(buf), format, args);
 
@@ -1067,7 +1067,7 @@ string ofVAArgsToString(const char * format, va_list args){
 }
 
 //--------------------------------------------------
-void ofLaunchBrowser(const string& url, bool uriEncodeQuery){
+void ofLaunchBrowser(const std::string& url, bool uriEncodeQuery){
 	UriParserStateA state;
 	UriUriA uri;
 	state.uri = &uri;
@@ -1105,7 +1105,7 @@ void ofLaunchBrowser(const string& url, bool uriEncodeQuery){
 
 	#ifdef TARGET_OSX
         // could also do with LSOpenCFURLRef
-		string commandStr = "open \"" + uriStr + "\"";
+		std::string commandStr = "open \"" + uriStr + "\"";
 		int ret = system(commandStr.c_str());
         if(ret!=0) {
 			ofLogError("ofUtils") << "ofLaunchBrowser(): couldn't open browser, commandStr \"" << commandStr << "\"";
@@ -1113,7 +1113,7 @@ void ofLaunchBrowser(const string& url, bool uriEncodeQuery){
 	#endif
 
 	#ifdef TARGET_LINUX
-		string commandStr = "xdg-open \"" + uriStr + "\"";
+		std::string commandStr = "xdg-open \"" + uriStr + "\"";
 		int ret = system(commandStr.c_str());
 		if(ret!=0) {
 			ofLogError("ofUtils") << "ofLaunchBrowser(): couldn't open browser, commandStr \"" << commandStr << "\"";
@@ -1134,8 +1134,8 @@ void ofLaunchBrowser(const string& url, bool uriEncodeQuery){
 }
 
 //--------------------------------------------------
-string ofGetVersionInfo(){
-	stringstream sstr;
+std::string ofGetVersionInfo(){
+	std::stringstream sstr;
 	sstr << OF_VERSION_MAJOR << "." << OF_VERSION_MINOR << "." << OF_VERSION_PATCH;
 
 	if (!std::string(OF_VERSION_PRE_RELEASE).empty())
@@ -1168,7 +1168,7 @@ std::string ofGetVersionPreRelease() {
 //from the forums http://www.openframeworks.cc/forum/viewtopic.php?t=1413
 
 //--------------------------------------------------
-void ofSaveScreen(const string& filename) {
+void ofSaveScreen(const std::string& filename) {
    /*ofImage screen;
    screen.allocate(ofGetWidth(), ofGetHeight(), OF_IMAGE_COLOR);
    screen.grabScreen(0, 0, ofGetWidth(), ofGetHeight());
@@ -1179,7 +1179,7 @@ void ofSaveScreen(const string& filename) {
 }
 
 //--------------------------------------------------
-void ofSaveViewport(const string& filename) {
+void ofSaveViewport(const std::string& filename) {
 	// because ofSaveScreen doesn't related to viewports
 	/*ofImage screen;
 	ofRectangle view = ofGetCurrentViewport();
@@ -1195,7 +1195,7 @@ void ofSaveViewport(const string& filename) {
 //--------------------------------------------------
 int saveImageCounter = 0;
 void ofSaveFrame(bool bUseViewport){
-   string fileName = ofToString(saveImageCounter) + ".png";
+	std::string fileName = ofToString(saveImageCounter) + ".png";
 	if (bUseViewport){
 		ofSaveViewport(fileName);
 	} else {
@@ -1205,7 +1205,7 @@ void ofSaveFrame(bool bUseViewport){
 }
 
 //--------------------------------------------------
-string ofSystem(const string& command){
+std::string ofSystem(const std::string& command){
 	FILE * ret = nullptr;
 #ifdef TARGET_WIN32
 	ret = _popen(command.c_str(),"r");
@@ -1213,7 +1213,7 @@ string ofSystem(const string& command){
 	ret = popen(command.c_str(),"r");
 #endif
 
-	string strret;
+	std::string strret;
 	int c;
 
 	if (ret == nullptr){
@@ -1237,7 +1237,7 @@ string ofSystem(const string& command){
 //--------------------------------------------------
 ofTargetPlatform ofGetTargetPlatform(){
 #ifdef TARGET_LINUX
-    string arch = ofSystem("uname -m");
+    std::string arch = ofSystem("uname -m");
     if(ofIsStringInString(arch,"x86_64")) {
         return OF_TARGET_LINUX64;
     } else if(ofIsStringInString(arch,"armv6l")) {

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -148,7 +148,7 @@ void ofSleepMillis(int millis);
 /// 2011-01-15-18-29-35-299).
 ///
 /// \returns the current time as a string with the default format.
-string ofGetTimestampString();
+std::string ofGetTimestampString();
 
 /// \brief Formats the current system time according to the given format.
 ///
@@ -185,7 +185,7 @@ string ofGetTimestampString();
 /// \param timestampFormat The formatting pattern.
 /// \returns the formatted timestamp as a string.
 /// \warning an invalid timestampFormat may crash windows apps.
-string ofGetTimestampString(const string& timestampFormat);
+std::string ofGetTimestampString(const std::string& timestampFormat);
 
 /// \brief Get the current year.
 /// \returns the current year.
@@ -230,7 +230,7 @@ void ofDisableDataPath();
 /// \param path The path to make relative to the data/ folder.
 /// \param absolute Set to true to return an absolute path.
 /// \returns the new path, unless paths were disabled with ofDisableDataPath().
-string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
+std::string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
 
 /// \brief Reset the working directory to the platform default.
 ///
@@ -258,7 +258,7 @@ void ofSetDataPathRoot(const std::filesystem::path& root);
 /// \param values The vector of values to modify.
 /// \sa http://www.cplusplus.com/reference/algorithm/random_shuffle/
 template<class T>
-void ofRandomize(vector<T>& values) {
+void ofRandomize(std::vector<T>& values) {
 	random_shuffle(values.begin(), values.end());
 }
 
@@ -301,7 +301,7 @@ void ofRandomize(vector<T>& values) {
 /// \param shouldErase A boolean function as described above.
 /// \sa http://www.cplusplus.com/reference/algorithm/remove_if/
 template<class T, class BoolFunction>
-void ofRemove(vector<T>& values, BoolFunction shouldErase) {
+void ofRemove(std::vector<T>& values, BoolFunction shouldErase) {
 	values.erase(remove_if(values.begin(), values.end(), shouldErase), values.end());
 }
 
@@ -315,7 +315,7 @@ void ofRemove(vector<T>& values, BoolFunction shouldErase) {
 /// \param values The vector of values to be sorted.
 /// \sa http://www.cplusplus.com/reference/algorithm/sort/
 template<class T>
-void ofSort(vector<T>& values) {
+void ofSort(std::vector<T>& values) {
 	sort(values.begin(), values.end());
 }
 
@@ -360,7 +360,7 @@ void ofSort(vector<T>& values) {
 /// \param compare The comparison function.
 /// \sa http://www.cplusplus.com/reference/algorithm/sort/
 template<class T, class BoolFunction>
-void ofSort(vector<T>& values, BoolFunction compare) {
+void ofSort(std::vector<T>& values, BoolFunction compare) {
 	std::sort(values.begin(), values.end(), compare);
 }
 
@@ -371,7 +371,7 @@ void ofSort(vector<T>& values, BoolFunction compare) {
 /// \returns true the index of the first target value found.
 /// \sa http://www.cplusplus.com/reference/iterator/distance/
 template <class T>
-std::size_t ofFind(const vector<T>& values, const T& target) {
+std::size_t ofFind(const std::vector<T>& values, const T& target) {
 	return std::distance(values.begin(), find(values.begin(), values.end(), target));
 }
 
@@ -381,7 +381,7 @@ std::size_t ofFind(const vector<T>& values, const T& target) {
 /// \param target The target value to be found.
 /// \returns true if at least one value equal to the target value is found.
 template <class T>
-bool ofContains(const vector<T>& values, const T& target) {
+bool ofContains(const std::vector<T>& values, const T& target) {
 	return ofFind(values, target) != values.size();
 }
 
@@ -413,19 +413,19 @@ bool ofContains(const vector<T>& values, const T& target) {
 /// \param ignoreEmpty Set to true to remove empty tokens.
 /// \param trim Set to true to trim the resulting tokens.
 /// \returns A vector of strings split with the delimiter.
-vector<string> ofSplitString(const string& source, const string& delimiter, bool ignoreEmpty = false, bool trim = false);
+std::vector<std::string> ofSplitString(const std::string& source, const std::string& delimiter, bool ignoreEmpty = false, bool trim = false);
 
 /// \brief Join a vector of strings together into one string.
 /// \param stringElements The vector of strings to join.
 /// \param delimiter The delimiter to put betweeen each string.
-string ofJoinString(const vector<string>& stringElements, const string& delimiter);
+std::string ofJoinString(const std::vector<std::string>& stringElements, const std::string& delimiter);
 
 /// \brief Replace all occurrences of a string with another string.
 /// \note The input string is passed by reference, so it will be modified.
 /// \param input The string to run the replacement on.
 /// \param searchStr The string to be replaced.
 /// \param replaceStr The string to put in place.
-void ofStringReplace(string& input, const string& searchStr, const string& replaceStr);
+void ofStringReplace(std::string& input, const std::string& searchStr, const std::string& replaceStr);
 
 /// \brief Check if string contains another string.
 /// 
@@ -438,12 +438,12 @@ void ofStringReplace(string& input, const string& searchStr, const string& repla
 /// ~~~
 /// \param haystack The string to check for occurrence in.
 /// \param needle The string to check for.
-bool ofIsStringInString(const string& haystack, const string& needle);
+bool ofIsStringInString(const std::string& haystack, const std::string& needle);
 
 /// \brief Check how many times a string contains another string.
 /// \param haystack The string to check for occurrence in .
 /// \param needle The string to check for.
-std::size_t ofStringTimesInString(const string& haystack, const string& needle);
+std::size_t ofStringTimesInString(const std::string& haystack, const std::string& needle);
 
 /// \brief Converts all characters in a string to lowercase.
 ///
@@ -458,7 +458,7 @@ std::size_t ofStringTimesInString(const string& haystack, const string& needle);
 ///
 /// \param src The UTF-8 encoded string to convert to lowercase.
 /// \returns the UTF-8 encoded string as all lowercase characters.
-string ofToLower(const string& src, const string & locale="");
+std::string ofToLower(const std::string& src, const std::string & locale="");
 
 /// \brief Converts all characters in the string to uppercase.
 ///
@@ -473,31 +473,31 @@ string ofToLower(const string& src, const string & locale="");
 ///
 /// \param src The UTF-8 encoded string to convert to uppercase.
 /// \returns the UTF-8 encoded string as all uppercase characters.
-string ofToUpper(const string& src, const string & locale="");
+std::string ofToUpper(const std::string& src, const std::string & locale="");
 
-string ofTrimFront(const string & src, const string & locale = "");
-string ofTrimBack(const string & src, const string & locale = "");
-string ofTrim(const string & src, const string & locale = "");
+std::string ofTrimFront(const std::string & src, const std::string & locale = "");
+std::string ofTrimBack(const std::string & src, const std::string & locale = "");
+std::string ofTrim(const std::string & src, const std::string & locale = "");
 
-OF_DEPRECATED_MSG("Use ofUTF8Append instead", void ofAppendUTF8(string & str, uint32_t utf8));
+OF_DEPRECATED_MSG("Use ofUTF8Append instead", void ofAppendUTF8(std::string & str, uint32_t utf8));
 
-void ofUTF8Append(string & str, uint32_t utf8);
-void ofUTF8Insert(string & str, size_t pos, uint32_t utf8);
-void ofUTF8Erase(string & str, size_t start, size_t len);
-std::string ofUTF8Substring(const string & str, size_t start, size_t len);
+void ofUTF8Append(std::string & str, uint32_t utf8);
+void ofUTF8Insert(std::string & str, size_t pos, uint32_t utf8);
+void ofUTF8Erase(std::string & str, size_t start, size_t len);
+std::string ofUTF8Substring(const std::string & str, size_t start, size_t len);
 std::string ofUTF8ToString(uint32_t utf8);
 size_t ofUTF8Length(const std::string & str);
 
 /// \brief Convert a variable length argument to a string.
 /// \param format a printf-style format string.
 /// \returns A string representation of the argument list.
-string ofVAArgsToString(const char * format, ...);
+std::string ofVAArgsToString(const char * format, ...);
 
 /// \brief Convert a variable length argument to a string.
 /// \param format A printf-style format string.
 /// \param args A variable argument list.
 /// \returns A string representation of the argument list.
-string ofVAArgsToString(const char * format, va_list args);
+std::string ofVAArgsToString(const char * format, va_list args);
 
 /// \section String Conversion
 /// \brief Convert a value to a string.
@@ -516,8 +516,8 @@ string ofVAArgsToString(const char * format, va_list args);
 /// \param value The value to convert to a string.
 /// \returns A string representing the value or an empty string on failure.
 template <class T>
-string ofToString(const T& value){
-	ostringstream out;
+std::string ofToString(const T& value){
+	std::ostringstream out;
 	out << value;
 	return out.str();
 }
@@ -531,9 +531,9 @@ string ofToString(const T& value){
 /// \param precision The precision to use when converting to a string.
 /// \returns The string representation of the value.
 template <class T>
-string ofToString(const T& value, int precision){
-	ostringstream out;
-	out << fixed << setprecision(precision) << value;
+std::string ofToString(const T& value, int precision){
+	std::ostringstream out;
+	out << std::fixed << std::setprecision(precision) << value;
 	return out.str();
 }
 
@@ -547,9 +547,9 @@ string ofToString(const T& value, int precision){
 /// \param fill The character to use when padding the converted string.
 /// \returns The string representation of the value.
 template <class T>
-string ofToString(const T& value, int width, char fill ){
-	ostringstream out;
-	out << fixed << setfill(fill) << setw(width) << value;
+std::string ofToString(const T& value, int width, char fill ){
+	std::ostringstream out;
+	out << std::fixed << std::setfill(fill) << std::setw(width) << value;
 	return out.str();
 }
 
@@ -564,9 +564,9 @@ string ofToString(const T& value, int width, char fill ){
 /// \param fill The character to use when padding the converted string.
 /// \returns The string representation of the value.
 template <class T>
-string ofToString(const T& value, int precision, int width, char fill ){
-	ostringstream out;
-	out << fixed << setfill(fill) << setw(width) << setprecision(precision) << value;
+std::string ofToString(const T& value, int precision, int width, char fill ){
+	std::ostringstream out;
+	out << std::fixed << std::setfill(fill) << std::setw(width) << std::setprecision(precision) << value;
 	return out.str();
 }
 
@@ -579,8 +579,8 @@ string ofToString(const T& value, int precision, int width, char fill ){
 /// \param values The vector of values to be converted to a string.
 /// \returns a comma-delimited string representation of the intput values.
 template<class T>
-string ofToString(const vector<T>& values) {
-	stringstream out;
+std::string ofToString(const std::vector<T>& values) {
+	std::stringstream out;
 	int n = values.size();
 	out << "{";
 	if(n > 0) {
@@ -601,9 +601,9 @@ string ofToString(const vector<T>& values) {
 /// \param value The string value to convert to type T.
 /// \returns the string converted to the target data type T.
 template<class T>
-T ofFromString(const string & value){
+T ofFromString(const std::string & value){
 	T data;
-    stringstream ss;
+	std::stringstream ss;
     ss << value;
     ss >> data;
     return data;
@@ -613,7 +613,7 @@ T ofFromString(const string & value){
 /// \param value The string value to convert to another string.
 /// \returns the string converted to another string.
 template<>
-string ofFromString(const string & value);
+std::string ofFromString(const std::string & value);
 
 /// \brief Convert a string represetnation to another string.
 ///
@@ -622,11 +622,11 @@ string ofFromString(const string & value);
 /// \param value The string value to convert to another string.
 /// \returns the string converted to a c-style string.
 template<>
-const char * ofFromString(const string & value);
+const char * ofFromString(const std::string & value);
 
 template<typename T> T ofTo(const std::string & str){
 	T x;
-	istringstream cur(str);
+	std::istringstream cur(str);
 	cur >> x;
 	return x;
 }
@@ -639,7 +639,7 @@ template<typename T> T ofTo(const std::string & str){
 ///
 /// \param intString The string representation of the integer.
 /// \returns the integer represented by the string or 0 on failure.
-int ofToInt(const string& intString);
+int ofToInt(const std::string& intString);
 
 /// \brief Convert a string to a int64_t.
 ///
@@ -648,7 +648,7 @@ int ofToInt(const string& intString);
 ///
 /// \param intString The string representation of the long integer.
 /// \returns the long integer represented by the string or 0 on failure.
-int64_t ofToInt64(const string& intString);
+int64_t ofToInt64(const std::string& intString);
 
 /// \brief Convert a string to a float.
 ///
@@ -657,7 +657,7 @@ int64_t ofToInt64(const string& intString);
 ///
 /// \param floatString string representation of the float.
 /// \returns the float represented by the string or 0 on failure.
-float ofToFloat(const string& floatString);
+float ofToFloat(const std::string& floatString);
 
 /// \brief Convert a string to a double.
 ///
@@ -666,7 +666,7 @@ float ofToFloat(const string& floatString);
 ///
 /// \param doubleString The string representation of the double.
 /// \returns the double represented by the string or 0 on failure.
-double ofToDouble(const string& doubleString);
+double ofToDouble(const std::string& doubleString);
 
 /// \brief Convert a string to a boolean.
 ///
@@ -676,7 +676,7 @@ double ofToDouble(const string& doubleString);
 ///
 /// \param boolString The string representation of the boolean.
 /// \returns the boolean represented by the string or 0 on failure.
-bool ofToBool(const string& boolString);
+bool ofToBool(const std::string& boolString);
 
 /// \brief Converts any value to its equivalent hexadecimal representation.
 ///
@@ -687,8 +687,8 @@ bool ofToBool(const string& boolString);
 /// \param value The value to convert to a hexadecimal string.
 /// \returns the hexadecimal string representation of the value.
 template <class T>
-string ofToHex(const T& value) {
-	ostringstream out;
+std::string ofToHex(const T& value) {
+	std::ostringstream out;
 	// pretend that the value is a bunch of bytes
 	unsigned char* valuePtr = (unsigned char*) &value;
 	// the number of bytes is determined by the datatype
@@ -696,7 +696,7 @@ string ofToHex(const T& value) {
 	// the bytes are stored backwards (least significant first)
 	for(int i = numBytes - 1; i >= 0; i--) {
 		// print each byte out as a 2-character wide hex value
-		out << setfill('0') << setw(2) << hex << (int) valuePtr[i];
+		out << std::setfill('0') << std::setw(2) << std::hex << (int) valuePtr[i];
 	}
 	return out.str();
 }
@@ -709,7 +709,7 @@ string ofToHex(const T& value) {
 /// \param value The value to convert to a hexadecimal string.
 /// \returns a hexadecimal string.
 template <>
-string ofToHex(const string& value);
+std::string ofToHex(const std::string& value);
 
 /// \brief Convert a c-style string to a hexadecimal string.
 ///
@@ -718,7 +718,7 @@ string ofToHex(const string& value);
 ///
 /// \param value The value to convert to a hexadecimal string.
 /// \returns a hexadecimal string.
-string ofToHex(const char* value);
+std::string ofToHex(const char* value);
 
 /// \brief Convert a string representing an integer in hexadecimal to a string.
 ///
@@ -727,7 +727,7 @@ string ofToHex(const char* value);
 ///
 /// \param intHexString The string representing an integer in hexadecimal.
 /// \returns the integer represented by the string.
-int ofHexToInt(const string& intHexString);
+int ofHexToInt(const std::string& intHexString);
 
 /// \brief Convert a string representing an char in hexadecimal to a char.
 ///
@@ -736,7 +736,7 @@ int ofHexToInt(const string& intHexString);
 ///
 /// \param charHexString The string representing an char in hexadecimal.
 /// \returns the char represented by the string.
-char ofHexToChar(const string& charHexString);
+char ofHexToChar(const std::string& charHexString);
 
 /// \brief Convert a string representing an float in hexadecimal to a float.
 ///
@@ -745,7 +745,7 @@ char ofHexToChar(const string& charHexString);
 ///
 /// \param floatHexString The string representing an float in hexadecimal.
 /// \returns the float represented by the string.
-float ofHexToFloat(const string& floatHexString);
+float ofHexToFloat(const std::string& floatHexString);
 
 /// \brief Convert a string representing an string in hexadecimal to a string.
 ///
@@ -754,7 +754,7 @@ float ofHexToFloat(const string& floatHexString);
 ///
 /// \param stringHexString The string representing an string in hexadecimal.
 /// \returns the string represented by the string.
-string ofHexToString(const string& stringHexString);
+std::string ofHexToString(const std::string& stringHexString);
 
 /// \brief Convert a string representation of a char to a actual char.
 ///
@@ -765,7 +765,7 @@ string ofHexToString(const string& stringHexString);
 ///
 /// \param charString The char string to convert.
 /// \returns The string as a char or 0 on failure.
-char ofToChar(const string& charString);
+char ofToChar(const std::string& charString);
 
 /// \brief Converts any datatype value to a string of only 1s and 0s.
 ///
@@ -776,7 +776,7 @@ char ofToChar(const string& charString);
 /// \param value The data to convert to a binary string.
 /// \returns a binary string.
 template <class T>
-string ofToBinary(const T& value) {
+std::string ofToBinary(const T& value) {
 	return std::bitset<8 * sizeof(T)>(*reinterpret_cast<const uint64_t*>(&value)).to_string();
 }
 
@@ -788,7 +788,7 @@ string ofToBinary(const T& value) {
 /// \param value The string to convert to a binary string.
 /// \returns a binary string.
 template <>
-string ofToBinary(const string& value);
+std::string ofToBinary(const std::string& value);
 
 /// \brief Converts a c-style string to a string of only 1s and 0s.
 ///
@@ -797,7 +797,7 @@ string ofToBinary(const string& value);
 ///
 /// \param value The c-style string to convert to a binary string.
 /// \returns a binary string.
-string ofToBinary(const char* value);
+std::string ofToBinary(const char* value);
 
 /// \brief Convert a binary string to an int.
 ///
@@ -806,7 +806,7 @@ string ofToBinary(const char* value);
 ///
 /// \value The binary string.
 /// \returns the integer represented by the string or 0 on failure.
-int ofBinaryToInt(const string& value);
+int ofBinaryToInt(const std::string& value);
 
 /// \brief Convert a binary string to an char.
 ///
@@ -815,7 +815,7 @@ int ofBinaryToInt(const string& value);
 ///
 /// \value The binary string.
 /// \returns the char represented by the string or 0 on failure.
-char ofBinaryToChar(const string& value);
+char ofBinaryToChar(const std::string& value);
 
 /// \brief Convert a binary string to a float.
 ///
@@ -824,7 +824,7 @@ char ofBinaryToChar(const string& value);
 ///
 /// \value The binary string.
 /// \returns the float represented by the string or 0 on failure.
-float ofBinaryToFloat(const string& value);
+float ofBinaryToFloat(const std::string& value);
 
 /// \brief Convert a binary string to ASCII characters.
 ///
@@ -833,7 +833,7 @@ float ofBinaryToFloat(const string& value);
 ///
 /// \value The binary string.
 /// \returns the ASCII string represented by the string.
-string ofBinaryToString(const string& value);
+std::string ofBinaryToString(const std::string& value);
 
 /// \section openFrameworks Version
 /// \brief Get the current version of openFrameworks as a string.
@@ -842,7 +842,7 @@ string ofBinaryToString(const string& value);
 ///
 /// \sa http://semver.org/
 /// \returns The string representation of the version (e.g. `0.9.0`).
-string 	ofGetVersionInfo();
+std::string 	ofGetVersionInfo();
 
 /// \brief Get the major version number of openFrameworks.
 ///
@@ -893,7 +893,7 @@ std::string ofGetVersionPreRelease();
 /// The output file type will be deduced from the given file name.
 ///
 /// \param filename The image output file.
-void ofSaveScreen(const string& filename);
+void ofSaveScreen(const std::string& filename);
 
 /// \brief Saves the current frame as a PNG image.
 ///
@@ -908,7 +908,7 @@ void ofSaveFrame(bool bUseViewport = false);
 /// The output file type will be deduced from the given file name.
 ///
 /// \param filename The image output file.
-void ofSaveViewport(const string& filename);
+void ofSaveViewport(const std::string& filename);
 
 
 /// \section System
@@ -917,13 +917,13 @@ void ofSaveViewport(const string& filename);
 /// \param uriEncodeQuery true if the query parameters in the given URL have
 /// already been URL encoded.
 #ifndef TARGET_EMSCRIPTEN
-void ofLaunchBrowser(const string& url, bool uriEncodeQuery=false);
+void ofLaunchBrowser(const std::string& url, bool uriEncodeQuery=false);
 #endif
 
 /// \brief Executes a system command. Similar to run a command in terminal.
 /// \note Will block until the executed program/command has finished.
 /// \returns the system command output as string. 
-string ofSystem(const string& command);
+std::string ofSystem(const std::string& command);
 
 /// \brief Get the target platform of the current system.
 /// \returns the current ofTargetPlatform.
@@ -944,7 +944,7 @@ std::string ofGetEnv(const std::string & var);
 /// string.
 class ofUTF8Iterator{
 public:
-	ofUTF8Iterator(const string & str);
+	ofUTF8Iterator(const std::string & str);
 	utf8::iterator<std::string::const_iterator> begin() const;
 	utf8::iterator<std::string::const_iterator> end() const;
 	utf8::iterator<std::string::const_reverse_iterator> rbegin() const;

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -51,7 +51,7 @@ bool ofXml::save(const std::filesystem::path & file) const{
 }
 
 std::string ofXml::toString(const std::string & indent) const{
-	ostringstream stream;
+	std::ostringstream stream;
 	if(xml == doc->root()){
 		doc->print(stream, indent.c_str());
 	}else{
@@ -383,7 +383,7 @@ void ofSerialize(ofXml & xml, const ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	if(name == ""){
 		name = "UnknownName";
 	}
@@ -402,7 +402,7 @@ void ofSerialize(ofXml & xml, const ofAbstractParameter & parameter){
 		}
 		ofLogVerbose("ofXml") << "end group " << name;
 	}else{
-		string value = parameter.toString();
+		std::string value = parameter.toString();
 		child.set(value);
 	}
 }
@@ -412,7 +412,7 @@ void ofDeserialize(const ofXml & xml, ofAbstractParameter & parameter){
 	if(!parameter.isSerializable()){
 		return;
 	}
-	string name = parameter.getEscapedName();
+	std::string name = parameter.getEscapedName();
 	
 	ofXml child = xml.findFirst(name);
 	if(child){
@@ -428,8 +428,8 @@ void ofDeserialize(const ofXml & xml, ofAbstractParameter & parameter){
 				parameter.cast <float>() = child.getFloatValue();
 			}else if(parameter.type() == typeid(ofParameter <bool> ).name()){
 				parameter.cast <bool>() = child.getBoolValue();
-			}else if(parameter.type() == typeid(ofParameter <string> ).name()){
-				parameter.cast <string>() = child.getValue();
+			}else if(parameter.type() == typeid(ofParameter <std::string> ).name()){
+				parameter.cast <std::string>() = child.getValue();
 			}else{
 				parameter.fromString(child.getValue());
 			}

--- a/libs/openFrameworks/video/ofAVFoundationGrabber.h
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.h
@@ -46,7 +46,7 @@ class ofAVFoundationGrabber;
 -(void)startCapture;
 -(void)stopCapture;
 -(void)lockExposureAndFocus;
--(vector <string>)listDevices;
+-(std::vector <std::string>)listDevices;
 -(void)setDevice:(int)_device;
 -(void)eraseGrabberPtr;
 
@@ -87,7 +87,7 @@ class ofAVFoundationGrabber : virtual public ofBaseVideoGrabber{
         bool isInitialized() const;
 	
 		void updatePixelsCB();
-		vector <ofVideoDevice> listDevices() const;
+		std::vector <ofVideoDevice> listDevices() const;
 		ofPixelFormat getPixelFormat() const;
 	
 	protected:

--- a/libs/openFrameworks/video/ofAVFoundationGrabber.mm
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.mm
@@ -90,7 +90,7 @@
 			// Set the new dimensions and format
 			if( bestFormat != nullptr && bestW != 0 && bestH != 0 ){
 				if( bestW != width || bestH != height ){
-					ofLogWarning("ofAvFoundationGrabber") << " requested width and height aren't supported. Setting capture size to closest match: " << bestW << " by " << bestH<< endl;
+					ofLogWarning("ofAvFoundationGrabber") << " requested width and height aren't supported. Setting capture size to closest match: " << bestW << " by " << bestH<< std::endl;
 				}
 				
 				[device setActiveFormat:bestFormat];
@@ -239,8 +239,8 @@
 	return currentFrame;
 }
 
--(vector <string>)listDevices{
-    vector <string> deviceNames;
+-(std::vector <std::string>)listDevices{
+    std::vector <std::string> deviceNames;
 	NSArray * devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 	int i=0;
 	for (AVCaptureDevice * captureDevice in devices){
@@ -475,10 +475,10 @@ void ofAVFoundationGrabber::updatePixelsCB(){
 	bHavePixelsChanged = true;
 }
 
-vector <ofVideoDevice> ofAVFoundationGrabber::listDevices() const{
-	vector <string> devList = [grabber listDevices];
+std::vector <ofVideoDevice> ofAVFoundationGrabber::listDevices() const{
+	std::vector <std::string> devList = [grabber listDevices];
     
-    vector <ofVideoDevice> devices; 
+    std::vector <ofVideoDevice> devices; 
     for(int i = 0; i < devList.size(); i++){
         ofVideoDevice vd; 
         vd.deviceName = devList[i]; 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -26,8 +26,8 @@ public:
 	ofAVFoundationPlayer();
 	~ofAVFoundationPlayer();
 	   
-    bool load(string name);
-	void loadAsync(string name);
+    bool load(std::string name);
+	void loadAsync(std::string name);
     void close();
     void update();
 
@@ -85,14 +85,14 @@ public:
 	void * getAVFoundationVideoPlayer();
 #endif
     
-    OF_DEPRECATED_MSG("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(string name));
+    OF_DEPRECATED_MSG("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(std::string name));
     OF_DEPRECATED_MSG("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels & getPixelsRef());
     OF_DEPRECATED_MSG("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels & getPixelsRef() const);
     OF_DEPRECATED_MSG("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.", ofTexture * getTexture());
     
 protected:
 	
-    bool loadPlayer(string name, bool bAsync);
+    bool loadPlayer(std::string name, bool bAsync);
 	void disposePlayer();
     bool isReady() const;
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -50,17 +50,17 @@ ofAVFoundationPlayer& ofAVFoundationPlayer::operator=(ofAVFoundationPlayer other
 }
 
 //--------------------------------------------------------------
-void ofAVFoundationPlayer::loadAsync(string name){
+void ofAVFoundationPlayer::loadAsync(std::string name){
     loadPlayer(name, true);
 }
 
 //--------------------------------------------------------------
-bool ofAVFoundationPlayer::load(string name) {
+bool ofAVFoundationPlayer::load(std::string name) {
     return loadPlayer(name, false);
 }
 
 //--------------------------------------------------------------
-bool ofAVFoundationPlayer::loadPlayer(string name, bool bAsync) {
+bool ofAVFoundationPlayer::loadPlayer(std::string name, bool bAsync) {
 	if( ofGetUsingArbTex() == false ){
         killTextureCache();
 		bUseTextureCache = false;
@@ -770,7 +770,7 @@ void * ofAVFoundationPlayer::getAVFoundationVideoPlayer() {
 #endif
 
 //-------------------------------------------------------------- DEPRECATED.
-bool ofAVFoundationPlayer::loadMovie(string name) {
+bool ofAVFoundationPlayer::loadMovie(std::string name) {
     return load(name);
 }
 

--- a/libs/openFrameworks/video/ofDirectShowGrabber.cpp
+++ b/libs/openFrameworks/video/ofDirectShowGrabber.cpp
@@ -105,9 +105,9 @@ ofPixelFormat ofDirectShowGrabber::getPixelFormat() const {
 }
 
 //--------------------------------------------------------------------
-vector<ofVideoDevice> ofDirectShowGrabber::listDevices() const {
+std::vector<ofVideoDevice> ofDirectShowGrabber::listDevices() const {
     
-    vector <ofVideoDevice> devices; 
+    std::vector <ofVideoDevice> devices; 
 	
     //---------------------------------
 	#ifdef OF_VIDEO_CAPTURE_DIRECTSHOW
@@ -116,7 +116,7 @@ vector<ofVideoDevice> ofDirectShowGrabber::listDevices() const {
         VI.listDevices();
         ofLogNotice() << "---";
         
-		vector <string> devList = VI.getDeviceList(); 
+        std::vector <std::string> devList = VI.getDeviceList(); 
         
         for(int i = 0; i < devList.size(); i++){
             ofVideoDevice vd; 

--- a/libs/openFrameworks/video/ofDirectShowGrabber.h
+++ b/libs/openFrameworks/video/ofDirectShowGrabber.h
@@ -17,7 +17,7 @@ class ofDirectShowGrabber : public ofBaseVideoGrabber{
 		ofDirectShowGrabber();
 		virtual ~ofDirectShowGrabber();
 
-		vector<ofVideoDevice>	listDevices() const;
+		std::vector<ofVideoDevice>	listDevices() const;
 		bool					setup(int w, int h);
 		void					update();
 		bool					isFrameNew() const;

--- a/libs/openFrameworks/video/ofDirectShowPlayer.cpp
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.cpp
@@ -426,7 +426,7 @@ class DirectShowVideo : public ISampleGrabberCB{
         return E_NOTIMPL;
     }
 
-    bool loadMovie(string path, ofPixelFormat format){
+    bool loadMovie(std::string path, ofPixelFormat format){
         tearDown();
 		this->pixelFormat = format;
 
@@ -1118,14 +1118,14 @@ ofDirectShowPlayer & ofDirectShowPlayer::operator=(ofDirectShowPlayer&& other) {
 	return *this;
 }
 
-bool ofDirectShowPlayer::load(string path){
+bool ofDirectShowPlayer::load(std::string path){
     path = ofToDataPath(path); 
 
     close();
     player.reset(new DirectShowVideo());
     bool loadOk = player->loadMovie(path, pixelFormat);
     if( !loadOk ){
-        ofLogError("ofDirectShowPlayer") << " Cannot load video of this file type.  Make sure you have codecs installed on your system.  OF recommends the free K-Lite Codec pack. " << endl;
+        ofLogError("ofDirectShowPlayer") << " Cannot load video of this file type.  Make sure you have codecs installed on your system.  OF recommends the free K-Lite Codec pack. " << std::endl;
     }
     return loadOk;
 }
@@ -1260,7 +1260,7 @@ void ofDirectShowPlayer::setLoopState(ofLoopType state){
         else if( state == OF_LOOP_NORMAL ){
             player->setLoop(true);
         }else{
-            ofLogError("ofDirectShowPlayer") << " cannot set loop of type palindrome " << endl;
+            ofLogError("ofDirectShowPlayer") << " cannot set loop of type palindrome " << std::endl;
         }
     }
 }

--- a/libs/openFrameworks/video/ofDirectShowPlayer.h
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.h
@@ -15,7 +15,7 @@ class ofDirectShowPlayer : public ofBaseVideoPlayer{
 		ofDirectShowPlayer(ofDirectShowPlayer &&);
 		ofDirectShowPlayer & operator=(ofDirectShowPlayer&&);
 
-        bool                load(string path);
+        bool                load(std::string path);
         void                update();
 
         void                close();

--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -66,18 +66,18 @@ static bool gst_inited = false;
 
 static GstFlowReturn on_new_buffer_from_source (GstAppSink * elt, void * data){
 #if GST_VERSION_MAJOR==0
-	shared_ptr<GstBuffer> buffer(gst_app_sink_pull_buffer (GST_APP_SINK (elt)),&gst_buffer_unref);
+	std::shared_ptr<GstBuffer> buffer(gst_app_sink_pull_buffer (GST_APP_SINK (elt)),&gst_buffer_unref);
 #else
-	shared_ptr<GstSample> buffer(gst_app_sink_pull_sample (GST_APP_SINK (elt)),&gst_sample_unref);
+	std::shared_ptr<GstSample> buffer(gst_app_sink_pull_sample (GST_APP_SINK (elt)),&gst_sample_unref);
 #endif
 	return ((ofGstUtils*)data)->buffer_cb(buffer);
 }
 
 static GstFlowReturn on_new_preroll_from_source (GstAppSink * elt, void * data){
 #if GST_VERSION_MAJOR==0
-	shared_ptr<GstBuffer> buffer(gst_app_sink_pull_preroll(GST_APP_SINK (elt)),&gst_buffer_unref);
+	std::shared_ptr<GstBuffer> buffer(gst_app_sink_pull_preroll(GST_APP_SINK (elt)),&gst_buffer_unref);
 #else
-	shared_ptr<GstSample> buffer(gst_app_sink_pull_preroll(GST_APP_SINK (elt)),&gst_sample_unref);
+	std::shared_ptr<GstSample> buffer(gst_app_sink_pull_preroll(GST_APP_SINK (elt)),&gst_sample_unref);
 #endif
 	return ((ofGstUtils*)data)->preroll_cb(buffer);
 }
@@ -125,7 +125,7 @@ ofGstUtils::ofGstUtils() {
 
 	if(!gst_inited){
 #ifdef TARGET_WIN32
-		string gst_path;
+		std::string gst_path;
 		if (sizeof(int) == 32) {
 			 gst_path = g_getenv("GSTREAMER_1_0_ROOT_X86");
 		}else
@@ -155,9 +155,9 @@ ofGstUtils::~ofGstUtils() {
 }
 
 #if GST_VERSION_MAJOR==0
-GstFlowReturn ofGstUtils::preroll_cb(shared_ptr<GstBuffer> buffer){
+GstFlowReturn ofGstUtils::preroll_cb(std::shared_ptr<GstBuffer> buffer){
 #else
-GstFlowReturn ofGstUtils::preroll_cb(shared_ptr<GstSample> buffer){
+GstFlowReturn ofGstUtils::preroll_cb(std::shared_ptr<GstSample> buffer){
 #endif
 	bIsMovieDone = false;
 	if(appsink) return appsink->on_preroll(buffer);
@@ -166,9 +166,9 @@ GstFlowReturn ofGstUtils::preroll_cb(shared_ptr<GstSample> buffer){
 
 
 #if GST_VERSION_MAJOR==0
-GstFlowReturn ofGstUtils::buffer_cb(shared_ptr<GstBuffer> buffer){
+GstFlowReturn ofGstUtils::buffer_cb(std::shared_ptr<GstBuffer> buffer){
 #else
-GstFlowReturn ofGstUtils::buffer_cb(shared_ptr<GstSample> buffer){
+GstFlowReturn ofGstUtils::buffer_cb(std::shared_ptr<GstSample> buffer){
 #endif
 	bIsMovieDone = false;
 	if(appsink) return appsink->on_buffer(buffer);
@@ -184,7 +184,7 @@ void ofGstUtils::eos_cb(){
 	}
 }
 
-bool ofGstUtils::setPipelineWithSink(string pipeline, string sinkname, bool isStream){
+bool ofGstUtils::setPipelineWithSink(std::string pipeline, std::string sinkname, bool isStream){
 	ofGstUtils::startGstMainLoop();
 
 	GError * error = NULL;
@@ -219,7 +219,7 @@ bool ofGstUtils::setPipelineWithSink(GstElement * pipeline, GstElement * sink, b
 		gst_base_sink_set_sync(GST_BASE_SINK(gstSink), true);
 	}
 
-	if(gstSink && string(gst_plugin_feature_get_name( GST_PLUGIN_FEATURE(gst_element_get_factory(gstSink))))=="appsink"){
+	if(gstSink && std::string(gst_plugin_feature_get_name( GST_PLUGIN_FEATURE(gst_element_get_factory(gstSink))))=="appsink"){
 		isAppSink = true;
 	}else{
 		isAppSink = false;
@@ -543,7 +543,7 @@ void ofGstUtils::close(){
 	bLoaded = false;
 }
 
-/*static string getName(GstState state){
+/*static std::string getName(GstState state){
 	switch(state){
 	case   GST_STATE_VOID_PENDING:
 		return "void pending";
@@ -749,7 +749,7 @@ GstElement 	* ofGstUtils::getSink() const{
 	return gstSink;
 }
 
-GstElement 	* ofGstUtils::getGstElementByName(const string & name) const{
+GstElement 	* ofGstUtils::getGstElementByName(const std::string & name) const{
 	return gst_bin_get_by_name(GST_BIN(gstPipeline),name.c_str());
 }
 
@@ -859,7 +859,7 @@ void ofGstVideoUtils::update(){
 			bHavePixelsChanged = bBackPixelsChanged;
 			if (bHavePixelsChanged){
 				bBackPixelsChanged=false;
-				swap(pixels,backPixels);
+				std::swap(pixels,backPixels);
 				#ifdef OF_USE_GST_GL
 				if(backTexture.isAllocated()){
 					frontTexture.getTextureData() = backTexture.getTextureData();
@@ -891,7 +891,7 @@ void ofGstVideoUtils::update(){
 					gst_buffer_map (buffer, &mapinfo, GST_MAP_READ);
 					//TODO: stride = mapinfo.size / height;
 					pixels.setFromExternalPixels(mapinfo.data,pixels.getWidth(),pixels.getHeight(),pixels.getNumChannels());
-					backBuffer = shared_ptr<GstSample>(sample,gst_sample_unref);
+					backBuffer = std::shared_ptr<GstSample>(sample,gst_sample_unref);
 					bHavePixelsChanged=true;
 					gst_buffer_unmap(buffer,&mapinfo);
 				}
@@ -915,7 +915,7 @@ float ofGstVideoUtils::getWidth() const{
 
 
 #if GST_VERSION_MAJOR>0
-string	ofGstVideoUtils::getGstFormatName(ofPixelFormat format){
+std::string	ofGstVideoUtils::getGstFormatName(ofPixelFormat format){
 	switch(format){
 	case OF_PIXELS_GRAY:
 		return "GRAY8";
@@ -1072,10 +1072,10 @@ void ofGstVideoUtils::setCopyPixels(bool copy){
 	copyPixels = copy;
 }
 
-bool ofGstVideoUtils::setPipeline(string pipeline, ofPixelFormat pixelFormat, bool isStream, int w, int h){
+bool ofGstVideoUtils::setPipeline(std::string pipeline, ofPixelFormat pixelFormat, bool isStream, int w, int h){
 	internalPixelFormat = pixelFormat;
 #ifndef OF_USE_GST_GL
-	string caps;
+	std::string caps;
 #if GST_VERSION_MAJOR==0
 	switch(pixelFormat){
 	case OF_PIXELS_MONO:
@@ -1104,7 +1104,7 @@ bool ofGstVideoUtils::setPipeline(string pipeline, ofPixelFormat pixelFormat, bo
 		caps+=", width=" + ofToString(w) + ", height=" + ofToString(h);
 	}
 
-	string pipeline_string =
+	std::string pipeline_string =
 		pipeline + " ! appsink name=ofappsink enable-last-sample=0 caps=\"" + caps + "\"";
 
 	if((w==-1 || h==-1) || pixelFormat==OF_PIXELS_NATIVE || allocate(w,h,pixelFormat)){
@@ -1113,7 +1113,7 @@ bool ofGstVideoUtils::setPipeline(string pipeline, ofPixelFormat pixelFormat, bo
 		return false;
 	}
 #else
-	string pipeline_string =
+	std::string pipeline_string =
 		pipeline + " ! glcolorscale name=gl_filter ! appsink name=ofappsink enable-last-sample=0 caps=\"video/x-raw,format=RGBA\"";
 
 	bool ret;
@@ -1206,7 +1206,7 @@ void ofGstVideoUtils::reallocateOnNextFrame(){
 }
 
 #if GST_VERSION_MAJOR==0
-GstFlowReturn ofGstVideoUtils::process_buffer(shared_ptr<GstBuffer> _buffer){
+GstFlowReturn ofGstVideoUtils::process_buffer(std::shared_ptr<GstBuffer> _buffer){
 	guint size = GST_BUFFER_SIZE (_buffer.get());
 	int stride = 0;
 	if(pixels.isAllocated() && pixels.getTotalBytes()!=(int)size){
@@ -1254,7 +1254,7 @@ static GstVideoInfo getVideoInfo(GstSample * sample){
     return vinfo;
 }
 
-GstFlowReturn ofGstVideoUtils::process_sample(shared_ptr<GstSample> sample){
+GstFlowReturn ofGstVideoUtils::process_sample(std::shared_ptr<GstSample> sample){
 	GstBuffer * _buffer = gst_sample_get_buffer(sample.get());
 
 #ifdef OF_USE_GST_GL
@@ -1353,7 +1353,7 @@ GstFlowReturn ofGstVideoUtils::process_sample(shared_ptr<GstSample> sample){
 #endif
 
 #if GST_VERSION_MAJOR==0
-GstFlowReturn ofGstVideoUtils::preroll_cb(shared_ptr<GstBuffer> buffer){
+GstFlowReturn ofGstVideoUtils::preroll_cb(std::shared_ptr<GstBuffer> buffer){
 	GstFlowReturn ret = process_buffer(buffer);
 	if(ret==GST_FLOW_OK){
 		return ofGstUtils::preroll_cb(buffer);
@@ -1362,7 +1362,7 @@ GstFlowReturn ofGstVideoUtils::preroll_cb(shared_ptr<GstBuffer> buffer){
 	}
 }
 #else
-GstFlowReturn ofGstVideoUtils::preroll_cb(shared_ptr<GstSample> sample){
+GstFlowReturn ofGstVideoUtils::preroll_cb(std::shared_ptr<GstSample> sample){
 	GstFlowReturn ret = process_sample(sample);
 	if(ret==GST_FLOW_OK){
 		return ofGstUtils::preroll_cb(sample);
@@ -1373,7 +1373,7 @@ GstFlowReturn ofGstVideoUtils::preroll_cb(shared_ptr<GstSample> sample){
 #endif
 
 #if GST_VERSION_MAJOR==0
-GstFlowReturn ofGstVideoUtils::buffer_cb(shared_ptr<GstBuffer> buffer){
+GstFlowReturn ofGstVideoUtils::buffer_cb(std::shared_ptr<GstBuffer> buffer){
 	GstFlowReturn ret = process_buffer(buffer);
 	if(ret==GST_FLOW_OK){
 		return ofGstUtils::buffer_cb(buffer);
@@ -1382,7 +1382,7 @@ GstFlowReturn ofGstVideoUtils::buffer_cb(shared_ptr<GstBuffer> buffer){
 	}
 }
 #else
-GstFlowReturn ofGstVideoUtils::buffer_cb(shared_ptr<GstSample> sample){
+GstFlowReturn ofGstVideoUtils::buffer_cb(std::shared_ptr<GstSample> sample){
 	GstFlowReturn ret = process_sample(sample);
 	if(ret==GST_FLOW_OK){
 		return ofGstUtils::buffer_cb(sample);

--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -1141,7 +1141,7 @@ bool ofGstVideoUtils::setPipeline(std::string pipeline, ofPixelFormat pixelForma
 
 	glXMakeCurrent (ofGetX11Display(), ofGetX11Window(), ofGetGLXContext());
 #elif defined(TARGET_OPENGLES)
-	cout << "current display " << ofGetEGLDisplay() << endl;
+	    std::cout << "current display " << ofGetEGLDisplay() << std::endl;
 	eglMakeCurrent (eglGetDisplay(EGL_DEFAULT_DISPLAY), 0,0, 0);
 	glDisplay = (GstGLDisplay *)gst_gl_display_egl_new_with_egl_display(eglGetDisplay(EGL_DEFAULT_DISPLAY));
 	glContext = gst_gl_context_new_wrapped (glDisplay, (guintptr) ofGetEGLContext(),

--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -37,7 +37,7 @@ public:
 	ofGstUtils();
 	virtual ~ofGstUtils();
 
-	bool 	setPipelineWithSink(string pipeline, string sinkname="sink", bool isStream=false);
+	bool 	setPipelineWithSink(std::string pipeline, std::string sinkname="sink", bool isStream=false);
 	bool 	setPipelineWithSink(GstElement * pipeline, GstElement * sink, bool isStream=false);
 	bool	startPipeline();
 
@@ -65,7 +65,7 @@ public:
 
 	GstElement 	* getPipeline() const;
 	GstElement 	* getSink() const;
-	GstElement 	* getGstElementByName(const string & name) const;
+	GstElement 	* getGstElementByName(const std::string & name) const;
 	uint64_t getMinLatencyNanos() const;
 	uint64_t getMaxLatencyNanos() const;
 
@@ -75,11 +75,11 @@ public:
 
 	// callbacks to get called from gstreamer
 #if GST_VERSION_MAJOR==0
-	virtual GstFlowReturn preroll_cb(shared_ptr<GstBuffer> buffer);
-	virtual GstFlowReturn buffer_cb(shared_ptr<GstBuffer> buffer);
+	virtual GstFlowReturn preroll_cb(std::shared_ptr<GstBuffer> buffer);
+	virtual GstFlowReturn buffer_cb(std::shared_ptr<GstBuffer> buffer);
 #else
-	virtual GstFlowReturn preroll_cb(shared_ptr<GstSample> buffer);
-	virtual GstFlowReturn buffer_cb(shared_ptr<GstSample> buffer);
+	virtual GstFlowReturn preroll_cb(std::shared_ptr<GstSample> buffer);
+	virtual GstFlowReturn buffer_cb(std::shared_ptr<GstSample> buffer);
 #endif
 	virtual void 		  eos_cb();
 
@@ -160,7 +160,7 @@ public:
 	ofGstVideoUtils();
 	virtual ~ofGstVideoUtils();
 
-	bool 			setPipeline(string pipeline, ofPixelFormat pixelFormat=OF_PIXELS_RGB, bool isStream=false, int w=-1, int h=-1);
+	bool 			setPipeline(std::string pipeline, ofPixelFormat pixelFormat=OF_PIXELS_RGB, bool isStream=false, int w=-1, int h=-1);
 
 	bool 			setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat 	getPixelFormat() const;
@@ -179,7 +179,7 @@ public:
 	void 			close();
 
 #if GST_VERSION_MAJOR>0
-	static string			getGstFormatName(ofPixelFormat format);
+	static std::string			getGstFormatName(ofPixelFormat format);
 	static GstVideoFormat	getGstFormat(ofPixelFormat format);
 	static ofPixelFormat	getOFFormat(GstVideoFormat format);
 #endif
@@ -198,13 +198,13 @@ public:
 
 protected:
 #if GST_VERSION_MAJOR==0
-	GstFlowReturn process_buffer(shared_ptr<GstBuffer> buffer);
-	GstFlowReturn preroll_cb(shared_ptr<GstBuffer> buffer);
-	GstFlowReturn buffer_cb(shared_ptr<GstBuffer> buffer);
+	GstFlowReturn process_buffer(std::shared_ptr<GstBuffer> buffer);
+	GstFlowReturn preroll_cb(std::shared_ptr<GstBuffer> buffer);
+	GstFlowReturn buffer_cb(std::shared_ptr<GstBuffer> buffer);
 #else
-	GstFlowReturn process_sample(shared_ptr<GstSample> sample);
-	GstFlowReturn preroll_cb(shared_ptr<GstSample> buffer);
-	GstFlowReturn buffer_cb(shared_ptr<GstSample> buffer);
+	GstFlowReturn process_sample(std::shared_ptr<GstSample> sample);
+	GstFlowReturn preroll_cb(std::shared_ptr<GstSample> buffer);
+	GstFlowReturn buffer_cb(std::shared_ptr<GstSample> buffer);
 #endif
 	void			eos_cb();
 
@@ -219,10 +219,10 @@ private:
 	bool			bBackPixelsChanged;
 	std::mutex		mutex;
 #if GST_VERSION_MAJOR==0
-	shared_ptr<GstBuffer> 	frontBuffer, backBuffer;
+	std::shared_ptr<GstBuffer> 	frontBuffer, backBuffer;
 #else
-	shared_ptr<GstSample> 	frontBuffer, backBuffer;
-	queue<shared_ptr<GstSample> > bufferQueue;
+	std::shared_ptr<GstSample> 	frontBuffer, backBuffer;
+	std::queue<std::shared_ptr<GstSample> > bufferQueue;
 	GstMapInfo mapinfo;
 	#ifdef OF_USE_GST_GL
 		ofTexture		frontTexture, backTexture;
@@ -246,17 +246,17 @@ class ofGstAppSink{
 public:
 	virtual ~ofGstAppSink(){}
 #if GST_VERSION_MAJOR==0
-	virtual GstFlowReturn on_preroll(shared_ptr<GstBuffer> buffer){
+	virtual GstFlowReturn on_preroll(std::shared_ptr<GstBuffer> buffer){
 		return GST_FLOW_OK;
 	}
-	virtual GstFlowReturn on_buffer(shared_ptr<GstBuffer> buffer){
+	virtual GstFlowReturn on_buffer(std::shared_ptr<GstBuffer> buffer){
 		return GST_FLOW_OK;
 	}
 #else
-	virtual GstFlowReturn on_preroll(shared_ptr<GstSample> buffer){
+	virtual GstFlowReturn on_preroll(std::shared_ptr<GstSample> buffer){
 		return GST_FLOW_OK;
 	}
-	virtual GstFlowReturn on_buffer(shared_ptr<GstSample> buffer){
+	virtual GstFlowReturn on_buffer(std::shared_ptr<GstSample> buffer){
 		return GST_FLOW_OK;
 	}
 #endif

--- a/libs/openFrameworks/video/ofGstVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofGstVideoGrabber.cpp
@@ -477,7 +477,7 @@ static void get_supported_video_formats (ofGstDevice &webcam_device, GstCaps &ca
 			if(gst_structure_get_string(structure,"format"))
 				video_format.format_name = gst_structure_get_string(structure,"format");
 			#endif
-			//cout << gst_structure_to_string(structure) << endl;;
+			//std::cout << gst_structure_to_string(structure) << std::endl;;
 			add_video_format(webcam_device, video_format, *structure, desired_framerate, desiredPixelFormat);
 		}else if (GST_VALUE_HOLDS_INT_RANGE (width)){
 			int min_width, max_width, min_height, max_height;

--- a/libs/openFrameworks/video/ofGstVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofGstVideoGrabber.cpp
@@ -89,15 +89,15 @@ static void get_video_devices (ofGstCamData & cam_data)
 	udev_list_entry_foreach(entry,list){
 		const char * name = udev_list_entry_get_name(entry);
 		struct udev_device * device = udev_device_new_from_syspath(my_udev, name);
-		string subsystem = udev_device_get_subsystem(device);
+		std::string subsystem = udev_device_get_subsystem(device);
 
 		if(subsystem != "video4linux") continue;
 		const char  *gstreamer_src, *product_name;
 		struct v4l2_capability  v2cap;
 		struct video_capability v1cap;
-		string vendor_id;
-		string product_id;
-		string serial_id;
+		std::string vendor_id;
+		std::string product_id;
+		std::string serial_id;
 
 		const char * dev_node = udev_device_get_devnode(device);
 		struct udev_list_entry * properties = udev_device_get_properties_list_entry(device);
@@ -529,7 +529,7 @@ static void get_supported_video_formats (ofGstDevice &webcam_device, GstCaps &ca
 
 static void get_device_data (ofGstDevice &webcam_device, int desired_framerate, ofPixelFormat desiredPixelFormat)
 {
-	string pipeline_desc = webcam_device.gstreamer_src + " name=source device=" +
+	std::string pipeline_desc = webcam_device.gstreamer_src + " name=source device=" +
 			webcam_device.video_device + " ! fakesink";
 
 	GError * err = NULL;
@@ -622,7 +622,7 @@ bool ofGstVideoGrabber::isInitialized() const{
 	return videoUtils.isInitialized();
 }
 
-ofPixelFormat ofPixelFormatFromGstFormat(string format){
+ofPixelFormat ofPixelFormatFromGstFormat(std::string format){
 #if GST_VERSION_MAJOR>=1
 	switch(gst_video_format_from_string(format.c_str())){
 	case GST_VIDEO_FORMAT_RGB: return OF_PIXELS_RGB;
@@ -638,10 +638,10 @@ ofPixelFormat ofPixelFormatFromGstFormat(string format){
 #endif
 }
 
-vector<ofVideoDevice> ofGstVideoGrabber::listDevices() const {
+std::vector<ofVideoDevice> ofGstVideoGrabber::listDevices() const {
 #if GST_VERSION_MAJOR>=1
 	if(!camData.bInited) get_video_devices(camData);
-	vector<ofVideoDevice> devices(camData.webcam_devices.size());
+	std::vector<ofVideoDevice> devices(camData.webcam_devices.size());
 	for(unsigned i=0; i<camData.webcam_devices.size(); i++){
 		devices[i].id = i;
         devices[i].bAvailable = true; 
@@ -663,7 +663,7 @@ vector<ofVideoDevice> ofGstVideoGrabber::listDevices() const {
 	return devices;
 #else
 	ofLogWarning("ofGstVideoGrabber") << "listDevices(): only supported for gstreamer 1.0";
-	return vector<ofVideoDevice>();
+	return std::vector<ofVideoDevice>();
 #endif
 }
 
@@ -725,7 +725,7 @@ bool ofGstVideoGrabber::setup(int w, int h){
 	const char * scale = "! ffmpegcolorspace ";
 	if( w!=format.width || h!=format.height )	scale = "! ffvideoscale method=2 ";
 
-	string format_str_pipeline = "%s name=video_source device=%s ! "
+	std::string format_str_pipeline = "%s name=video_source device=%s ! "
 			 "%s,width=%d,height=%d,framerate=%d/%d "
 			 "%s %s ";
 
@@ -740,14 +740,14 @@ bool ofGstVideoGrabber::setup(int w, int h){
 		      format.choosen_framerate.denominator,
 		      decodebin, scale);
 #else
-	string pipeline_string;
-	string format_str_pipeline;
-	string fix_v4l2_316;
+	std::string pipeline_string;
+	std::string format_str_pipeline;
+	std::string fix_v4l2_316;
 #if defined(TARGET_LINUX) && !defined(OF_USE_GST_GL) && GST_VERSION_MAJOR>0 && GST_VERSION_MINOR>2 && GST_VERSION_MINOR<5
 	videoUtils.setCopyPixels(true);
 #endif
 	if(internalPixelFormat!=OF_PIXELS_NATIVE){
-		string decodebin, scale;
+		std::string decodebin, scale;
 		if(format.mimetype == "video/x-bayer"){
 			decodebin = "! bayer2rgb ";
 		}else if(gst_video_format_from_string(format.format_name.c_str()) == GST_VIDEO_FORMAT_ENCODED || gst_video_format_from_string(format.format_name.c_str()) ==GST_VIDEO_FORMAT_UNKNOWN){

--- a/libs/openFrameworks/video/ofGstVideoGrabber.h
+++ b/libs/openFrameworks/video/ofGstVideoGrabber.h
@@ -10,25 +10,25 @@ struct ofGstFramerate{
 };
 
 struct ofGstVideoFormat{
-  string mimetype;
-  string format_name;
-  int    width;
-  int    height;
-  vector<ofGstFramerate> framerates;
+  std::string mimetype;
+  std::string format_name;
+  int width;
+  int height;
+  std::vector<ofGstFramerate> framerates;
   ofGstFramerate choosen_framerate;
 };
 
 struct ofGstDevice{
-  string video_device;
-  string gstreamer_src;
-  string product_name;
-  string serial_id;
-  vector<ofGstVideoFormat> video_formats;
+  std::string video_device;
+  std::string gstreamer_src;
+  std::string product_name;
+  std::string serial_id;
+  std::vector<ofGstVideoFormat> video_formats;
   int current_format;
 };
 
 struct ofGstCamData{
-  vector<ofGstDevice> webcam_devices;
+  std::vector<ofGstDevice> webcam_devices;
   bool bInited;
 };
 
@@ -43,7 +43,7 @@ public:
 	
 	void videoSettings(){};//TODO: what is this??
 
-	vector<ofVideoDevice> listDevices() const;
+	std::vector<ofVideoDevice> listDevices() const;
 	void setDeviceID(int id);
 	void setDesiredFrameRate(int framerate);
 	bool setup(int w, int h);

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -39,7 +39,7 @@ ofPixelFormat ofGstVideoPlayer::getPixelFormat() const {
 }
 
 
-bool ofGstVideoPlayer::createPipeline(string name){
+bool ofGstVideoPlayer::createPipeline(std::string name){
 #ifndef OF_USE_GST_GL
 #if GST_VERSION_MAJOR==0
 	GstCaps *caps;
@@ -100,13 +100,13 @@ bool ofGstVideoPlayer::createPipeline(string name){
 		break;
 	}
 #else
-	string mime="video/x-raw";
+	std::string mime="video/x-raw";
 
 	GstCaps *caps;
 	if(internalPixelFormat==OF_PIXELS_NATIVE){
 		caps = gst_caps_from_string((mime + ",format={RGBA,BGRA,RGB,BGR,RGB16,GRAY8,YV12,I420,NV12,NV21,YUY2}").c_str());
 	}else{
-		string format = ofGstVideoUtils::getGstFormatName(internalPixelFormat);
+		std::string format = ofGstVideoUtils::getGstFormatName(internalPixelFormat);
 		caps = gst_caps_new_simple(mime.c_str(),
 											"format", G_TYPE_STRING, format.c_str(),
 											NULL);
@@ -181,15 +181,15 @@ bool ofGstVideoPlayer::createPipeline(string name){
 #endif
 }
 
-void ofGstVideoPlayer::loadAsync(string name){
+void ofGstVideoPlayer::loadAsync(std::string name){
 	bAsyncLoad = true;
 	load(name);
 }
 
-bool ofGstVideoPlayer::load(string name){
-	if( name.find( "file://",0 ) != string::npos){
+bool ofGstVideoPlayer::load(std::string name){
+	if( name.find( "file://",0 ) != std::string::npos){
 		bIsStream = bAsyncLoad;
-	}else if( name.find( "://",0 ) == string::npos){
+	}else if( name.find( "://",0 ) == std::string::npos){
 		GError * err = NULL;
 		gchar* name_ptr = gst_filename_to_uri(ofToDataPath(name).c_str(),&err);
 		name = name_ptr;

--- a/libs/openFrameworks/video/ofGstVideoPlayer.h
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.h
@@ -13,8 +13,8 @@ public:
 	bool 	setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat	getPixelFormat() const;
 	
-	void	loadAsync(string name);
-	bool 	load(string uri);
+	void	loadAsync(std::string name);
+	bool 	load(std::string uri);
 
 	void 	update();
 
@@ -65,7 +65,7 @@ public:
 
 protected:
 	bool allocate();
-	bool createPipeline(string uri);
+	bool createPipeline(std::string uri);
 	void on_stream_prepared();
 
 	// return true to set the message as attended so upstream doesn't try to process it

--- a/libs/openFrameworks/video/ofQTKitGrabber.h
+++ b/libs/openFrameworks/video/ofQTKitGrabber.h
@@ -16,9 +16,9 @@
 
 class ofVideoSavedEventArgs : public ofEventArgs {
   public:
-	string videoPath;
+	std::string videoPath;
 	ofBaseVideoGrabber* grabber;
-	string error; //"" if there is no error
+	std::string error; //"" if there is no error
 };
 
 class ofQTKitGrabber : public ofBaseVideoGrabber {
@@ -37,17 +37,17 @@ class ofQTKitGrabber : public ofBaseVideoGrabber {
         const ofPixels& getPixels() const;
 		void            setVerbose(bool bTalkToMe);
 
-		vector <ofVideoDevice> listDevices() const;
-		const vector <string> & listAudioDevices() const;
-		const vector <string> & listVideoDevices() const;
+		std::vector <ofVideoDevice> listDevices() const;
+		const std::vector <std::string> & listAudioDevices() const;
+		const std::vector <std::string> & listVideoDevices() const;
 
 		bool            initRecording();
-		const vector <string> & listVideoCodecs() const;
-		const vector <string> & listAudioCodecs() const;
-		void            setVideoCodec(string videoCodecIDString);
-		void            setAudioCodec(string audioCodecIDString);
+		const std::vector <std::string> & listVideoCodecs() const;
+		const std::vector <std::string> & listAudioCodecs() const;
+		void            setVideoCodec(std::string videoCodecIDString);
+		void            setAudioCodec(std::string audioCodecIDString);
 		void            setUseAudio(bool bUseAudio);
-		void            startRecording(string filePath);
+		void            startRecording(std::string filePath);
 		void            stopRecording();
 		bool            isRecording() const;
 	    bool            isRecordingReady() const;
@@ -57,15 +57,15 @@ class ofQTKitGrabber : public ofBaseVideoGrabber {
 		void            close();
 
 		void            setDeviceID(int videoDeviceID);
-		void            setDeviceID(string videoDeviceIDString);
+		void            setDeviceID(std::string videoDeviceIDString);
 		int             getDeviceID() const;
 
 		void            setVideoDeviceID(int videoDeviceID);
-		void            setVideoDeviceID(string videoDeviceIDString);
+		void            setVideoDeviceID(std::string videoDeviceIDString);
 		int             getVideoDeviceID() const;
 
 		void            setAudioDeviceID(int audioDeviceID);
-		void            setAudioDeviceID(string audioDeviceIDString);
+		void            setAudioDeviceID(std::string audioDeviceIDString);
 		int             getAudioDeviceID() const;
 
 		void            setDesiredFrameRate(int framerate);
@@ -81,15 +81,15 @@ class ofQTKitGrabber : public ofBaseVideoGrabber {
 		ofPixelFormat pixelFormat;
 	    ofPixels pixels;
     
-		mutable vector <string>  videoDeviceVec;
-		mutable vector <string>  audioDeviceVec;
-		mutable vector <string>  videoCodecsVec;
-		mutable vector <string>  audioCodecsVec;
+		mutable std::vector <std::string>  videoDeviceVec;
+		mutable std::vector <std::string>  audioDeviceVec;
+		mutable std::vector <std::string>  videoCodecsVec;
+		mutable std::vector <std::string>  audioCodecsVec;
 
 		int videoDeviceID;
 		int audioDeviceID;
-		string videoCodecIDString;
-		string audioCodecIDString;
+		std::string videoCodecIDString;
+		std::string audioCodecIDString;
 
 		bool isInited;
 		bool bUseAudio;

--- a/libs/openFrameworks/video/ofQTKitGrabber.mm
+++ b/libs/openFrameworks/video/ofQTKitGrabber.mm
@@ -281,7 +281,7 @@
         
 		selectedAudioDevice = [audioDevices objectAtIndex:_audioDeviceID];
         if(selectedAudioDevice == nil){
-            ofLogError("ofQTKitGrabber") << "audio device is NULL for id " << _audioDeviceID << endl;
+		ofLogError("ofQTKitGrabber") << "audio device is NULL for id " << _audioDeviceID << std::endl;
         }
 		if([self setSelectedAudioDevice:selectedAudioDevice]){
 			audioDeviceID = _audioDeviceID;
@@ -649,11 +649,11 @@ void ofQTKitGrabber::setAudioDeviceID(int _audioDeviceID){
 	}
 }
 
-void ofQTKitGrabber::setDeviceID(string _videoDeviceIDString){
+void ofQTKitGrabber::setDeviceID(std::string _videoDeviceIDString){
     setVideoDeviceID(_videoDeviceIDString);
 }
 
-void ofQTKitGrabber::setVideoDeviceID(string _videoDeviceIDString){
+void ofQTKitGrabber::setVideoDeviceID(std::string _videoDeviceIDString){
 	@autoreleasepool {	
 		// set array filled with devices
 		NSArray* deviceArray = [[QTCaptureDevice inputDevicesWithMediaType:QTMediaTypeVideo] 
@@ -672,7 +672,7 @@ void ofQTKitGrabber::setVideoDeviceID(string _videoDeviceIDString){
 	}
 }
 
-void ofQTKitGrabber::setAudioDeviceID(string _audioDeviceIDString){
+void ofQTKitGrabber::setAudioDeviceID(std::string _audioDeviceIDString){
 	@autoreleasepool {
 		// set array filled with devices
 		NSArray* deviceArray = [QTCaptureDevice inputDevicesWithMediaType:QTMediaTypeSound];
@@ -731,31 +731,31 @@ bool ofQTKitGrabber::initRecording(){
 	return success;
 }
 
-const vector<string>& ofQTKitGrabber::listVideoCodecs() const{
+const std::vector<std::string>& ofQTKitGrabber::listVideoCodecs() const{
 	@autoreleasepool {
 		NSArray* videoCodecs = [QTKitVideoGrabber listVideoCodecs];
 		videoCodecsVec.clear();
 		for (id object in videoCodecs){
-			string str = [[object description] UTF8String];
+			std::string str = [[object description] UTF8String];
 			videoCodecsVec.push_back(str);
 		}
 	}
 	return videoCodecsVec;
 }
 
-const vector<string>& ofQTKitGrabber::listAudioCodecs() const{
+const std::vector<std::string>& ofQTKitGrabber::listAudioCodecs() const{
 	@autoreleasepool {
 		NSArray* audioCodecs = [QTKitVideoGrabber listAudioCodecs];
 		audioCodecsVec.clear();
 		for (id object in audioCodecs){
-			string str = [[object description] UTF8String];
+			std::string str = [[object description] UTF8String];
 			audioCodecsVec.push_back(str);
 		}
 	}
 	return audioCodecsVec;
 }
 
-void ofQTKitGrabber::setVideoCodec(string _videoCodec){
+void ofQTKitGrabber::setVideoCodec(std::string _videoCodec){
 	videoCodecIDString = _videoCodec;
 	if(confirmInit()){
 		@autoreleasepool {
@@ -765,7 +765,7 @@ void ofQTKitGrabber::setVideoCodec(string _videoCodec){
 	}
 }
 
-void ofQTKitGrabber::setAudioCodec(string _audioCodec){
+void ofQTKitGrabber::setAudioCodec(std::string _audioCodec){
 	if(confirmInit()){
 		audioCodecIDString = _audioCodec;
 		@autoreleasepool {
@@ -775,7 +775,7 @@ void ofQTKitGrabber::setAudioCodec(string _audioCodec){
 	}
 }
 
-void ofQTKitGrabber::startRecording(string filePath){
+void ofQTKitGrabber::startRecording(std::string filePath){
 	if(confirmInit()){
 		@autoreleasepool {
 			NSString * NSfilePath = [NSString stringWithUTF8String: ofToDataPath(filePath).c_str()];
@@ -824,10 +824,10 @@ bool ofQTKitGrabber::hasPreview() const {
     return bPreview;
 }
 
-vector <ofVideoDevice> ofQTKitGrabber::listDevices() const {
-    vector <string> devList = listVideoDevices();
+std::vector <ofVideoDevice> ofQTKitGrabber::listDevices() const {
+    std::vector <std::string> devList = listVideoDevices();
     
-    vector <ofVideoDevice> devices; 
+    std::vector <ofVideoDevice> devices; 
     for(int i = 0; i < devList.size(); i++){
         ofVideoDevice vd; 
         vd.deviceName = devList[i]; 
@@ -856,24 +856,24 @@ ofPixelFormat ofQTKitGrabber::getPixelFormat() const{
 }
 
 //---------------------------------------------------------------------------
-const vector<string>& ofQTKitGrabber::listVideoDevices() const{
+const std::vector<std::string>& ofQTKitGrabber::listVideoDevices() const{
 	@autoreleasepool {
 		NSArray* videoDevices = [QTKitVideoGrabber listVideoDevices];
 		videoDeviceVec.clear();
 		for (id object in videoDevices){
-			string str = [[object description] UTF8String];
+			std::string str = [[object description] UTF8String];
 			videoDeviceVec.push_back(str);
 		}
 	}
 	return videoDeviceVec;
 }
 
-const vector<string>& ofQTKitGrabber::listAudioDevices() const{
+const std::vector<std::string>& ofQTKitGrabber::listAudioDevices() const{
 	@autoreleasepool {
 		NSArray* audioDevices = [QTKitVideoGrabber listAudioDevices];
 		audioDeviceVec.clear();
 		for (id object in audioDevices){
-			string str = [[object description] UTF8String];
+			std::string str = [[object description] UTF8String];
 			audioDeviceVec.push_back(str);
 		}
 	}

--- a/libs/openFrameworks/video/ofQTKitPlayer.h
+++ b/libs/openFrameworks/video/ofQTKitPlayer.h
@@ -40,8 +40,8 @@ class ofQTKitPlayer  : public ofBaseVideoPlayer {
 		ofQTKitPlayer();
 		virtual ~ofQTKitPlayer();
 
-		bool                load(string path); //default mode is PIXELS_ONLY
-		bool                load(string path, ofQTKitDecodeMode mode);
+		bool                load(std::string path); //default mode is PIXELS_ONLY
+		bool                load(std::string path, ofQTKitDecodeMode mode);
 
 		void                closeMovie();
 		void                close();
@@ -127,7 +127,7 @@ class ofQTKitPlayer  : public ofBaseVideoPlayer {
 		
         ofQTKitDecodeMode decodeMode;
 	    
-        string moviePath;
+	std::string moviePath;
 		
         bool bSynchronousSeek;
 		

--- a/libs/openFrameworks/video/ofQTKitPlayer.mm
+++ b/libs/openFrameworks/video/ofQTKitPlayer.mm
@@ -25,12 +25,12 @@ ofQTKitPlayer::~ofQTKitPlayer() {
 }
 
 //--------------------------------------------------------------------
-bool ofQTKitPlayer::load(string path){
+bool ofQTKitPlayer::load(std::string path){
 	return load(path, OF_QTKIT_DECODE_PIXELS_ONLY);
 }
 
 //--------------------------------------------------------------------
-bool ofQTKitPlayer::load(string movieFilePath, ofQTKitDecodeMode mode) {
+bool ofQTKitPlayer::load(std::string movieFilePath, ofQTKitDecodeMode mode) {
 	if(mode != OF_QTKIT_DECODE_PIXELS_ONLY && mode != OF_QTKIT_DECODE_TEXTURE_ONLY && mode != OF_QTKIT_DECODE_PIXELS_AND_TEXTURE){
 		ofLogError("ofQTKitPlayer") << "loadMovie(): unknown ofQTKitDecodeMode mode";
 		return false;

--- a/libs/openFrameworks/video/ofQuickTimeGrabber.cpp
+++ b/libs/openFrameworks/video/ofQuickTimeGrabber.cpp
@@ -251,9 +251,9 @@ bool ofQuickTimeGrabber::isInitialized() const{
 }
 
 //--------------------------------------------------------------------
-vector<ofVideoDevice> ofQuickTimeGrabber::listDevices() const{
+std::vector<ofVideoDevice> ofQuickTimeGrabber::listDevices() const{
 
-    vector <ofVideoDevice> devices; 
+    std::vector <ofVideoDevice> devices; 
     
 	//---------------------------------
 	#ifdef OF_VIDEO_CAPTURE_QUICKTIME
@@ -518,7 +518,7 @@ bool ofQuickTimeGrabber::saveSettings(){
 			ofLogError("ofQuickTimeGrabber") << "saveSettings(): couldn't get camera settings: ComponentResult " << err;
 			return false;
 		}
-		string pref = "ofVideoSettings-"+deviceName;
+		std::string pref = "ofVideoSettings-"+deviceName;
 		CFStringRef cameraString = CFStringCreateWithCString(kCFAllocatorDefault,pref.c_str(),kCFStringEncodingMacRoman);
 
 		//get the settings using the key "ofVideoSettings-the name of the device"
@@ -537,7 +537,7 @@ bool ofQuickTimeGrabber::loadSettings(){
    UserData mySGVideoSettings = nullptr;
 
    // get the settings using the key "ofVideoSettings-the name of the device"
-   string pref = "ofVideoSettings-"+deviceName;
+   std::string pref = "ofVideoSettings-"+deviceName;
    CFStringRef cameraString = CFStringCreateWithCString(kCFAllocatorDefault,pref.c_str(),kCFStringEncodingMacRoman);
 
    GetSettingsPreference(cameraString, &mySGVideoSettings);

--- a/libs/openFrameworks/video/ofQuickTimeGrabber.h
+++ b/libs/openFrameworks/video/ofQuickTimeGrabber.h
@@ -21,7 +21,7 @@ class ofQuickTimeGrabber : public ofBaseVideoGrabber{
 		ofQuickTimeGrabber();
 		virtual ~ofQuickTimeGrabber();
 
-        vector<ofVideoDevice>	listDevices() const;
+		std::vector<ofVideoDevice>	listDevices() const;
 		bool					setup(int w, int h);
 		void					update();
 		bool					isFrameNew() const;
@@ -65,7 +65,7 @@ class ofQuickTimeGrabber : public ofBaseVideoGrabber{
 		SGChannel				gVideoChannel;
 		Rect					videoRect;
 		bool					bSgInited;
-		string					deviceName;
+		std::string					deviceName;
 		SGGrabCompleteBottleUPP	myGrabCompleteProc;
 		
 		bool					qtInitSeqGrabber();

--- a/libs/openFrameworks/video/ofQuickTimePlayer.h
+++ b/libs/openFrameworks/video/ofQuickTimePlayer.h
@@ -16,7 +16,7 @@ class ofQuickTimePlayer : public ofBaseVideoPlayer{
 		ofQuickTimePlayer();
 		~ofQuickTimePlayer();
 
-		 bool			load(string name);
+		 bool			load(std::string name);
 		 void			closeMovie();	
 		 void			close();
 		 void			update();

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -18,19 +18,19 @@ ofVideoGrabber::~ofVideoGrabber(){
 }
 
 //--------------------------------------------------------------------
-void ofVideoGrabber::setGrabber(shared_ptr<ofBaseVideoGrabber> newGrabber){
+void ofVideoGrabber::setGrabber(std::shared_ptr<ofBaseVideoGrabber> newGrabber){
 	grabber = newGrabber;
 }
 
 //--------------------------------------------------------------------
-shared_ptr<ofBaseVideoGrabber> ofVideoGrabber::getGrabber(){
+std::shared_ptr<ofBaseVideoGrabber> ofVideoGrabber::getGrabber(){
 	if(!grabber){
-		setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		setGrabber( std::shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
 	}
 	return grabber;
 }
 
-const shared_ptr<ofBaseVideoGrabber> ofVideoGrabber::getGrabber() const{
+const std::shared_ptr<ofBaseVideoGrabber> ofVideoGrabber::getGrabber() const{
 	return grabber;
 }
 
@@ -42,7 +42,7 @@ bool ofVideoGrabber::setup(int w, int h, bool setUseTexture){
 #endif
 
 	if(!grabber){
-		setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		setGrabber( std::shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
 	}
 
 	bUseTexture = setUseTexture;
@@ -107,10 +107,10 @@ ofPixelFormat ofVideoGrabber::getPixelFormat() const{
 }
 
 //--------------------------------------------------------------------
-vector<ofVideoDevice> ofVideoGrabber::listDevices() const{
+std::vector<ofVideoDevice> ofVideoGrabber::listDevices() const{
 	if(!grabber){
 		ofVideoGrabber * mutThis = const_cast<ofVideoGrabber*>(this);
-		mutThis->setGrabber( shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
+		mutThis->setGrabber( std::shared_ptr<OF_VID_GRABBER_TYPE>(new OF_VID_GRABBER_TYPE) );
 	}
 	return grabber->listDevices();
 }
@@ -189,7 +189,7 @@ const ofTexture & ofVideoGrabber::getTextureReference() const{
 }
 
 //------------------------------------
-vector<ofTexture> & ofVideoGrabber::getTexturePlanes(){
+std::vector<ofTexture> & ofVideoGrabber::getTexturePlanes(){
 	if(grabber->getTexturePtr() != nullptr){
 		tex.clear();
 		tex.push_back(*grabber->getTexturePtr());
@@ -198,7 +198,7 @@ vector<ofTexture> & ofVideoGrabber::getTexturePlanes(){
 }
 
 //------------------------------------
-const vector<ofTexture> & ofVideoGrabber::getTexturePlanes() const{
+const std::vector<ofTexture> & ofVideoGrabber::getTexturePlanes() const{
 	if(grabber->getTexturePtr() != nullptr){
 		ofVideoGrabber* mutThis = const_cast<ofVideoGrabber*>(this);
 		mutThis->tex.clear();
@@ -290,7 +290,7 @@ void ofVideoGrabber::draw(float _x, float _y) const{
 
 //------------------------------------
 void ofVideoGrabber::bind() const{
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		renderer->bind(*this);
 	}
@@ -298,7 +298,7 @@ void ofVideoGrabber::bind() const{
 
 //------------------------------------
 void ofVideoGrabber::unbind() const{
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		renderer->unbind(*this);
 	}

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -54,7 +54,7 @@ class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
 		ofVideoGrabber();
 		virtual ~ofVideoGrabber();
 
-		vector<ofVideoDevice> listDevices() const;
+		std::vector<ofVideoDevice> listDevices() const;
 		bool				isFrameNew() const;
 		void				update();
 		void				close();	
@@ -75,8 +75,8 @@ class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
 		const ofTexture &	getTexture() const;
 		OF_DEPRECATED_MSG("Use getTexture",ofTexture &			getTextureReference());
 		OF_DEPRECATED_MSG("Use getTexture",const ofTexture &	getTextureReference() const);
-		vector<ofTexture> & getTexturePlanes();
-		const vector<ofTexture> & getTexturePlanes() const;
+		std::vector<ofTexture> & getTexturePlanes();
+		const std::vector<ofTexture> & getTexturePlanes() const;
 		void				setVerbose(bool bTalkToMe);
 		void				setDeviceID(int _deviceID);
 		void				setDesiredFrameRate(int framerate);
@@ -100,25 +100,25 @@ class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
 
 		bool				isInitialized() const;
 
-		void					setGrabber(shared_ptr<ofBaseVideoGrabber> newGrabber);
-		shared_ptr<ofBaseVideoGrabber> getGrabber();
-		const shared_ptr<ofBaseVideoGrabber> getGrabber() const;
+		void					setGrabber(std::shared_ptr<ofBaseVideoGrabber> newGrabber);
+		std::shared_ptr<ofBaseVideoGrabber> getGrabber();
+		const std::shared_ptr<ofBaseVideoGrabber> getGrabber() const;
 
 		template<typename GrabberType>
-		shared_ptr<GrabberType> getGrabber(){
-			return dynamic_pointer_cast<GrabberType>(getGrabber());
+		std::shared_ptr<GrabberType> getGrabber(){
+			return std::dynamic_pointer_cast<GrabberType>(getGrabber());
 		}
 
 		template<typename GrabberType>
-		const shared_ptr<GrabberType> getGrabber() const{
-			return dynamic_pointer_cast<GrabberType>(getGrabber());
+		const std::shared_ptr<GrabberType> getGrabber() const{
+			return std::dynamic_pointer_cast<GrabberType>(getGrabber());
 		}
 
 	private:
 		
-		vector<ofTexture> tex;
+		std::vector<ofTexture> tex;
 		bool bUseTexture;
-		shared_ptr<ofBaseVideoGrabber> grabber;
+		std::shared_ptr<ofBaseVideoGrabber> grabber;
 		int requestedDeviceID;
 
 		mutable ofPixelFormat internalPixelFormat;

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -13,21 +13,21 @@ ofVideoPlayer::ofVideoPlayer (){
 }
 
 //---------------------------------------------------------------------------
-void ofVideoPlayer::setPlayer(shared_ptr<ofBaseVideoPlayer> newPlayer){
+void ofVideoPlayer::setPlayer(std::shared_ptr<ofBaseVideoPlayer> newPlayer){
 	player = newPlayer;
 	setPixelFormat(internalPixelFormat);	//this means that it will try to set the pixel format you have been using before. 
 											//if the format is not supported ofVideoPlayer's internalPixelFormat will be updated to that of the player's
 }
 
 //---------------------------------------------------------------------------
-shared_ptr<ofBaseVideoPlayer> ofVideoPlayer::getPlayer(){
+std::shared_ptr<ofBaseVideoPlayer> ofVideoPlayer::getPlayer(){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer( std::shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
 	}
 	return player;
 }
 
-const shared_ptr<ofBaseVideoPlayer>	ofVideoPlayer::getPlayer() const{
+const std::shared_ptr<ofBaseVideoPlayer>	ofVideoPlayer::getPlayer() const{
 	return player;
 }
 
@@ -64,9 +64,9 @@ ofPixelFormat ofVideoPlayer::getPixelFormat() const{
 }
 
 //---------------------------------------------------------------------------
-bool ofVideoPlayer::load(string name){
+bool ofVideoPlayer::load(std::string name){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer( std::shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
 		player->setPixelFormat(internalPixelFormat);
 	}
 	
@@ -97,9 +97,9 @@ bool ofVideoPlayer::load(string name){
 }
 
 //---------------------------------------------------------------------------
-void ofVideoPlayer::loadAsync(string name){
+void ofVideoPlayer::loadAsync(std::string name){
 	if( !player ){
-		setPlayer( shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
+		setPlayer( std::shared_ptr<OF_VID_PLAYER_TYPE>(new OF_VID_PLAYER_TYPE) );
 		player->setPixelFormat(internalPixelFormat);
 	}
 	
@@ -108,12 +108,12 @@ void ofVideoPlayer::loadAsync(string name){
 }
 
 //---------------------------------------------------------------------------
-bool ofVideoPlayer::loadMovie(string name){
+bool ofVideoPlayer::loadMovie(std::string name){
 	return load(name);
 }
 
 //---------------------------------------------------------------------------
-string ofVideoPlayer::getMoviePath() const{
+std::string ofVideoPlayer::getMoviePath() const{
     return moviePath;	
 }
 
@@ -166,7 +166,7 @@ const ofTexture & ofVideoPlayer::getTextureReference() const{
 }
 
 //---------------------------------------------------------------------------
-vector<ofTexture> & ofVideoPlayer::getTexturePlanes(){
+std::vector<ofTexture> & ofVideoPlayer::getTexturePlanes(){
 	if(playerTex != nullptr){
 		tex.clear();
 		tex.push_back(*playerTex);
@@ -175,7 +175,7 @@ vector<ofTexture> & ofVideoPlayer::getTexturePlanes(){
 }
 
 //---------------------------------------------------------------------------
-const vector<ofTexture> & ofVideoPlayer::getTexturePlanes() const{
+const std::vector<ofTexture> & ofVideoPlayer::getTexturePlanes() const{
 	if(playerTex != nullptr){
 		ofVideoPlayer * mutThis = const_cast<ofVideoPlayer*>(this);
 		mutThis->tex.clear();
@@ -415,7 +415,7 @@ void ofVideoPlayer::draw(float _x, float _y) const{
 
 //------------------------------------
 void ofVideoPlayer::bind() const{
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		renderer->bind(*this);
 	}
@@ -423,7 +423,7 @@ void ofVideoPlayer::bind() const{
 
 //------------------------------------
 void ofVideoPlayer::unbind() const{
-	shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
+	std::shared_ptr<ofBaseGLRenderer> renderer = ofGetGLRenderer();
 	if(renderer){
 		renderer->unbind(*this);
 	}

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -53,9 +53,9 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		ofVideoPlayer ();
 
 
-		bool 				load(string name);
-		void				loadAsync(string name);
-		OF_DEPRECATED_MSG("Use load instead",bool loadMovie(string name));
+		bool 				load(std::string name);
+		void				loadAsync(std::string name);
+		OF_DEPRECATED_MSG("Use load instead",bool loadMovie(std::string name));
 
 
 		/// \brief Get the path to the loaded video file.
@@ -63,7 +63,7 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// If no video file is loaded this returns an empty string.
 		///
 		/// \returns A path to the loaded video or an empty string if not loaded.
-		string				getMoviePath() const;
+		std::string				getMoviePath() const;
 
 		bool				setPixelFormat(ofPixelFormat pixelFormat);
 		ofPixelFormat		getPixelFormat() const;
@@ -112,8 +112,8 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		const ofTexture &	getTexture() const;
 		OF_DEPRECATED_MSG("Use getTexture",ofTexture &			getTextureReference());
 		OF_DEPRECATED_MSG("Use getTexture",const ofTexture &	getTextureReference() const);
-		vector<ofTexture> & getTexturePlanes();
-		const vector<ofTexture> & getTexturePlanes() const;
+		std::vector<ofTexture> & getTexturePlanes();
+		const std::vector<ofTexture> & getTexturePlanes() const;
 		void 				draw(float x, float y, float w, float h) const;
 		void 				draw(float x, float y) const;
 		using ofBaseDraws::draw;
@@ -162,7 +162,7 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		///
 		/// \param newPlayer Shared pointer to the new video player that extends
 		/// from ofBaseVideoPlayer.
-		void				setPlayer(shared_ptr<ofBaseVideoPlayer> newPlayer);
+		void				setPlayer(std::shared_ptr<ofBaseVideoPlayer> newPlayer);
 		/// \brief Get a pointer to the internal video player implementation.
 		///
 		/// This returns a pointer to the ofBaseVideoPlayer interface. For
@@ -171,7 +171,7 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// templated getPlayer<MyVideoPlayerImplementation>() method.
 		///
 		/// \returns A pointer to the internal video player implementation.
-		shared_ptr<ofBaseVideoPlayer>	getPlayer();
+		std::shared_ptr<ofBaseVideoPlayer>	getPlayer();
 		/// \brief Get a const pointer to the internal video player implementation.
 		///
 		/// This returns a pointer to the ofBaseVideoPlayer interface. For
@@ -180,7 +180,7 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// or the templated getPlayer<MyVideoPlayerImplementation>() method.
 		///
 		/// \returns A const pointer to the internal video player implementation.
-		const shared_ptr<ofBaseVideoPlayer>	getPlayer() const;
+		const std::shared_ptr<ofBaseVideoPlayer>	getPlayer() const;
 
 		/// \brief Get a pointer to the internal video player implementation.
 		///
@@ -190,8 +190,8 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// \returns A pointer to the internal video player implementation or
 		///			 nullptr if the cast fails.
 		template<typename PlayerType>
-		shared_ptr<PlayerType> getPlayer(){
-			return dynamic_pointer_cast<PlayerType>(getPlayer());
+		std::shared_ptr<PlayerType> getPlayer(){
+			return std::dynamic_pointer_cast<PlayerType>(getPlayer());
 		}
 
 		/// \brief Get a const pointer to the internal video player implementation.
@@ -202,17 +202,17 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// \returns A const pointer to the internal video player implementation
 		///			 or nullptr if the cast fails.
 		template<typename PlayerType>
-		const shared_ptr<PlayerType> getPlayer() const{
-			return dynamic_pointer_cast<PlayerType>(getPlayer());
+		const std::shared_ptr<PlayerType> getPlayer() const{
+			return std::dynamic_pointer_cast<PlayerType>(getPlayer());
 		}
 
 	private:
 		/// \brief Initialize the default player implementations.
 		void initDefaultPlayer();
 		/// \brief A pointer to the internal video player implementation.
-		shared_ptr<ofBaseVideoPlayer>		player;
+		std::shared_ptr<ofBaseVideoPlayer>		player;
 		/// \brief A collection of texture planes used by the video player.
-		vector<ofTexture> tex;
+		std::vector<ofTexture> tex;
 		/// \brief A pointer to the internal player's texture if available.
 		///
 		/// Video players that implement ofBaseVideoPlayer::getTexturePtr()
@@ -225,5 +225,5 @@ class ofVideoPlayer : public ofBaseVideoPlayer,public ofBaseVideoDraws{
 		/// \brief The internal pixel format.
 		mutable ofPixelFormat internalPixelFormat;
 		/// \brief The stored path to the video's path.
-	    string moviePath;
+		std::string moviePath;
 };

--- a/scripts/templates/unittest/src/main.cpp
+++ b/scripts/templates/unittest/src/main.cpp
@@ -11,8 +11,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/addons/networkTcp/src/main.cpp
+++ b/tests/addons/networkTcp/src/main.cpp
@@ -244,8 +244,8 @@ public:
 		// wait for connection to be made
 		server.waitConnectedClient(500);
 
-		string str;
-		string received;
+		std::string str;
+		std::string received;
 		for(int i=0;i<TCP_MAX_MSG_SIZE;i++){
 			str.append(ofToString((int)ofRandom(10)));
 		}
@@ -272,8 +272,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/addons/networkUdp/src/main.cpp
+++ b/tests/addons/networkUdp/src/main.cpp
@@ -203,8 +203,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/events/events/src/main.cpp
+++ b/tests/events/events/src/main.cpp
@@ -183,8 +183,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/graphics/pixels/src/main.cpp
+++ b/tests/graphics/pixels/src/main.cpp
@@ -66,7 +66,7 @@ class ofApp: public ofxUnitTestsApp{
 		return OF_IMAGE_UNDEFINED;
 	}
 
-	string formatName(ofPixelFormat pixelFormat){
+	std::string formatName(ofPixelFormat pixelFormat){
 		switch(pixelFormat){
 			case OF_PIXELS_RGB:
 				return "RGB";
@@ -282,7 +282,7 @@ class ofApp: public ofxUnitTestsApp{
 		for(ofPixelFormat pixelFormat=OF_PIXELS_GRAY;pixelFormat<OF_PIXELS_NUM_FORMATS;pixelFormat = (ofPixelFormat)(pixelFormat+1)){
 			pixels.allocate(w,h,pixelFormat);
 			int bpp = bitsPerPixel(pixelFormat);
-			string format = formatName(pixelFormat);
+			std::string format = formatName(pixelFormat);
 			test_eq(pixels.getBitsPerChannel(),8,"getBitsPerChannel() " + format);
 			test_eq(pixels.getBitsPerPixel(),bpp,"getBitsPerPixel() " + format);
 			test_eq(pixels.getBytesPerChannel(),1,"getBytesPerChannel() " + format);
@@ -315,8 +315,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/math/ofNodeRegressionTests/src/main.cpp
+++ b/tests/math/ofNodeRegressionTests/src/main.cpp
@@ -146,8 +146,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/math/quaternionTests/src/main.cpp
+++ b/tests/math/quaternionTests/src/main.cpp
@@ -40,8 +40,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/utils/fileUtils/src/main.cpp
+++ b/tests/utils/fileUtils/src/main.cpp
@@ -47,8 +47,8 @@ class ofApp: public ofxUnitTestsApp{
 				ofFile fr("noread");
 				std::string str;
 				fr >> str;
-				cout << "testing if file can be really read" << endl;
-				cout << str << endl;
+				std::cout << "testing if file can be really read" << std::endl;
+				std::cout << str << std::endl;
 			}
 		}
 

--- a/tests/utils/strings/src/main.cpp
+++ b/tests/utils/strings/src/main.cpp
@@ -62,7 +62,7 @@ class ofApp: public ofxUnitTestsApp{
 #endif
 
 		// test #4363
-		std::vector<string> strs;
+		std::vector<std::string> strs;
 		strs.push_back("hi");
 		strs.push_back("this");
 		strs.push_back("is");
@@ -76,8 +76,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:


### PR DESCRIPTION
As discussed in #5647, GCC 7.1 seems to break OF due to the inclusion of ```using namespace std```. Actually, the problem seems to be a conflict with a [json](https://github.com/nlohmann/json) library, but it fixed by removing ```using namespace std``` from the core library, which is known is a bad practice and seems to be on the TODO list for quite a while (#2581).

This PR removes the last occurrences of this in the core library and fixes the compilation problem with GCC 7.1.

It breaks projectGenerator (a PR will follow soon).

I created this pull request to get feedback on this. IT IS NOT READY FOR MERGING YET.

More testing should be done to make sure something else doesn't break, including with other versions of GCC. Also, there are still some occurrences of ```using namespace std``` in some addons, which I am happy to remove if there is interest in this.

Another problem which should be considered is backwards compatibility. There is quite a lot of OF code present and some of it probably relies on the presence of ```using namespace std``` in the core library. A decision should be made in this sense. My suggestion (not yet added to this PR) is to add a ```using namespace std``` at the end of a header file for the core library (```ofMain.h```?) such that the code that uses the library is not impacted and the library can compile under the new GCC.
