### PR TITLE
Revert "fix-ofTrueTypeFont. avoid unnecesary filepath copy."

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -446,11 +446,11 @@ static std::string linuxFontPathByName(const std::string& fontname){
 
 //-----------------------------------------------------------
 static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename){
+	std::filesystem::path fontname = _fontname;
 	filename = ofToDataPath(_fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
 	int fontID = 0;
 	if(!fontFile.exists()){
-		std::filesystem::path fontname = _fontname;
 #ifdef TARGET_LINUX
         filename = linuxFontPathByName(fontname.string());
 #elif defined(TARGET_OSX)
@@ -485,7 +485,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 		// simple error table in lieu of full table (see fterrors.h)
 		string errorString = "unknown freetype";
 		if(err == 1) errorString = "INVALID FILENAME";
-		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << _fontname << "\": FT_Error " << err << " " << errorString;
+		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << fontname << "\": FT_Error " << err << " " << errorString;
 		return false;
 	}
 


### PR DESCRIPTION
This introduced a bug!
This reverts commit f285e8958231c71d5545053ffa6cb89ca4ce5149.

Discussed with @arturoc  previously in https://github.com/openframeworks/openFrameworks/pull/5762#issuecomment-333388005
The problem arises because 
[`static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename)`](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L448)

is called like this
[`if(!loadFontFace(settings.fontName,` loadFace, `settings.fontName)){`](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L797)

So, in `loadFontFace(....)` the line
`filename = ofToDataPath(_fontname,true);`
actually modifies `settings.fontName`, hence all subsequent calls to `_fontname` will actually have the same value as `filename`.
This makes the use of OF_TTF_SERIF, OF_TTF_SANS, OF_TTF_MONO or any system font impossible a lines like
[`if(fontname==OF_TTF_SANS){`](https://github.com/openframeworks/openFrameworks/blob/master/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L457) will never be true.

So, making the copy of `_fontname` is necessary unless a lot of other parts of the code are changed.

