### PR TITLE
Fix Qt Creator macOS

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
@@ -47,7 +47,7 @@ CppApplication{
 
     Properties{
         condition: of.platform === "osx"
-        cpp.minimumOsxVersion: 10.8
+        cpp.minimumMacosVersion: "10.9"
     }
 
     Probe{

--- a/libs/openFrameworksCompiled/project/qtcreator/openFrameworks.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/openFrameworks.qbs
@@ -48,7 +48,7 @@ Product{
 
     Properties{
         condition: of.platform === "osx"
-        cpp.minimumOsxVersion: 10.9
+        cpp.minimumMacosVersion: "10.9"
     }
 
     property stringList FILES_EXCLUDE: {


### PR DESCRIPTION
This is being discusses here:

https://github.com/openframeworks/openFrameworks/issues/5572

and will fix #5572 when it is complete.

- [X] Update `cpp.minimumMacosVersion` and fix missing quotes.
- [ ] Add libcurl linker / header flags to core, rather than in the project .qbs (as noted in the thread).
- [ ] Figure out the `$(PRODUCT_NAME)` error.
- [ ] Copy libfmodex.dylib and the the Resources folder to the .app bundle.
- [ ] Fix release compiler (missing symbols error)


@c-mendoza
@Daandelange 
@arturoc 