### PR TITLE
Fixing hideCursor() for Fullscreen on Linux

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -618,7 +618,11 @@ void ofAppGLFWWindow::setWindowShape(int w, int h){
 
 //------------------------------------------------------------
 void ofAppGLFWWindow::hideCursor(){
-	glfwSetInputMode(windowP,GLFW_CURSOR,GLFW_CURSOR_HIDDEN);
+	if(settings.windowMode == OF_FULLSCREEN || settings.windowMode == OF_GAME_MODE){
+		glfwSetInputMode(windowP,GLFW_CURSOR,GLFW_CURSOR_DISABLED);
+	}else{
+		glfwSetInputMode(windowP,GLFW_CURSOR,GLFW_CURSOR_HIDDEN);
+	}
 };
 
 //------------------------------------------------------------


### PR DESCRIPTION
This should behave well on all other platforms as well.
On Linux the cursor does not disappear in fullscreen, guessing this has to do with how GLFW_CURSOR_HIDDEN is handled internally, in window mode it work fine but in fullscreen GLFW_CURSOR_DISABLED is necessary.

This was also discussed here: https://github.com/openframeworks/openFrameworks/issues/2812