### PR TITLE
Replace “wget” with “curl -L --retry 20 -O --progress”.

### DIFF
--- a/scripts/ci/addons/install.cmd
+++ b/scripts/ci/addons/install.cmd
@@ -9,7 +9,7 @@ if "%BUILDER%"=="VS" (
     set PG_OF_PATH=%APPVEYOR_BUILD_FOLDER%\..\openFrameworks
     %MSYS2_PATH%\usr\bin\bash -lc "scripts/vs/download_libs.sh --silent"
     echo "Downloading projectGenerator from ci server"
-    %MSYS2_PATH%\usr\bin\bash -lc "wget http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip -nv"
+    %MSYS2_PATH%\usr\bin\bash -lc "curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip -nv"
     %MSYS2_PATH%\usr\bin\bash -lc "unzip -qq projectGenerator-vs.zip"
     rm projectGenerator-vs.zip
     if exist addons\%APPVEYOR_PROJECT_NAME%\scripts\ci\vs\install.sh call %MSYS2_PATH%\usr\bin\bash -lc "source addons/%APPVEYOR_PROJECT_NAME%/scripts/ci/vs/install.sh"
@@ -27,7 +27,7 @@ if "%BUILDER%"=="MSYS2" (
         copy scripts\templates\msys2\Makefile %%e\Makefile
         copy scripts\templates\msys2\config.make %%e\config.make
     )
-    if exist addons\%APPVEYOR_PROJECT_NAME%\scripts\ci\msys2\install.sh ( 
-        %MSYS2_PATH%\usr\bin\bash -lc "addons/%APPVEYOR_PROJECT_NAME%/scripts/ci/msys2/install.sh" 
-    ) 
+    if exist addons\%APPVEYOR_PROJECT_NAME%\scripts\ci\msys2\install.sh (
+        %MSYS2_PATH%\usr\bin\bash -lc "addons/%APPVEYOR_PROJECT_NAME%/scripts/ci/msys2/install.sh"
+    )
 )

--- a/scripts/ci/addons/install.cmd
+++ b/scripts/ci/addons/install.cmd
@@ -9,7 +9,7 @@ if "%BUILDER%"=="VS" (
     set PG_OF_PATH=%APPVEYOR_BUILD_FOLDER%\..\openFrameworks
     %MSYS2_PATH%\usr\bin\bash -lc "scripts/vs/download_libs.sh --silent"
     echo "Downloading projectGenerator from ci server"
-    %MSYS2_PATH%\usr\bin\bash -lc "downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }"
+    %MSYS2_PATH%\usr\bin\bash -lc "downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }"
     %MSYS2_PATH%\usr\bin\bash -lc "downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip -nv"
     %MSYS2_PATH%\usr\bin\bash -lc "unzip -qq projectGenerator-vs.zip"
     rm projectGenerator-vs.zip

--- a/scripts/ci/addons/install.cmd
+++ b/scripts/ci/addons/install.cmd
@@ -9,7 +9,7 @@ if "%BUILDER%"=="VS" (
     set PG_OF_PATH=%APPVEYOR_BUILD_FOLDER%\..\openFrameworks
     %MSYS2_PATH%\usr\bin\bash -lc "scripts/vs/download_libs.sh --silent"
     echo "Downloading projectGenerator from ci server"
-    %MSYS2_PATH%\usr\bin\bash -lc "downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }"
+    %MSYS2_PATH%\usr\bin\bash -lc "downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }"
     %MSYS2_PATH%\usr\bin\bash -lc "downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip -nv"
     %MSYS2_PATH%\usr\bin\bash -lc "unzip -qq projectGenerator-vs.zip"
     rm projectGenerator-vs.zip

--- a/scripts/ci/addons/install.sh
+++ b/scripts/ci/addons/install.sh
@@ -39,7 +39,7 @@ cd ~
 mv $TRAVIS_BUILD_DIR $OF_ROOT/addons/
 mkdir -p $OF_ROOT/libs/openFrameworksCompiled/lib/$TARGET/
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 cd $OF_ROOT/libs/openFrameworksCompiled/lib/$TARGET/
 if [ "$TARGET" == "android" ]; then

--- a/scripts/ci/addons/install.sh
+++ b/scripts/ci/addons/install.sh
@@ -39,7 +39,7 @@ cd ~
 mv $TRAVIS_BUILD_DIR $OF_ROOT/addons/
 mkdir -p $OF_ROOT/libs/openFrameworksCompiled/lib/$TARGET/
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 cd $OF_ROOT/libs/openFrameworksCompiled/lib/$TARGET/
 if [ "$TARGET" == "android" ]; then

--- a/scripts/ci/addons/install.sh
+++ b/scripts/ci/addons/install.sh
@@ -45,12 +45,12 @@ if [ "$TARGET" == "android" ]; then
     mkdir x86;
 
     cd armv7;
-    wget http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/armv7/libopenFrameworksDebug.a;
+    curl -L --retry 20 -O --progress http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/armv7/libopenFrameworksDebug.a;
     cd ../x86;
-    wget http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/x86/libopenFrameworksDebug.a;
+    curl -L --retry 20 -O --progresshttp://ci.openframeworks.cc/openFrameworks_libs/$TARGET/x86/libopenFrameworksDebug.a;
     cd ..;
 elif [ "$TARGET" == "emscripten" ]; then
-    wget http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/libopenFrameworksDebug.bc;
+    curl -L --retry 20 -O --progresshttp://ci.openframeworks.cc/openFrameworks_libs/$TARGET/libopenFrameworksDebug.bc;
 else
-    wget http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/libopenFrameworksDebug.a;
+    curl -L --retry 20 -O --progress http://ci.openframeworks.cc/openFrameworks_libs/$TARGET/libopenFrameworksDebug.a;
 fi

--- a/scripts/ci/android/install.sh
+++ b/scripts/ci/android/install.sh
@@ -11,7 +11,7 @@ fi
 # Install linux dependencies (for project generator to work)
 sudo $OF_ROOT/scripts/linux/ubuntu/install_dependencies.sh -y;
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 # Download NDK
 cd ~

--- a/scripts/ci/android/install.sh
+++ b/scripts/ci/android/install.sh
@@ -19,7 +19,7 @@ if [ "$(ls -A ${NDK_DIR})" ]; then
     ls -A ${NDK_DIR}
 else
     echo "Downloading NDK"
-    wget "https://dl.google.com/android/repository/$NDK_DIR-linux-x86_64.zip"
+    curl -L --retry 20 -O --progress "https://dl.google.com/android/repository/$NDK_DIR-linux-x86_64.zip"
     echo "Uncompressing NDK"
     unzip "$NDK_DIR-linux-x86_64.zip" > /dev/null 2>&1
 fi
@@ -30,5 +30,5 @@ rm -rf projectGenerator
 mkdir -p ~/projectGenerator
 cd ~/projectGenerator
 echo "Downloading projectGenerator from ci server"
-wget http://ci.openframeworks.cc/projectGenerator/projectGenerator_linux
+curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_linux
 chmod +x projectGenerator_linux

--- a/scripts/ci/android/install.sh
+++ b/scripts/ci/android/install.sh
@@ -11,7 +11,7 @@ fi
 # Install linux dependencies (for project generator to work)
 sudo $OF_ROOT/scripts/linux/ubuntu/install_dependencies.sh -y;
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 # Download NDK
 cd ~

--- a/scripts/ci/linuxarmv6l/install.sh
+++ b/scripts/ci/linuxarmv6l/install.sh
@@ -22,7 +22,7 @@ createRaspbianImg(){
     multistrap -a armhf -d raspbian -f multistrap.conf
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 downloadToolchain(){
     downloader http://ci.openframeworks.cc/rpi_toolchain.tar.bz2

--- a/scripts/ci/linuxarmv6l/install.sh
+++ b/scripts/ci/linuxarmv6l/install.sh
@@ -22,7 +22,7 @@ createRaspbianImg(){
     multistrap -a armhf -d raspbian -f multistrap.conf
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 downloadToolchain(){
     downloader http://ci.openframeworks.cc/rpi_toolchain.tar.bz2

--- a/scripts/ci/linuxarmv6l/install.sh
+++ b/scripts/ci/linuxarmv6l/install.sh
@@ -23,13 +23,13 @@ createRaspbianImg(){
 }
 
 downloadToolchain(){
-    wget http://ci.openframeworks.cc/rpi_toolchain.tar.bz2
+    curl -L --retry 20 -O --progress http://ci.openframeworks.cc/rpi_toolchain.tar.bz2
     tar xjf rpi_toolchain.tar.bz2
     rm rpi_toolchain.tar.bz2
 }
 
 downloadFirmware(){
-    wget https://github.com/raspberrypi/firmware/archive/master.zip -O firmware.zip
+    curl -L --retry 20 -O --progress https://github.com/raspberrypi/firmware/archive/master.zip -O firmware.zip
     unzip firmware.zip
     cp -r firmware-master/opt raspbian/
     rm -r firmware-master
@@ -37,16 +37,16 @@ downloadFirmware(){
 }
 
 relativeSoftLinks(){
-    for link in $(ls -la | grep "\-> /" | sed "s/.* \([^ ]*\) \-> \/\(.*\)/\1->\/\2/g"); do 
-        lib=$(echo $link | sed "s/\(.*\)\->\(.*\)/\1/g"); 
-        link=$(echo $link | sed "s/\(.*\)\->\(.*\)/\2/g"); 
+    for link in $(ls -la | grep "\-> /" | sed "s/.* \([^ ]*\) \-> \/\(.*\)/\1->\/\2/g"); do
+        lib=$(echo $link | sed "s/\(.*\)\->\(.*\)/\1/g");
+        link=$(echo $link | sed "s/\(.*\)\->\(.*\)/\2/g");
         rm $lib
-        ln -s ../../..$link $lib 
+        ln -s ../../..$link $lib
     done
 
-    for f in *; do 
-        error=$(grep " \/lib/" $f > /dev/null 2>&1; echo $?) 
-        if [ $error -eq 0 ]; then 
+    for f in *; do
+        error=$(grep " \/lib/" $f > /dev/null 2>&1; echo $?)
+        if [ $error -eq 0 ]; then
             sed -i "s/ \/lib/ ..\/..\/..\/lib/g" $f
             sed -i "s/ \/usr/ ..\/..\/..\/usr/g" $f
         fi

--- a/scripts/ci/linuxarmv7l/arch-bootstrap.sh
+++ b/scripts/ci/linuxarmv7l/arch-bootstrap.sh
@@ -48,7 +48,7 @@ extract_href() {
   sed -n '/<a / s/^.*<a [^>]*href="\([^\"]*\)".*$/\1/p'
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 fetch() {
   downloader "$@"

--- a/scripts/ci/linuxarmv7l/arch-bootstrap.sh
+++ b/scripts/ci/linuxarmv7l/arch-bootstrap.sh
@@ -36,8 +36,8 @@ acl archlinux-keyring attr bzip2 curl expat glibc gpgme libarchive  libassuan li
 )
 BASIC_PACKAGE_ARMS=(${PACMAN_PACKAGES_ARM[*]} filesystem)
 
-stderr() { 
-  echo "$@" >&2 
+stderr() {
+  echo "$@" >&2
 }
 
 debug() {
@@ -54,14 +54,14 @@ fetch() {
 
 uncompress() {
   local FILEPATH=$1 DEST=$2
-  
+
   case "$FILEPATH" in
     *.gz) tar xzf "$FILEPATH" -C "$DEST";;
     *.xz) xz -dc "$FILEPATH" | tar x -C "$DEST";;
     *) debug "Error: unknown package format: $FILEPATH"
        return 1;;
   esac
-}  
+}
 
 ###
 get_default_repo() {
@@ -101,27 +101,27 @@ configure_pacman() {
 
 configure_minimal_system() {
   local DEST=$1
-  
+
   mkdir -p "$DEST/dev"
-  echo "root:x:0:0:root:/root:/bin/bash" > "$DEST/etc/passwd" 
+  echo "root:x:0:0:root:/root:/bin/bash" > "$DEST/etc/passwd"
   echo 'root:$1$GT9AUpJe$oXANVIjIzcnmOpY07iaGi/:14657::::::' > "$DEST/etc/shadow"
   touch "$DEST/etc/group"
   echo "bootstrap" > "$DEST/etc/hostname"
-  
+
   test -e "$DEST/etc/mtab" || echo "rootfs / rootfs rw 0 0" > "$DEST/etc/mtab"
   #test -e "$DEST/dev/null" || mknod "$DEST/dev/null" c 1 3
   #test -e "$DEST/dev/random" || mknod -m 0644 "$DEST/dev/random" c 1 8
   #test -e "$DEST/dev/urandom" || mknod -m 0644 "$DEST/dev/urandom" c 1 9
   mount -o bind /dev $DEST/dev
   mount -o bind /proc $DEST/proc
-  
+
   sed -i "s/^[[:space:]]*\(CheckSpace\)/# \1/" "$DEST/etc/pacman.conf"
   sed -i "s/^[[:space:]]*SigLevel[[:space:]]*=.*$/SigLevel = Never/" "$DEST/etc/pacman.conf"
 }
 
 install_rpi_image(){
   mkdir -p $DEST/root/archlinux_arm
-  wget http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
+  curl -L --retry 20 -O --progress http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
   tar xzf ArchLinuxARM-rpi-2-latest.tar.gz -C $DEST/root/archlinux_arm
   echo "Server = http://eu.mirror.archlinuxarm.org/\$arch/\$repo" > $DEST/etc/pacman.d/mirrorlist
   sed -i "s/Architecture = auto/Architecture = armv7h/g" $DEST/etc/pacman.conf
@@ -137,8 +137,8 @@ install_rpi_image(){
 }
 
 fetch_packages_list() {
-  local REPO=$1 
-  
+  local REPO=$1
+
   debug "fetch packages list: $REPO/"
   fetch "$REPO/" | extract_href | awk -F"/" '{print $NF}' | sort -rn ||
     { debug "Error: cannot fetch packages list: $REPO"; return 1; }
@@ -147,12 +147,12 @@ fetch_packages_list() {
 install_pacman_packages() {
   local BASIC_PACKAGES=$1 DEST=$2 LIST=$3 DOWNLOAD_DIR=$4
   debug "pacman package and dependencies: $BASIC_PACKAGES"
-  
+
   for PACKAGE in $BASIC_PACKAGES; do
     local FILE=$(echo "$LIST" | grep -m1 "^$PACKAGE-[[:digit:]].*\(\.gz\|\.xz\)$")
     test "$FILE" || { debug "Error: cannot find package: $PACKAGE"; return 1; }
     local FILEPATH="$DOWNLOAD_DIR/$FILE"
-    
+
     debug "download package: $REPO/$FILE"
     fetch -o "$FILEPATH" "$REPO/$FILE"
     debug "uncompress package: $FILEPATH"
@@ -194,7 +194,7 @@ main() {
   local REPO_URL=
   local USE_QEMU=
   local DOWNLOAD_DIR=
-  
+
   while getopts "qa:r:d:h" ARG; do
     case "$ARG" in
       a) ARCH=$OPTARG;;
@@ -206,10 +206,10 @@ main() {
   done
   shift $(($OPTIND-1))
   test $# -eq 1 || { show_usage; return 1; }
-  
+
   [[ -z "$ARCH" ]] && ARCH=$(uname -m)
   [[ -z "$REPO_URL" ]] &&REPO_URL=$(get_default_repo "$ARCH")
-  
+
   local DEST=$1
   local REPO=$(get_core_repo_url "$REPO_URL" "$ARCH")
   [[ -z "$DOWNLOAD_DIR" ]] && DOWNLOAD_DIR=$(mktemp -d)
@@ -218,7 +218,7 @@ main() {
   debug "destination directory: $DEST"
   debug "core repository: $REPO"
   debug "temporary directory: $DOWNLOAD_DIR"
-  
+
   # Fetch packages, install system and do a minimal configuration
   mkdir -p "$DEST"
   local LIST=$(fetch_packages_list $REPO)
@@ -230,7 +230,7 @@ main() {
   configure_pacman "$DEST" "$ARCH" # Pacman must be re-configured
   [[ "$DOWNLOAD_DIR" ]] && rm -rf "$DOWNLOAD_DIR"
   install_rpi_image
-  
+
   debug "done"
 }
 

--- a/scripts/ci/linuxarmv7l/arch-bootstrap.sh
+++ b/scripts/ci/linuxarmv7l/arch-bootstrap.sh
@@ -48,7 +48,7 @@ extract_href() {
   sed -n '/<a / s/^.*<a [^>]*href="\([^\"]*\)".*$/\1/p'
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 fetch() {
   downloader "$@"

--- a/scripts/ci/linuxarmv7l/arch-bootstrap_downloadonly.sh
+++ b/scripts/ci/linuxarmv7l/arch-bootstrap_downloadonly.sh
@@ -67,7 +67,7 @@ extract_href() {
   sed -n '/<a / s/^.*<a [^>]*href="\([^\"]*\)".*$/\1/p'
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 fetch() {
   downloader "$@"

--- a/scripts/ci/linuxarmv7l/arch-bootstrap_downloadonly.sh
+++ b/scripts/ci/linuxarmv7l/arch-bootstrap_downloadonly.sh
@@ -67,7 +67,7 @@ extract_href() {
   sed -n '/<a / s/^.*<a [^>]*href="\([^\"]*\)".*$/\1/p'
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 fetch() {
   downloader "$@"

--- a/scripts/ci/linuxarmv7l/install.sh
+++ b/scripts/ci/linuxarmv7l/install.sh
@@ -15,7 +15,7 @@ trapError() {
 	exit 1
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 
 createArchImg(){
     #sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libasound2-dev
@@ -29,8 +29,8 @@ createArchImg(){
         #$ROOT/arch-bootstrap_downloadonly.sh -a armv7h -r "http://eu.mirror.archlinuxarm.org/" ~/archlinux
 		junest -u << EOF
 			cd ~
-			downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
-			downloader "http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz"
+			downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+			downloader http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
 			mkdir archlinux
 		    tar xzf ArchLinuxARM-rpi-2-latest.tar.gz -C archlinux/ 2> /dev/null
 			sed -i s_/etc/pacman_$HOME/archlinux/etc/pacman_g archlinux/etc/pacman.conf
@@ -53,8 +53,8 @@ downloadToolchain(){
 		if [ -f x-tools7h.tar.xz ]; then
 			rm x-tools7h.tar.xz
 		fi
-		downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
-		downloader "http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz"
+		downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+		downloader http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz
 	    tar -x --delay-directory-restore --no-same-owner -f x-tools7h.tar.xz -C ~/
 	    rm x-tools7h.tar.xz
 EOF
@@ -69,7 +69,7 @@ downloadFirmware(){
         echo "Using cached RPI2 firmware-master"
     else
         cd ~
-        downloader "https://github.com/raspberrypi/firmware/archive/master.zip" firmware.zip
+        downloader https://github.com/raspberrypi/firmware/archive/master.zip firmware.zip
         unzip firmware.zip
     fi
     ${SUDO} cp -r ~/firmware-master/opt archlinux/

--- a/scripts/ci/linuxarmv7l/install.sh
+++ b/scripts/ci/linuxarmv7l/install.sh
@@ -27,7 +27,7 @@ createArchImg(){
         #$ROOT/arch-bootstrap_downloadonly.sh -a armv7h -r "http://eu.mirror.archlinuxarm.org/" ~/archlinux
 		junest -u << EOF
 			cd ~
-			wget http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
+			curl -L --retry 20 -O --progress http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
 			mkdir archlinux
 		    tar xzf ArchLinuxARM-rpi-2-latest.tar.gz -C archlinux/ 2> /dev/null
 			sed -i s_/etc/pacman_$HOME/archlinux/etc/pacman_g archlinux/etc/pacman.conf
@@ -50,11 +50,11 @@ downloadToolchain(){
 		if [ -f x-tools7h.tar.xz ]; then
 			rm x-tools7h.tar.xz
 		fi
-		wget http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz
+		curl -L --retry 20 -O --progress http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz
 	    tar -x --delay-directory-restore --no-same-owner -f x-tools7h.tar.xz -C ~/
 	    rm x-tools7h.tar.xz
 EOF
-        #wget http://ci.openframeworks.cc/rpi2_toolchain.tar.bz2
+        #curl -L --retry 20 -O --progress http://ci.openframeworks.cc/rpi2_toolchain.tar.bz2
         #tar xjf rpi2_toolchain.tar.bz2 -C ~/
         #rm rpi2_toolchain.tar.bz2
     fi
@@ -65,7 +65,7 @@ downloadFirmware(){
         echo "Using cached RPI2 firmware-master"
     else
         cd ~
-        wget https://github.com/raspberrypi/firmware/archive/master.zip -O firmware.zip
+        curl -L --retry 20 -O --progress https://github.com/raspberrypi/firmware/archive/master.zip -O firmware.zip
         unzip firmware.zip
     fi
     ${SUDO} cp -r ~/firmware-master/opt archlinux/
@@ -94,7 +94,7 @@ relativeSoftLinks(){
 
 installRtAudio(){
     #cd $ROOT
-    #wget http://www.music.mcgill.ca/~gary/rtaudio/release/rtaudio-4.1.1.tar.gz
+    #curl -L --retry 20 -O --progress http://www.music.mcgill.ca/~gary/rtaudio/release/rtaudio-4.1.1.tar.gz
     #tar xzf rtaudio-4.1.1.tar.gz
     #cd rtaudio-4.1.1
     #./configure --host=${GCC_PREFIX}
@@ -108,7 +108,7 @@ installRtAudio(){
     #rm rtaudio-4.1.1.tar.gz
     #rm -r rtaudio-4.1.1
     cd ~/archlinux
-    wget http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
+    curl -L --retry 20 -O --progress http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
     tar xjf rtaudio-armv7hf.tar.bz2
     rm rtaudio-armv7hf.tar.bz2
 }

--- a/scripts/ci/linuxarmv7l/install.sh
+++ b/scripts/ci/linuxarmv7l/install.sh
@@ -29,7 +29,8 @@ createArchImg(){
         #$ROOT/arch-bootstrap_downloadonly.sh -a armv7h -r "http://eu.mirror.archlinuxarm.org/" ~/archlinux
 		junest -u << EOF
 			cd ~
-			downloader http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
+			downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+			downloader "http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz"
 			mkdir archlinux
 		    tar xzf ArchLinuxARM-rpi-2-latest.tar.gz -C archlinux/ 2> /dev/null
 			sed -i s_/etc/pacman_$HOME/archlinux/etc/pacman_g archlinux/etc/pacman.conf
@@ -52,7 +53,8 @@ downloadToolchain(){
 		if [ -f x-tools7h.tar.xz ]; then
 			rm x-tools7h.tar.xz
 		fi
-		downloader http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz
+		downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+		downloader "http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz"
 	    tar -x --delay-directory-restore --no-same-owner -f x-tools7h.tar.xz -C ~/
 	    rm x-tools7h.tar.xz
 EOF
@@ -67,7 +69,7 @@ downloadFirmware(){
         echo "Using cached RPI2 firmware-master"
     else
         cd ~
-        downloader --progress https://github.com/raspberrypi/firmware/archive/master.zip -O firmware.zip
+        downloader "https://github.com/raspberrypi/firmware/archive/master.zip" firmware.zip
         unzip firmware.zip
     fi
     ${SUDO} cp -r ~/firmware-master/opt archlinux/

--- a/scripts/ci/linuxarmv7l/install.sh
+++ b/scripts/ci/linuxarmv7l/install.sh
@@ -15,7 +15,7 @@ trapError() {
 	exit 1
 }
 
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 
 createArchImg(){
     #sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libasound2-dev
@@ -29,7 +29,7 @@ createArchImg(){
         #$ROOT/arch-bootstrap_downloadonly.sh -a armv7h -r "http://eu.mirror.archlinuxarm.org/" ~/archlinux
 		junest -u << EOF
 			cd ~
-			downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+			downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 			downloader http://archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz
 			mkdir archlinux
 		    tar xzf ArchLinuxARM-rpi-2-latest.tar.gz -C archlinux/ 2> /dev/null
@@ -53,7 +53,7 @@ downloadToolchain(){
 		if [ -f x-tools7h.tar.xz ]; then
 			rm x-tools7h.tar.xz
 		fi
-		downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+		downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 		downloader http://archlinuxarm.org/builder/xtools/x-tools7h.tar.xz
 	    tar -x --delay-directory-restore --no-same-owner -f x-tools7h.tar.xz -C ~/
 	    rm x-tools7h.tar.xz

--- a/scripts/ci/vs/install.sh
+++ b/scripts/ci/vs/install.sh
@@ -3,7 +3,7 @@ cd ~/
 rm -rf projectGenerator
 mkdir -p ~/projectGenerator
 cd ~/projectGenerator
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
 echo "Downloading projectGenerator from ci server"
 downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
 unzip projectGenerator-vs.zip 2> /dev/null

--- a/scripts/ci/vs/install.sh
+++ b/scripts/ci/vs/install.sh
@@ -4,7 +4,7 @@ rm -rf projectGenerator
 mkdir -p ~/projectGenerator
 cd ~/projectGenerator
 echo "Downloading projectGenerator from ci server"
-wget http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
+curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
 unzip projectGenerator-vs.zip 2> /dev/null
 rm projectGenerator-vs.zip
 

--- a/scripts/ci/vs/install.sh
+++ b/scripts/ci/vs/install.sh
@@ -3,7 +3,7 @@ cd ~/
 rm -rf projectGenerator
 mkdir -p ~/projectGenerator
 cd ~/projectGenerator
-downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3; else wget $1 $2 $3; fi; }
+downloader() { if command -v wget 2>/dev/null; then wget $1 $2 $3; else curl -LO --retry 20 -O --progress $1 $2 $3; fi; }
 echo "Downloading projectGenerator from ci server"
 downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
 unzip projectGenerator-vs.zip 2> /dev/null

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -93,7 +93,7 @@ fi
 
 cd $packageroot
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
 
 function deleteCodeblocks {
     #delete codeblock files

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -2,7 +2,7 @@
 # $1 -> platform: msys2, linux, linux64, vs, osx, ios, all
 # $2 -> version number: 006
 #
-# This script removes folders clones the openFrameworks repo 
+# This script removes folders clones the openFrameworks repo
 # and deletes parts of it to create the final package.
 # Do not try to modify it to run over your local install of
 # openFrameworks or it'll remove it along with any projects it
@@ -35,7 +35,7 @@ PG_BRANCH=$branch
 hostArch=`uname`
 
 if [ "$platform" != "msys2" ] && [ "$platform" != "linux" ] && [ "$platform" != "linux64" ] && [ "$platform" != "linuxarmv6l" ] && [ "$platform" != "linuxarmv7l" ] && [ "$platform" != "vs" ] && [ "$platform" != "osx" ] && [ "$platform" != "android" ] && [ "$platform" != "ios" ]; then
-    echo usage: 
+    echo usage:
     echo ./create_package.sh platform version
     echo platform:
     echo msys2, linux, linux64, linuxarmv6l, linuxarmv7l, vs, osx, android, ios, all
@@ -43,11 +43,11 @@ if [ "$platform" != "msys2" ] && [ "$platform" != "linux" ] && [ "$platform" != 
 fi
 
 if [ "$version" == "" ]; then
-    echo usage: 
+    echo usage:
     echo ./create_package.sh platform version [branch]
     echo platform:
     echo msys2, linux, linux64, vs, osx, android, ios, all
-    echo 
+    echo
     echo branch:
     echo master, stable
     exit 1
@@ -61,7 +61,7 @@ echo "Creating package $version for $platform $libs_abi"
 echo --------------------------------------------------------------------------
 echo
 
-# This script removes folders clones the openFrameworks repo 
+# This script removes folders clones the openFrameworks repo
 # and deletes parts of it to create the final package.
 # Do not try to modify it to run over your local install of
 # openFrameworks or it'll remove it along with any projects it
@@ -71,7 +71,7 @@ echo
 pkgfolder=openFrameworks_pkg_creation
 
 rm -rf ${pkgfolder}
-echo "Cloning OF from $REPO $BRANCH" 
+echo "Cloning OF from $REPO $BRANCH"
 git clone $REPO --depth=1 --branch=$BRANCH ${pkgfolder} 2> /dev/null
 gitfinishedok=$?
 if [ $gitfinishedok -ne 0 ]; then
@@ -83,7 +83,7 @@ cd ${pkgfolder}
 packageroot=$PWD
 
 cd apps
-echo "Cloning project generator from $PG_REPO $PG_BRANCH" 
+echo "Cloning project generator from $PG_REPO $PG_BRANCH"
 git clone $PG_REPO --depth=1 --branch=$PG_BRANCH 2> /dev/null
 gitfinishedok=$?
 if [ $gitfinishedok -ne 0 ]; then
@@ -155,16 +155,16 @@ function createPackage {
     pkg_version=$2
     pkg_ofroot=$3
     main_ofroot=$4
-    
-    #remove previously created package 
+
+    #remove previously created package
     cd $pkg_ofroot/..
 	rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}.*
 	rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_*
     echo "Creating package $pkg_platform $version in $pkg_ofroot"
-    
+
     #remove devApps folder
     rm -r $pkg_ofroot/apps/devApps
-    
+
     #remove projectGenerator folder
     if [ "$pkg_platform" = "android" ] || [ "$pkg_platform" = "msys2" ]; then
     	rm -rf $pkg_ofroot/apps/projectGenerator
@@ -173,18 +173,18 @@ function createPackage {
 	cd $pkg_ofroot/examples
 
 	#delete ios examples in other platforms
-	if [ "$pkg_platform" != "ios" ]; then 
+	if [ "$pkg_platform" != "ios" ]; then
 		rm -Rf ios
 		rm -Rf tvOS
 	fi
 
 	#delete android examples in other platforms
-	if [ "$pkg_platform" != "android" ]; then 
+	if [ "$pkg_platform" != "android" ]; then
 		rm -Rf android
 	fi
 
 	#delete desktop examples in mobile packages
-	if [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then 
+	if [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then
 		rm -Rf 3d
 		rm -Rf communication
 		rm -Rf computer_vision
@@ -201,25 +201,25 @@ function createPackage {
 		rm -Rf templates
 		rm -Rf threads
 		rm -Rf video
-	fi 
-	
+	fi
+
 	#delete osx examples in linux
 	if [ "$pkg_platform" == "linux" ] || [ "$pkg_platform" == "linux64" ] || [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ]; then
 	    rm -Rf video/osxHighPerformanceVideoPlayerExample
 	    rm -Rf video/osxVideoRecorderExample
 	fi
-	
+
 	if [ "$pkg_platform" == "linux" ] || [ "$pkg_platform" == "linux64" ]; then
 	    rm -Rf gles
 	fi
-	
+
 	if [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ]; then
 	    rm -Rf addons/3DModelLoaderExample
         rm -Rf addons/allAddonsExample
         rm -Rf addons/assimpExample
         rm -Rf addons/kinectExample
         rm -Rf addons/vectorGraphicsExample
-        
+
 	    rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
         rm -Rf gl/billboardExample
@@ -235,40 +235,40 @@ function createPackage {
         rm -Rf gl/pixelBufferExample
         rm -Rf gl/textureBufferInstancedExample
         rm -Rf gl/threadedPixelBufferExample
-  
+
         rm -Rf utils/systemSpeakExample
         rm -Rf utils/fileBufferLoadingCSVExample
-        
+
         rm -Rf 3d/modelNoiseExample
     fi
-    
+
     if [ "$pkg_platform" == "linuxarmv6l" ]; then
         rm -Rf utils/dragDropExample
         rm -Rf utils/fileOpenSaveDialogExample
 	fi
-	
+
 	if [ "$pkg_platform" == "msys2" ] || [ "$pkg_platform" == "vs" ]; then
 	    rm -Rf video/osxHighPerformanceVideoPlayerExample
 	    rm -Rf video/osxVideoRecorderExample
 	    rm -Rf gles
 	fi
-	
+
 	if [ "$pkg_platform" == "osx" ]; then
 	    rm -Rf gles
 	    rm -Rf gl/computeShaderParticlesExample
 	    rm -Rf gl/computeShaderTextureExample
 	fi
-	
-	
-	
+
+
+
 	#delete tutorials by now
 	rm -Rf $pkg_ofroot/tutorials
-    
-	
-	
+
+
+
     #create project files for platform
     createProjectFiles $pkg_platform $pkg_ofroot
-	
+
 
     #delete other platform libraries
     if [ "$pkg_platform" = "linux" ]; then
@@ -282,11 +282,11 @@ function createPackage {
     if [ "$pkg_platform" = "linuxarmv6l" ]; then
         otherplatforms="linux64 linux linuxarmv7l osx msys2 vs ios tvos android"
     fi
-    
+
     if [ "$pkg_platform" = "linuxarmv7l" ]; then
         otherplatforms="linux64 linux linuxarmv6l osx msys2 vs ios tvos android"
     fi
-    
+
     if [ "$pkg_platform" = "osx" ]; then
         otherplatforms="linux linux64 linuxarmv6l linuxarmv7l msys2 vs ios tvos android"
     fi
@@ -306,8 +306,8 @@ function createPackage {
     if [ "$pkg_platform" = "android" ]; then
         otherplatforms="linux linux64 linuxarmv6l linuxarmv7l osx msys2 vs ios tvos"
     fi
-    
-    
+
+
 	#download and uncompress PG
 	echo "Creating projectGenerator"
 	mkdir -p $HOME/.tmp
@@ -320,7 +320,7 @@ function createPackage {
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
 		cd ${pkg_ofroot}/projectGenerator-vs/resources/app/app/
-		wget http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
+		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
 		unzip projectGenerator-vs.zip 2> /dev/null
 		rm projectGenerator-vs.zip
 		cd ${pkg_ofroot}
@@ -333,7 +333,7 @@ function createPackage {
 		mv dist/projectGenerator-darwin-x64 ${pkg_ofroot}/projectGenerator-osx
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
-		wget http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-osx/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
+		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-osx/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
 		sed -i "s/osx/osx/g" projectGenerator-osx/projectGenerator.app/Contents/Resources/app/settings.json
 	fi
     if [ "$pkg_platform" = "ios" ]; then
@@ -343,10 +343,10 @@ function createPackage {
 		mv dist/projectGenerator-darwin-x64 ${pkg_ofroot}/projectGenerator-ios
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
-		wget http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-ios/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
+		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-ios/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
 		sed -i "s/osx/ios/g" projectGenerator-ios/projectGenerator.app/Contents/Resources/app/settings.json
 	fi
-	
+
 	if [ "$pkg_platform" = "linux" ]; then
 		cd ${pkg_ofroot}/apps/projectGenerator/frontend
 		npm install > /dev/null
@@ -355,7 +355,7 @@ function createPackage {
 		cd ${pkg_ofroot}
 		sed -i "s/osx/linux/g" projectGenerator-linux/resources/app/settings.json
 	fi
-	
+
 	if [ "$pkg_platform" = "linux64" ]; then
 		cd ${pkg_ofroot}/apps/projectGenerator/frontend
 		npm install > /dev/null
@@ -364,7 +364,7 @@ function createPackage {
 		cd ${pkg_ofroot}
 		sed -i "s/osx/linux64/g" projectGenerator-linux64/resources/app/settings.json
 	fi
-	
+
 	# linux remove other platform projects from PG source and copy ofxGui
 	if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxarmv7l" ]; then
 	    cd ${pkg_ofroot}
@@ -401,7 +401,7 @@ function createPackage {
     elif [ "$pkg_platform" = "ios" ]; then
         scripts/ios/download_libs.sh
     fi
-    
+
 	#delete ofxAndroid in non android
 	if [ "$pkg_platform" != "android" ]; then
 		rm -Rf ofxAndroid
@@ -413,20 +413,20 @@ function createPackage {
 		rm -Rf ofxiOS
 		rm -Rf ofxUnitTests
 	fi
-	
+
 	#delete ofxMultiTouch & ofxAccelerometer in non mobile
 	if [ "$pkg_platform" != "android" ] && [ "$pkg_platform" != "ios" ]; then
 		rm -Rf ofxMultiTouch
 		rm -Rf ofxAccelerometer
 		rm -Rf ofxUnitTests
 	fi
-	
+
 	if [ "$pkg_platform" == "ios" ] || [ "$pkg_platform" == "android" ]; then
 	    rm -Rf ofxVectorGraphics
    	    rm -Rf ofxKinect
 		rm -Rf ofxUnitTests
 	fi
-	
+
 	#delete unit tests by now
 	rm -Rf ${pkg_ofroot}/tests
 
@@ -438,7 +438,7 @@ function createPackage {
     		rm -R libs/openFrameworks/.settings
     	fi
 	fi
-	
+
 	#android, move paths.default.make to paths.make
 	if [ "$pkg_platform" == "android" ]; then
 	    cd ${pkg_ofroot}
@@ -458,12 +458,12 @@ function createPackage {
 	else
     	rm -Rf msys2 vs osx ios
 	fi
-	
+
     #delete omap4 scripts for non armv7l
 	if [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linuxarmv6l" ]; then
 	    rm -Rf linux/ubuntu-omap4
 	fi
-	
+
 	if [ "$pkg_platform" == "ios" ]; then
 		rm -Rf osx
 	fi
@@ -471,11 +471,11 @@ function createPackage {
     #delete .svn dirs
     cd $pkg_ofroot
     rm -Rf $(find . -type d -name .svn)
-    
-    #delete .gitignore 
+
+    #delete .gitignore
     cd $pkg_ofroot
     rm -Rf $(find . -name .gitignore)
-    
+
     #delete dev folders
     cd ${pkg_ofroot}/scripts
     rm -Rf dev
@@ -489,21 +489,21 @@ function createPackage {
     echo ----------------------------------------------------------------------
     echo
     echo
-    
+
     #choose readme
     cd $pkg_ofroot
     if [ "$platform" = "linux" ] || [ "$platform" = "linux64" ] || [ "$platform" = "linuxarmv6l" ] || [ "$platform" = "linuxarmv7l" ]; then
         cp docs/linux.md INSTALL.md
     fi
-    
+
     if [ "$platform" = "vs" ]; then
         cp docs/visualstudio.md INSTALL.md
     fi
-    
+
     if [ "$platform" = "msys2" ]; then
         cp docs/msys2.md INSTALL.md
     fi
-    
+
     if [ "$platform" = "osx" ] || [ "$platform" = "ios" ]; then
         cp docs/osx.md INSTALL.md
     fi
@@ -512,12 +512,12 @@ function createPackage {
         cp docs/android_eclipse.md INSTALL_ECLIPSE.md
         cp docs/android_studio.md INSTALL_ANDROID_STUDIO.md
     fi
-    
+
     rm CONTRIBUTING.md
 
     #copy empty example
     cd $pkg_ofroot
-    mkdir -p apps/myApps 
+    mkdir -p apps/myApps
     if [ "$pkg_platform" = "android" ]; then
         cp -r examples/android/androidEmptyExample apps/myApps/
     elif [ "$pkg_platform" = "ios" ]; then
@@ -525,7 +525,7 @@ function createPackage {
     else
         cp -r examples/templates/emptyExample apps/myApps/
     fi
-    
+
     #create compressed package
     if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "android" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxarmv7l" ]; then
         echo "compressing package to of_v${pkg_version}_${pkg_platform}${libs_abi}_release.tar.gz"
@@ -550,8 +550,8 @@ set -o nounset   # set -u : exit the script if you try to use an uninitialized v
 set -o errexit   # set -e : exit the script if any statement returns a non-true return value
 
 cleanup() {
-    cd $packageroot/..  
-    rm -rf ${pkgfolder} 
+    cd $packageroot/..
+    rm -rf ${pkgfolder}
     rm -rf $HOME/.tmp/npm*
 }
 trap cleanup 0
@@ -570,6 +570,6 @@ error() {
 }
 trap 'error ${LINENO}' ERR
 
-createPackage $platform $version $packageroot $of_root    
+createPackage $platform $version $packageroot $of_root
 
- 
+

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -93,6 +93,7 @@ fi
 
 cd $packageroot
 
+downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
 
 function deleteCodeblocks {
     #delete codeblock files
@@ -320,7 +321,7 @@ function createPackage {
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
 		cd ${pkg_ofroot}/projectGenerator-vs/resources/app/app/
-		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip 2> /dev/null
+		downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator-vs.zip
 		unzip projectGenerator-vs.zip 2> /dev/null
 		rm projectGenerator-vs.zip
 		cd ${pkg_ofroot}
@@ -333,7 +334,7 @@ function createPackage {
 		mv dist/projectGenerator-darwin-x64 ${pkg_ofroot}/projectGenerator-osx
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
-		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-osx/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
+		downloader http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-osx/projectGenerator.app/Contents/Resources/app/app/projectGenerator
 		sed -i "s/osx/osx/g" projectGenerator-osx/projectGenerator.app/Contents/Resources/app/settings.json
 	fi
     if [ "$pkg_platform" = "ios" ]; then
@@ -343,7 +344,7 @@ function createPackage {
 		mv dist/projectGenerator-darwin-x64 ${pkg_ofroot}/projectGenerator-ios
 		cd ${pkg_ofroot}
 		rm -rf apps/projectGenerator
-		curl -L --retry 20 -O --progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-ios/projectGenerator.app/Contents/Resources/app/app/projectGenerator 2> /dev/null
+		downloader progress http://ci.openframeworks.cc/projectGenerator/projectGenerator_osx -O projectGenerator-ios/projectGenerator.app/Contents/Resources/app/app/projectGenerator
 		sed -i "s/osx/ios/g" projectGenerator-ios/projectGenerator.app/Contents/Resources/app/settings.json
 	fi
 

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -28,7 +28,7 @@ cat << EOF
 EOF
 }
 
-function downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1; else wget $1; fi; }
+function downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1; else wget $1; fi; }
 
 download(){
     echo "Downloading $1"

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -30,7 +30,7 @@ EOF
 
 download(){
     echo "Downloading $1"
-    wget ci.openframeworks.cc/libs/$1 $SILENT_ARGS
+    curl -L --retry 20 -O --progress ci.openframeworks.cc/libs/$1 $SILENT_ARGS
 }
 
 # trap any script errors and exit

--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -70,7 +70,7 @@ mv /var/www/versions/nightly/of_v${lastversion}_android_release.tar.gz /var/www/
 mv /var/www/versions/nightly/of_v${lastversion}_linuxarmv6l_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linuxarmv6l_nightly.tar.gz
 mv /var/www/versions/nightly/of_v${lastversion}_linuxarmv7l_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linuxarmv7l_nightly.tar.gz
 
-echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'> /var/www/nightlybuilds.html
 echo '<html>' >> /var/www/nightlybuilds.html
 echo '<head>' >> /var/www/nightlybuilds.html
@@ -91,9 +91,9 @@ done
 echo '</body>' >> /var/www/nightlybuilds.html
 echo '</html>' >> /var/www/nightlybuilds.html
 
-#wget http://openframeworks.cc/nightly_hook.php?version=${lastversion} -O /dev/null
+#curl -L --retry 20 -O --progress http://openframeworks.cc/nightly_hook.php?version=${lastversion} -O /dev/null
 
-echo 
+echo
 echo
 echo "Successfully created nightly builds for ${lastversion}"
 echo

--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -10,7 +10,7 @@ set -o errtrace  # trace ERR through 'time command' and other functions
 set -o nounset   # set -u : exit the script if you try to use an uninitialized variable
 set -o errexit   # set -e : exit the script if any statement returns a non-true return value
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
 
 error() {
   local parent_lineno="$1"

--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -10,6 +10,8 @@ set -o errtrace  # trace ERR through 'time command' and other functions
 set -o nounset   # set -u : exit the script if you try to use an uninitialized variable
 set -o errexit   # set -e : exit the script if any statement returns a non-true return value
 
+downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+
 error() {
   local parent_lineno="$1"
   if [[ "$#" = "3" ]] ; then
@@ -91,7 +93,7 @@ done
 echo '</body>' >> /var/www/nightlybuilds.html
 echo '</html>' >> /var/www/nightlybuilds.html
 
-#curl -L --retry 20 -O --progress http://openframeworks.cc/nightly_hook.php?version=${lastversion} -O /dev/null
+#downloader http://openframeworks.cc/nightly_hook.php?version=${lastversion} -O 
 
 echo
 echo

--- a/scripts/dev/release.sh
+++ b/scripts/dev/release.sh
@@ -7,6 +7,8 @@ set -o errtrace  # trace ERR through 'time command' and other functions
 set -o nounset   # set -u : exit the script if you try to use an uninitialized variable
 set -o errexit   # set -e : exit the script if any statement returns a non-true return value
 
+downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+
 error() {
   local parent_lineno="$1"
   if [[ "$#" = "3" ]] ; then
@@ -55,7 +57,7 @@ mkdir -p /var/www/versions/v${version}
 mv *.tar.gz /var/www/versions/v${version}
 mv *.zip /var/www/versions/v${version}
 
-curl -L --retry 20 -O --progress http://openframeworks.cc/release_hook.php?version=${version} -O /dev/null
+downloader http://openframeworks.cc/release_hook.php?version=${version}
 
 cd $(cat ~/.ofprojectgenerator/config)
 git checkout master

--- a/scripts/dev/release.sh
+++ b/scripts/dev/release.sh
@@ -55,7 +55,7 @@ mkdir -p /var/www/versions/v${version}
 mv *.tar.gz /var/www/versions/v${version}
 mv *.zip /var/www/versions/v${version}
 
-wget http://openframeworks.cc/release_hook.php?version=${version} -O /dev/null
+curl -L --retry 20 -O --progress http://openframeworks.cc/release_hook.php?version=${version} -O /dev/null
 
 cd $(cat ~/.ofprojectgenerator/config)
 git checkout master

--- a/scripts/dev/release.sh
+++ b/scripts/dev/release.sh
@@ -7,7 +7,7 @@ set -o errtrace  # trace ERR through 'time command' and other functions
 set -o nounset   # set -u : exit the script if you try to use an uninitialized variable
 set -o errexit   # set -e : exit the script if any statement returns a non-true return value
 
-downloader() { if command -v curl 2>/dev/null; then curl -L --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
 
 error() {
   local parent_lineno="$1"

--- a/scripts/linux/archlinux_armv7/install_dependencies.sh
+++ b/scripts/linux/archlinux_armv7/install_dependencies.sh
@@ -10,9 +10,11 @@ if [ $EUID != 0 ]; then
    exit 1
 fi
 
+downloader() { if command -v curl 2>/dev/null; then curl -LO --retry 20 -O --progress $1 $2 $3 2> /dev/null; else wget $1 $2 $3 2> /dev/null; fi; }
+
 pacman -Sy --needed make pkg-config gcc openal glew freeglut freeimage freetype2 cairo poco gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav raspberrypi-firmware gst-omx-rpi assimp boost libxcursor opencv assimp glfw-x11  uriparser curl pugixml
 
-curl -L --retry 20 -O --progress http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
+downloader http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
 tar xjf rtaudio-armv7hf.tar.bz2 -C /
 
 exit_code=$?

--- a/scripts/linux/archlinux_armv7/install_dependencies.sh
+++ b/scripts/linux/archlinux_armv7/install_dependencies.sh
@@ -12,7 +12,7 @@ fi
 
 pacman -Sy --needed make pkg-config gcc openal glew freeglut freeimage freetype2 cairo poco gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav raspberrypi-firmware gst-omx-rpi assimp boost libxcursor opencv assimp glfw-x11  uriparser curl pugixml
 
-wget http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
+curl -L --retry 20 -O --progress http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
 tar xjf rtaudio-armv7hf.tar.bz2 -C /
 
 exit_code=$?

--- a/scripts/linux/ubuntu/install_dependencies.sh
+++ b/scripts/linux/ubuntu/install_dependencies.sh
@@ -155,7 +155,7 @@ else
     # tools for git use
     GLFW_GIT_TAG=$GLFW_VER
     apt-get install -y -qq libxrandr-dev libxinerama-dev libxcursor-dev cmake
-    curl -L --retry 20 -O --progress https://github.com/glfw/glfw/archive/$GLFW_GIT_TAG.tar.gz -O glfw-$GLFW_GIT_TAG.tar.gz
+    curl -LO --retry 20 -O --progress https://github.com/glfw/glfw/archive/$GLFW_GIT_TAG.tar.gz -O glfw-$GLFW_GIT_TAG.tar.gz
     tar -xf glfw-$GLFW_GIT_TAG.tar.gz
 	mv glfw-$GLFW_GIT_TAG glfw
 	rm glfw-$GLFW_GIT_TAG.tar.gz

--- a/scripts/linux/ubuntu/install_dependencies.sh
+++ b/scripts/linux/ubuntu/install_dependencies.sh
@@ -155,7 +155,7 @@ else
     # tools for git use
     GLFW_GIT_TAG=$GLFW_VER
     apt-get install -y -qq libxrandr-dev libxinerama-dev libxcursor-dev cmake
-    wget https://github.com/glfw/glfw/archive/$GLFW_GIT_TAG.tar.gz -O glfw-$GLFW_GIT_TAG.tar.gz
+    curl -L --retry 20 -O --progress https://github.com/glfw/glfw/archive/$GLFW_GIT_TAG.tar.gz -O glfw-$GLFW_GIT_TAG.tar.gz
     tar -xf glfw-$GLFW_GIT_TAG.tar.gz
 	mv glfw-$GLFW_GIT_TAG glfw
 	rm glfw-$GLFW_GIT_TAG.tar.gz


### PR DESCRIPTION
Fixes #5371 

Replace `wget $URL` with `curl -L --retry 20 -O --progress $URL`

`-L` follows redirects (the default for `wget`).
`--retry 20` retries failed connections 20 times (the default for `wget`).
`-O` saves the target file with the name on the server (the default for `wget`).
`--progress` Uses a `wget`-like progress bar rather than default curl "meters".