### PR TITLE
refactor: move ofTtfSettings into ofTrueTypeFont

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,3 @@
- OF 0.9.9
-========                          
-
-#### change key
-          + added
-          - removed
-          / modified
-
-CORE
-----
-
-### graphics
-    / refactor ofTtfSettings -> ofTrueTypeFont::Settings
-
-
-PLATFORM SPECIFIC
------------------
-
-### osx
-
-### linux
-
-### windows
-
-
-------------------------------------------------------------------------------
-
-
   ___         ___         ___  
  / _ \       / _ \       / _ \
 | | | |     | (_) |     | (_) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+ OF 0.9.9
+========                          
+
+#### change key
+          + added
+          - removed
+          / modified
+
+CORE
+----
+
+### graphics
+    / refactor ofTtfSettings -> ofTrueTypeFont::Settings
+
+
+PLATFORM SPECIFIC
+-----------------
+
+### osx
+
+### linux
+
+### windows
+
+
+------------------------------------------------------------------------------
+
+
   ___         ___         ___  
  / _ \       / _ \       / _ \
 | | | |     | (_) |     | (_) |

--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -10,7 +10,7 @@ void ofxGuiSetFont(const string & fontPath, int fontsize, bool _bAntiAliased, bo
 	ofxBaseGui::loadFont(fontPath, fontsize, _bAntiAliased, _bFullCharacterSet, dpi);
 }
 
-void ofxGuiSetFont(const ofTtfSettings & fontSettings){
+void ofxGuiSetFont(const ofTrueTypeFont::Settings & fontSettings){
 	ofxBaseGui::loadFont(fontSettings);
 }
 
@@ -97,7 +97,7 @@ void ofxBaseGui::loadFont(const std::string& filename, int fontsize, bool _bAnti
 	useTTF = true;
 }
 
-void ofxBaseGui::loadFont(const ofTtfSettings & fontSettings){
+void ofxBaseGui::loadFont(const ofTrueTypeFont::Settings & fontSettings){
 	font.load(fontSettings);
 	fontLoaded = true;
 	useTTF = true;

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -65,7 +65,7 @@ class ofxBaseGui {
 		static void setDefaultEventsPriority(ofEventOrder eventsPriority);
 
 		static void loadFont(const std::string& filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, int dpi = 0);
-		static void loadFont(const ofTtfSettings & fontSettings);
+		static void loadFont(const ofTrueTypeFont::Settings & fontSettings);
 		static void setUseTTF(bool bUseTTF);
 
 		void registerMouseEvents();

--- a/addons/ofxGui/src/ofxGui.h
+++ b/addons/ofxGui/src/ofxGui.h
@@ -12,7 +12,7 @@
 #include "ofEvents.h"
 
 void ofxGuiSetFont(const string & fontPath,int fontsize, bool _bAntiAliased=true, bool _bFullCharacterSet=true, int dpi=0);
-void ofxGuiSetFont(const ofTtfSettings & fontSettings);
+void ofxGuiSetFont(const ofTrueTypeFont::Settings & fontSettings);
 void ofxGuiSetBitmapFont();
 
 void ofxGuiSetHeaderColor(const ofColor & color);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -764,7 +764,7 @@ ofTrueTypeFont::glyph ofTrueTypeFont::loadGlyph(uint32_t utf8) const{
 
 //-----------------------------------------------------------
 bool ofTrueTypeFont::load(const std::filesystem::path& filename, int fontSize, bool antialiased, bool fullCharacterSet, bool makeContours, float simplifyAmt, int dpi) {
-	ofTtfSettings settings(filename,fontSize);
+	ofTrueTypeFont::Settings settings(filename,fontSize);
 	settings.antialiased = antialiased;
 	settings.contours = makeContours;
 	settings.simplifyAmt = simplifyAmt;
@@ -777,7 +777,7 @@ bool ofTrueTypeFont::load(const std::filesystem::path& filename, int fontSize, b
 	return load(settings);
 }
 
-bool ofTrueTypeFont::load(const ofTtfSettings & _settings){
+bool ofTrueTypeFont::load(const ofTrueTypeFont::Settings & _settings){
 	#if defined(TARGET_ANDROID)
 	ofAddListener(ofxAndroidEvents().unloadGL,this,&ofTrueTypeFont::unloadTextures);
 	ofAddListener(ofxAndroidEvents().reloadGL,this,&ofTrueTypeFont::reloadTextures);
@@ -1114,7 +1114,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 		newLineDirection = -1;
 	}
 
-	int directionX = settings.direction == ofTtfSettings::LeftToRight?1:-1;
+	int directionX = settings.direction == Settings::Direction::LeftToRight?1:-1;
 
 	uint32_t prevC = 0;
 	for(auto c: ofUTF8Iterator(str)){
@@ -1124,7 +1124,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 				pos.x = x ; //reset X Pos back to zero
 				prevC = 0;
 			} else if (c == '\t') {
-				if ( settings.direction == ofTtfSettings::LeftToRight ){
+				if ( settings.direction == Settings::Direction::LeftToRight ){
 					f( c, pos );
 					pos.x += getGlyphProperties( ' ' ).advance * TAB_WIDTH * letterSpacing  * directionX;
 				} else{
@@ -1137,7 +1137,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 				if(prevC>0){
 					pos.x += getKerning(c,prevC);// * directionX;
 				}
-				if(settings.direction == ofTtfSettings::LeftToRight){
+				if(settings.direction == Settings::Direction::LeftToRight){
 				    f(c,pos);
 				    pos.x += props.advance * letterSpacing * directionX;
 				}else{
@@ -1153,7 +1153,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 }
 
 //-----------------------------------------------------------
-void ofTrueTypeFont::setDirection(ofTtfSettings::Direction direction){
+void ofTrueTypeFont::setDirection(ofTrueTypeFont::Settings::Direction direction){
 	settings.direction = direction;
 }
 
@@ -1288,7 +1288,7 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 	if(!str.empty()){
 		try{
 			auto c = *ofUTF8Iterator(str).begin();
-			if(settings.direction == ofTtfSettings::LeftToRight){
+			if(settings.direction == ofTrueTypeFont::Settings::Direction::LeftToRight){
 				if (c != '\n') {
 					auto g = loadGlyph(c);
 					return {-float(g.props.xmin), getLineHeight() + g.props.ymin + getDescenderHeight()};
@@ -1354,7 +1354,7 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
 	totalPixels.set(1,0);
 	size_t i = 0;
 	for(auto & g: glyphs){
-		if(settings.direction == ofTtfSettings::LeftToRight){
+		if(settings.direction == Settings::Direction::LeftToRight){
 			g.pixels.blendInto(totalPixels, glyphPositions[i].x, glyphPositions[i].y + getLineHeight() + g.props.ymin + getDescenderHeight() );
 		}else{
 			g.pixels.blendInto(totalPixels, width-glyphPositions[i].x, glyphPositions[i].y + getLineHeight() + g.props.ymin + getDescenderHeight() );

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -112,45 +112,38 @@ public:
 	static const std::initializer_list<ofUnicode::range> Cyrillic;
 };
 
-
-
-
-class ofTtfSettings{
-	friend class ofTrueTypeFont;
-	vector<ofUnicode::range> ranges;
-
-public:
-    ofTtfSettings(const std::filesystem::path & name, int size)
-	:fontName(name)
-	,fontSize(size){}
-
-    std::filesystem::path fontName;
-	int fontSize;
-	bool antialiased = true;
-	bool contours = false;
-	float simplifyAmt = 0.3f;
-	int dpi = 0;
-
-	enum Direction{
-		LeftToRight,
-		RightToLeft
-	};
-	Direction direction = LeftToRight;
-
-	void addRanges(std::initializer_list<ofUnicode::range> alphabet){
-		ranges.insert(ranges.end(), alphabet);
-	}
-
-	void addRange(const ofUnicode::range & range){
-		ranges.push_back(range);
-	}
-};
-
-
 class ofTrueTypeFont{
 
 public:
 
+	struct Settings{
+
+		enum class Direction : uint32_t {
+			LeftToRight,
+			RightToLeft
+		};
+
+		std::filesystem::path    fontName;
+		int                      fontSize = 0;
+		bool                     antialiased = true;
+		bool                     contours = false;
+		float                    simplifyAmt = 0.3f;
+		int                      dpi = 0;
+		Direction                direction = Direction::LeftToRight;
+		vector<ofUnicode::range> ranges;
+
+		Settings(const std::filesystem::path & name, int size)
+		:fontName(name)
+		,fontSize(size){}
+
+		void addRanges(std::initializer_list<ofUnicode::range> alphabet){
+			ranges.insert(ranges.end(), alphabet);
+		}
+
+		void addRange(const ofUnicode::range & range){
+			ranges.push_back(range);
+		}
+	};
 
 	/// \brief Construct a default ofTrueTypeFont.
 	ofTrueTypeFont();
@@ -199,7 +192,7 @@ public:
                   float simplifyAmt=0.3f,
 				  int dpi=0));
 	
-	bool load(const ofTtfSettings & settings);
+	bool load(const Settings & settings);
 
 	/// \brief Has the font been loaded successfully?
 	/// \returns true if the font was loaded.
@@ -355,7 +348,7 @@ public:
 	bool isValidGlyph(uint32_t) const;
 	/// \}
 
-	void setDirection(ofTtfSettings::Direction direction);
+	void setDirection(Settings::Direction direction);
 protected:
 	/// \cond INTERNAL
 	
@@ -394,7 +387,7 @@ protected:
 
 	vector<glyphProps> cps; // properties for each character
 
-	ofTtfSettings settings;
+	Settings settings;
 	unordered_map<uint32_t,size_t> glyphIndexMap;
 
 


### PR DESCRIPTION
+ following the same pattern we use with ofFbo and other objects

*Example:* Create a `Settings` object, and pass it to `load()` - here we are instructing an Icon font to load specific unicode ranges:

	ofTrueTypeFont myFont;

	ofTrueTypeFont::Settings settings("MaterialIcons-Regular.ttf", 26);
	settings.antialiased = true;
	settings.addRange({0xe889,0xe889}); // history
	settings.addRange({0xe034,0xe039}); // play/pause buttons
	
	myFont.load(settings);

The hope is to make the Settings object more discoverable, which should help especially with IDEs that have code completion.