### PR TITLE
Add unimplemented methods to ofTexture on Android

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -832,20 +832,6 @@ shared_ptr<ofBaseGLRenderer> ofGetGLRenderer(){
 }
 #endif
 
-#if defined(TARGET_ANDROID)
-void ofRegenerateAllVbos();
-void ofRegenerateAllTextures();
-void ofReloadAllImageTextures();
-void ofReloadAllFontTextures();
-
-void ofReloadGLResources(){
-	ofRegenerateAllTextures();
-	ofRegenerateAllVbos();
-	ofReloadAllImageTextures();
-	ofReloadAllFontTextures();
-}
-#endif
-
 #ifndef TARGET_OPENGLES
 namespace{
 	void gl_debug_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, void * user){

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -183,18 +183,6 @@ void ofRegenerateAllTextures(){
 	}
 }
 
-void ofRegenerateAllVbos() {
-
-}
-
-void ofReloadAllImageTextures() {
-
-}
-
-void ofReloadAllFontTextures() {
-
-}
-
 #endif
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -182,6 +182,19 @@ void ofRegenerateAllTextures(){
 		tex->clear();
 	}
 }
+
+void ofRegenerateAllVbos() {
+
+}
+
+void ofReloadAllImageTextures() {
+
+}
+
+void ofReloadAllFontTextures() {
+
+}
+
 #endif
 
 //----------------------------------------------------------


### PR DESCRIPTION
I have added the implementation of the following methods (which are defined for Android in ofGLUtils) to ofTexture class to avoid missing method implementation issues on Android:

```
void ofRegenerateAllVbos() {}
void ofReloadAllImageTextures() {}
void ofReloadAllFontTextures() {}
```
