### PR TITLE
ofAppGLFWWindow: better handling of window mode

### DIFF
--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -89,7 +89,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
 		ofLogError() << "couldn't get configs";
 		return;
 	}
-	
+
 	ofLogNotice("ofxAppEmscriptenWindow") << "Got " << numConfigs << " display configs";
 
 	// Choose config
@@ -118,7 +118,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
 		return;
 	}
 
-	setWindowShape(settings.width,settings.height);
+	setWindowShape(settings.getWidth(),settings.getHeight());
 
 	_renderer = make_shared<ofGLProgrammableRenderer>(this);
 	((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
@@ -128,7 +128,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_mousedown_callback(0,this,1,&mousedown_cb);
     emscripten_set_mouseup_callback(0,this,1,&mouseup_cb);
     emscripten_set_mousemove_callback(0,this,1,&mousemoved_cb);
-    
+
     emscripten_set_touchstart_callback(0,this,1,&touch_cb);
     emscripten_set_touchend_callback(0,this,1,&touch_cb);
     emscripten_set_touchmove_callback(0,this,1,&touch_cb);
@@ -213,7 +213,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
-    
+
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:
@@ -359,4 +359,3 @@ ofCoreEvents & ofxAppEmscriptenWindow::events(){
 shared_ptr<ofBaseRenderer> & ofxAppEmscriptenWindow::renderer(){
 	return _renderer;
 }
-

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -475,7 +475,7 @@ void ofAppEGLWindow::setup(const Settings & _settings) {
 	windowMode = settings.windowMode;
 	bShowCursor = true;
 
-	nonFullscreenWindowRect.set(0,0,settings.width,settings.height);
+	nonFullscreenWindowRect.set(0,0,settings.getWidth(),settings.getHeight());
 	nonFullscreenWindowRect.standardize();
 
 	ofRectangle startRect = nonFullscreenWindowRect;

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -199,7 +199,7 @@ private:
 	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	ofGLFWWindowSettings settings;
 
-	ofWindowMode	windowMode;
+	ofWindowMode	targetWindowMode;
 
 	bool			bEnableSetupScreen;
 	int				windowW, windowH;		/// Physical framebuffer pixels extents

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -5,7 +5,7 @@
 #include "ofGLRenderer.h"
 
 #ifdef TARGET_WIN32
-	#if (_MSC_VER) 
+	#if (_MSC_VER)
 		#define GLUT_BUILDING_LIB
 		#include "glut.h"
 	#else
@@ -36,7 +36,7 @@ static ofWindowMode windowMode;
 static bool			bNewScreenMode;
 static int			buttonInUse;
 static bool			bEnableSetupScreen;
-static bool			bDoubleBuffered; 
+static bool			bDoubleBuffered;
 
 static int			requestedWidth;
 static int			requestedHeight;
@@ -194,7 +194,7 @@ ofAppGlutWindow::ofAppGlutWindow(){
  }
 
  //------------------------------------------------------------
-void ofAppGlutWindow::setDoubleBuffering(bool _bDoubleBuffered){ 
+void ofAppGlutWindow::setDoubleBuffering(bool _bDoubleBuffered){
 	bDoubleBuffered = _bDoubleBuffered;
 }
 
@@ -209,7 +209,7 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 	if( displayString != ""){
 		glutInitDisplayString( displayString.c_str() );
 	}else{
-		if(bDoubleBuffered){  
+		if(bDoubleBuffered){
 			glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_ALPHA );
 		}else{
 			glutInitDisplayMode(GLUT_RGB | GLUT_SINGLE | GLUT_DEPTH | GLUT_ALPHA );
@@ -222,11 +222,11 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 	if (windowMode == OF_FULLSCREEN){
 		glutInitWindowSize(glutGet(GLUT_SCREEN_WIDTH), glutGet(GLUT_SCREEN_HEIGHT));
 		windowId = glutCreateWindow("");
-		
-		requestedWidth  = settings.width;
-		requestedHeight = settings.height;
+
+		requestedWidth  = settings.getWidth();
+		requestedHeight = settings.getHeight();
 	} else if (windowMode != OF_GAME_MODE){
-		glutInitWindowSize(settings.width, settings.height);
+		glutInitWindowSize(settings.getWidth(), settings.getHeight());
 		glutCreateWindow("");
 
 		/*
@@ -250,7 +250,7 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 
     	// w x h, 32bit pixel depth, 60Hz refresh rate
 		char gameStr[64];
-		sprintf( gameStr, "%dx%d:%d@%d", settings.width, settings.height, 32, 60 );
+		sprintf( gameStr, "%dx%d:%d@%d", settings.getWidth(), settings.getHeight(), 32, 60 );
 
     	glutGameModeString(gameStr);
 
@@ -727,7 +727,7 @@ static void rotateMouseXY(ofOrientation orientation, int w, int h, int &x, int &
 //------------------------------------------------------------
 void ofAppGlutWindow::mouse_cb(int button, int state, int x, int y) {
 	rotateMouseXY(orientation, instance->getWidth(), instance->getHeight(), x, y);
-    
+
 
 	switch(button){
 	case GLUT_LEFT_BUTTON:
@@ -740,7 +740,7 @@ void ofAppGlutWindow::mouse_cb(int button, int state, int x, int y) {
 		button = OF_MOUSE_BUTTON_MIDDLE;
 		break;
 	}
-    
+
 	if (instance->events().getFrameNum() > 0){
 		if (state == GLUT_DOWN) {
 			instance->events().notifyMousePressed(x, y, button);

--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -226,8 +226,8 @@ ofAppNoWindow::ofAppNoWindow()
 
 //----------------------------------------------------------
 void ofAppNoWindow::setup(const ofWindowSettings & settings){
-	width = settings.width;
-	height = settings.height;
+	width = settings.getWidth();
+	height = settings.getHeight();
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -31,8 +31,7 @@ using namespace std;
 	void ofSetupOpenGL(shared_ptr<ofAppGLFWWindow> windowPtr, int w, int h, ofWindowMode screenMode){
 		ofInit();
 		auto settings = windowPtr->getSettings();
-		settings.width = w;
-		settings.height = h;
+		settings.setSize(w,h);
 		settings.windowMode = screenMode;
 		ofGetMainLoop()->addWindow(windowPtr);
 		windowPtr->setup(settings);
@@ -208,8 +207,7 @@ void ofSetupOpenGL(int w, int h, ofWindowMode screenMode){
 	settings.glVersionMinor = 1;
 #endif
 
-	settings.width = w;
-	settings.height = h;
+	settings.setSize(w, h);
 	settings.windowMode = screenMode;
 	ofCreateWindow(settings);
 }

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -24,8 +24,7 @@ template<typename Window>
 void ofSetupOpenGL(std::shared_ptr<Window> windowPtr, int w, int h, ofWindowMode screenMode){
 	ofInit();
 	ofWindowSettings settings;
-	settings.width = w;
-	settings.height = h;
+	settings.setSize(w, h);
 	settings.windowMode = screenMode;
 	ofGetMainLoop()->addWindow(windowPtr);
 	windowPtr->setup(settings);

--- a/libs/openFrameworks/app/ofWindowSettings.h
+++ b/libs/openFrameworks/app/ofWindowSettings.h
@@ -37,22 +37,39 @@ enum ofOrientation: short{
 class ofWindowSettings{
 public:
 	ofWindowSettings()
-	:width(1024)
+	:windowMode(OF_WINDOW)
+	,width(1024)
 	,height(768)
-	,windowMode(OF_WINDOW)
+	,sizeSet(false)
 	,position(0,0)
 	,positionSet(false){}
 
 	virtual ~ofWindowSettings(){};
 
-	int width;
-	int height;
 	std::string title;
 	ofWindowMode windowMode;
 
 	void setPosition(const glm::vec2 & position) {
 		this->position = position;
 		this->positionSet = true;
+	}
+
+	void setSize(int width, int height) {
+		this->width = width;
+		this->height = height;
+		this->sizeSet = true;
+	}
+
+	bool isSizeSet() const {
+		return sizeSet;
+	}
+
+	int getWidth() const {
+		return width;
+	}
+
+	int getHeight() const {
+		return height;
 	}
 
 	const glm::vec2 & getPosition() const {
@@ -64,6 +81,9 @@ public:
 	}
 
 protected:
+	int width;
+	int height;
+	bool sizeSet;
 	glm::vec2 position;
 	bool positionSet;
 };


### PR DESCRIPTION
Fixes #5861
Also fixes a problem where setting GAME_MODE using a window settings struct would change the screen resolution to 1024x768 when the size wasn't set.

To fix this we are making width and height in window settings protected which will break some code but the fix is pretty straightforward, just use setSize instead of directly assigning values to width and height