### PR TITLE
Set mouseEvent.x and y values based on absolute limits of the axis

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -1384,7 +1384,30 @@ void ofAppEGLWindow::setupNativeMouse() {
 		mouseDetected = true;
 	}
 
+	// Detect min and max values for absolute axes. Useful for trackpads and touchscreens.
+	// More info on input_absinfo https://github.com/torvalds/linux/blob/master/include/uapi/linux/input.h
+	if(mouseDetected){
 
+		// Do this for the x axis. EVIOCGABS(0): 0 stands for x axis.
+		struct input_absinfo mabsx;
+		if (ioctl(mouse_fd, EVIOCGABS(0), &mabsx) < 0){
+			ofLogError("ofAppEGLWindow") << "ioctl GABS failed";
+		} else {
+			mouseAbsXMin = mabsx.minimum;
+			mouseAbsXMax = mabsx.maximum;
+			ofLogNotice("ofAppEGLWindow") << "mouse x axis min, max: " << mouseAbsXMin << ", " << mouseAbsXMax;
+		}
+		
+		// Do that for the y axis. EVIOCGABS(1): 1 stands for y axis.
+		struct input_absinfo mabsy;
+		if (ioctl(mouse_fd, EVIOCGABS(1), &mabsy) < 0){
+			ofLogError("ofAppEGLWindow") << "ioctl GABS failed";
+		} else {
+			mouseAbsYMin = mabsy.minimum;
+			mouseAbsYMax = mabsy.maximum;
+			ofLogNotice("ofAppEGLWindow") << "mouse y axis min, max: " << mouseAbsYMin << ", " << mouseAbsYMax;
+		}
+	}
 }
 
 //------------------------------------------------------------
@@ -1705,7 +1728,7 @@ void ofAppEGLWindow::readNativeMouseEvents() {
 				if(ev.type == EV_REL) {
 					mouseEvent.x += amount * mouseScaleX;
 				} else {
-					mouseEvent.x = amount * mouseScaleX;
+					mouseEvent.x = amount * (float)currentWindowRect.width / (float)mouseAbsXMax;
 				}
 
 				mouseEvent.x = ofClamp(mouseEvent.x, 0, currentWindowRect.width);
@@ -1715,7 +1738,7 @@ void ofAppEGLWindow::readNativeMouseEvents() {
 				if(ev.type == EV_REL) {
 					mouseEvent.y += amount * mouseScaleY;
 				} else {
-					mouseEvent.y = amount * mouseScaleY;
+					mouseEvent.y = amount * (float)currentWindowRect.height / (float)mouseAbsYMax;
 				}
 
 				mouseEvent.y = ofClamp(mouseEvent.y, 0, currentWindowRect.height);

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -180,6 +180,13 @@ protected:
 	// void setMouseScaleX(float x);
 	// float getMouseScaleY() const;
 	// void setMouseScaleY(float y);
+
+	// For absolute input devices that send ABS_X and ABS_Y events, we want to store
+	// information about the min and max axis values.
+	int mouseAbsXMin;
+	int mouseAbsXMax;
+	int mouseAbsYMin;
+	int mouseAbsYMax;
 	
 	bool hasMouse() { return mouseDetected; }
 	bool hasKeyboard() { return keyboardDetected; }


### PR DESCRIPTION
The Adafruit 5" 800x480 Backpack did not give reasonable touch values and I discovered that in ofAppEGLWindow the way how relative and absolute input positions are handled is the same. The absolute values depend on the device min and max absolute x and absolute y axis settings. This fix stores the min and max values of the x and y axes, as well as sets the mouse event x and y values according to those.