### PR TITLE
fix for OS X OF_TTF_SANS default on 10.13 closes #5865

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -453,7 +453,11 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 #elif defined(TARGET_OSX)
 		if(fontname==OF_TTF_SANS){
 			fontname = "Helvetica Neue";
-			fontID = 4;
+			#if MAC_OS_X_VERSION_10_13 && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_13
+				fontID = 0;
+			#else
+				fontID = 4;
+			#endif
 		}else if(fontname==OF_TTF_SERIF){
 			fontname = "Times New Roman";
 		}else if(fontname==OF_TTF_MONO){


### PR DESCRIPTION
The PR changes the default font face for 10.13 to be regular - (it is currently condensed). 
See details #5865

10.12 and prior are unchanged. 
