### PR TITLE
changes types to please gcc6.

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -150,7 +150,7 @@ void ofxAssimpModelLoader::calculateDimensions(){
 void ofxAssimpModelLoader::createLightsFromAiModel(){
 	lights.clear();
 	lights.resize(scene->mNumLights);
-	for(int i=0; i<(int)scene->mNumLights; i++){
+	for(unsigned int i = 0; i < scene->mNumLights; i++){
 		lights[i].enable();
 		if(scene->mLights[i]->mType==aiLightSource_DIRECTIONAL){
 			lights[i].setDirectional();
@@ -253,7 +253,7 @@ void ofxAssimpModelLoader::loadGLResources(){
             
             ofxAssimpTexture assimpTexture;
             bool bTextureAlreadyExists = false;
-            for(int j=0; j<textures.size(); j++) {
+            for(size_t j = 0; j < textures.size(); j++) {
                 assimpTexture = textures[j];
                 if(assimpTexture.getTexturePath() == realPath) {
                     bTextureAlreadyExists = true;
@@ -386,7 +386,7 @@ void ofxAssimpModelLoader::update() {
 }
 
 void ofxAssimpModelLoader::updateAnimations() {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].update();
     }
 }
@@ -401,13 +401,13 @@ void ofxAssimpModelLoader::updateMeshes(aiNode * node, ofMatrix4x4 parentMatrix)
                        m.d1, m.d2, m.d3, m.d4);
     matrix *= parentMatrix;
     
-    for(unsigned int i=0; i<node->mNumMeshes; i++) {
+    for(unsigned int i = 0; i < node->mNumMeshes; i++) {
         int meshIndex = node->mMeshes[i];
         ofxAssimpMeshHelper & mesh = modelMeshes[meshIndex];
         mesh.matrix = matrix;
     }
     
-    for(unsigned int i=0; i<node->mNumChildren; i++) {
+    for(unsigned int i = 0; i < node->mNumChildren; i++) {
         updateMeshes(node->mChildren[i], matrix);
     }
 }
@@ -417,13 +417,13 @@ void ofxAssimpModelLoader::updateBones() {
         return;
     }
     // update mesh position for the animation
-	for(unsigned int i=0; i<modelMeshes.size(); ++i) {
+	for(size_t i = 0; i < modelMeshes.size(); ++i) {
 		// current mesh we are introspecting
 		const aiMesh* mesh = modelMeshes[i].mesh;
         
 		// calculate bone matrices
 		vector<aiMatrix4x4> boneMatrices(mesh->mNumBones);
-		for(unsigned int a=0; a<mesh->mNumBones; ++a) {
+		for(unsigned int a = 0; a < mesh->mNumBones; ++a) {
 			const aiBone* bone = mesh->mBones[a];
             
 			// find the corresponding node by again looking recursively through the node hierarchy for the same name
@@ -448,11 +448,11 @@ void ofxAssimpModelLoader::updateBones() {
 			modelMeshes[i].animatedNorm.assign(modelMeshes[i].animatedNorm.size(), aiVector3D(0.0f));
 		}
 		// loop through all vertex weights of all bones
-		for(unsigned int a=0; a<mesh->mNumBones; ++a) {
+		for(unsigned int a = 0; a < mesh->mNumBones; ++a) {
 			const aiBone* bone = mesh->mBones[a];
 			const aiMatrix4x4& posTrafo = boneMatrices[a];
             
-			for(unsigned int b=0; b<bone->mNumWeights; ++b) {
+			for(unsigned int b = 0; b < bone->mNumWeights; ++b) {
 				const aiVertexWeight& weight = bone->mWeights[b];
                 
 				size_t vertexId = weight.mVertexId;
@@ -463,7 +463,7 @@ void ofxAssimpModelLoader::updateBones() {
 			if(mesh->HasNormals()){
 				// 3x3 matrix, contains the bone matrix without the translation, only with rotation and possibly scaling
 				aiMatrix3x3 normTrafo = aiMatrix3x3( posTrafo);
-				for(unsigned int b=0; b<bone->mNumWeights; ++b) {
+				for(unsigned int b = 0; b < bone->mNumWeights; ++b) {
 					const aiVertexWeight& weight = bone->mWeights[b];
 					size_t vertexId = weight.mVertexId;
                     
@@ -498,7 +498,7 @@ void ofxAssimpModelLoader::updateModelMatrix() {
     if(normalizeScale) {
         modelMatrix.glScale(normalizedScale , normalizedScale, normalizedScale);
     }
-    for(int i = 0; i < (int)rotAngle.size(); i++){ // @julapy - not sure why rotAngle isn't a ofVec4f.
+    for(size_t i = 0; i < rotAngle.size(); i++){ // @julapy - not sure why rotAngle isn't a ofVec4f.
         modelMatrix.glRotate(rotAngle[i], rotAxis[i].x, rotAxis[i].y, rotAxis[i].z);
     }
     modelMatrix.glScale(scale.x, scale.y, scale.z);
@@ -519,37 +519,37 @@ ofxAssimpAnimation & ofxAssimpModelLoader::getAnimation(int animationIndex) {
 }
 
 void ofxAssimpModelLoader::playAllAnimations() {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].play();
     }
 }
 
 void ofxAssimpModelLoader::stopAllAnimations() {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].stop();
     }
 }
 
 void ofxAssimpModelLoader::resetAllAnimations() {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].reset();
     }
 }
 
 void ofxAssimpModelLoader::setPausedForAllAnimations(bool pause) {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].setPaused(pause);
     }
 }
 
 void ofxAssimpModelLoader::setLoopStateForAllAnimations(ofLoopType state) {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].setLoopState(state);
     }
 }
 
 void ofxAssimpModelLoader::setPositionForAllAnimations(float position) {
-    for(unsigned int i=0; i<animations.size(); i++) {
+    for(size_t i = 0; i < animations.size(); i++) {
         animations[i].setPosition(position);
     }
 }
@@ -625,7 +625,7 @@ void ofxAssimpModelLoader::getBoundingBoxWithMinVector( aiVector3D* min, aiVecto
 //-------------------------------------------
 void ofxAssimpModelLoader::getBoundingBoxForNode(const ofxAssimpMeshHelper & mesh, aiVector3D* min, aiVector3D* max){
     if (!hasAnimations()){
-        for (size_t i=0; i<mesh.mesh->mNumVertices; i++){
+        for(unsigned int i = 0; i < mesh.mesh->mNumVertices; i++){
             auto vertex = mesh.mesh->mVertices[i];
             auto tmp = ofVec3f(vertex.x,vertex.y,vertex.z) * mesh.matrix;
             
@@ -726,7 +726,7 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
         glPolygonMode(GL_FRONT_AND_BACK, ofGetGLPolyMode(renderType));
 #endif
     
-    for(unsigned int i=0; i<modelMeshes.size(); i++) {
+    for(size_t i = 0; i < modelMeshes.size(); i++) {
         ofxAssimpMeshHelper & mesh = modelMeshes[i];
         
         ofPushMatrix();
@@ -796,14 +796,14 @@ void ofxAssimpModelLoader::draw(ofPolyRenderMode renderType) {
 //-------------------------------------------
 vector<string> ofxAssimpModelLoader::getMeshNames(){
 	vector<string> names(scene->mNumMeshes);
-	for(int i=0; i<(int)scene->mNumMeshes; i++){
+	for(unsigned int i=0; i< scene->mNumMeshes; i++){
 		names[i] = scene->mMeshes[i]->mName.data;
 	}
 	return names;
 }
 
 //-------------------------------------------
-int ofxAssimpModelLoader::getNumMeshes(){
+unsigned int ofxAssimpModelLoader::getNumMeshes(){
 	return scene->mNumMeshes;
 }
 
@@ -813,7 +813,7 @@ ofMesh ofxAssimpModelLoader::getMesh(string name){
 	// default to triangle mode
 	ofm.setMode(OF_PRIMITIVE_TRIANGLES);
 	aiMesh * aim = NULL;
-	for(int i=0; i<(int)scene->mNumMeshes; i++){
+	for(unsigned int i=0; i < scene->mNumMeshes; i++){
 		if(string(scene->mMeshes[i]->mName.data)==name){
 			aim = scene->mMeshes[i];
 			break;
@@ -830,9 +830,9 @@ ofMesh ofxAssimpModelLoader::getMesh(string name){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getMesh(int num){
+ofMesh ofxAssimpModelLoader::getMesh(unsigned int num){
 	ofMesh ofm;
-	if((int)scene->mNumMeshes<=num){
+	if(scene->mNumMeshes <= num){
 		ofLogError("ofxAssimpModelLoader") << "getMesh(): mesh id " << num
 		<< " out of range for total num meshes: " << scene->mNumMeshes;
 		return ofm;
@@ -844,7 +844,7 @@ ofMesh ofxAssimpModelLoader::getMesh(int num){
 
 //-------------------------------------------
 ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(string name){
-	for(int i=0; i<(int)modelMeshes.size(); i++){
+	for(size_t i=0; i < modelMeshes.size(); i++){
 		if(string(modelMeshes[i].mesh->mName.data)==name){
 			if(!modelMeshes[i].validCache){
 				modelMeshes[i].cachedMesh.clearVertices();
@@ -865,8 +865,8 @@ ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(string name){
 }
 
 //-------------------------------------------
-ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(int num){
-	if((int)modelMeshes.size()<=num){
+ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(unsigned int num){
+	if(modelMeshes.size() <= num){
 		ofLogError("ofxAssimpModelLoader") << "getCurrentAnimatedMesh(): mesh id: " << num
 			<< "out of range for total num meshes: " << scene->mNumMeshes;
 		return ofMesh();
@@ -883,7 +883,7 @@ ofMesh ofxAssimpModelLoader::getCurrentAnimatedMesh(int num){
 
 //-------------------------------------------
 ofMaterial ofxAssimpModelLoader::getMaterialForMesh(string name){
-	for(int i=0; i<(int)modelMeshes.size(); i++){
+	for(size_t i = 0; i < modelMeshes.size(); i++){
 		if(string(modelMeshes[i].mesh->mName.data)==name){
 			return modelMeshes[i].material;
 		}
@@ -893,8 +893,8 @@ ofMaterial ofxAssimpModelLoader::getMaterialForMesh(string name){
 }
 
 //-------------------------------------------
-ofMaterial ofxAssimpModelLoader::getMaterialForMesh(int num){
-	if((int)modelMeshes.size()<=num){
+ofMaterial ofxAssimpModelLoader::getMaterialForMesh(unsigned int num){
+	if(modelMeshes.size() <= num){
 		ofLogError("ofxAssimpModelLoader") << "getMaterialForMesh(): mesh id: " << num
 			<< "out of range for total num meshes: " << scene->mNumMeshes;
 		return ofMaterial();
@@ -904,7 +904,7 @@ ofMaterial ofxAssimpModelLoader::getMaterialForMesh(int num){
 
 //-------------------------------------------
 ofTexture ofxAssimpModelLoader::getTextureForMesh(string name){
-	for(int i=0; i<(int)modelMeshes.size(); i++){
+	for(size_t i = 0; i < modelMeshes.size(); i++){
 		if(string(modelMeshes[i].mesh->mName.data)==name){
             if(modelMeshes[i].hasTexture()) {
                 return modelMeshes[i].getTextureRef();
@@ -916,7 +916,7 @@ ofTexture ofxAssimpModelLoader::getTextureForMesh(string name){
 }
 
 //-------------------------------------------
-ofTexture ofxAssimpModelLoader::getTextureForMesh(int i){
+ofTexture ofxAssimpModelLoader::getTextureForMesh(unsigned int i){
 	if(i < modelMeshes.size()){
         if(modelMeshes[i].hasTexture()) {
         	return modelMeshes[i].getTextureRef();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -65,19 +65,19 @@ class ofxAssimpModelLoader{
         void setNormalizationFactor(float factor);
 
         vector<string> getMeshNames();
-        int getNumMeshes();
+        unsigned int getNumMeshes();
 
         ofMesh getMesh(string name);
-        ofMesh getMesh(int num);
+        ofMesh getMesh(unsigned int num);
 
         ofMesh getCurrentAnimatedMesh(string name);
-        ofMesh getCurrentAnimatedMesh(int num);
+        ofMesh getCurrentAnimatedMesh(unsigned int num);
 
         ofMaterial getMaterialForMesh(string name);
-        ofMaterial getMaterialForMesh(int num);
+        ofMaterial getMaterialForMesh(unsigned int num);
 
         ofTexture getTextureForMesh(string name);
-        ofTexture getTextureForMesh(int num);
+        ofTexture getTextureForMesh(unsigned int num);
 
 
     	void drawWireframe();

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -22,7 +22,7 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     VecType min = value.getMin();
     VecType max = value.getMax();
     
-	for (int i=0; i<dim(); i++) {
+	for (size_t i = 0; i < dim(); i++) {
     	ofParameter<float> p(names[i], val[i], min[i], max[i]);
         add(new ofxSlider<float>(p, width, height));
         p.addListener(this, & ofxVecSlider_::changeSlider);
@@ -55,7 +55,7 @@ void ofxVecSlider_<VecType>::changeValue(VecType & value){
     if (sliderChanging){
         return;
     }
-	for (int i=0; i<dim(); i++){
+	for (size_t i = 0; i < dim(); i++){
         parameters[i].template cast<float>() = value[i];
     }
 }

--- a/addons/ofxKinect/src/ofxKinect.cpp
+++ b/addons/ofxKinect/src/ofxKinect.cpp
@@ -1089,7 +1089,7 @@ void ofxKinectContext::listDevices(bool verbose) {
 	}
 	stream.str("");
 	
-	for(unsigned int i = 0; i < deviceList.size(); ++i) {
+	for(size_t i = 0; i < deviceList.size(); ++i) {
 		stream << "    id: " << deviceList[i].id << " serial: " << deviceList[i].serial;
 		if(verbose) {
 			ofLogVerbose("ofxKinect") << stream.str();
@@ -1127,7 +1127,7 @@ ofxKinect* ofxKinectContext::getKinect(freenect_device* dev) {
 }
 
 int ofxKinectContext::getDeviceIndex(int id) {
-	for(unsigned int i = 0; i < deviceList.size(); ++i) {
+	for(size_t i = 0; i < deviceList.size(); ++i) {
 		if(deviceList[i].id == id)
 			return i;
 	}
@@ -1135,7 +1135,7 @@ int ofxKinectContext::getDeviceIndex(int id) {
 }
 
 int ofxKinectContext::getDeviceIndex(string serial) {
-	for(unsigned int i = 0; i < deviceList.size(); ++i) {
+	for(size_t i = 0; i < deviceList.size(); ++i) {
 		if(deviceList[i].serial == serial)
 			return i;
 	}
@@ -1143,7 +1143,7 @@ int ofxKinectContext::getDeviceIndex(string serial) {
 }
 
 
-int ofxKinectContext::getDeviceId(int index) {
+int ofxKinectContext::getDeviceId(unsigned int index) {
     if( index >= 0 && index < deviceList.size() ){
         return deviceList[index].id;
     }
@@ -1151,7 +1151,7 @@ int ofxKinectContext::getDeviceId(int index) {
 }
 
 int ofxKinectContext::getDeviceId(string serial){
-	for(unsigned int i = 0; i < deviceList.size(); ++i) {
+	for(size_t i = 0; i < deviceList.size(); ++i) {
 		if(deviceList[i].serial == serial){
 			return deviceList[i].id;
         }
@@ -1179,7 +1179,7 @@ int ofxKinectContext::nextAvailableId() {
 	
 	// a brute force free index finder :D
 	std::map<int,ofxKinect*>::iterator iter;
-	for(unsigned int i = 0; i < deviceList.size(); ++i) {
+	for(size_t i = 0; i < deviceList.size(); ++i) {
 		iter = kinects.find(deviceList[i].id);
 		if(iter == kinects.end())
 			return deviceList[i].id;

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -479,11 +479,11 @@ public:
 
 	/// get the deviceList id from an index
 	/// returns -1 if not found
-    int getDeviceId(int index);
+        int getDeviceId(unsigned int index);
 
 	/// get the deviceList id from a serial
 	/// returns -1 if not found
-    int getDeviceId(string serial);
+        int getDeviceId(string serial);
 
 	/// is a device with this id already connected?
 	bool isConnected(int id);

--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -298,7 +298,7 @@ int ofxTCPClient::receiveRawMsg(char * receiveBuffer, int numBytes){
 	int posDelimiter = findDelimiter(tmpBuffReceive.getData(),tmpBuffReceive.size(),messageDelimiter);
 	if(posDelimiter>0){
 		memcpy(receiveBuffer,tmpBuffReceive.getData(),posDelimiter);
-		if(tmpBuffReceive.size() > posDelimiter + (int)messageDelimiter.size()){
+		if(tmpBuffReceive.size() > (unsigned int) posDelimiter + messageDelimiter.size()){
 			memcpy(tmpBuff,tmpBuffReceive.getData()+posDelimiter+messageDelimiter.size(),tmpBuffReceive.size()-(posDelimiter+messageDelimiter.size()));
 			tmpBuffReceive.set(tmpBuff,tmpBuffReceive.size()-(posDelimiter+messageDelimiter.size()));
 		}else{

--- a/addons/ofxOsc/libs/oscpack/src/osc/OscReceivedElements.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/osc/OscReceivedElements.cpp
@@ -48,8 +48,8 @@ namespace osc{
 // the string is terminated correctly.
 static inline const char* FindStr4End( const char *p )
 {
-	if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
-		return p + 4;
+    if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
+      return p + 4;
 
     p += 3;
 
@@ -67,8 +67,8 @@ static inline const char* FindStr4End( const char *p, const char *end )
     if( p >= end )
         return 0;
 
-	if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
-		return p + 4;
+    if( p[0] == '\0' )    // special case for SuperCollider integer address pattern
+        return p + 4;
 
     p += 3;
     end -= 1;

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -188,7 +188,7 @@ void ofxOscSender::appendBundle(const ofxOscBundle &bundle, osc::OutboundPacketS
 //--------------------------------------------------------------
 void ofxOscSender::appendMessage(const ofxOscMessage &message, osc::OutboundPacketStream &p){
 	p << osc::BeginMessage(message.getAddress().c_str());
-	for(int i = 0; i < message.getNumArgs(); ++i) {
+	for(size_t i = 0; i < message.getNumArgs(); ++i) {
 		switch(message.getArgType(i)){
 			case OFXOSC_TYPE_INT32:
 				p << message.getArgAsInt32(i);

--- a/addons/ofxVectorGraphics/libs/CreEPS.cpp
+++ b/addons/ofxVectorGraphics/libs/CreEPS.cpp
@@ -29,6 +29,11 @@ THE SOFTWARE.
 
 #include "CreEPS.hpp"
 
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+
 namespace ns_creeps
 {
 
@@ -58,13 +63,6 @@ namespace ns_creeps
 	#MAJORVERSIOM "." #MINORVERSION
 #define  CREEPS_VERSION_STR \
 	CREATE_VERSION_STRING(CREEPS_MAJOR_VERSION, CREEPS_MINOR_VERSION)
-
-/*********************************************************/
-
-#include <stdlib.h>
-#include <string.h>
-#include <math.h>
-#include <time.h>
 
 /*********************************************************
  * The attribute classes for CreEPS

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.cpp
@@ -694,7 +694,7 @@ void ofSerialize(ofxXmlSettings & xml, const ofAbstractParameter & parameter){
 		const ofParameterGroup & group = static_cast<const ofParameterGroup&>(parameter);
 		if(!xml.tagExists(name)) xml.addTag(name);
 		xml.pushTag(name);
-		for(int i=0;i<group.size();i++){
+		for(size_t i = 0;i < group.size(); i++){
 			ofSerialize(xml, group.get(i));
 		}
 		xml.popTag();
@@ -715,7 +715,7 @@ void ofDeserialize(const ofxXmlSettings & xml, ofAbstractParameter & parameter){
 		ofParameterGroup & group = static_cast<ofParameterGroup&>(parameter);
 		if(xml.tagExists(name)){
 			const_cast<ofxXmlSettings&>(xml).pushTag(name);
-			for(int i=0;i<group.size();i++){
+			for(size_t i = 0;i < group.size(); i++){
 				ofDeserialize(xml, group.get(i));
 			}
 			const_cast<ofxXmlSettings&>(xml).popTag();

--- a/examples/communication/oscChatSystemExample/src/ofApp.cpp
+++ b/examples/communication/oscChatSystemExample/src/ofApp.cpp
@@ -227,7 +227,7 @@ string ofApp::getOscMsgAsString(ofxOscMessage m){
 	string msg_string;
 	msg_string = m.getAddress();
 	msg_string += ":";
-	for(int i = 0; i < m.getNumArgs(); i++){
+	for(size_t i = 0; i < m.getNumArgs(); i++){
 		// get the argument type
 		msg_string += " " + m.getArgTypeName(i);
 		msg_string += ":";

--- a/examples/communication/oscReceiveExample/src/ofApp.cpp
+++ b/examples/communication/oscReceiveExample/src/ofApp.cpp
@@ -52,7 +52,7 @@ void ofApp::update(){
             string msg_string;
             msg_string = m.getAddress();
             msg_string += ":";
-            for(int i = 0; i < m.getNumArgs(); i++){
+            for(size_t i = 0; i < m.getNumArgs(); i++){
                 // get the argument type
                 msg_string += " ";
                 msg_string += m.getArgTypeName(i);

--- a/examples/graphics/lutFilterExample/src/ofApp.cpp
+++ b/examples/graphics/lutFilterExample/src/ofApp.cpp
@@ -84,8 +84,8 @@ void ofApp::loadLUT(string path){
 void ofApp::applyLUT(ofPixelsRef pix){
 	if (LUTloaded) {
 		
-		for(int y = 0; y < pix.getHeight(); y++){
-			for(int x = 0; x < pix.getWidth(); x++){
+		for(size_t y = 0; y < pix.getHeight(); y++){
+			for(size_t x = 0; x < pix.getWidth(); x++){
 				
 				ofColor color = pix.getColor(x, y);
 				

--- a/examples/input_output/imageSequenceExample/src/ofApp.cpp
+++ b/examples/input_output/imageSequenceExample/src/ofApp.cpp
@@ -32,7 +32,7 @@ void ofApp::setup() {
     int nFiles = dir.listDir("plops");
     if(nFiles) {
         
-        for(int i=0; i<dir.size(); i++) { 
+        for(size_t i=0; i<dir.size(); i++) { 
             
             // add the image to the vector
             string filePath = dir.getPath(i);

--- a/examples/input_output/systemSpeakExample/src/ofApp.cpp
+++ b/examples/input_output/systemSpeakExample/src/ofApp.cpp
@@ -26,24 +26,21 @@ void ofApp::threadedFunction() {
 
 	while (isThreadRunning()) {
 
-
 		// call the system command say
-
 		#ifdef TARGET_OSX
-			string cmd = "say -v "+voice+" "+words[step]+" ";   // create the command
-			system(cmd.c_str());
+			string cmd = "say -v " + voice + " " + words[step] + " "; // create the command
 		#endif
 		#ifdef TARGET_WIN32
-			string cmd = "data\\SayStatic.exe "+words[step];   // create the command
-			cout << cmd << endl;
-			system(cmd.c_str());
+			string cmd = "data\\SayStatic.exe " + words[step];        // create the command
 		#endif
 		#ifdef TARGET_LINUX
-			string cmd = "echo "+words[step]+"|espeak";   // create the command
-			cout << cmd << endl;
-			system(cmd.c_str());
+			string cmd = "echo " + words[step] + "|espeak";           // create the command
 		#endif
 
+                // print command and execute it
+                cout << cmd << endl;
+                ofSystem(cmd.c_str());
+                  
 		// step to the next word
 		step ++;
 		step %= words.size();

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -162,7 +162,7 @@ void ofApp::audioIn(ofSoundBuffer & input){
 	int numCounted = 0;	
 
 	//lets go through each sample and calculate the root mean square which is a rough way to calculate volume	
-	for (int i = 0; i < input.getNumFrames(); i++){
+	for (size_t i = 0; i < input.getNumFrames(); i++){
 		left[i]		= input[i*2]*0.5;
 		right[i]	= input[i*2+1]*0.5;
 

--- a/examples/sound/audioOutputExample/src/ofApp.cpp
+++ b/examples/sound/audioOutputExample/src/ofApp.cpp
@@ -219,13 +219,13 @@ void ofApp::audioOut(ofSoundBuffer & buffer){
 
 	if ( bNoise == true){
 		// ---------------------- noise --------------
-		for (int i = 0; i < buffer.getNumFrames(); i++){
+		for (size_t i = 0; i < buffer.getNumFrames(); i++){
 			lAudio[i] = buffer[i*buffer.getNumChannels()    ] = ofRandom(0, 1) * volume * leftScale;
 			rAudio[i] = buffer[i*buffer.getNumChannels() + 1] = ofRandom(0, 1) * volume * rightScale;
 		}
 	} else {
 		phaseAdder = 0.95f * phaseAdder + 0.05f * phaseAdderTarget;
-		for (int i = 0; i < buffer.getNumFrames(); i++){
+		for (size_t i = 0; i < buffer.getNumFrames(); i++){
 			phase += phaseAdder;
 			float sample = sin(phase);
 			lAudio[i] = buffer[i*buffer.getNumChannels()    ] = sample * volume * leftScale;

--- a/examples/video/videoGrabberExample/src/ofApp.cpp
+++ b/examples/video/videoGrabberExample/src/ofApp.cpp
@@ -8,7 +8,7 @@ void ofApp::setup(){
     //get back a list of devices.
     vector<ofVideoDevice> devices = vidGrabber.listDevices();
 
-    for(int i = 0; i < devices.size(); i++){
+    for(size_t i = 0; i < devices.size(); i++){
         if(devices[i].bAvailable){
             //log the device
             ofLogNotice() << devices[i].id << ": " << devices[i].deviceName;
@@ -35,7 +35,7 @@ void ofApp::update(){
 
     if(vidGrabber.isFrameNew()){
         ofPixels & pixels = vidGrabber.getPixels();
-        for(int i = 0; i < pixels.size(); i++){
+        for(size_t i = 0; i < pixels.size(); i++){
             //invert the color of the pixel
             videoInverted[i] = 255 - pixels[i];
         }

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -282,8 +282,8 @@ int ofRtAudioSoundStream::rtAudioCallback(void *outputBuffer, void *inputBuffer,
 	// you need to cut in the middle. if the simpleApp
 	// doesn't produce audio, we pass silence instead of duplex...
 
-	auto nInputChannels = rtStreamPtr->getNumInputChannels();
-	auto nOutputChannels = rtStreamPtr->getNumOutputChannels();
+	size_t nInputChannels  = rtStreamPtr->getNumInputChannels();
+	size_t nOutputChannels = rtStreamPtr->getNumOutputChannels();
 
 	if (nInputChannels > 0) {
 		if (rtStreamPtr->settings.inCallback) {


### PR DESCRIPTION
Mostly type changes to make gcc6 a happy camper. CreEPS.cpp had includes in namespaces which gcc6 does not like any more. For system commands in systemSpeakExample I casted the result to (void) which is idiomatic c/c++ to subpress unused return value warnings. But gcc6 ignores it! At least one can see that everything is meant to be right when you compile the code. There seems to be a discussion in the gcc community how to handle this warning. Here is the official documentation https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html saying that it should work. And here is an old ticket which has been updated lately: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425