### PR TITLE
Allow setting attributes on the root XML node

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -153,16 +153,10 @@ ofXml::Attribute ofXml::getLastAttribute() const{
 }
 
 ofXml::Attribute ofXml::appendAttribute(const std::string & name){
-	if(xml==doc->document_element()){
-		xml = doc->append_child(pugi::node_element);
-	}
 	return this->xml.append_attribute(name.c_str());
 }
 
 ofXml::Attribute ofXml::prependAttribute(const std::string & name){
-	if(xml==doc->document_element()){
-		xml = doc->append_child(pugi::node_element);
-	}
 	return this->xml.prepend_attribute(name.c_str());
 }
 


### PR DESCRIPTION
Apparently this might be a copy/paste error. 
It results in a new `<:anonymous/>` tag when trying to add attributes to the root XML node.

Discussion here: https://forum.openframeworks.cc/t/27585