### PR TITLE
advanced3DExample: remove reference to OrthoCam.h

### DIFF
--- a/examples/3d/advanced3dExample/src/ofApp.h
+++ b/examples/3d/advanced3dExample/src/ofApp.h
@@ -15,7 +15,6 @@
 // Custom objects for this example
 #include "Swarm.h"
 #include "Grid.h"
-#include "OrthoCamera.h"
 
 #define N_CAMERAS 4
 


### PR DESCRIPTION
+ removes a leftover reference to deleted header file (oops)