### PR TITLE
Added make_preferred() to paths where necessary.

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -75,13 +75,13 @@ namespace{
             return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
         }
     #elif defined TARGET_ANDROID
-            return string("sdcard/");
+        return string("sdcard/");
     #else
-            try{
-                return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).string();
-            }catch(...){
-                return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
-            }
+        try{
+            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).make_preferred().string();
+        }catch(...){
+            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
+        }
     #endif
     }
 
@@ -544,7 +544,7 @@ string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
 	// if path is already absolute, just return it
 	if (inputPath.is_absolute()) {
 		try {
-            auto outpath = std::filesystem::canonical(inputPath);
+            auto outpath = std::filesystem::canonical(inputPath).make_preferred();
             if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
                 return ofFilePath::addTrailingSlash(outpath.string());
             }else{
@@ -582,7 +582,7 @@ string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
 	if(makeAbsolute){
 	    // then we return the absolute form of the path
 	    try {
-            auto outpath = std::filesystem::canonical(std::filesystem::absolute(outputPath));
+            auto outpath = std::filesystem::canonical(std::filesystem::absolute(outputPath)).make_preferred();
             if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
                 return ofFilePath::addTrailingSlash(outpath.string());
             }else{


### PR DESCRIPTION
Some absolute paths were returning a flipped separator on Windows at the drive level (e.g. `C:/some\\folder\\path\\`. Although this is no problem in most cases, it doesn't work with some Windows specific stuff, like setting the default path when using `ofSystemLoadDialog(...)`.

Here's a better description of a similar problem: https://stackoverflow.com/questions/27110973/boost-filesystem-canonical-path-is-not-valid-after-conversion-to-const-char