### PR TITLE
ofSoundBuffer: fixed wrong interpolation algorithm

### DIFF
--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -356,8 +356,8 @@ void ofSoundBuffer::linearResampleTo(ofSoundBuffer &outBuffer, std::size_t fromF
 	for(std::size_t i=0;i<to;i++){
 		intPosition *= inChannels;
 		for(std::size_t j=0;j<inChannels;j++){
-			a = buffer[intPosition];
-			b = buffer[intPosition+inChannels];
+			a = buffer[intPosition+j];
+			b = buffer[intPosition+inChannels+j];
 			*resBufferPtr++ = ofLerp(a,b,remainder);
 		}
 		position += increment;
@@ -371,9 +371,9 @@ void ofSoundBuffer::linearResampleTo(ofSoundBuffer &outBuffer, std::size_t fromF
 			for(std::size_t i=0;i<to;i++){
 				intPosition *= inChannels;
 				for(std::size_t j=0;j<inChannels;j++){
-					a = buffer[intPosition];
-					b = buffer[intPosition+inChannels];
-					*resBufferPtr++ = (b-a)*remainder+a;
+					a = buffer[intPosition+j];
+					b = buffer[intPosition+inChannels+j];
+					*resBufferPtr++ = ofLerp(a,b,remainder);
 				}
 				resBufferPtr+=inChannels;
 				position += increment;


### PR DESCRIPTION
The interpolation algorithm was only taking the first channel as it was not using the correct index