### PR TITLE
fix ortho projection matrix calc

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -151,10 +151,10 @@ glm::mat4 ofCamera::getProjectionMatrix(const ofRectangle & viewport) const {
 
 	if(isOrtho) {
 		return glm::ortho(
-			viewport.x - viewport.width/2,
-			viewport.x + viewport.width/2,
-			viewport.y - viewport.height/2,
-			viewport.y + viewport.height/2,
+			- viewport.width/2,
+			+ viewport.width/2,
+			- viewport.height/2,
+			+ viewport.height/2,
 			nearClip,
 			farClip
 		);


### PR DESCRIPTION
+ ortho matrix must not use viewport offset for its own calculations, only viewport dimensions.

This is in line for how projection matrix is calculated for perspective matrices, where only the aspect ratio of the viewport is used.


Otherwise the centre of projection will be off (not viewport centre) when the camera view is drawn using a viewport with offset - as you could see when placing an ortho camera in main view in advanced3DExample.
