### PR TITLE
qt creator project file fixes for QT Creator 4.4

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
@@ -1,8 +1,8 @@
-var Process = loadExtension("qbs.Process");
-var File = loadExtension("qbs.File");
-var TextFile = loadExtension("qbs.TextFile");
-var Environment = loadExtension("qbs.Environment");
-var FileInfo = loadExtension("qbs.FileInfo");
+var Process = require("qbs.Process");
+var File = require("qbs.File");
+var TextFile = require("qbs.TextFile");
+var Environment = require("qbs.Environment");
+var FileInfo = require("qbs.FileInfo");
 
 function findCommand(){
     // check if it's unix

--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -21,19 +21,29 @@ Module{
         if(qbs.targetOS.contains("android")){
             return "android";
         }else if(qbs.targetOS.contains("linux")){
-            if(qbs.architecture==="x86_64"){
+            // For now, we hard-code linux64 as our architecture of choice, since
+            // qbs doesn't appear to set the architecture property autimatically
+            // anymore starting with qt 4.4.
+            //
+            // If you wanted to compile for 386, uncomment these lines, and
+            // add this property in Build Settings: "qbs.architecture:x86"
+            //
+//            if(qbs.architecture==="x86_64"){
                 return "linux64";
-            }else if(qbs.architecture==="x86"){
-                return "linux";
-            }else{
-                throw(qbs.architecture + " not supported yet on " + qbs.targetOS);
-            }
+//            }else if(qbs.architecture==="x86"){
+//                return "linux";
+//            }else{
+//                throw("qbs error: Target architecture: '" + qbs.architecture + "' not supported yet on target OS: '" + qbs.targetOS + "'" +
+//                      "Check if the project's build settings ");
+//            }
         }else if(qbs.targetOS.contains("windows")){
             return "msys2";
         }else if(qbs.targetOS.contains("osx")){
             return "osx";
+        }else if(qbs.targetOS.contains("macos")){
+            return "osx";
         }else{
-            throw(qbs.targetOS + " not supported yet");
+            throw("Target architecture: '" + qbs.targetOS + "' not supported yet");
         }
     }
 


### PR DESCRIPTION
+ replaces deprecated `loadExtension` with `require` in `helpers.js`
+ hard-codes `linux` architecture to `x86_64`: this is necessary, as
  the qbs build system otherwise expects the user to specify the
  architecture property explicitly.

  For further reference, the architecture property may be set explicitly
  in Qt Creator as follows:

  Under Projects -> Build Settings -> Build Steps -> Properties, set:
  `qbs.architecture:x86_64`