### PR TITLE
ofCamera: fixed coordinate system transform functions

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -176,17 +176,14 @@ glm::mat4 ofCamera::getModelViewProjectionMatrix(ofRectangle viewport) const {
 glm::vec3 ofCamera::worldToScreen(glm::vec3 WorldXYZ, ofRectangle viewport) const {
 	viewport = getViewport(viewport);
 
-	auto CameraXYZ4 = getModelViewProjectionMatrix(viewport) * glm::vec4(WorldXYZ, 1.0);
-	auto CameraXYZ = CameraXYZ4.xyz() / CameraXYZ4.w;
+	auto CameraXYZ = worldToCamera(WorldXYZ, viewport);
+	
 	glm::vec3 ScreenXYZ;
-
 	ScreenXYZ.x = (CameraXYZ.x + 1.0f) / 2.0f * viewport.width + viewport.x;
 	ScreenXYZ.y = (1.0f - CameraXYZ.y) / 2.0f * viewport.height + viewport.y;
-
 	ScreenXYZ.z = CameraXYZ.z;
 
 	return ScreenXYZ;
-
 }
 
 //----------------------------------------
@@ -194,32 +191,32 @@ glm::vec3 ofCamera::screenToWorld(glm::vec3 ScreenXYZ, ofRectangle viewport) con
 	viewport = getViewport(viewport);
 
 	//convert from screen to camera
-	glm::vec4 CameraXYZ;
+	glm::vec3 CameraXYZ;
 	CameraXYZ.x = 2.0f * (ScreenXYZ.x - viewport.x) / viewport.width - 1.0f;
 	CameraXYZ.y = 1.0f - 2.0f *(ScreenXYZ.y - viewport.y) / viewport.height;
 	CameraXYZ.z = ScreenXYZ.z;
-	CameraXYZ.w = 1.0;
 
-	//get inverse camera matrix
-	auto inverseCamera = glm::inverse(getModelViewProjectionMatrix(viewport));
-
-	//convert camera to world
-	auto world = inverseCamera * CameraXYZ;
-	return world.xyz() / world.w;
-
+	return cameraToWorld(CameraXYZ, viewport);
 }
 
 //----------------------------------------
 glm::vec3 ofCamera::worldToCamera(glm::vec3 WorldXYZ, ofRectangle viewport) const {
-	auto camera = getModelViewProjectionMatrix(getViewport(viewport)) * glm::vec4(WorldXYZ, 1.0);
+	auto MVPmatrix = getModelViewProjectionMatrix(getViewport(viewport));
+	if(vFlip){
+		MVPmatrix = glm::scale(glm::mat4(1.0), glm::vec3(1.f,-1.f,1.f)) * MVPmatrix;
+	}
+	auto camera = MVPmatrix * glm::vec4(WorldXYZ, 1.0);
 	return camera.xyz() / camera.w;
+	
 }
 
 //----------------------------------------
 glm::vec3 ofCamera::cameraToWorld(glm::vec3 CameraXYZ, ofRectangle viewport) const {
-	auto inverseCamera = glm::inverse(getModelViewProjectionMatrix(getViewport(viewport)));
-
-	auto world = inverseCamera * glm::vec4(CameraXYZ, 1.0);
+	auto MVPmatrix = getModelViewProjectionMatrix(getViewport(viewport));
+	if(vFlip){
+		MVPmatrix = glm::scale(glm::mat4(1.0), glm::vec3(1.f,-1.f,1.f)) * MVPmatrix;
+	}
+	auto world = glm::inverse(MVPmatrix) * glm::vec4(CameraXYZ, 1.0);
 	return world.xyz() / world.w;
 }
 


### PR DESCRIPTION
ofCamera: fixed coordinate system transform functions
These functions are:
```
    glm::vec3 worldToScreen(glm::vec3 WorldXYZ, ofRectangle viewport = ofRectangle()) const;
    glm::vec3 screenToWorld(glm::vec3 ScreenXYZ, ofRectangle viewport = ofRectangle()) const;
    glm::vec3 worldToCamera(glm::vec3 WorldXYZ, ofRectangle viewport = ofRectangle()) const;
    glm::vec3 cameraToWorld(glm::vec3 CameraXYZ, ofRectangle viewport = ofRectangle()) const;
```

Now these take into account the cameras V flip.
Also removed redundant code from these.

The vFlip was not being taken into account when getting the camera's modelViewProjection matrix. I didn't add this fix directly into `ofCamera::getModelViewProjectionMatrix()` because this was being done in the ofMatrixStack and probably elsewhere. This fix would not break any other thing and it will behave as one would expect.

