### PR TITLE
Fix missing std:: namespace in ofxOpenCv.

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvBlob.h
+++ b/addons/ofxOpenCv/src/ofxCvBlob.h
@@ -24,7 +24,7 @@ class ofxCvBlob {
         ofPoint             centroid;
         bool                hole;
 
-        vector <ofPoint>    pts;    // the contour of the blob
+        std::vector <ofPoint> pts;    // the contour of the blob
         int                 nPts;   // number of pts;
 
         //----------------------------------------

--- a/addons/ofxOpenCv/src/ofxCvContourFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvContourFinder.h
@@ -19,8 +19,8 @@ class ofxCvContourFinder : public ofBaseDraws {
 
   public:
   
-    vector<ofxCvBlob>  blobs;
-    int                nBlobs;    // DEPRECATED: use blobs.size() instead
+    std::vector<ofxCvBlob>  blobs;
+    int nBlobs;    // DEPRECATED: use blobs.size() instead
       
 
     ofxCvContourFinder();
@@ -57,7 +57,7 @@ class ofxCvContourFinder : public ofBaseDraws {
     CvMemStorage*           contour_storage;
     CvMemStorage*           storage;
     CvMoments*              myMoments;
-    vector<CvSeq*>          cvSeqBlobs;  //these will become blobs
+    std::vector<CvSeq*>     cvSeqBlobs;  //these will become blobs
     
     ofPoint  anchor;
     bool  bAnchorIsPct;      

--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
@@ -43,7 +43,7 @@ void ofxCvHaarFinder::setNeighbors(unsigned neighbors) {
 	this->neighbors = neighbors;
 }
 
-void ofxCvHaarFinder::setup(string haarFile) {
+void ofxCvHaarFinder::setup(std::string haarFile) {
 	if(cascade != NULL)
 		cvReleaseHaarClassifierCascade(&cascade);
 

--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.h
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.h
@@ -19,14 +19,14 @@ http://www.comp.leeds.ac.uk/vision/opencv/opencvref_cv.html#decl_cvHaarDetectObj
 
 class ofxCvHaarFinder {
 public:
-	vector<ofxCvBlob> blobs;
+	std::vector<ofxCvBlob> blobs;
 
 	ofxCvHaarFinder();
 	ofxCvHaarFinder(const ofxCvHaarFinder& finder);
 	~ofxCvHaarFinder();
-	
-	void setup(string haarFile);
-	
+
+	void setup(std::string haarFile);
+
 	// The default value is 1.2. For accuracy, bring it closer but not equal to 1.0. To make it faster, use a larger value.
 	void setScaleHaar(float scaleHaar);
 	// How many neighbors can be grouped into a face? Default value is 2. If set to 0, no grouping will be done.
@@ -34,7 +34,7 @@ public:
 
 	int findHaarObjects(ofImage& input, int minWidth = 0, int minHeight = 0);
 	int findHaarObjects(const ofxCvGrayscaleImage& input, int minWidth = 0, int minHeight = 0);
-		
+
 	int findHaarObjects(const ofxCvGrayscaleImage& input, ofRectangle& roi,	int minWidth = 0, int minHeight = 0);
 	int findHaarObjects(const ofxCvGrayscaleImage&, int x, int y, int w, int h,	int minWidth = 0, int minHeight = 0);
 
@@ -42,12 +42,12 @@ public:
 
 	float getWidth();
 	float getHeight();
-	
+
 	void draw(float x, float y);
 
 protected:
 	CvHaarClassifierCascade* cascade;
-	string haarFile;
+	std::string haarFile;
 	ofxCvGrayscaleImage img;
 	float scaleHaar;
 	unsigned neighbors;


### PR DESCRIPTION
This addon was not compiling in certain circumstances w/ master and other addons.  Adding std:: fixes this.