### PR TITLE
Fixes #4596 - Medium P to High P for Shader Floating Point Precision

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1865,14 +1865,14 @@ void ofGLProgrammableRenderer::drawString(const ofTrueTypeFont & font, string te
 #ifdef TARGET_OPENGLES
 static const string vertex_shader_header =
 		"%extensions%\n"
-		"precision mediump float;\n"
+		"precision highp float;\n"
 		"#define IN attribute\n"
 		"#define OUT varying\n"
 		"#define TEXTURE texture2D\n"
 		"#define TARGET_OPENGLES\n";
 static const string fragment_shader_header =
 		"%extensions%\n"
-		"precision mediump float;\n"
+		"precision highp float;\n"
 		"#define IN varying\n"
 		"#define OUT\n"
 		"#define TEXTURE texture2D\n"


### PR DESCRIPTION
Fixes: #4596

No performance difference noticed with this simple shader / medium to high.
However, massive quality improvements in Vertex orders and positions.