### PR TITLE
Remove ofMesh and ofPolyline inlined implementations

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoPlayer.cpp
@@ -8,6 +8,7 @@
 #include "ofxAndroidVideoPlayer.h"
 #include "ofxAndroidUtils.h"
 #include "ofLog.h"
+#include "ofVectorMath.h"
 
 using namespace std;
 

--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -9,6 +9,7 @@
 #include "ofxInputField.h"
 
 #include "ofGraphics.h"
+#include "ofAppRunner.h"
 
 using namespace std;
 

--- a/libs/openFrameworks/3d/ofMesh.cpp
+++ b/libs/openFrameworks/3d/ofMesh.cpp
@@ -1821,7 +1821,7 @@ void ofMesh_<V,N,C,T>::flatNormals() {
                 ofIndexType indexNext2 = getIndex(i + 2);
                 auto e1 = verts[indexCurr] - verts[indexNext1];
                 auto e2 = verts[indexNext2] - verts[indexNext1];
-                normal = glm::normalize(glm::cross(e1, e2));
+				normal = glm::normalize(glm::cross(glm::vec3(e1), glm::vec3(e2)));
             }
     
             addIndex(i);
@@ -2989,3 +2989,6 @@ template<class V, class N, class C, class T>
 bool ofMeshFace_<V,N,C,T>::hasTexcoords() const{
 	return bHasTexcoords;
 }
+
+template class ofMesh_<ofVec3f, ofVec3f, ofFloatColor, ofVec2f>;
+template class ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2>;

--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -739,7 +739,9 @@ private:
 	T texCoords[3];
 };
 
-#include "ofMesh.inl"
-
 using ofMesh = ofMesh_<ofDefaultVertexType, ofDefaultNormalType, ofDefaultColorType, ofDefaultTexCoordType>;
 using ofMeshFace = ofMeshFace_<ofDefaultVertexType, ofDefaultNormalType, ofDefaultColorType, ofDefaultTexCoordType>;
+
+
+extern template class ofMesh_<ofVec3f, ofVec3f, ofFloatColor, ofVec2f>;
+extern template class ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2>;

--- a/libs/openFrameworks/app/ofAppNoWindow.h
+++ b/libs/openFrameworks/app/ofAppNoWindow.h
@@ -56,11 +56,15 @@ private:
 	void finishRender(){}
 	void update(){}
 
-	void draw(const ofPolyline & poly) const{}
+	void draw(const ofPolyline_<ofVec3f> & poly) const{}
+	void draw(const ofPolyline_<ofVec2f> & poly) const{}
+	void draw(const ofPolyline_<glm::vec3> & poly) const{}
+	void draw(const ofPolyline_<glm::vec2> & poly) const{}
 	void draw(const ofPath & shape) const{}
 	void draw(const of3dPrimitive&, ofPolyRenderMode) const{}
 	void draw(const ofNode&) const{}
-	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
+	void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
+	void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
 	void draw(const ofImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}
 	void draw(const ofShortImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -111,7 +111,23 @@ void ofGLProgrammableRenderer::finishRender() {
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{
+void ofGLProgrammableRenderer::draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{
+	draw_(vertexData, renderType, useColors, useTextures, useNormals);
+}
+
+void ofGLProgrammableRenderer::draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{
+	draw_(vertexData, renderType, useColors, useTextures, useNormals);
+}
+
+//----------------------------------------------------------
+template<typename V, typename N, typename C, typename T>
+void ofGLProgrammableRenderer::draw_(
+		const ofMesh_<V,N,C,T>& vertexData,
+		ofPolyRenderMode renderType,
+		bool useColors,
+		bool useTextures,
+		bool useNormals) const
+{
 	if (vertexData.getVertices().empty()) return;
 	
 	
@@ -293,7 +309,8 @@ void ofGLProgrammableRenderer::draw(const ofNode& node) const{
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::draw(const ofPolyline & poly) const{
+template<typename V>
+void ofGLProgrammableRenderer::draw_(const ofPolyline_<V> & poly, int coords) const{
 	if(poly.getVertices().empty()) return;
 
 	// use smoothness, if requested:
@@ -302,7 +319,7 @@ void ofGLProgrammableRenderer::draw(const ofPolyline & poly) const{
 #if defined( TARGET_OPENGLES ) && !defined(TARGET_EMSCRIPTEN)
 
 	glEnableVertexAttribArray(ofShader::POSITION_ATTRIBUTE);
-	glVertexAttribPointer(ofShader::POSITION_ATTRIBUTE, 3, GL_FLOAT, GL_FALSE, sizeof(ofVec3f), &poly[0]);
+	glVertexAttribPointer(ofShader::POSITION_ATTRIBUTE, coords, GL_FLOAT, GL_FALSE, sizeof(V), &poly[0]);
 
 	const_cast<ofGLProgrammableRenderer*>(this)->setAttributes(true,false,false,false);
 
@@ -318,6 +335,26 @@ void ofGLProgrammableRenderer::draw(const ofPolyline & poly) const{
 #endif
 	// use smoothness, if requested:
 	//if (bSmoothHinted) endSmoothing();
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::draw(const ofPolyline_<ofVec3f> & poly) const{
+	draw_(poly,3);
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::draw(const ofPolyline_<ofVec2f> & poly) const{
+	draw_(poly,2);
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::draw(const ofPolyline_<glm::vec3> & poly) const{
+	draw_(poly,3);
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::draw(const ofPolyline_<glm::vec2> & poly) const{
+	draw_(poly,2);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -29,10 +29,14 @@ public:
 
 	using ofBaseRenderer::draw;
 	using ofBaseGLRenderer::draw;
-	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType) const;
-    void draw(const ofNode& node) const;
-	void draw(const ofPolyline & poly) const;
+	void draw(const ofNode& node) const;
+	void draw(const ofPolyline_<ofVec3f> & poly) const;
+	void draw(const ofPolyline_<ofVec2f> & poly) const;
+	void draw(const ofPolyline_<glm::vec3> & poly) const;
+	void draw(const ofPolyline_<glm::vec2> & poly) const;
 	void draw(const ofPath & path) const;
 	void draw(const ofImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
@@ -320,4 +324,15 @@ private:
 	std::deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
     GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
+
+	template<typename V, typename N, typename C, typename T>
+	void draw_(
+			const ofMesh_<V,N,C,T>& vertexData,
+			ofPolyRenderMode renderType,
+			bool useColors,
+			bool useTextures,
+			bool useNormals) const;
+
+	template<typename V>
+	void draw_(const ofPolyline_<V> & poly, int coords) const;
 };

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -27,10 +27,14 @@ public:
 
 	using ofBaseRenderer::draw;
 	using ofBaseGLRenderer::draw;
-	void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType) const;
-    void draw(const ofNode& model) const;
-	void draw(const ofPolyline & poly) const;
+	void draw(const ofNode& model) const;
+	void draw(const ofPolyline_<ofVec3f> & poly) const;
+	void draw(const ofPolyline_<ofVec2f> & poly) const;
+	void draw(const ofPolyline_<glm::vec3> & poly) const;
+	void draw(const ofPolyline_<glm::vec2> & poly) const;
 	void draw(const ofPath & path) const;
 	void draw(const ofImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
@@ -251,4 +255,14 @@ private:
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
 	GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
 
+	template<typename V, typename N, typename C, typename T>
+	void draw_(
+			const ofMesh_<V,N,C,T>& vertexData,
+			ofPolyRenderMode renderType,
+			bool useColors,
+			bool useTextures,
+			bool useNormals) const;
+
+	template<typename V>
+	void draw_(const ofPolyline_<V> & poly, int coords) const;
 };

--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -286,44 +286,6 @@ ofVbo::~ofVbo(){
 }
 
 //--------------------------------------------------------------
-void ofVbo::setMesh(const ofMesh & mesh, int usage){
-	setMesh(mesh,usage,mesh.hasColors(),mesh.hasTexCoords(),mesh.hasNormals());
-}
-
-//--------------------------------------------------------------
-void ofVbo::setMesh(const ofMesh & mesh, int usage, bool useColors, bool useTextures, bool useNormals){
-	if(mesh.getVertices().empty()){
-		ofLogWarning("ofVbo") << "setMesh(): ignoring mesh with no vertices";
-		return;
-	}
-	setVertexData(mesh.getVerticesPointer(),mesh.getNumVertices(),usage);
-	if(mesh.hasColors() && useColors){
-		setColorData(mesh.getColorsPointer(),mesh.getNumColors(),usage);
-		enableColors();
-	}else{
-		disableColors();
-	}
-	if(mesh.hasNormals() && useNormals){
-		setNormalData(mesh.getNormalsPointer(),mesh.getNumNormals(),usage);
-		enableNormals();
-	}else{
-		disableNormals();
-	}
-	if(mesh.hasTexCoords() && useTextures){
-		setTexCoordData(mesh.getTexCoordsPointer(),mesh.getNumTexCoords(),usage);
-		enableTexCoords();
-	}else{
-		disableTexCoords();
-	}
-	if(mesh.hasIndices()){
-		setIndexData(mesh.getIndexPointer(), mesh.getNumIndices(), usage);
-		enableIndices();
-	}else{
-		disableIndices();
-	}
-}
-
-//--------------------------------------------------------------
 void ofVbo::setVertexData(const glm::vec3 * verts, int total, int usage) {
 	setVertexData(&verts[0].x,3,total,usage,sizeof(glm::vec3));
 }

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -18,8 +18,10 @@ public:
 	ofVbo & operator=(const ofVbo& mom);
 	~ofVbo();
 
-	void setMesh(const ofMesh & mesh, int usage);
-	void setMesh(const ofMesh & mesh, int usage, bool useColors, bool useTextures, bool useNormals);
+	template<typename V, typename N, typename C, typename T>
+	void setMesh(const ofMesh_<V,N,C,T> & mesh, int usage);
+	template<typename V, typename N, typename C, typename T>
+	void setMesh(const ofMesh_<V,N,C,T> & mesh, int usage, bool useColors, bool useTextures, bool useNormals);
 	
 	void setVertexData(const glm::vec3 * verts, int total, int usage);
 	void setVertexData(const glm::vec2 * verts, int total, int usage);
@@ -204,3 +206,44 @@ private:
 
 	VertexAttribute & getOrCreateAttr(int location);
 };
+
+
+//--------------------------------------------------------------
+template<typename V, typename N, typename C, typename T>
+void ofVbo::setMesh(const ofMesh_<V,N,C,T> & mesh, int usage){
+	setMesh(mesh,usage,mesh.hasColors(),mesh.hasTexCoords(),mesh.hasNormals());
+}
+
+//--------------------------------------------------------------
+template<typename V, typename N, typename C, typename T>
+void ofVbo::setMesh(const ofMesh_<V,N,C,T> & mesh, int usage, bool useColors, bool useTextures, bool useNormals){
+	if(mesh.getVertices().empty()){
+		ofLogWarning("ofVbo") << "setMesh(): ignoring mesh with no vertices";
+		return;
+	}
+	setVertexData(mesh.getVerticesPointer(),mesh.getNumVertices(),usage);
+	if(mesh.hasColors() && useColors){
+		setColorData(mesh.getColorsPointer(),mesh.getNumColors(),usage);
+		enableColors();
+	}else{
+		disableColors();
+	}
+	if(mesh.hasNormals() && useNormals){
+		setNormalData(mesh.getNormalsPointer(),mesh.getNumNormals(),usage);
+		enableNormals();
+	}else{
+		disableNormals();
+	}
+	if(mesh.hasTexCoords() && useTextures){
+		setTexCoordData(mesh.getTexCoordsPointer(),mesh.getNumTexCoords(),usage);
+		enableTexCoords();
+	}else{
+		disableTexCoords();
+	}
+	if(mesh.hasIndices()){
+		setIndexData(mesh.getIndexPointer(), mesh.getNumIndices(), usage);
+		enableIndices();
+	}else{
+		disableIndices();
+	}
+}

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -36,8 +36,12 @@ public:
 	using ofBaseRenderer::draw;
 	void draw(const ofPath & shape) const;
 	void draw(const ofPath::Command & path) const;
-	void draw(const ofPolyline & poly) const;
-	void draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofPolyline_<ofVec3f> & poly) const;
+	void draw(const ofPolyline_<ofVec2f> & poly) const;
+	void draw(const ofPolyline_<glm::vec3> & poly) const;
+	void draw(const ofPolyline_<glm::vec2> & poly) const;
+	void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
+	void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const;
     void draw(const of3dPrimitive& model, ofPolyRenderMode renderType ) const;
     void draw(const ofNode& node) const;
 	void draw(const std::vector<glm::vec3> & vertexData, ofPrimitiveMode drawMode) const;
@@ -206,4 +210,15 @@ private:
 	std::deque <ofStyle> styleHistory;
 	of3dGraphics graphics3d;
 	ofPath path;
+
+	template<typename V, typename N, typename C, typename T>
+	void draw_(
+			const ofMesh_<V,N,C,T> & primitive,
+			ofPolyRenderMode mode,
+			bool useColors,
+			bool useTextures,
+			bool useNormals) const;
+
+	template<typename V>
+	void draw_(const ofPolyline_<V> & poly) const;
 };

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -63,10 +63,10 @@ public:
 
 
 	template<typename U>
-	constexpr static auto is3d = std::is_same<U, ofVec3f>::value || std::is_same<U, glm::vec3>::value;
+	constexpr static bool is3d = std::is_same<U, ofVec3f>::value || std::is_same<U, glm::vec3>::value;
 
 	template<typename U>
-	constexpr static auto is2d = std::is_same<U, ofVec2f>::value || std::is_same<U, glm::vec2>::value;
+	constexpr static bool is2d = std::is_same<U, ofVec2f>::value || std::is_same<U, glm::vec2>::value;
 
 	static ofPolyline_ fromRectangle(const ofRectangle& rect);
 

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -63,10 +63,10 @@ public:
 
 
 	template<typename U>
-	constexpr static bool is3d = std::is_same<U, ofVec3f>::value || std::is_same<U, glm::vec3>::value;
+	const static bool is3d = std::is_same<U, ofVec3f>::value || std::is_same<U, glm::vec3>::value;
 
 	template<typename U>
-	constexpr static bool is2d = std::is_same<U, ofVec2f>::value || std::is_same<U, glm::vec2>::value;
+	const static bool is2d = std::is_same<U, ofVec2f>::value || std::is_same<U, glm::vec2>::value;
 
 	static ofPolyline_ fromRectangle(const ofRectangle& rect);
 

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "ofConstants.h"
+#include "ofGLUtils.h"
+#include "ofVectorMath.h"
 #include <deque>
 
 /// \file 
@@ -59,6 +61,13 @@ public:
 	/// \brief Creates an ofPolyline from a vector of ofVec2f or T objects.
 	ofPolyline_(const std::vector<T>& verts);
 
+
+	template<typename U>
+	constexpr static auto is3d = std::is_same<U, ofVec3f>::value || std::is_same<U, glm::vec3>::value;
+
+	template<typename U>
+	constexpr static auto is2d = std::is_same<U, ofVec2f>::value || std::is_same<U, glm::vec2>::value;
+
 	static ofPolyline_ fromRectangle(const ofRectangle& rect);
 
     /// \}
@@ -72,7 +81,16 @@ public:
 	void addVertex( const T& p );
 
     /// \brief Adds a point using floats at the end of the ofPolyline.
-	void addVertex( float x, float y, float z=0 );
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type addVertex( float x, float y, float z=0 ){
+		addVertex(T(x,y,z));
+	}
+
+	/// \brief Adds a point using floats at the end of the ofPolyline.
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type addVertex( float x, float y ){
+		addVertex(T(x,y));
+	}
 
 	/// \brief Add multiple points at the end of the ofPolyline using a vector of
 	/// T objects
@@ -101,7 +119,16 @@ public:
 	void addVertices(const T* verts, int numverts);
 
 	void insertVertex(const T &p, int index);
-    void insertVertex(float x, float y, float z, int index);
+
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type insertVertex(float x, float y, float z, int index){
+		insertVertex(T(x,y,z), index);
+	}
+
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type insertVertex(float x, float y, int index){
+		insertVertex(T(x,y), index);
+	}
 
 	/// \brief Resize the number of points in the ofPolyline to the value 
 	/// passed in.
@@ -113,7 +140,9 @@ public:
 
 	/// \brief The number of points in the ofPolyline.
 	size_t size() const;
-		
+
+	void draw(const ofMesh_<ofVec2f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
+	void draw(const ofMesh_<glm::vec2, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const{}
 	/// Allows you to access the points of the ofPolyline just like you would
 	/// in an array, so to make the points of a line follow the mouse
 	/// movement, you could do:
@@ -153,8 +182,16 @@ public:
 	
 	/// \brief Add a straight line from the last point added, or from 0,0 if no point
 	/// is set, to the point indicated by the floats x,y,z passesd in.
-	void lineTo(float x, float y, float z=0){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type lineTo(float x, float y, float z=0){
 		addVertex(x,y,z);
+	}
+
+	/// \brief Add a straight line from the last point added, or from 0,0 if no point
+	/// is set, to the point indicated by the floats x,y passesd in.
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type lineTo(float x, float y){
+		addVertex(x,y);
 	}
     
 	/// \brief Adds an arc around the T `center` with the width of `radiusX`
@@ -200,7 +237,8 @@ public:
 	/// ~~~~
 	/// 
 	/// ![Arc Example](graphics/ofpolyline_arc.jpg)
-	void arc(const T & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20) {
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type arc(const T & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20) {
         arc(center, radiusX,  radiusY,  angleBegin,  angleEnd, true,  circleResolution);
     }
 
@@ -212,7 +250,8 @@ public:
 	/// 
 	/// Optionally, you can specify `circleResolution`, which is the number
 	/// of line segments a circle would be drawn with.
-	void arc(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type arc(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
 		arc(T(x, y, 0.f), radiusX, radiusY, angleBegin, angleEnd, true, circleResolution);
 	}
 
@@ -224,16 +263,23 @@ public:
 	/// 
 	/// Optionally, you can specify `circleResolution`, which is the number of
 	/// line segments a circle would be drawn with.
-	void arc(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type arc(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
 		arc(T(x, y, z), radiusX, radiusY, angleBegin, angleEnd, true, circleResolution);
 	}
 	void arcNegative(const T & center, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20) {
         arc(center, radiusX, radiusY, angleBegin, angleEnd, false, circleResolution);
     }
-	void arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
 		arc(T(x,y,0.f), radiusX, radiusY, angleBegin, angleEnd, false, circleResolution);
     }
-	void arcNegative(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type arcNegative(float x, float y, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
+		arc(T(x,y), radiusX, radiusY, angleBegin, angleEnd, false, circleResolution);
+	}
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type arcNegative(float x, float y, float z, float radiusX, float radiusY, float angleBegin, float angleEnd, int circleResolution = 20){
 		arc(T(x, y, z), radiusX, radiusY, angleBegin, angleEnd, false, circleResolution);
     }
     
@@ -255,8 +301,16 @@ public:
 	void curveTo( const T & to, int curveResolution = 20 );
 
 	/// \brief Adds a curve to the x,y,z points passed in with the optional
+	/// resolution.
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type curveTo(float x, float y,  int curveResolution = 20 ){
+		curveTo({x,y},curveResolution);
+	}
+
+	/// \brief Adds a curve to the x,y,z points passed in with the optional
 	/// resolution.	
-	void curveTo(float x, float y, float z = 0,  int curveResolution = 20 ){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type curveTo(float x, float y, float z = 0,  int curveResolution = 20 ){
 		curveTo({x,y,z},curveResolution);
 	}
 
@@ -275,14 +329,24 @@ public:
 	/// \brief Adds a cubic bezier line from the current drawing point with the 2
 	/// control points indicated by the coordinates cx1, cy1 and cx2, cy2,
 	/// that ends at the coordinates x, y.
-	void bezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type bezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
 		bezierTo({cx1,cy1,0.f}, {cx2,cy2,0.f}, {x,y,0.f}, curveResolution);
+	}
+
+	/// \brief Adds a cubic bezier line from the current drawing point with the 2
+	/// control points indicated by the coordinates cx1, cy1 and cx2, cy2,
+	/// that ends at the coordinates x, y.
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type bezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
+		bezierTo({cx1,cy1}, {cx2,cy2}, {x,y}, curveResolution);
 	}
 
 	/// \brief Adds a cubic bezier line in 3D space from the current drawing point
 	/// with the 2 control points indicated by the coordinates cx1, cy1, cz1
 	/// and cx2, cy2, cz2, that ends at the coordinates x, y, z.
-	void bezierTo(float cx1, float cy1, float cz1, float cx2, float cy2, float cz2, float x, float y, float z, int curveResolution = 20){
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type bezierTo(float cx1, float cy1, float cz1, float cx2, float cy2, float cz2, float x, float y, float z, int curveResolution = 20){
 		bezierTo({cx1,cy1,cz1}, {cx2,cy2,cz2}, {x,y,z}, curveResolution);
 	}
 
@@ -292,21 +356,31 @@ public:
 	/// x, y, z.
 	///
 	/// ![polyline curves](graphics/curves.png)
-	void quadBezierTo(float cx1, float cy1, float cz1, float cx2, float cy2, float cz2, float x, float y, float z, int curveResolution = 20);
-
-	/// \brief Adds a quadratic bezier line in 2D space from the current drawing
-	/// point with the beginning indicated by the point p1, the control point
-	/// at p2, and that ends at the point p3.
-	void quadBezierTo(  const T & p1, const T & p2, const T & p3,  int curveResolution = 20 ){
-		quadBezierTo(p1.x,p1.y,p1.z,p2.x,p2.y,p2.z,p3.x,p3.y,p3.z,curveResolution);
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type quadBezierTo(float cx1, float cy1, float cz1, float cx2, float cy2, float cz2, float x, float y, float z, int curveResolution = 20){
+		quadBezierTo({cx1,cy1,cz1}, {cx2,cy2,cz2}, {x,y,z}, curveResolution);
 	}
 
 	/// \brief Adds a quadratic bezier line in 2D space from the current drawing
 	/// point with the beginning indicated by the coordinates cx1, cy1, the
 	/// control point at cx2, cy2, and that ends at the coordinates x, y.
-	void quadBezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
-		quadBezierTo(cx1,cy1,0,cx2,cy2,0,x,y,0,curveResolution);
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type quadBezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
+		quadBezierTo({cx1,cy1,0},{cx2,cy2,0},{x,y,0},curveResolution);
 	}
+
+	/// \brief Adds a quadratic bezier line in 2D space from the current drawing
+	/// point with the beginning indicated by the coordinates cx1, cy1, the
+	/// control point at cx2, cy2, and that ends at the coordinates x, y.
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type quadBezierTo(float cx1, float cy1, float cx2, float cy2, float x, float y, int curveResolution = 20){
+		quadBezierTo({cx1,cy1},{cx2,cy2},{x,y},curveResolution);
+	}
+
+	/// \brief Adds a quadratic bezier line in 2D space from the current drawing
+	/// point with the beginning indicated by the point p1, the control point
+	/// at p2, and that ends at the point p3.
+	void quadBezierTo(  const T & p1, const T & p2, const T & p3,  int curveResolution = 20 );
 
 	/// \}
 	/// \name Smoothing and Resampling
@@ -441,11 +515,23 @@ public:
 	OF_DEPRECATED_MSG("Use the Deg/Rad versions", float getAngleAtIndexInterpolated(float findex) const);
     
     /// \brief Get rotation vector at index (magnitude is sin of angle)
-	T getRotationAtIndex(int index) const;
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, T>::type getRotationAtIndex(int index) const{
+		if(points.size() < 2) return T();
+		updateCache();
+		return rotations[getWrappedIndex(index)];
+	}
     
     /// \brief Get rotation vector at interpolated index 
     /// (interpolated between neighboring indices) (magnitude is sin of angle)
-	T getRotationAtIndexInterpolated(float findex) const;
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, T>::type getRotationAtIndexInterpolated(float findex) const{
+		if(points.size() < 2) return T();
+		int i1, i2;
+		float t;
+		getInterpolationParams(findex, i1, i2, t);
+		return glm::lerp(toGlm(getRotationAtIndex(i1)), toGlm(getRotationAtIndex(i2)), t);
+	}
 
 	/// \brief Get angle (degrees) of the path at index
 	float getDegreesAtIndex(int index) const;
@@ -479,7 +565,18 @@ public:
     int getWrappedIndex(int index) const;
 
     // used for calculating the normals
-	void setRightVector(T v = T(0, 0, -1));
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type setRightVector(T v = T(0, 0, -1)){
+		rightVector = v;
+		flagHasChanged();
+	}
+
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type setRightVector(T v = T(1, 0)){
+		rightVector = v;
+		flagHasChanged();
+	}
+
 	T getRightVector() const;
 
     /// \}
@@ -510,7 +607,7 @@ private:
     
     
 	std::deque<T> curveVertices;
-	std::vector<T> circlePoints;
+	std::vector<glm::vec2> circlePoints;
 
 	bool bClosed;
 	bool bHasChanged;   // public API has access to this
@@ -521,10 +618,72 @@ private:
     // given an interpolated index (e.g. 5.75) return neighboring indices and interolation factor (e.g. 5, 6, 0.75)
     void getInterpolationParams(float findex, int &i1, int &i2, float &t) const;
     
-	void calcData(int index, T &tangent, float &angle, T &rotation, T &normal) const;
-};
+	template<typename U=T>
+	typename std::enable_if<is3d<U>, void>::type calcData(int index, T &tangent, float &angle, T &rotation, T &normal) const{
 
-#include "ofPolyline.inl"
+		int i1 = getWrappedIndex( index - 1 );
+		int i2 = getWrappedIndex( index     );
+		int i3 = getWrappedIndex( index + 1 );
+
+		const auto &p1 = points[i1];
+		const auto &p2 = points[i2];
+		const auto &p3 = points[i3];
+
+		auto v1 = toGlm(p1 - p2); // vector to previous point
+		auto v2 = toGlm(p3 - p2); // vector to next point
+
+		v1 = glm::normalize(v1);
+		v2 = glm::normalize(v2);
+
+		// If just one of p1, p2, or p3 was identical, further calculations
+		// are (almost literally) pointless, as v1 or v2 will then contain
+		// NaN values instead of floats.
+
+		bool noSegmentHasZeroLength = (v1 == v1 && v2 == v2);
+
+		if ( noSegmentHasZeroLength ){
+			tangent  = glm::length2(v2 - v1) > 0 ? glm::normalize(v2 - v1) : toGlm(-v1);
+			normal   = glm::normalize( glm::cross( toGlm(rightVector), toGlm(tangent) ) );
+			rotation = glm::cross( v1, v2 );
+			angle    = glm::pi<float>() - acosf( ofClamp( glm::dot( v1, v2 ), -1.f, 1.f ) );
+		} else{
+			rotation = tangent = normal = T( 0.f );
+			angle    = 0.f;
+		}
+	}
+
+	template<typename U=T>
+	typename std::enable_if<is2d<U>, void>::type calcData(int index, T &tangent, float &angle, T &rotation, T &normal) const{
+
+		int i1 = getWrappedIndex( index - 1 );
+		int i2 = getWrappedIndex( index     );
+		int i3 = getWrappedIndex( index + 1 );
+
+		const auto &p1 = points[i1];
+		const auto &p2 = points[i2];
+		const auto &p3 = points[i3];
+
+		auto v1 = toGlm(p1 - p2); // vector to previous point
+		auto v2 = toGlm(p3 - p2); // vector to next point
+
+		v1 = glm::normalize(v1);
+		v2 = glm::normalize(v2);
+
+		// If just one of p1, p2, or p3 was identical, further calculations
+		// are (almost literally) pointless, as v1 or v2 will then contain
+		// NaN values instead of floats.
+
+		bool noSegmentHasZeroLength = (v1 == v1 && v2 == v2);
+
+		if ( noSegmentHasZeroLength ){
+			tangent  = glm::length2(v2 - v1) > 0 ? glm::normalize(v2 - v1) : -v1;
+			normal   = T(tangent.y, -tangent.x);
+			angle    = glm::pi<float>() - acosf( ofClamp( glm::dot( v1, v2 ), -1.f, 1.f ) );
+		} else{
+			angle    = 0.f;
+		}
+	}
+};
 
 using ofPolyline = ofPolyline_<ofDefaultVertexType>;
 
@@ -547,3 +706,8 @@ template<class T>
 bool ofInsidePoly(const T& p, const std::vector<T>& poly){
 	return ofPolyline_<T>::inside(p.x,p.y, ofPolyline_<T>(poly));
 }
+
+extern template class ofPolyline_<ofVec3f>;
+extern template class ofPolyline_<ofVec2f>;
+extern template class ofPolyline_<glm::vec3>;
+extern template class ofPolyline_<glm::vec2>;

--- a/libs/openFrameworks/graphics/ofRendererCollection.h
+++ b/libs/openFrameworks/graphics/ofRendererCollection.h
@@ -44,18 +44,43 @@ public:
 
 	 using ofBaseRenderer::draw;
 
-	 void draw(const ofPolyline & poly) const{
+	 void draw(const ofPolyline_<ofVec3f> & poly) const{
 		 for(auto renderer: renderers){
 			 renderer->draw(poly);
 		 }
 	 }
+
+	 void draw(const ofPolyline_<ofVec2f> & poly) const{
+		 for(auto renderer: renderers){
+			 renderer->draw(poly);
+		 }
+	 }
+
+	 void draw(const ofPolyline_<glm::vec3> & poly) const{
+		 for(auto renderer: renderers){
+			 renderer->draw(poly);
+		 }
+	 }
+
+	 void draw(const ofPolyline_<glm::vec2> & poly) const{
+		 for(auto renderer: renderers){
+			 renderer->draw(poly);
+		 }
+	 }
+
 	 void draw(const ofPath & shape) const{
 		 for(auto renderer: renderers){
 			 renderer->draw(shape);
 		 }
 	 }
 
-	 void draw(const ofMesh & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
+	 void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
+		 for(auto renderer: renderers){
+			 renderer->draw(vertexData,mode,useColors,useTextures,useNormals);
+		 }
+	 }
+
+	 void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & vertexData, ofPolyRenderMode mode, bool useColors, bool useTextures, bool useNormals) const{
 		 for(auto renderer: renderers){
 			 renderer->draw(vertexData,mode,useColors,useTextures,useNormals);
 		 }

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -298,7 +298,7 @@ int ofRtAudioSoundStream::rtAudioCallback(void *outputBuffer, void *inputBuffer,
 	if (nOutputChannels > 0) {
 		if (rtStreamPtr->settings.outCallback) {
 
-			if (rtStreamPtr->outputBuffer.size() != nFramesPerBuffer*nOutputChannels || rtStreamPtr->outputBuffer.getNumChannels() != nOutputChannels) {
+			if (rtStreamPtr->outputBuffer.size() != nFramesPerBuffer*nOutputChannels || rtStreamPtr->outputBuffer.getNumChannels() != size_t(nOutputChannels)) {
 				rtStreamPtr->outputBuffer.setNumChannels(nOutputChannels);
 				rtStreamPtr->outputBuffer.resize(nFramesPerBuffer*nOutputChannels);
 			}

--- a/libs/openFrameworks/types/ofBaseTypes.cpp
+++ b/libs/openFrameworks/types/ofBaseTypes.cpp
@@ -149,7 +149,11 @@ glm::mat4 ofBaseRenderer::getCurrentOrientationMatrix() const {
 	return glm::mat4(1.0);
 }
 
-void ofBaseRenderer::draw(const ofMesh & mesh, ofPolyRenderMode renderType) const{
+void ofBaseRenderer::draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & mesh, ofPolyRenderMode renderType) const{
+	draw(mesh,renderType,mesh.usingColors(),mesh.usingTextures(),mesh.usingNormals());
+}
+
+void ofBaseRenderer::draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & mesh, ofPolyRenderMode renderType) const{
 	draw(mesh,renderType,mesh.usingColors(),mesh.usingTextures(),mesh.usingNormals());
 }
 

--- a/libs/openFrameworks/types/ofBaseTypes.h
+++ b/libs/openFrameworks/types/ofBaseTypes.h
@@ -646,7 +646,10 @@ public:
 
 	/// \brief Draw a polyline with this renderer.
 	/// \param poly The polyline to draw with this renderer.
-	virtual void draw(const ofPolyline & poly) const=0;
+	virtual void draw(const ofPolyline_<ofVec3f> & poly) const=0;
+	virtual void draw(const ofPolyline_<ofVec2f> & poly) const=0;
+	virtual void draw(const ofPolyline_<glm::vec3> & poly) const=0;
+	virtual void draw(const ofPolyline_<glm::vec2> & poly) const=0;
 	/// \brief Draw a path with this renderer.
 	/// \param shape The path to draw with this renderer.
 	virtual void draw(const ofPath & shape) const=0;
@@ -671,7 +674,8 @@ public:
 	/// \param renderType The render mode to use to draw \p mesh with this
 	/// renderer.
 	/// \sa ofPolyRenderMode
-	virtual void draw(const ofMesh & mesh, ofPolyRenderMode renderType) const;
+	virtual void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & mesh, ofPolyRenderMode renderType) const;
+	virtual void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & mesh, ofPolyRenderMode renderType) const;
 
 	/// \brief Draw a mesh with this renderer.
 	///
@@ -689,7 +693,8 @@ public:
 	/// vertexData.
 	/// \param useNormals True to use normals to draw the \p vertexData.
 	/// \sa ofPolyRenderMode
-	virtual void draw(const ofMesh & vertexData, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const=0;
+	virtual void draw(const ofMesh_<ofVec3f,ofVec3f,ofFloatColor,ofVec2f> & mesh, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const=0;
+	virtual void draw(const ofMesh_<glm::vec3, glm::vec3, ofFloatColor, glm::vec2> & mesh, ofPolyRenderMode renderType, bool useColors, bool useTextures, bool useNormals) const=0;
 
 	/// \brief Draw a \p model with this renderer using the \p renderType.
 	///

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -2,6 +2,8 @@
 #include "ofImage.h"
 #include "ofFileUtils.h"
 #include "ofLog.h"
+#include "ofMainLoop.h"
+#include "ofAppRunner.h"
 
 #include <chrono>
 #include <numeric>

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -176,8 +176,8 @@
 		2E6EA7051603AABD00B7ADF3 /* of3dPrimitives.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dPrimitives.h; sourceTree = "<group>"; };
 		2E6EA7071603AAD600B7ADF3 /* of3dPrimitives.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = of3dPrimitives.cpp; sourceTree = "<group>"; };
 		53EEEF49130766EF0027C199 /* ofMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMesh.h; sourceTree = "<group>"; };
-		6448E6FB1CAD7679000877BC /* ofMesh.inl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ofMesh.inl; sourceTree = "<group>"; };
-		6448E6FC1CAD771D000877BC /* ofPolyline.inl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ofPolyline.inl; sourceTree = "<group>"; };
+		6448E6FB1CAD7679000877BC /* ofMesh.cpp */ = {isa = PBXFileReference; lastKnownFileType = text; path = ofMesh.cpp; sourceTree = "<group>"; };
+		6448E6FC1CAD771D000877BC /* ofPolyline.cpp */ = {isa = PBXFileReference; lastKnownFileType = text; path = ofPolyline.cpp; sourceTree = "<group>"; };
 		6678E96B19FEAE1900C00581 /* ofBaseSoundStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseSoundStream.cpp; sourceTree = "<group>"; };
 		6678E96D19FEAFA900C00581 /* ofSoundBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundBuffer.cpp; sourceTree = "<group>"; };
 		6678E96E19FEAFA900C00581 /* ofSoundBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundBuffer.h; sourceTree = "<group>"; };
@@ -485,7 +485,7 @@
 				E4F3BA5612F4C4BF002D19BB /* ofCamera.h */,
 				E4F3BA5712F4C4BF002D19BB /* ofEasyCam.cpp */,
 				E4F3BA5812F4C4BF002D19BB /* ofEasyCam.h */,
-				6448E6FB1CAD7679000877BC /* ofMesh.inl */,
+				6448E6FB1CAD7679000877BC /* ofMesh.cpp */,
 				53EEEF49130766EF0027C199 /* ofMesh.h */,
 				E4F3BA5F12F4C4BF002D19BB /* ofNode.cpp */,
 				E4F3BA6012F4C4BF002D19BB /* ofNode.h */,
@@ -597,7 +597,7 @@
 			children = (
 				92C55F86132DA7DD00EC2631 /* ofPath.cpp */,
 				92C55F87132DA7DD00EC2631 /* ofPath.h */,
-				6448E6FC1CAD771D000877BC /* ofPolyline.inl */,
+				6448E6FC1CAD771D000877BC /* ofPolyline.cpp */,
 				DA48FE74131D85A6000062BC /* ofPolyline.h */,
 				DA94C2ED1301D32200CCC773 /* ofRendererCollection.h */,
 				22A1C452170AFCB60079E473 /* ofRendererCollection.cpp */,


### PR DESCRIPTION
In an attempt to make compiling and auto complete faster Implementation has been moved back to cpp files and now uses explicit instantiation templates in the style of other classes that did this before like ofColor.

This also enables 2d polylines which were instantiable before but couldn't be drawn