### PR TITLE
vs: update download_libs.ps1

### DIFF
--- a/scripts/vs/download_libs.ps1
+++ b/scripts/vs/download_libs.ps1
@@ -1,11 +1,11 @@
 # You may override default parameters for this script by specifying 
 #       -paramName paramValue
 # When calling this script. For example: 
-#       download_libs.ps1 -vs_ver 2017
+#       download_libs.ps1 -platform vs2017
 # Which will load the visual studio 2017 libraries
 param(
     [String]$ver="master",
-    [String]$vs_ver="2015"
+    [String]$platform="vs2015"
     )
 $currentPath = $pwd
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
@@ -15,7 +15,7 @@ function DownloadLibs{
     cd $scriptPath
     $client = new-object System.Net.WebClient
     $arch = $args[0]
-    $pkg = "openFrameworksLibs_"+$ver+"_vs"+$vs_ver+"_"+$arch+".zip"
+    $pkg = "openFrameworksLibs_"+$ver+"_"+$platform+"_"+$arch+".zip"
     $url = "http://ci.openframeworks.cc/libs/$pkg"
     If(Test-Path "$pkg") {
         echo "Deleting old package"

--- a/scripts/vs/download_libs.ps1
+++ b/scripts/vs/download_libs.ps1
@@ -1,4 +1,12 @@
-param([String]$ver="master")
+# You may override default parameters for this script by specifying 
+#       -paramName paramValue
+# When calling this script. For example: 
+#       download_libs.ps1 -vs_ver 2017
+# Which will load the visual studio 2017 libraries
+param(
+    [String]$ver="master",
+    [String]$vs_ver="2015"
+    )
 $currentPath = $pwd
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $libsDir = $scriptPath + "\..\..\libs"
@@ -7,7 +15,7 @@ function DownloadLibs{
     cd $scriptPath
     $client = new-object System.Net.WebClient
     $arch = $args[0]
-    $pkg = "openFrameworksLibs_"+$ver+"_vs"+$arch+".zip"
+    $pkg = "openFrameworksLibs_"+$ver+"_vs"+$vs_ver+"_"+$arch+".zip"
     $url = "http://ci.openframeworks.cc/libs/$pkg"
     If(Test-Path "$pkg") {
         echo "Deleting old package"


### PR DESCRIPTION
+ adds vs_ver as a selectable option to the powershell download script, which allows you to select which version of the libraries to download.
+ adds a comment at top of script to explain how paramters may be specified

Default paramter value for vs_ver is 2015, which will load the libraries compiled with the visual studio 2015(== 140) toollset.

Call the script with:

    powershell.exe -f download_libs.ps1 -vs_ver 2017

To download & install the libraries compiled with the visual studio 2017(== 141) toolset.

This should also fix an issue where the old download_libs.ps1 script would not work, as the libraries archives on the server now have a slightly different naming scheme.

Fixes #5695