### PR TITLE
fix ofCamera::drawFrustum

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -253,7 +253,7 @@ void ofCamera::setRenderer(shared_ptr<ofBaseRenderer> _renderer){
 	renderer = _renderer;
 }
 
-void ofCamera::drawFrustum() {
+void ofCamera::drawFrustum(const ofRectangle viewport) const {
 	ofPushMatrix(); // we assume we are currently in world space.
 	ofMultMatrix( getGlobalTransformMatrix() ); 
 	// Move origin to camera origin == global transform of camera == inverse (view matrix)
@@ -282,7 +282,7 @@ void ofCamera::drawFrustum() {
 
 	// calculate projection matrix using frustum: 
 
-	ofMatrix4x4 projectionMatrixInverse = glm::inverse( getProjectionMatrix() );
+	ofMatrix4x4 projectionMatrixInverse = glm::inverse( getProjectionMatrix(viewport) );
 
 	for ( int i = 0; i < 8; i++ ) {
 		clipCube[i] = clipCube[i] * projectionMatrixInverse;
@@ -297,6 +297,7 @@ void ofCamera::drawFrustum() {
 	}
 
 	ofPushStyle();
+	ofSetRectMode(OF_RECTMODE_CORNER);
 	ofNoFill();
 	//// draw the clip cube cap
 	ofDrawRectangle( clipCube[0], clipCube[3].x - clipCube[0].x, clipCube[3].y - clipCube[0].y );

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -214,7 +214,7 @@ public:
 	/// \brief Draw a visual representation of the camera's frustum
 	/// \note  This will only be visible when the camera drawing its 
 	///        frustum is viewed through another camera.
-	void drawFrustum();
+	void drawFrustum(const ofRectangle viewport = ofRectangle()) const;
 
 protected:
 	ofRectangle getViewport(const ofRectangle & _viewport) const;


### PR DESCRIPTION
Maintenance PR for feature #5712, where cameras may draw their frustum into the scene for debugging.

* `drawFrustum` would foolishly assume ofRectMode to be set to its default value, `OF_RECTMODE_CENTER` when drawing the frustum caps.  This might lead to frustum caps being drawn incorrectly when, somewhere before, rectmode had been set to something other than `OF_RECTMODE_CORNER`.  This is fixed now - style is pushed before drawing the frustum, set correctly for drawing the frustum, and restored to user specified values after drawing the frustum, using
ofPush/PopStyle.

+ also adds parameter to optionally explicitly define a viewport from which to calculate the frustum to be drawn - this brings the method more in line with other camera-specific methods, which allow optional
specification of a viewport.

By default, the current viewport state is used, as before.