### PR TITLE
Fix GL_INVALID_OPERATION on OpenGL ES 2.0 +

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1202,29 +1202,6 @@ void ofGLProgrammableRenderer::setAttributes(bool vertices, bool color, bool tex
 	if(wasColorsEnabled!=color){
 		if(currentShader) currentShader->setUniform1f(USE_COLORS_UNIFORM,color);
 	}
-#if defined(TARGET_OPENGLES) && !defined(TARGET_EMSCRIPTEN)
-	if(getGLVersionMajor() == 1) {
-		if(vertices){
-			glEnableClientState(GL_VERTEX_ARRAY);
-		}
-		if(color){
-			glEnableClientState(GL_COLOR_ARRAY);
-		}else{
-			glDisableClientState(GL_COLOR_ARRAY);
-		}
-		if(tex){
-			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-		}else{
-			glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-		}
-		if(normals){
-			glEnableClientState(GL_NORMAL_ARRAY);
-		}else{
-			glDisableClientState(GL_NORMAL_ARRAY);
-		}
-	}
-
-#endif
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1203,23 +1203,25 @@ void ofGLProgrammableRenderer::setAttributes(bool vertices, bool color, bool tex
 		if(currentShader) currentShader->setUniform1f(USE_COLORS_UNIFORM,color);
 	}
 #if defined(TARGET_OPENGLES) && !defined(TARGET_EMSCRIPTEN)
-	if(vertices){
-		glEnableClientState(GL_VERTEX_ARRAY);
-	}
-	if(color){
-		glEnableClientState(GL_COLOR_ARRAY);
-	}else{
-		glDisableClientState(GL_COLOR_ARRAY);
-	}
-	if(tex){
-		glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-	}else{
-		glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-	}
-	if(normals){
-		glEnableClientState(GL_NORMAL_ARRAY);
-	}else{
-		glDisableClientState(GL_NORMAL_ARRAY);
+	if(getGLVersionMajor() == 1) {
+		if(vertices){
+			glEnableClientState(GL_VERTEX_ARRAY);
+		}
+		if(color){
+			glEnableClientState(GL_COLOR_ARRAY);
+		}else{
+			glDisableClientState(GL_COLOR_ARRAY);
+		}
+		if(tex){
+			glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+		}else{
+			glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+		}
+		if(normals){
+			glEnableClientState(GL_NORMAL_ARRAY);
+		}else{
+			glDisableClientState(GL_NORMAL_ARRAY);
+		}
 	}
 
 #endif


### PR DESCRIPTION
Fix Open GL ES 1.0/1.1 command being sent into Open GL ES 2/3.

According to Analyser this is a severe error and happening every frame multiple times.

<img width="869" alt="screen shot 2018-02-20 at 11 48 50 am" src="https://user-images.githubusercontent.com/830748/36790735-e5ea8ef6-1ce9-11e8-99b6-ebed65573bf1.png">
<img width="755" alt="screen shot 2018-03-01 at 12 41 16 am" src="https://user-images.githubusercontent.com/830748/36790738-e7d29254-1ce9-11e8-98c1-284720019c2c.png">

Fixed by checking against major GL version.