### PR TITLE
Added api parameter to ofSoundStream::getMatchingDevices()

### DIFF
--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -337,8 +337,8 @@ int ofSoundStream::getBufferSize() const{
 }
 
 //------------------------------------------------------------
-vector<ofSoundDevice> ofSoundStream::getMatchingDevices(const std::string& name, unsigned int inChannels, unsigned int outChannels) const {
-	vector<ofSoundDevice> devs = getDeviceList();
+vector<ofSoundDevice> ofSoundStream::getMatchingDevices(const std::string& name, unsigned int inChannels, unsigned int outChannels, ofSoundDevice::Api api) const {
+	vector<ofSoundDevice> devs = getDeviceList(api);
 	vector<ofSoundDevice> hits;
 	
 	for(size_t i = 0; i < devs.size(); i++) {

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -96,7 +96,7 @@ public:
 	std::vector<ofSoundDevice> getDeviceList(ofSoundDevice::Api api = ofSoundDevice::Api::DEFAULT) const;
 
 	/// \brief Get all devices which match the arguments (name can be a partial match)
-	std::vector<ofSoundDevice> getMatchingDevices(const std::string& name, unsigned int inChannels = UINT_MAX, unsigned int outChannels = UINT_MAX) const;
+	std::vector<ofSoundDevice> getMatchingDevices(const std::string& name, unsigned int inChannels = UINT_MAX, unsigned int outChannels = UINT_MAX, ofSoundDevice::Api api = ofSoundDevice::Api::DEFAULT) const;
 
 	/// \brief sets the device represented by the stream, see ofSoundStream::getDeviceList().
 	OF_DEPRECATED_MSG("Use an ofSoundStreamSettings object instead of directly passing the parameters",


### PR DESCRIPTION
Currently `ofSoundStream::getMatchingDevices()` calls `ofSoundStream::getDeviceList()` with no arguments, resulting in `ofSoundStream::getDeviceList()` defaulting to `ofSoundDevice::Api::DEFAULT` which means searches are restricted to ASIO devices on Windows.

This PR simply adds an optional `api` param to  `getMatchingDevices()` that gets passed along to `getDeviceList()` so that the search works for all APIs.