### PR TITLE
fix dual-monitor-resolution issue and HiDpi

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -68,6 +68,7 @@ void ofAppGLFWWindow::close(){
 		glfwSetCursorEnterCallback( windowP, nullptr );
 		glfwSetKeyCallback( windowP, nullptr );
 		glfwSetWindowSizeCallback( windowP, nullptr );
+		glfwSetFramebufferSizeCallback( windowP, nullptr);
 		glfwSetWindowCloseCallback( windowP, nullptr );
 		glfwSetScrollCallback( windowP, nullptr );
 #if GLFW_VERSION_MAJOR>3 || GLFW_VERSION_MINOR>=1
@@ -318,6 +319,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 	glfwSetKeyCallback(windowP, keyboard_cb);	
 	glfwSetCharCallback(windowP, char_cb);
 	glfwSetWindowSizeCallback(windowP, resize_cb);
+	glfwSetFramebufferSizeCallback( windowP, framebuffer_size_cb);
 	glfwSetWindowCloseCallback(windowP, exit_cb);
 	glfwSetScrollCallback(windowP, scroll_cb);
 #if GLFW_VERSION_MAJOR>3 || GLFW_VERSION_MINOR>=1
@@ -1475,6 +1477,12 @@ void ofAppGLFWWindow::char_cb(GLFWwindow* windowP_, uint32_t key){
 //------------------------------------------------------------
 void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_,int w, int h) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
+
+    //detect if the window is running in a retina mode
+    int framebufferW, framebufferH;
+    glfwGetFramebufferSize(windowP_, &framebufferW, &framebufferH);
+    instance->pixelScreenCoordScale = framebufferW / w;
+
 	if(instance->windowMode == OF_WINDOW){
 		instance->windowW = w * instance->pixelScreenCoordScale;
 		instance->windowH = h * instance->pixelScreenCoordScale;
@@ -1483,6 +1491,10 @@ void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_,int w, int h) {
 	instance->currentH = h;
 	instance->events().notifyWindowResized(w*instance->pixelScreenCoordScale, h*instance->pixelScreenCoordScale);
 	instance->nFramesSinceWindowResized = 0;
+}
+
+void ofAppGLFWWindow::framebuffer_size_cb(GLFWwindow* windowP_, int w, int h){
+	resize_cb(windowP_, w,h);
 }
 
 //--------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -183,6 +183,7 @@ private:
 	static void 	keyboard_cb(GLFWwindow* windowP_, int key, int scancode, int action, int mods);
 	static void 	char_cb(GLFWwindow* windowP_, uint32_t key);
 	static void 	resize_cb(GLFWwindow* windowP_, int w, int h);
+	static void 	framebuffer_size_cb(GLFWwindow* windowP_, int w, int h);
 	static void 	exit_cb(GLFWwindow* windowP_);
 	static void		scroll_cb(GLFWwindow* windowP_, double x, double y);
 	static void 	drop_cb(GLFWwindow* windowP_, int numFiles, const char** dropString);


### PR DESCRIPTION
Closes #4703

+ when moving an app from a scaled monitor to a non-scaled
  monitor, pixel scale was not recalculated. Pixel scale
  must be recalculated, however, as monitors with different
  pixel scales differ in pixel scale, and the framebuffer
  allocated to back a window will be of different size.

+ if a window was dragged onto another monitor and there is
  enough space to accomodate the window without rescaling
  it, the backing framebuffer might still change in pixel
  scale - responding to the `framebuffer_size` callback from
  GLFW fixes this.