### PR TITLE
ofEasyCam. fix disabling mouse interaction at start. 

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -176,7 +176,7 @@ void ofEasyCam::setEvents(ofCoreEvents & _events){
 
 	// we need a temporary copy of bMouseInputEnabled, since it will 
 	// get changed by disableMouseInput as a side-effect.
-	bool wasMouseInputEnabled = bMouseInputEnabled || !events;
+	bool wasMouseInputEnabled = bMouseInputEnabled;// || !events;
 	disableMouseInput();
 	events = &_events;
 	if (wasMouseInputEnabled) {

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -183,7 +183,7 @@ private:
 	bool bApplyInertia = false;
 	
 	bool bInsideArcball = false;
-	bool bMouseInputEnabled = false;
+	bool bMouseInputEnabled = true;
 	bool bDistanceSet = false;
 	bool bAutoDistance = true;
 	bool bEventsSet = false;


### PR DESCRIPTION
This should fix this issue #5703 

This fix is actually very simple. The setEvents(...)method was checking if the events pointer was valid as a way to determine if it was the first time setEvents(...) was being called, thus allowing the automatic events registration upon startup. The problem is that if disableMouseEvents() is called before the events registration; during setup, the events pointer will still be null thus rendering the bMouseInputEnabled flag useless during the first run of setEvents(...).
So, the idea is to forget about checking the events pointer validity, and instead have the bMouseInputEnabledbool set totrue upon construction. When setEvents(...) gets called the fissrt time it will register automatically the events. Hence if disableMouseEvents() is called during setup() it will set bMouseInputEnabled = false; thus disabling the automatic registration.
It is a bit of a hack but I think that this is better than adding a new flag just to make the initial registration.
BTW, I made another PR from the wrong branch in my repo.