### PR TITLE
Add logger channel getters (closes #5558)

### DIFF
--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -251,6 +251,14 @@ void ofSetLoggerChannel(shared_ptr<ofBaseLoggerChannel> loggerChannel){
 	ofLog::setChannel(loggerChannel);
 }
 
+shared_ptr<ofBaseLoggerChannel> ofLog::getChannel(){
+	return channel;
+}
+
+shared_ptr<ofBaseLoggerChannel> ofGetLoggerChannel(){
+	return ofLog::getChannel();
+}
+
 string ofGetLogLevelName(ofLogLevel level, bool pad){
 	switch(level){
 		case OF_LOG_VERBOSE:

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -231,6 +231,9 @@ void ofLogToDebugView();
 /// \param loggerChannel A shared pointer to the logger channel.
 void ofSetLoggerChannel(shared_ptr<ofBaseLoggerChannel> loggerChannel);
 
+/// \brief Get the current logger channel.
+shared_ptr<ofBaseLoggerChannel> ofGetLoggerChannel();
+
 /// \}
 
 /// \class ofLog
@@ -421,6 +424,9 @@ class ofLog{
 		/// \sa ofFileLoggerChannel ofConsoleLoggerChannel
 		/// \param channel The channel to log to.
 		static void setChannel(shared_ptr<ofBaseLoggerChannel> channel);
+	
+		/// \brief Get the current logging channel.
+		static shared_ptr<ofBaseLoggerChannel> getChannel();
 	
 		/// \}
 


### PR DESCRIPTION
As discussed in the issue, this adds getters for the currently set logger channel. Specifically an `ofGetLoggerChannel()` function and a `ofLog::getChannel()` method. This allows channels to be swapped in and out more easily, or for custom channels to continue forwarding to whatever channel was already set.