### PR TITLE
removes some obvious warnings and errors.

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -253,7 +253,7 @@ void ofxAssimpModelLoader::loadGLResources(){
             
             ofxAssimpTexture assimpTexture;
             bool bTextureAlreadyExists = false;
-            for(int j=0; j<textures.size(); j++) {
+            for(unsigned int j=0; j<textures.size(); j++) {
                 assimpTexture = textures[j];
                 if(assimpTexture.getTexturePath() == realPath) {
                     bTextureAlreadyExists = true;
@@ -513,7 +513,7 @@ unsigned int ofxAssimpModelLoader::getAnimationCount(){
     return animations.size();
 }
 
-ofxAssimpAnimation & ofxAssimpModelLoader::getAnimation(int animationIndex) {
+ofxAssimpAnimation & ofxAssimpModelLoader::getAnimation(unsigned int animationIndex) {
     animationIndex = ofClamp(animationIndex, 0, animations.size()-1);
     return animations[animationIndex];
 }
@@ -585,7 +585,7 @@ void ofxAssimpModelLoader::setTime(float time) {
 }
 
 // DEPRECATED.
-float ofxAssimpModelLoader::getDuration(int animationIndex) {
+float ofxAssimpModelLoader::getDuration(unsigned int animationIndex) {
     if(!hasAnimations()) {
         return 0;
     }
@@ -603,7 +603,7 @@ unsigned int ofxAssimpModelLoader::getMeshCount() {
     return modelMeshes.size();
 }
 
-ofxAssimpMeshHelper & ofxAssimpModelLoader::getMeshHelper(int meshIndex) {
+ofxAssimpMeshHelper & ofxAssimpModelLoader::getMeshHelper(unsigned int meshIndex) {
     meshIndex = ofClamp(meshIndex, 0, modelMeshes.size()-1);
     return modelMeshes[meshIndex];
 }
@@ -830,9 +830,9 @@ ofMesh ofxAssimpModelLoader::getMesh(string name){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getMesh(int num){
+ofMesh ofxAssimpModelLoader::getMesh(unsigned int num){
 	ofMesh ofm;
-	if((int)scene->mNumMeshes<=num){
+	if(scene->mNumMeshes<=num){
 		ofLogError("ofxAssimpModelLoader") << "getMesh(): mesh id " << num
 		<< " out of range for total num meshes: " << scene->mNumMeshes;
 		return ofm;
@@ -865,8 +865,8 @@ ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(string name){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(int num){
-	if((int)modelMeshes.size()<=num){
+ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(unsigned int num){
+	if(modelMeshes.size()<=num){
 		ofLogError("ofxAssimpModelLoader") << "getCurrentAnimatedMesh(): mesh id: " << num
 			<< "out of range for total num meshes: " << scene->mNumMeshes;
 		return ofMesh();
@@ -893,8 +893,8 @@ ofMaterial ofxAssimpModelLoader::getMaterialForMesh(string name){
 }
 
 //-------------------------------------------
-ofMaterial ofxAssimpModelLoader::getMaterialForMesh(int num){
-	if((int)modelMeshes.size()<=num){
+ofMaterial ofxAssimpModelLoader::getMaterialForMesh(unsigned int num){
+	if(modelMeshes.size()<=num){
 		ofLogError("ofxAssimpModelLoader") << "getMaterialForMesh(): mesh id: " << num
 			<< "out of range for total num meshes: " << scene->mNumMeshes;
 		return ofMaterial();
@@ -916,7 +916,7 @@ ofTexture ofxAssimpModelLoader::getTextureForMesh(string name){
 }
 
 //-------------------------------------------
-ofTexture ofxAssimpModelLoader::getTextureForMesh(int i){
+ofTexture ofxAssimpModelLoader::getTextureForMesh(unsigned int i){
 	if(i < modelMeshes.size()){
         if(modelMeshes[i].hasTexture()) {
         	return modelMeshes[i].getTextureRef();
@@ -978,8 +978,8 @@ int ofxAssimpModelLoader::getNumRotations(){
 }
 
 //-------------------------------------------
-ofPoint ofxAssimpModelLoader::getRotationAxis(int which){
-	if((int)rotAxis.size() > which){
+ofPoint ofxAssimpModelLoader::getRotationAxis(unsigned int which){
+	if(rotAxis.size() > which){
 		return rotAxis[which];
 	}else{
 		return ofPoint();
@@ -987,8 +987,8 @@ ofPoint ofxAssimpModelLoader::getRotationAxis(int which){
 }
 
 //-------------------------------------------
-float ofxAssimpModelLoader::getRotationAngle(int which){
-	if((int)rotAngle.size() > which){
+float ofxAssimpModelLoader::getRotationAngle(unsigned int which){
+	if(rotAngle.size() > which){
 		return rotAngle[which];
 	}else{
 		return 0.0;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -38,7 +38,7 @@ class ofxAssimpModelLoader{
     
         bool hasAnimations();
         unsigned int getAnimationCount();
-        ofxAssimpAnimation & getAnimation(int animationIndex);
+        ofxAssimpAnimation & getAnimation(unsigned int animationIndex);
         void playAllAnimations();
         void stopAllAnimations();
         void resetAllAnimations();
@@ -48,11 +48,11 @@ class ofxAssimpModelLoader{
         OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setAnimation(int animationIndex));
         OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setNormalizedTime(float time));
         OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setTime(float time));
-        OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", float getDuration(int animationIndex));
+        OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", float getDuration(unsigned int animationIndex));
 
         bool hasMeshes();
         unsigned int getMeshCount();
-        ofxAssimpMeshHelper & getMeshHelper(int meshIndex);
+        ofxAssimpMeshHelper & getMeshHelper(unsigned int meshIndex);
     
         void clear();
     
@@ -68,16 +68,16 @@ class ofxAssimpModelLoader{
         int getNumMeshes();
 
         ofMesh getMesh(string name);
-        ofMesh getMesh(int num);
+        ofMesh getMesh(unsigned int num);
 
         ofMesh getCurrentAnimatedMesh(string name);
-        ofMesh getCurrentAnimatedMesh(int num);
+        ofMesh getCurrentAnimatedMesh(unsigned int num);
 
         ofMaterial getMaterialForMesh(string name);
-        ofMaterial getMaterialForMesh(int num);
+        ofMaterial getMaterialForMesh(unsigned int num);
 
         ofTexture getTextureForMesh(string name);
-        ofTexture getTextureForMesh(int num);
+        ofTexture getTextureForMesh(unsigned int num);
 
 
     	void drawWireframe();
@@ -105,8 +105,8 @@ class ofxAssimpModelLoader{
 		ofPoint	getSceneMax(bool bScaled = false);
 						
 		int	getNumRotations();	// returns the no. of applied rotations
-		ofPoint	getRotationAxis(int which); // gets each rotation axis
-		float getRotationAngle(int which); //gets each rotation angle
+		ofPoint	getRotationAxis(unsigned int which); // gets each rotation axis
+		float getRotationAngle(unsigned int which); //gets each rotation angle
 
         void calculateDimensions();
 

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -22,7 +22,7 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     VecType min = value.getMin();
     VecType max = value.getMax();
     
-	for (int i=0; i<dim(); i++) {
+	for (unsigned int i=0; i<dim(); i++) {
     	ofParameter<float> p(names[i], val[i], min[i], max[i]);
         add(new ofxSlider<float>(p, width, height));
         p.addListener(this, & ofxVecSlider_::changeSlider);
@@ -55,7 +55,7 @@ void ofxVecSlider_<VecType>::changeValue(VecType & value){
     if (sliderChanging){
         return;
     }
-	for (int i=0; i<dim(); i++){
+	for (unsigned int i=0; i<dim(); i++){
         parameters[i].template cast<float>() = value[i];
     }
 }

--- a/addons/ofxKinect/src/ofxKinect.cpp
+++ b/addons/ofxKinect/src/ofxKinect.cpp
@@ -1143,7 +1143,7 @@ int ofxKinectContext::getDeviceIndex(string serial) {
 }
 
 
-int ofxKinectContext::getDeviceId(int index) {
+int ofxKinectContext::getDeviceId(unsigned int index) {
     if( index >= 0 && index < deviceList.size() ){
         return deviceList[index].id;
     }

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -479,11 +479,11 @@ public:
 
 	/// get the deviceList id from an index
 	/// returns -1 if not found
-    int getDeviceId(int index);
+	int getDeviceId(unsigned int index);
 
 	/// get the deviceList id from a serial
 	/// returns -1 if not found
-    int getDeviceId(string serial);
+	int getDeviceId(string serial);
 
 	/// is a device with this id already connected?
 	bool isConnected(int id);

--- a/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
@@ -502,7 +502,7 @@ public:
                 if( FD_ISSET( breakPipe_[0], &tempfds ) ){
                     // clear pending data from the asynchronous break pipe
                     char c;
-                    read( breakPipe_[0], &c, 1 );
+                    if(read( breakPipe_[0], &c, 1 )) {};
                 }
                 
                 if( break_ )
@@ -557,7 +557,7 @@ public:
 		break_ = true;
 
 		// Send a termination message to the asynchronous break pipe, so select() will return
-		write( breakPipe_[1], "!", 1 );
+		if(write( breakPipe_[1], "!", 1 )) {};
 	}
 };
 

--- a/addons/ofxOsc/libs/oscpack/src/osc/OscReceivedElements.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/osc/OscReceivedElements.cpp
@@ -67,8 +67,8 @@ static inline const char* FindStr4End( const char *p, const char *end )
     if( p >= end )
         return 0;
 
-	if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
-		return p + 4;
+    if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
+        return p + 4;
 
     p += 3;
     end -= 1;

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -188,7 +188,7 @@ void ofxOscSender::appendBundle(const ofxOscBundle &bundle, osc::OutboundPacketS
 //--------------------------------------------------------------
 void ofxOscSender::appendMessage(const ofxOscMessage &message, osc::OutboundPacketStream &p){
 	p << osc::BeginMessage(message.getAddress().c_str());
-	for(int i = 0; i < message.getNumArgs(); ++i) {
+	for(unsigned int i = 0; i < message.getNumArgs(); ++i) {
 		switch(message.getArgType(i)){
 			case OFXOSC_TYPE_INT32:
 				p << message.getArgAsInt32(i);

--- a/addons/ofxVectorGraphics/libs/CreEPS.cpp
+++ b/addons/ofxVectorGraphics/libs/CreEPS.cpp
@@ -28,6 +28,10 @@ THE SOFTWARE.
 *******************************************************************************/
 
 #include "CreEPS.hpp"
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
 
 namespace ns_creeps
 {
@@ -58,13 +62,6 @@ namespace ns_creeps
 	#MAJORVERSIOM "." #MINORVERSION
 #define  CREEPS_VERSION_STR \
 	CREATE_VERSION_STRING(CREEPS_MAJOR_VERSION, CREEPS_MINOR_VERSION)
-
-/*********************************************************/
-
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <time.h>
 
 /*********************************************************
  * The attribute classes for CreEPS

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -694,7 +694,7 @@ void ofSerialize(ofxXmlSettings & xml, const ofAbstractParameter & parameter){
 		const ofParameterGroup & group = static_cast<const ofParameterGroup&>(parameter);
 		if(!xml.tagExists(name)) xml.addTag(name);
 		xml.pushTag(name);
-		for(int i=0;i<group.size();i++){
+		for(unsigned int i=0;i<group.size();i++){
 			ofSerialize(xml, group.get(i));
 		}
 		xml.popTag();
@@ -715,7 +715,7 @@ void ofDeserialize(const ofxXmlSettings & xml, ofAbstractParameter & parameter){
 		ofParameterGroup & group = static_cast<ofParameterGroup&>(parameter);
 		if(xml.tagExists(name)){
 			const_cast<ofxXmlSettings&>(xml).pushTag(name);
-			for(int i=0;i<group.size();i++){
+			for(unsigned int i=0;i<group.size();i++){
 				ofDeserialize(xml, group.get(i));
 			}
 			const_cast<ofxXmlSettings&>(xml).popTag();

--- a/examples/communication/oscChatSystemExample/src/ofApp.cpp
+++ b/examples/communication/oscChatSystemExample/src/ofApp.cpp
@@ -227,7 +227,7 @@ string ofApp::getOscMsgAsString(ofxOscMessage m){
 	string msg_string;
 	msg_string = m.getAddress();
 	msg_string += ":";
-	for(int i = 0; i < m.getNumArgs(); i++){
+	for(unsigned int i = 0; i < m.getNumArgs(); i++){
 		// get the argument type
 		msg_string += " " + m.getArgTypeName(i);
 		msg_string += ":";

--- a/examples/communication/oscReceiveExample/src/ofApp.cpp
+++ b/examples/communication/oscReceiveExample/src/ofApp.cpp
@@ -52,7 +52,7 @@ void ofApp::update(){
             string msg_string;
             msg_string = m.getAddress();
             msg_string += ":";
-            for(int i = 0; i < m.getNumArgs(); i++){
+            for(unsigned int i = 0; i < m.getNumArgs(); i++){
                 // get the argument type
                 msg_string += " ";
                 msg_string += m.getArgTypeName(i);

--- a/examples/graphics/fontsExample/src/ofApp.cpp
+++ b/examples/graphics/fontsExample/src/ofApp.cpp
@@ -133,7 +133,7 @@ void ofApp::keyPressed(int key){
 			typeStr.clear();
 			bFirst = false;
 		}
-		ofAppendUTF8(typeStr,key);
+		ofUTF8Append(typeStr,key);
 	}
 }
 

--- a/examples/graphics/lutFilterExample/src/ofApp.cpp
+++ b/examples/graphics/lutFilterExample/src/ofApp.cpp
@@ -84,8 +84,8 @@ void ofApp::loadLUT(string path){
 void ofApp::applyLUT(ofPixelsRef pix){
 	if (LUTloaded) {
 		
-		for(int y = 0; y < pix.getHeight(); y++){
-			for(int x = 0; x < pix.getWidth(); x++){
+		for(unsigned int y = 0; y < pix.getHeight(); y++){
+			for(unsigned int x = 0; x < pix.getWidth(); x++){
 				
 				ofColor color = pix.getColor(x, y);
 				

--- a/examples/input_output/fileBufferLoadingCSVExample/src/MorseCodePlayer.cpp
+++ b/examples/input_output/fileBufferLoadingCSVExample/src/MorseCodePlayer.cpp
@@ -14,15 +14,15 @@ MorseCodePlayer::MorseCodePlayer(){
 }
 
 void MorseCodePlayer::setup(){
-	dotPlayer.loadSound("dot.wav", false);
-	dashPlayer.loadSound("dash.wav", false);
+	dotPlayer.load("dot.wav", false);
+	dashPlayer.load("dash.wav", false);
 	//ofLogVerbose("dotPlayer duration: " + ofToString(dotPlayer.length/dotPlayer.internalFreq));
 	//ofLogVerbose("dashPlayer duration: " + ofToString(dashPlayer.length/dashPlayer.internalFreq));
 	isReady = true;
 }
 
 void MorseCodePlayer::update(){
-	if (!dotPlayer.getIsPlaying() && !dashPlayer.getIsPlaying()) {
+	if (!dotPlayer.isPlaying() && !dashPlayer.isPlaying()) {
 		if (codes.size()>0){
 			
 			currentCode = codes[0];

--- a/examples/input_output/imageSequenceExample/src/ofApp.cpp
+++ b/examples/input_output/imageSequenceExample/src/ofApp.cpp
@@ -32,7 +32,7 @@ void ofApp::setup() {
     int nFiles = dir.listDir("plops");
     if(nFiles) {
         
-        for(int i=0; i<dir.size(); i++) { 
+        for(unsigned int i=0; i<dir.size(); i++) { 
             
             // add the image to the vector
             string filePath = dir.getPath(i);

--- a/examples/input_output/systemSpeakExample/src/ofApp.cpp
+++ b/examples/input_output/systemSpeakExample/src/ofApp.cpp
@@ -31,17 +31,17 @@ void ofApp::threadedFunction() {
 
 		#ifdef TARGET_OSX
 			string cmd = "say -v "+voice+" "+words[step]+" ";   // create the command
-			system(cmd.c_str());
+			if(system(cmd.c_str())) {};
 		#endif
 		#ifdef TARGET_WIN32
 			string cmd = "data\\SayStatic.exe "+words[step];   // create the command
 			cout << cmd << endl;
-			system(cmd.c_str());
+			if(system(cmd.c_str())) {};
 		#endif
 		#ifdef TARGET_LINUX
 			string cmd = "echo "+words[step]+"|espeak";   // create the command
 			cout << cmd << endl;
-			system(cmd.c_str());
+			if(system(cmd.c_str())) {};
 		#endif
 
 		// step to the next word

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -162,7 +162,7 @@ void ofApp::audioIn(ofSoundBuffer & input){
 	int numCounted = 0;	
 
 	//lets go through each sample and calculate the root mean square which is a rough way to calculate volume	
-	for (int i = 0; i < input.getNumFrames(); i++){
+	for (unsigned int i = 0; i < input.getNumFrames(); i++){
 		left[i]		= input[i*2]*0.5;
 		right[i]	= input[i*2+1]*0.5;
 

--- a/examples/sound/audioOutputExample/src/ofApp.cpp
+++ b/examples/sound/audioOutputExample/src/ofApp.cpp
@@ -219,13 +219,13 @@ void ofApp::audioOut(ofSoundBuffer & buffer){
 
 	if ( bNoise == true){
 		// ---------------------- noise --------------
-		for (int i = 0; i < buffer.getNumFrames(); i++){
+		for (unsigned int i = 0; i < buffer.getNumFrames(); i++){
 			lAudio[i] = buffer[i*buffer.getNumChannels()    ] = ofRandom(0, 1) * volume * leftScale;
 			rAudio[i] = buffer[i*buffer.getNumChannels() + 1] = ofRandom(0, 1) * volume * rightScale;
 		}
 	} else {
 		phaseAdder = 0.95f * phaseAdder + 0.05f * phaseAdderTarget;
-		for (int i = 0; i < buffer.getNumFrames(); i++){
+		for (unsigned int i = 0; i < buffer.getNumFrames(); i++){
 			phase += phaseAdder;
 			float sample = sin(phase);
 			lAudio[i] = buffer[i*buffer.getNumChannels()    ] = sample * volume * leftScale;

--- a/examples/video/videoGrabberExample/src/ofApp.cpp
+++ b/examples/video/videoGrabberExample/src/ofApp.cpp
@@ -8,7 +8,7 @@ void ofApp::setup(){
     //get back a list of devices.
     vector<ofVideoDevice> devices = vidGrabber.listDevices();
 
-    for(int i = 0; i < devices.size(); i++){
+    for(unsigned int i = 0; i < devices.size(); i++){
         if(devices[i].bAvailable){
             //log the device
             ofLogNotice() << devices[i].id << ": " << devices[i].deviceName;
@@ -35,7 +35,7 @@ void ofApp::update(){
 
     if(vidGrabber.isFrameNew()){
         ofPixels & pixels = vidGrabber.getPixels();
-        for(int i = 0; i < pixels.size(); i++){
+        for(unsigned int i = 0; i < pixels.size(); i++){
             //invert the color of the pixel
             videoInverted[i] = 255 - pixels[i];
         }


### PR DESCRIPTION
Just getting rid of some warnings and errors under gcc 6. Actually only errors are the includes in CreEPS.cpp. Gcc does not like these includes in namespaces. Everything else is pretty obvious. Mostly changing from "int" to "unsigned int".