### PR TITLE
Fix texcoords primitives

### DIFF
--- a/examples/3d/3DPrimitivesExample/src/ofApp.cpp
+++ b/examples/3d/3DPrimitivesExample/src/ofApp.cpp
@@ -73,362 +73,353 @@ void ofApp::update() {
 
 //--------------------------------------------------------------
 void ofApp::draw() {
+
+	float spinX = sin(ofGetElapsedTimef()*.35f);
+	float spinY = cos(ofGetElapsedTimef()*.075f);
+
+	if (bMousePressed) {
+		spinX = spinY = 0.0f;
+	}
+
+	cam.setGlobalPosition({ 0,0,cam.getImagePlaneDistance(ofGetCurrentViewport()) });
+	cam.begin();
+
+	ofEnableDepthTest();
+
+	ofEnableLighting();
+	pointLight.enable();
+	pointLight2.enable();
+	pointLight3.enable();
+
+
+
+	// draw the outer sphere
+	material.begin();
+	ofNoFill();
+	ofDrawSphere(0, 0, max(ofGetWidth(),ofGetHeight()));
+	material.end();
+
+	if (mode == 1 || mode == 3) texture.getTexture().bind();
+	if (mode == 2) vidGrabber.getTexture().bind();
+
+	float screenWidth = ofGetWidth();
+	float screenHeight = ofGetHeight();
+
+	plane.setPosition(     -screenWidth * .5 + screenWidth *  1/4.f, screenHeight *  1.1/6.f, 0);
+	box.setPosition(       -screenWidth * .5 + screenWidth *  2/4.f, screenHeight *  1.1/6.f, 0);
+	sphere.setPosition(    -screenWidth * .5 + screenWidth *  3/4.f, screenHeight *  1.1/6.f, 0);
+	icoSphere.setPosition( -screenWidth * .5 + screenWidth *  1/4.f, screenHeight * -1.1/6.f, 0);
+	cylinder.setPosition(  -screenWidth * .5 + screenWidth *  2/4.f, screenHeight * -1.1/6.f, 0);
+	cone.setPosition(      -screenWidth * .5 + screenWidth *  3/4.f, screenHeight * -1.1/6.f, 0);
+
+	// Plane //
+
+	plane.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	plane.rotateDeg(spinY, 0, 1.0, 0.0);
+
+
+
+	if (mode == 3) {
+		deformPlane = plane.getMesh();
+		// x = columns, y = rows //
+		ofVec3f planeDims = plane.getResolution();
+		float planeAngleX = ofGetElapsedTimef()*3.6;
+		float planeAngleInc = 3.f / (float)planeDims.x;
+		ofVec3f vert;
+		for (size_t i = 0; i < deformPlane.getNumIndices(); i++) {
+			planeAngleX += planeAngleInc;
+			int ii = deformPlane.getIndex(i);
+			vert = deformPlane.getVertex(ii);
+			vert.z += cos(planeAngleX) * 50;
+			deformPlane.setVertex(ii, vert);
+		}
+	}
+
+	if (!bFill && bWireframe) {
+		// if we are only drawing the wireframe, use
+		// the material to draw it, otherwise the material
+		// will be bound and unbound for every geometry
+		// and the wireframe will be drawn in black
+		material.begin();
+	}
+
+	if (bFill) {
+		material.begin();
+		ofFill();
+		if (mode == 3) {
+			plane.transformGL();
+			deformPlane.draw();
+			plane.restoreTransformGL();
+		}
+		else {
+			plane.draw();
+		}
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z + 1);
+		plane.drawWireframe();
+		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z - 1);
+
+	}
+
+	// Box //
+
+	box.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	box.rotateDeg(spinY, 0, 1.0, 0.0);
+
+	if (bFill) {
+		material.begin();
+		ofFill();
+		if (mode == 3) {
+			box.transformGL();
+			for (int i = 0; i < ofBoxPrimitive::SIDES_TOTAL; i++) {
+				ofPushMatrix();
+				ofTranslate(boxSides[i].getNormal(0) * sin(ofGetElapsedTimef()) * 50);
+				boxSides[i].draw();
+				ofPopMatrix();
+			}
+			box.restoreTransformGL();
+		}
+		else {
+			box.draw();
+		}
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		box.setScale(1.01f);
+		box.drawWireframe();
+		box.setScale(1.f);
+	}
+
+
+	// Sphere //
+	sphere.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	sphere.rotateDeg(spinY, 0, 1.0, 0.0);
+
+	if (mode == 3) {
+		sphere.setMode(OF_PRIMITIVE_TRIANGLES);
+		triangles = sphere.getMesh().getUniqueFaces();
+	}
+
+	if (bFill) {
+		material.begin();
+		ofFill();
+		if (mode == 3) {
+			float angle = ofGetElapsedTimef()*3.2;
+			float strength = (sin(angle + .25)) * .5f * 5.f;
+			ofVec3f faceNormal;
+			for (size_t i = 0; i < triangles.size(); i++) {
+				// store the face normal here.
+				// we change the vertices, which makes the face normal change
+				// every time that we call getFaceNormal //
+				faceNormal = triangles[i].getFaceNormal();
+				for (int j = 0; j < 3; j++) {
+					triangles[i].setVertex(j, triangles[i].getVertex(j) + faceNormal * strength);
+				}
+			}
+			sphere.getMesh().setFromTriangles(triangles);
+		}
+		sphere.draw();
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		sphere.setScale(1.01f);
+		sphere.drawWireframe();
+		sphere.setScale(1.f);
+	}
+
+
+	// ICO Sphere //
+	
+	icoSphere.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	icoSphere.rotateDeg(spinY, 0, 1.0, 0.0);
+
+	if (mode == 3) {
+		triangles = icoSphere.getMesh().getUniqueFaces();
+	}
+
+	if (bFill) {
+		material.begin();
+		ofFill();
+
+		if (mode == 3) {
+			float angle = (ofGetElapsedTimef() * 1.4);
+			ofVec3f faceNormal;
+			for (size_t i = 0; i < triangles.size(); i++) {
+				float frc = ofSignedNoise(angle* (float)i * .1, angle*.05) * 4;
+				faceNormal = triangles[i].getFaceNormal();
+				for (int j = 0; j < 3; j++) {
+					triangles[i].setVertex(j, triangles[i].getVertex(j) + faceNormal * frc);
+				}
+			}
+			icoSphere.getMesh().setFromTriangles(triangles);
+		}
+
+		icoSphere.draw();
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		icoSphere.setScale(1.01f);
+		icoSphere.drawWireframe();
+		icoSphere.setScale(1.f);
+	}
+
+
+	// Cylinder //
+	if (mode == 3) {
+		topCap = cylinder.getTopCapMesh();
+		bottomCap = cylinder.getBottomCapMesh();
+		body = cylinder.getCylinderMesh();
+	}
+
+	cylinder.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	cylinder.rotateDeg(spinY, 0, 1.0, 0.0);
+	if (bFill) {
+		material.begin();
+		ofFill();
+		if (mode == 3) {
+			cylinder.transformGL();
+			ofPushMatrix(); {
+				if (topCap.getNumNormals() > 0) {
+					ofTranslate(topCap.getNormal(0) * (cos(ofGetElapsedTimef() * 5) + 1)*.5f * 100);
+					topCap.draw();
+				}
+			} ofPopMatrix();
+			ofPushMatrix(); {
+				if (bottomCap.getNumNormals() > 0) {
+					ofTranslate(bottomCap.getNormal(0) * (cos(ofGetElapsedTimef() * 4) + 1)*.5f * 100);
+					bottomCap.draw();
+				}
+			} ofPopMatrix();
+			ofPushMatrix(); {
+				float scale = (cos(ofGetElapsedTimef() * 3) + 1)*.5f + .2;
+				ofScale(scale, scale, scale);
+				body.draw();
+			} ofPopMatrix();
+			cylinder.restoreTransformGL();
+		}
+		else {
+			cylinder.draw();
+		}
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		cylinder.setScale(1.01f);
+		cylinder.drawWireframe();
+		cylinder.setScale(1.0f);
+	}
+
+
+	// Cone //
+	cone.rotateDeg(spinX, 1.0, 0.0, 0.0);
+	cone.rotateDeg(spinY, 0, 1.0, 0.0);
+
+	if (mode == 3) {
+		bottomCap = cone.getCapMesh();
+		body = cone.getConeMesh();
+	}
+	if (bFill) {
+		material.begin();
+		ofFill();
+		if (mode == 3) {
+			cone.transformGL();
+			ofPushMatrix();
+			if (bottomCap.getNumNormals() > 0) {
+				ofTranslate(bottomCap.getNormal(0) * cone.getHeight()*.5);
+				ofRotateDeg(sin(ofGetElapsedTimef() * 5) * RAD_TO_DEG, 1, 0, 0);
+				bottomCap.draw();
+			}
+			ofPopMatrix();
+
+			ofPushMatrix();
+			ofRotateDeg(90, 1, 0, 0);
+			ofRotateDeg((cos(ofGetElapsedTimef() * 6) + 1)*.5 * 360, 1, 0, 0);
+			body.draw();
+			ofPopMatrix();
+			cone.restoreTransformGL();
+		}
+		else {
+			cone.draw();
+		}
+		material.end();
+	}
+
+	if (bWireframe) {
+		ofNoFill();
+		ofSetColor(0, 0, 0);
+		cone.setScale(1.01f);
+		cone.drawWireframe();
+		cone.setScale(1.0f);
+	}
+
+	if (!bFill && bWireframe) {
+		material.end();
+	}
+
+	if (mode == 1 || mode == 3) texture.getTexture().unbind();
+	if (mode == 2) vidGrabber.getTexture().unbind();
+
+	material.end();
+	ofDisableLighting();
+
+	if (bDrawLights) {
+		ofFill();
+		ofSetColor(pointLight.getDiffuseColor());
+		pointLight.draw();
+		ofSetColor(pointLight2.getDiffuseColor());
+		pointLight2.draw();
+		ofSetColor(pointLight3.getDiffuseColor());
+		pointLight3.draw();
+	}
+
+	if (bDrawNormals) {
+		ofSetColor(225, 0, 255);
+		plane.drawNormals(20, bSplitFaces);
+		box.drawNormals(20, bSplitFaces);
+		sphere.drawNormals(20, bSplitFaces);
+		icoSphere.drawNormals(20, bSplitFaces);
+		cylinder.drawNormals(20, bSplitFaces);
+		cone.drawNormals(20, bSplitFaces);
+	}
+	if (bDrawAxes) {
+		plane.drawAxes(plane.getWidth()*.5 + 30);
+		box.drawAxes(box.getWidth() + 30);
+		sphere.drawAxes(sphere.getRadius() + 30);
+		icoSphere.drawAxes(icoSphere.getRadius() + 30);
+		cylinder.drawAxes(cylinder.getHeight() + 30);
+		cone.drawAxes(cone.getHeight() + 30);
+	}
+
+	ofDisableDepthTest();
+
+	ofFill();
+
+	cam.end();
+	
 	ofSetDrawBitmapMode(OF_BITMAPMODE_MODEL_BILLBOARD);
 
-    float spinX = sin(ofGetElapsedTimef()*.35f);
-    float spinY = cos(ofGetElapsedTimef()*.075f);
-
-    if(bMousePressed) {
-        spinX = spinY = 0.0f;
-    }
-
-    ofEnableDepthTest();
-
-    ofEnableLighting();
-    pointLight.enable();
-    pointLight2.enable();
-    pointLight3.enable();
-
-
-
-    // draw the outer sphere
-    material.begin();
-    ofNoFill();
-    ofDrawSphere(ofGetWidth()/2, ofGetHeight()/2, ofGetWidth());
-    material.end();
-
-    if(mode == 1 || mode == 3) texture.getTexture().bind();
-    if(mode == 2) vidGrabber.getTexture().bind();
-
-
-    // Plane //
-    plane.setPosition(ofGetWidth()*.2, ofGetHeight()*.25, 0);
-    plane.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    plane.rotateDeg(spinY, 0, 1.0, 0.0);
-
-
-
-    if(mode == 3) {
-        deformPlane = plane.getMesh();
-        // x = columns, y = rows //
-        ofVec3f planeDims = plane.getResolution();
-        float planeAngleX = ofGetElapsedTimef()*3.6;
-        float planeAngleInc = 3.f/(float)planeDims.x;
-        ofVec3f vert;
-        for(size_t i = 0; i < deformPlane.getNumIndices(); i++ ) {
-            planeAngleX += planeAngleInc;
-            int ii = deformPlane.getIndex( i );
-            vert = deformPlane.getVertex( ii );
-            vert.z += cos(planeAngleX) * 50;
-            deformPlane.setVertex( ii, vert );
-        }
-    }
-
-    if(!bFill && bWireframe){
-        // if we are only drawing the wireframe, use
-        // the material to draw it, otherwise the material
-        // will be bound and unbound for every geometry
-        // and the wireframe will be drawn in black
-        material.begin();
-    }
-
-    if(bFill) {
-        material.begin();
-        ofFill();
-        if(mode == 3) {
-            plane.transformGL();
-            deformPlane.draw();
-            plane.restoreTransformGL();
-        } else {
-            plane.draw();
-        }
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z+1);
-        plane.drawWireframe();
-		plane.setPosition(plane.getPosition().x, plane.getPosition().y, plane.getPosition().z-1);
-
-    }
-
-    // Box //
-    box.setPosition(ofGetWidth()*.5, ofGetHeight()*.25, 0);
-    box.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    box.rotateDeg(spinY, 0, 1.0, 0.0);
-
-    if(bFill) {
-        material.begin();
-        ofFill();
-        if(mode == 3) {
-            box.transformGL();
-            for(int i = 0; i < ofBoxPrimitive::SIDES_TOTAL; i++ ) {
-                ofPushMatrix();
-                ofTranslate( boxSides[i].getNormal(0) * sin(ofGetElapsedTimef()) * 50  );
-                boxSides[i].draw();
-                ofPopMatrix();
-            }
-            box.restoreTransformGL();
-        } else {
-            box.draw();
-        }
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-        box.setScale(1.01f);
-        box.drawWireframe();
-        box.setScale(1.f);
-    }
-
-
-    // Sphere //
-    sphere.setPosition(ofGetWidth()*.8f, ofGetHeight()*.25, 0);
-    sphere.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    sphere.rotateDeg(spinY, 0, 1.0, 0.0);
-
-    if(mode == 3) {
-        sphere.setMode( OF_PRIMITIVE_TRIANGLES );
-        triangles = sphere.getMesh().getUniqueFaces();
-    }
-
-    if(bFill) {
-        material.begin();
-        ofFill();
-        if(mode == 3) {
-            float angle = ofGetElapsedTimef()*3.2;
-            float strength = (sin( angle+.25 )) * .5f * 5.f;
-            ofVec3f faceNormal;
-            for(size_t i = 0; i < triangles.size(); i++ ) {
-                // store the face normal here.
-                // we change the vertices, which makes the face normal change
-                // every time that we call getFaceNormal //
-                faceNormal = triangles[i].getFaceNormal();
-                for(int j = 0; j < 3; j++ ) {
-                    triangles[i].setVertex( j, triangles[i].getVertex(j) + faceNormal * strength);
-                }
-            }
-            sphere.getMesh().setFromTriangles( triangles );
-        }
-        sphere.draw();
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-        sphere.setScale(1.01f);
-        sphere.drawWireframe();
-        sphere.setScale(1.f);
-    }
-
-
-    // ICO Sphere //
-    icoSphere.setPosition(ofGetWidth()*.2, ofGetHeight()*.75, 0);
-    icoSphere.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    icoSphere.rotateDeg(spinY, 0, 1.0, 0.0);
-
-    if(mode == 3) {
-        triangles = icoSphere.getMesh().getUniqueFaces();
-    }
-
-    if(bFill) {
-        material.begin();
-        ofFill();
-
-        if(mode == 3) {
-            float angle = (ofGetElapsedTimef() * 1.4);
-            ofVec3f faceNormal;
-            for(size_t i = 0; i < triangles.size(); i++ ) {
-                float frc = ofSignedNoise(angle* (float)i * .1, angle*.05) * 4;
-                faceNormal = triangles[i].getFaceNormal();
-                for(int j = 0; j < 3; j++ ) {
-                    triangles[i].setVertex(j, triangles[i].getVertex(j) + faceNormal * frc );
-                }
-            }
-            icoSphere.getMesh().setFromTriangles( triangles );
-        }
-
-        icoSphere.draw();
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-        icoSphere.setScale(1.01f);
-        icoSphere.drawWireframe();
-        icoSphere.setScale(1.f);
-    }
-
-
-    // Cylinder //
-    if(mode == 3) {
-        topCap      = cylinder.getTopCapMesh();
-        bottomCap   = cylinder.getBottomCapMesh();
-        body        = cylinder.getCylinderMesh();
-    }
-
-    cylinder.setPosition(ofGetWidth()*.5, ofGetHeight()*.75, 0);
-    cylinder.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    cylinder.rotateDeg(spinY, 0, 1.0, 0.0);
-    if(bFill) {
-        material.begin();
-        ofFill();
-        if(mode == 3) {
-            cylinder.transformGL();
-            ofPushMatrix(); {
-                if(topCap.getNumNormals() > 0) {
-                    ofTranslate( topCap.getNormal(0) * (cos(ofGetElapsedTimef()*5)+1)*.5f * 100 );
-                    topCap.draw();
-                }
-            } ofPopMatrix();
-            ofPushMatrix(); {
-                if(bottomCap.getNumNormals() > 0) {
-                    ofTranslate( bottomCap.getNormal(0) * (cos(ofGetElapsedTimef()*4)+1)*.5f * 100 );
-                    bottomCap.draw();
-                }
-            } ofPopMatrix();
-            ofPushMatrix(); {
-                float scale = (cos(ofGetElapsedTimef()*3)+1)*.5f + .2;
-                ofScale( scale, scale, scale );
-                body.draw();
-            } ofPopMatrix();
-            cylinder.restoreTransformGL();
-        } else {
-            cylinder.draw();
-        }
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-        cylinder.setScale(1.01f);
-        cylinder.drawWireframe();
-        cylinder.setScale(1.0f);
-    }
-
-
-    // Cone //
-    cone.setPosition(ofGetWidth()*.8, ofGetHeight()*.75, 0);
-    cone.rotateDeg(spinX, 1.0, 0.0, 0.0);
-    cone.rotateDeg(spinY, 0, 1.0, 0.0);
-
-    if(mode == 3) {
-        bottomCap   = cone.getCapMesh();
-        body        = cone.getConeMesh();
-    }
-    if(bFill) {
-        material.begin();
-        ofFill();
-        if(mode == 3) {
-            cone.transformGL();
-            ofPushMatrix();
-            if(bottomCap.getNumNormals() > 0 ) {
-                ofTranslate( bottomCap.getNormal(0) * cone.getHeight()*.5 );
-                ofRotateDeg( sin(ofGetElapsedTimef()*5) * RAD_TO_DEG, 1, 0, 0);
-                bottomCap.draw();
-            }
-            ofPopMatrix();
-
-            ofPushMatrix();
-            ofRotateDeg(90, 1, 0, 0);
-            ofRotateDeg( (cos(ofGetElapsedTimef()*6) +1)*.5 * 360 , 1, 0, 0 );
-            body.draw();
-            ofPopMatrix();
-            cone.restoreTransformGL();
-        } else {
-            cone.draw();
-        }
-        material.end();
-    }
-
-    if(bWireframe) {
-        ofNoFill();
-        ofSetColor(0, 0, 0);
-        cone.setScale(1.01f);
-        cone.drawWireframe();
-        cone.setScale(1.0f);
-    }
-
-    if(!bFill && bWireframe){
-        material.end();
-    }
-
-    if(mode == 1 || mode == 3) texture.getTexture().unbind();
-    if(mode == 2) vidGrabber.getTexture().unbind();
-
-    material.end();
-    ofDisableLighting();
-
-    if(bDrawLights) {
-        ofFill();
-        ofSetColor(pointLight.getDiffuseColor());
-        pointLight.draw();
-        ofSetColor(pointLight2.getDiffuseColor());
-        pointLight2.draw();
-        ofSetColor(pointLight3.getDiffuseColor());
-        pointLight3.draw();
-    }
-
-    if(bDrawNormals) {
-        ofSetColor(225, 0, 255);
-        plane.drawNormals(20, bSplitFaces);
-        box.drawNormals(20, bSplitFaces);
-        sphere.drawNormals(20, bSplitFaces);
-        icoSphere.drawNormals(20, bSplitFaces);
-        cylinder.drawNormals(20, bSplitFaces);
-        cone.drawNormals(20, bSplitFaces);
-    }
-    if(bDrawAxes) {
-        plane.drawAxes(plane.getWidth()*.5+30);
-        box.drawAxes(box.getWidth()+30);
-        sphere.drawAxes(sphere.getRadius()+30);
-        icoSphere.drawAxes(icoSphere.getRadius()+30);
-        cylinder.drawAxes(cylinder.getHeight()+30);
-        cone.drawAxes(cone.getHeight()+30);
-    }
-
-    ofDisableDepthTest();
-
-    ofFill();
-
-    ofSetColor(0);
-    ofDrawRectangle(plane.getPosition().x-154, plane.getPosition().y + 120, 140, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofPlanePrimitive", plane.getPosition().x-150, plane.getPosition().y+136 );
-
-    ofSetColor(0);
-    ofDrawRectangle(box.getPosition().x-154, box.getPosition().y + 120, 126, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofBoxPrimitive", box.getPosition().x-150, box.getPosition().y+136 );
-
-    ofSetColor(0);
-    ofDrawRectangle(sphere.getPosition().x-154, sphere.getPosition().y + 120, 148, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofSpherePrimitive", sphere.getPosition().x-150, sphere.getPosition().y+136 );
-
-    ofSetColor(0);
-    ofDrawRectangle(icoSphere.getPosition().x-154, icoSphere.getPosition().y + 120, 168, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofIcoSpherePrimitive", icoSphere.getPosition().x-150, icoSphere.getPosition().y+136 );
-
-    ofSetColor(0);
-    ofDrawRectangle(cylinder.getPosition().x-154, cylinder.getPosition().y + 120, 160, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofCylinderPrimitive", cylinder.getPosition().x-150, cylinder.getPosition().y+136 );
-
-    ofSetColor(0);
-    ofDrawRectangle(cone.getPosition().x-154, cone.getPosition().y + 120, 136, 24);
-    ofSetColor(255);
-    ofDrawBitmapString("ofConePrimitive", cone.getPosition().x-150, cone.getPosition().y+136 );
-
-
+	ofDrawBitmapStringHighlight("ofPlanePrimitive"    , glm::vec3(-90,-160,0) + cam.worldToScreen(plane.getGlobalPosition()) );
+	ofDrawBitmapStringHighlight("ofBoxPrimitive"      , glm::vec3(-90,-160,0) + cam.worldToScreen( box.getPosition()));
+    ofDrawBitmapStringHighlight("ofSpherePrimitive"   , glm::vec3(-90,-160,0) + cam.worldToScreen( sphere.getPosition()));
+	ofDrawBitmapStringHighlight("ofIcoSpherePrimitive", glm::vec3(-90,+160,0) + cam.worldToScreen( icoSphere.getPosition()));
+	ofDrawBitmapStringHighlight("ofCylinderPrimitive" , glm::vec3(-90,+160,0) + cam.worldToScreen( cylinder.getPosition()));
+	ofDrawBitmapStringHighlight("ofConePrimitive"     , glm::vec3(-90,+160,0) + cam.worldToScreen( cone.getPosition()));
 
     if(bHelpText) {
         stringstream ss;
@@ -437,11 +428,8 @@ void ofApp::draw() {
         ss <<"(1/2/3/4): Set Resolutions" <<endl<<"(n): Draw Normals"<<"\n(LEFT/RIGHT): Set Mode "<<ofToString(mode,0)<<endl;
         ss <<"(z): Split Faces " <<bSplitFaces<<endl;
         ss <<"(a): Draw Axes"<<endl<<"(l): Render lights" << endl <<"(h): Toggle help."<<endl;
-        ofDrawBitmapString(ss.str().c_str(), 20, 20);
+        ofDrawBitmapStringHighlight(ss.str().c_str(), 20, 20);
     }
-
-
-
 
 
 }

--- a/examples/3d/3DPrimitivesExample/src/ofApp.h
+++ b/examples/3d/3DPrimitivesExample/src/ofApp.h
@@ -52,5 +52,5 @@ public:
     ofVboMesh topCap, bottomCap, body;
     vector<ofMeshFace> triangles;
     
-
+	ofCamera cam;
 };

--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -141,14 +141,11 @@ void of3dPrimitive::disableColors() {
     getMesh().disableColors();
 }
 
-
-
-
 // SETTERS //
 
 //----------------------------------------------------------
 void of3dPrimitive::mapTexCoords( float u1, float v1, float u2, float v2 ) {
-    //setTexCoords( u1, v1, u2, v2 );
+	
 	auto prevTcoord = getTexCoords();
     
 	for(std::size_t j = 0; j < getMesh().getNumTexCoords(); j++ ) {
@@ -163,13 +160,13 @@ void of3dPrimitive::mapTexCoords( float u1, float v1, float u2, float v2 ) {
 }
 
 //----------------------------------------------------------
-void of3dPrimitive::mapTexCoordsFromTexture( ofTexture& inTexture ) {
+void of3dPrimitive::mapTexCoordsFromTexture( const ofTexture& inTexture ) {
     bool bNormalized = true;
 #ifndef TARGET_OPENGLES
     bNormalized = (inTexture.getTextureData().textureTarget!=GL_TEXTURE_RECTANGLE_ARB);
 #endif
     
-    ofTextureData& tdata = inTexture.getTextureData();
+    const ofTextureData& tdata = inTexture.getTextureData();
 	if(bNormalized){
         mapTexCoords( 0, 0, tdata.tex_t, tdata.tex_u );
 	}else{
@@ -188,9 +185,6 @@ void of3dPrimitive::normalizeAndApplySavedTexCoords() {
 	texCoords = {0.f, 0.f, 1.f, 1.f};
     mapTexCoords(tcoords.x, tcoords.y, tcoords.z, tcoords.w);
 }
-
-
-
 
 //--------------------------------------------------------------
 void of3dPrimitive::drawVertices()  const{

--- a/libs/openFrameworks/3d/of3dPrimitives.h
+++ b/libs/openFrameworks/3d/of3dPrimitives.h
@@ -23,7 +23,7 @@ public:
     // does not store texture. Creates tex coords from texture, if texture is
     // non-arb, then it will create normalized tex coords //
     // defaults to index 0
-    void mapTexCoordsFromTexture( ofTexture& inTexture );
+    void mapTexCoordsFromTexture( const ofTexture& inTexture );
 
 
     ofMesh* getMeshPtr();

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2625,10 +2625,10 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resX-1.f));
-			texcoord.y = ((float)iy/((float)resY-1.f));
+			texcoord.y = 1.f - ((float)iy/((float)resY-1.f));
 
 			vert.x = texcoord.x * width - halfW;
-			vert.y = texcoord.y * height - halfH;
+			vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.z = halfD;
 
 			mesh.addVertex(vert);
@@ -2662,11 +2662,11 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resZ-1.f));
-			texcoord.y = ((float)iy/((float)resY-1.f));
+			texcoord.y = 1.f - ((float)iy/((float)resY-1.f));
 
 			//vert.x = texcoord.x * width - halfW;
 			vert.x = halfW;
-			vert.y = texcoord.y * height - halfH;
+			vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.z = texcoord.x * -depth + halfD;
 
 			mesh.addVertex(vert);
@@ -2699,11 +2699,11 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resZ-1.f));
-			texcoord.y = ((float)iy/((float)resY-1.f));
+			texcoord.y = 1.f-((float)iy/((float)resY-1.f));
 
 			//vert.x = texcoord.x * width - halfW;
 			vert.x = -halfW;
-			vert.y = texcoord.y * height - halfH;
+			vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.z = texcoord.x * depth - halfD;
 
 			mesh.addVertex(vert);
@@ -2737,10 +2737,10 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resX-1.f));
-			texcoord.y = ((float)iy/((float)resY-1.f));
+			texcoord.y = 1.f-((float)iy/((float)resY-1.f));
 
 			vert.x = texcoord.x * -width + halfW;
-			vert.y = texcoord.y * height - halfH;
+			vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.z = -halfD;
 
 			mesh.addVertex(vert);
@@ -2774,10 +2774,10 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resX-1.f));
-			texcoord.y = ((float)iy/((float)resZ-1.f));
+			texcoord.y = 1.f-((float)iy/((float)resZ-1.f));
 
 			vert.x = texcoord.x * width - halfW;
-			//vert.y = texcoord.y * height - halfH;
+			//vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.y = -halfH;
 			vert.z = texcoord.y * depth - halfD;
 
@@ -2812,10 +2812,10 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 
 			// normalized tex coords //
 			texcoord.x = ((float)ix/((float)resX-1.f));
-			texcoord.y = ((float)iy/((float)resZ-1.f));
+			texcoord.y = 1.f-((float)iy/((float)resZ-1.f));
 
 			vert.x = texcoord.x * width - halfW;
-			//vert.y = texcoord.y * height - halfH;
+			//vert.y = -(texcoord.y-1.f) * height - halfH;
 			vert.y = halfH;
 			vert.z = texcoord.y * -depth + halfD;
 

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2063,7 +2063,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 	const float phi = (1.0f + sqrt5) * 0.5f;
 	const float invnorm = 1/sqrt(phi*phi+1);
 
-        sphere.addVertex(invnorm * V(-1,  phi, 0));//0
+    sphere.addVertex(invnorm * V(-1,  phi, 0));//0
 	sphere.addVertex(invnorm * V( 1,  phi, 0));//1
 	sphere.addVertex(invnorm * V(0,   1,  -phi));//2
 	sphere.addVertex(invnorm * V(0,   1,   phi));//3
@@ -2157,8 +2157,9 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 		u = alpha/TWO_PI+.5f;
 		v = atan2f(vec.y, r0)/PI + .5f;
 		// reverse the u coord, so the default is texture mapped left to
-		// right on the outside of a sphere //
-		texCoords.push_back(T(1.0-u,v));
+		// right on the outside of a sphere 
+		// reverse the v coord, so that texture origin is at top left
+		texCoords.push_back(T(1.0-u,1.f-v));
 	}
 
 	/// Step 4 : fix texcoords

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2488,7 +2488,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cone( float radius, float height, int radiusS
 			vert.z = sin((float)ix*angleIncRadius) * newRad;
 
 			tcoord.x = (float)ix/((float)radiusSegments-1.f);
-			tcoord.y = (float)iy/((float)maxTexY);
+			tcoord.y = 1.f - (float)iy/((float)maxTexY);
 
 			mesh.addTexCoord( tcoord );
 			mesh.addVertex( vert );
@@ -2546,7 +2546,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cone( float radius, float height, int radiusS
 			vert.y = halfH;
 
 			tcoord.x = (float)ix/((float)radiusSegments-1.f);
-			tcoord.y = ofMap(iy, 0, capSegs-1, maxTexYNormalized, 1.f);
+			tcoord.y = 1.f - ofMap(iy, 0, capSegs-1, maxTexYNormalized, 1.f);
 
 			mesh.addTexCoord( tcoord );
 			mesh.addVertex( vert );

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2293,7 +2293,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cylinder( float radius, float height, int rad
 				vert.y = -halfH;
 
 				tcoord.x = (float)ix/((float)radiusSegments-1.f);
-				tcoord.y = ofMap(iy, 0, capSegs-1, 0, maxTexYNormalized);
+				tcoord.y = 1.f - ofMap(iy, 0, capSegs-1, 0, maxTexYNormalized);
 
 				mesh.addTexCoord( tcoord );
 				mesh.addVertex( vert );
@@ -2347,7 +2347,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cylinder( float radius, float height, int rad
 			vert.z = sin(ix*angleIncRadius) * radius;
 
 			tcoord.x = float(ix)/(float(radiusSegments)-1.f);
-			tcoord.y = ofMap(iy, 0, heightSegments-1, minTexYNormalized, maxTexYNormalized );
+			tcoord.y = 1.f - ofMap(iy, 0, heightSegments-1, minTexYNormalized, maxTexYNormalized );
 
 			mesh.addTexCoord( tcoord );
 			mesh.addVertex( vert );
@@ -2397,7 +2397,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cylinder( float radius, float height, int rad
 				vert.y = halfH;
 
 				tcoord.x = (float)ix/((float)radiusSegments-1.f);
-				tcoord.y = ofMap(iy, 0, capSegs-1, minTexYNormalized, maxTexYNormalized);
+				tcoord.y = 1.f - ofMap(iy, 0, capSegs-1, minTexYNormalized, maxTexYNormalized);
 
 				mesh.addTexCoord( tcoord );
 				mesh.addVertex( vert );

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1948,7 +1948,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::sphere( float radius, int res, ofPrimitiveMod
 		float tr = sin( PI-i * polarInc );
 		float ny = cos( PI-i * polarInc );
 
-		tcoord.y = i / res;
+		tcoord.y = 1.f - (i / res);
 
 		for(float j = 0; j <= doubleRes; j++) {
 

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1866,19 +1866,20 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::plane(float width, float height, int columns,
 	N normal(0, 0, 1); // always facing forward //
 	T texcoord;
 
-	// the origin of the plane is the center //
-	float halfW = width/2.f;
-	float halfH = height/2.f;
+	// the origin of the plane is at the center //
+	float halfW = width  * 0.5f;
+	float halfH = height * 0.5f;
+	
 	// add the vertexes //
-	for(int iy = 0; iy < rows; iy++) {
-		for(int ix = 0; ix < columns; ix++) {
+	for(int iy = 0; iy != rows; iy++) {
+		for(int ix = 0; ix != columns; ix++) {
 
 			// normalized tex coords //
-			texcoord.x = ((float)ix/((float)columns-1.f));
-			texcoord.y = ((float)iy/((float)rows-1.f));
+			texcoord.x =       ((float)ix/((float)columns-1));
+			texcoord.y = 1.f - ((float)iy/((float)rows-1));
 
 			vert.x = texcoord.x * width - halfW;
-			vert.y = texcoord.y * height - halfH;
+			vert.y = -(texcoord.y-1) * height - halfH;
 
 			mesh.addVertex(vert);
 			mesh.addTexCoord(texcoord);


### PR DESCRIPTION
Flips texture coordinates for all oF primitives so that textures seen through a default camera (without view flipping) appear correct. 

Addresses #3139 

![ofboxexample](https://user-images.githubusercontent.com/423509/35990424-db6eb8ba-0cfb-11e8-9c11-7af001b52282.PNG)

* updates of3DPrimitivesExample to use a default camera
![capture](https://user-images.githubusercontent.com/423509/35990418-d62a2d3a-0cfb-11e8-8f57-0d1273301cb8.PNG)



