### PR TITLE
fix box primitive winding order

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2641,13 +2641,13 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 		for(int x = 0; x < resX-1; x++) {
 			// first triangle //
 			mesh.addIndex((y)*resX + x + vertOffset);
-			mesh.addIndex((y)*resX + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resX + x + vertOffset);
+			mesh.addIndex((y)*resX + x+1 + vertOffset);
 
 			// second triangle //
 			mesh.addIndex((y)*resX + x+1 + vertOffset);
-			mesh.addIndex((y+1)*resX + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resX + x + vertOffset);
+			mesh.addIndex((y+1)*resX + x+1 + vertOffset);
 		}
 	}
 
@@ -2679,13 +2679,13 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 		for(int x = 0; x < resZ-1; x++) {
 			// first triangle //
 			mesh.addIndex((y)*resZ + x + vertOffset);
-			mesh.addIndex((y)*resZ + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resZ + x + vertOffset);
+			mesh.addIndex((y)*resZ + x+1 + vertOffset);
 
 			// second triangle //
 			mesh.addIndex((y)*resZ + x+1 + vertOffset);
-			mesh.addIndex((y+1)*resZ + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resZ + x + vertOffset);
+			mesh.addIndex((y+1)*resZ + x+1 + vertOffset);
 		}
 	}
 
@@ -2716,13 +2716,13 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 		for(int x = 0; x < resZ-1; x++) {
 			// first triangle //
 			mesh.addIndex((y)*resZ + x + vertOffset);
-			mesh.addIndex((y)*resZ + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resZ + x + vertOffset);
+			mesh.addIndex((y)*resZ + x+1 + vertOffset);
 
 			// second triangle //
 			mesh.addIndex((y)*resZ + x+1 + vertOffset);
-			mesh.addIndex((y+1)*resZ + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resZ + x + vertOffset);
+			mesh.addIndex((y+1)*resZ + x+1 + vertOffset);
 		}
 	}
 
@@ -2753,13 +2753,13 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::box( float width, float height, float depth, 
 		for(int x = 0; x < resX-1; x++) {
 			// first triangle //
 			mesh.addIndex((y)*resX + x + vertOffset);
-			mesh.addIndex((y)*resX + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resX + x + vertOffset);
+			mesh.addIndex((y)*resX + x+1 + vertOffset);
 
 			// second triangle //
 			mesh.addIndex((y)*resX + x+1 + vertOffset);
-			mesh.addIndex((y+1)*resX + x+1 + vertOffset);
 			mesh.addIndex((y+1)*resX + x + vertOffset);
+			mesh.addIndex((y+1)*resX + x+1 + vertOffset);
 		}
 	}
 


### PR DESCRIPTION
Aligns box primitive triangle winding order so that it is consistent with the winding order of other primitives. That is, when viewed through an `ofCamera`, and `GL_CULL_FACE` is `enabled` with `glFrontFace(GL_CW)` it will look correct, the front faces visible, the back faces invisible.

All other oF primitives appear to follow this convention.