### PR TITLE
feature: draw camera frustum

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -250,3 +250,56 @@ shared_ptr<ofBaseRenderer> ofCamera::getRenderer() const{
 void ofCamera::setRenderer(shared_ptr<ofBaseRenderer> _renderer){
 	renderer = _renderer;
 }
+
+void ofCamera::drawFrustum() {
+	ofPushMatrix(); // we assume we are currently in world space.
+	ofMultMatrix( getGlobalTransformMatrix() ); 
+	// Move origin to camera origin == global transform of camera == inverse (view matrix)
+	// Which brings us into view space
+
+
+	// We want to draw the frustum of camera 0. To this end, we grab the matrix which transforms
+	// from view space into clip space (i.e. the projection matrix),
+	// then we take our unit clip cube (i.e. the cube that delimits clip space,
+	// and is defined to be +-1 onto each x, y , z),and transform this clip cube back 
+	// into view space. We transform it back into
+	// viewspace by applying the inverse transform viewspace -> clipspace
+	// which is the inverse of applying the projection matrix, which is applying
+	// the inverse projection matrix.
+
+	// the edges of our unit cube in clip space:
+
+	ofVec3f clipCube[8] = {
+		ofVec3f( -1,-1,-1 ), ofVec3f( -1, 1,-1 ), ofVec3f( 1,-1,-1 ), ofVec3f( 1, 1,-1 ),
+		ofVec3f( -1,-1, 1 ), ofVec3f( -1, 1, 1 ), ofVec3f( 1,-1, 1 ), ofVec3f( 1, 1, 1 ),
+	};
+	// since the clip cube is expressed in clip (=projection) space, we want this 
+	// transformed back into our current space, view space, i.e. apply the inverse 
+	// projection matrix to it.
+
+
+	// calculate projection matrix using frustum: 
+
+	ofMatrix4x4 projectionMatrixInverse = glm::inverse( getProjectionMatrix() );
+
+	for ( int i = 0; i < 8; i++ ) {
+		clipCube[i] = clipCube[i] * projectionMatrixInverse;
+	}
+
+
+	// now draw our clip cube side edge rays - note that since the coordinates are
+	// now in world space, we can draw them without applying any additional trans-
+	// formations.
+	for ( int i = 0; i < 4; i++ ) {
+		ofDrawLine( clipCube[i], clipCube[i + 4] );
+	}
+
+	ofPushStyle();
+	ofNoFill();
+	//// draw the clip cube cap
+	ofDrawRectangle( clipCube[0], clipCube[3].x - clipCube[0].x, clipCube[3].y - clipCube[0].y );
+	ofDrawRectangle( clipCube[4], clipCube[7].x - clipCube[4].x, clipCube[7].y - clipCube[4].y );
+	ofPopStyle();
+
+	ofPopMatrix();
+}

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -210,6 +210,12 @@ public:
     void setRenderer(shared_ptr<ofBaseRenderer> renderer);
 	
 	/// \}
+
+	/// \brief Draw a visual representation of the camera's frustum
+	/// \note  This will only be visible when the camera drawing its 
+	///        frustum is viewed through another camera.
+	void drawFrustum();
+
 protected:
 	ofRectangle getViewport(const ofRectangle & _viewport) const;
 	shared_ptr<ofBaseRenderer> getRenderer() const;


### PR DESCRIPTION
+ add method to draw camera frustum into scene, so that a camera may be previewed showing its frustum. This is useful to debug camera views, and also allows you to preview near and far planes for cameras. Inline comments explain the math behind the draw operation.

Proposed method name & signature: `void ofCamera.drawFrustum()`

Minimal demo app shows how this feature may be used: https://gist.github.com/tgfrerer/28b2bf3ad689e4f8cc778644c9d6595e

Screengrabs from demo app: 
![camera with perspective frustum](https://user-images.githubusercontent.com/423509/28728177-8feafdde-73bf-11e7-81a5-13dab257e465.png)
![perspective camera view](https://user-images.githubusercontent.com/423509/28728225-b976ead2-73bf-11e7-8375-927891370f62.png)
![camera enabled ortho](https://user-images.githubusercontent.com/423509/28728206-a67bb7f0-73bf-11e7-9182-b3b4dad72c15.png)


