### PR TITLE
OFAndroidVideoPlayer doesn't set bIsLoaded to true

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoPlayer.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroidVideoPlayer.java
@@ -103,6 +103,7 @@ public class OFAndroidVideoPlayer extends OFAndroidObject implements OnFrameAvai
 			}
 			mediaPlayer.setDataSource(fileName);
 			mediaPlayer.prepare();
+			bIsLoaded = true;
 			//setVolume(volume);
 			this.fileName = fileName;
 		} catch (Exception e) {


### PR DESCRIPTION
I found that bIsLoaded was never set to true leading to `play()` method in OFAndroidVideoPlayer throwing out error after `load()` is called. This can be verified with the example androidVideoPlayer.

From Android's API reference, [MediaPlayer](https://developer.android.com/reference/android/media/MediaPlayer.html), `prepare()` is synchronized. Hence, it is I/O blocking and `bIsLoaded` should be set to true immediately after `prepare()` is called otherwise `play()` will always throw "Movie not loaded".

Although `bIsLoaded` is set to true inside `mediaPlayer.setOnPreparedListener()`, the listener should only be called when `mediaPlayer.prepareAsync()` is used.
