### PR TITLE
Fix: ofTrueTypeFont. Was not loading system fonts.

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -446,11 +446,11 @@ static std::string linuxFontPathByName(const std::string& fontname){
 
 //-----------------------------------------------------------
 static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename){
-	std::filesystem::path fontname = _fontname;
 	filename = ofToDataPath(_fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
 	int fontID = 0;
 	if(!fontFile.exists()){
+		std::filesystem::path fontname = _fontname;
 #ifdef TARGET_LINUX
         filename = linuxFontPathByName(fontname.string());
 #elif defined(TARGET_OSX)
@@ -485,7 +485,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 		// simple error table in lieu of full table (see fterrors.h)
 		string errorString = "unknown freetype";
 		if(err == 1) errorString = "INVALID FILENAME";
-		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << fontname << "\": FT_Error " << err << " " << errorString;
+		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << _fontname << "\": FT_Error " << err << " " << errorString;
 		return false;
 	}
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -446,7 +446,7 @@ static std::string linuxFontPathByName(const std::string& fontname){
 
 //-----------------------------------------------------------
 static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename){
-	std::filesystem::path fontname;
+	std::filesystem::path fontname = _fontname;
 	filename = ofToDataPath(_fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
 	int fontID = 0;


### PR DESCRIPTION
ofTrueTypeFont will not load system fonts, either by explicitly passing their name or by using OF_TTF_SANS, OF_TTF_SERIF or OF_TTF_MONO

issue https://github.com/openframeworks/openFrameworks/issues/5761
