### PR TITLE
remove deprecated ofTtfCharacter and just use ofPath instead

### DIFF
--- a/examples/graphics/fontShapesExample/src/ofApp.h
+++ b/examples/graphics/fontShapesExample/src/ofApp.h
@@ -25,7 +25,7 @@ class ofApp : public ofBaseApp{
 		
 		ofTrueTypeFont testFont;
 		ofTrueTypeFont testFont2;
-		ofTTFCharacter testChar, testCharContour;
+		ofPath testChar, testCharContour;
 		uint32_t letter;
 };
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -160,7 +160,7 @@ void ofTrueTypeShutdown(){
 }
 
 //--------------------------------------------------------
-static ofTTFCharacter makeContoursForCharacter(FT_Face face){
+static ofPath makeContoursForCharacter(FT_Face face){
 
 		//int num			= face->glyph->outline.n_points;
 		int nContours	= face->glyph->outline.n_contours;
@@ -169,7 +169,7 @@ static ofTTFCharacter makeContoursForCharacter(FT_Face face){
 		char * tags		= face->glyph->outline.tags;
 		FT_Vector * vec = face->glyph->outline.points;
 
-		ofTTFCharacter charOutlines;
+		ofPath charOutlines;
 		charOutlines.setUseShapeColor(false);
 		charOutlines.setPolyWindingMode(OF_POLY_WINDING_NONZERO);
 
@@ -1016,13 +1016,13 @@ float ofTrueTypeFont::getSpaceSize() const{
 }
 
 //------------------------------------------------------------------
-ofTTFCharacter ofTrueTypeFont::getCharacterAsPoints(uint32_t character, bool vflip, bool filled) const{
+ofPath ofTrueTypeFont::getCharacterAsPoints(uint32_t character, bool vflip, bool filled) const{
 	if( settings.contours == false ){
 		ofLogError("ofxTrueTypeFont") << "getCharacterAsPoints(): contours not created, call loadFont() with makeContours set to true";
-		return ofTTFCharacter();
+		return ofPath();
 	}
 	if (!isValidGlyph(character)){
-		return ofTTFCharacter();
+		return ofPath();
 	}
 
 	if(vflip){
@@ -1156,8 +1156,8 @@ void ofTrueTypeFont::setDirection(ofTrueTypeFont::Settings::Direction direction)
 }
 
 //-----------------------------------------------------------
-vector<ofTTFCharacter> ofTrueTypeFont::getStringAsPoints(const string &  str, bool vflip, bool filled) const{
-	vector<ofTTFCharacter> shapes;
+vector<ofPath> ofTrueTypeFont::getStringAsPoints(const string &  str, bool vflip, bool filled) const{
+	vector<ofPath> shapes;
 
 	if (!bLoadedOk){
 		ofLogError("ofxTrueTypeFont") << "getStringAsPoints(): font not allocated: line " << __LINE__ << " in " << __FILE__;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -25,7 +25,6 @@
 /// \cond INTERNAL
 
 
-typedef ofPath ofTTFCharacter;
 typedef struct FT_FaceRec_*  FT_Face;
 
 /// \endcond
@@ -340,8 +339,8 @@ public:
 	void drawStringAsShapes(const std::string& s, float x, float y) const;
 	
 	/// \todo
-	ofTTFCharacter getCharacterAsPoints(uint32_t character, bool vflip=true, bool filled=true) const;
-	std::vector<ofTTFCharacter> getStringAsPoints(const std::string &  str, bool vflip=true, bool filled=true) const;
+	ofPath getCharacterAsPoints(uint32_t character, bool vflip=true, bool filled=true) const;
+	std::vector<ofPath> getStringAsPoints(const std::string &  str, bool vflip=true, bool filled=true) const;
 	const ofMesh & getStringMesh(const std::string &  s, float x, float y, bool vflip=true) const;
 	const ofTexture & getFontTexture() const;
 	ofTexture getStringTexture(const std::string &  s, bool vflip=true) const;
@@ -355,10 +354,10 @@ protected:
 	
 	bool bLoadedOk;
 	
-	std::vector <ofTTFCharacter> charOutlines;
-	std::vector <ofTTFCharacter> charOutlinesNonVFlipped;
-	std::vector <ofTTFCharacter> charOutlinesContour;
-	std::vector <ofTTFCharacter> charOutlinesNonVFlippedContour;
+	std::vector <ofPath> charOutlines;
+	std::vector <ofPath> charOutlinesNonVFlipped;
+	std::vector <ofPath> charOutlinesContour;
+	std::vector <ofPath> charOutlinesNonVFlippedContour;
 
 	float lineHeight;
 	float ascenderHeight;


### PR DESCRIPTION
I've changed fontShapesExamples to use ofPath, can't remember of anything else that uses ofTtfCharacter but would be good to check that all examples are still compiling after this

Closes #4942 