### PR TITLE
Add a getCamera() method to get the camera used

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoGrabber.java
@@ -25,6 +25,10 @@ public class OFAndroidVideoGrabber extends OFAndroidObject implements Runnable, 
 		return instanceId;
 	}
 
+	public Camera getCamera(){
+		return camera;
+	}
+
 	public static boolean supportsTextureRendering(){
 		return Build.VERSION.SDK_INT >= 11;
 	}


### PR DESCRIPTION
This would be helpful if you need to re-use the camera elsewhere in your project.