### PR TITLE
fix framebuffer/screen mouse mapping on HiDPi

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1477,26 +1477,35 @@ void ofAppGLFWWindow::char_cb(GLFWwindow* windowP_, uint32_t key){
 }
 
 //------------------------------------------------------------
-void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_,int w, int h) {
+void ofAppGLFWWindow::resize_cb(GLFWwindow* windowP_, int w, int h) {
 	ofAppGLFWWindow * instance = setCurrent(windowP_);
 
-    //detect if the window is running in a retina mode
-    int framebufferW, framebufferH;
+    // Detect if the window is running in a retina mode
+	
+    int framebufferW, framebufferH; // <- physical pixel extents
     glfwGetFramebufferSize(windowP_, &framebufferW, &framebufferH);
-    instance->pixelScreenCoordScale = framebufferW / w;
-
+	
+	int windowW, windowH; // <- screen coordinates, which may be scaled
+	glfwGetWindowSize(windowP_, &windowW, &windowH);
+	
+	// Find scale factor needed to transform from screen coordinates
+	// to physical pixel coordinates
+	instance->pixelScreenCoordScale = (float)framebufferW / (float)windowW;
+	
 	if(instance->windowMode == OF_WINDOW){
-		instance->windowW = w * instance->pixelScreenCoordScale;
-		instance->windowH = h * instance->pixelScreenCoordScale;
+		instance->windowW = framebufferW;
+		instance->windowH = framebufferH;
 	}
-	instance->currentW = w;
-	instance->currentH = h;
-	instance->events().notifyWindowResized(w*instance->pixelScreenCoordScale, h*instance->pixelScreenCoordScale);
+	
+	instance->currentW = windowW;
+	instance->currentH = windowH;
+	instance->events().notifyWindowResized(framebufferW, framebufferH);
 	instance->nFramesSinceWindowResized = 0;
 }
 
+//------------------------------------------------------------
 void ofAppGLFWWindow::framebuffer_size_cb(GLFWwindow* windowP_, int w, int h){
-	resize_cb(windowP_, w,h);
+	resize_cb(windowP_, w, h);
 }
 
 //--------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -203,8 +203,9 @@ private:
 	ofWindowMode	windowMode;
 
 	bool			bEnableSetupScreen;
-	int				windowW, windowH;		// physical pixels width
-	int				currentW, currentH;		// scaled pixels width
+	int				windowW, windowH;		/// Physical framebuffer pixels extents
+	int				currentW, currentH;		/// Extents of the window client area, which may be scaled by pixelsScreenCoordScale to map to physical framebuffer pixels.
+	float           pixelScreenCoordScale;  /// Scale factor from virtual operating-system defined client area extents (as seen in currentW, currentH) to physical framebuffer pixel coordinates (as seen in windowW, windowH).
 
 	ofRectangle windowRect;
 
@@ -220,7 +221,6 @@ private:
 
 	ofBaseApp *	ofAppPtr;
 
-    int pixelScreenCoordScale; 
 
 	ofOrientation orientation;
 


### PR DESCRIPTION
+ more explicit calculation of screen and framebuffer extents, clarifying what method does, and which dimensions to expect of values retrieved from GLFW

+ use float value for scalefactor, in case operating systems report non-int scaling for HiDPi.

This addresses an issue where mouse position would be reported wrongly if a window had been moved between hi- and/or lo-res monitors. 

Also annotates `windowW`, `currentW` with comment clarifying dimensions for these fields.

This should close the dracula-issue #4703 (again), if not, let's try garlic.