### PR TITLE
iOS/tvOS - Fixes Update and Draw being called before Setup

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -19,6 +19,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
     BOOL bInit;
 	shared_ptr<ofAppiOSWindow> window;
 	shared_ptr<ofxiOSApp> app;
+	BOOL bSetup;
 }
 - (void)updateDimensions;
 @end
@@ -52,6 +53,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
                      andRetina:window->isRetinaEnabled()
                 andRetinaScale:window->getRetinaScale()];
     
+	bSetup = NO;
     if(self) {
         
         _instanceRef = self;
@@ -102,6 +104,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 	ofDisableTextureEdgeHack();
 	
 	window->events().notifySetup();
+	bSetup = YES;
 	window->renderer()->clear();
 }
 
@@ -165,6 +168,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 }
 
 - (void)drawView {
+	if(bSetup == NO) return;
     window->events().notifyUpdate();
 
     //------------------------------------------
@@ -241,7 +245,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 - (void)touchesBegan:(NSSet *)touches 
            withEvent:(UIEvent *)event{
     
-    if(!bInit) {
+    if(!bInit || !bSetup) {
         // if the glView is destroyed which also includes the OF app,
         // we no longer need to pass on these touch events.
         return; 
@@ -283,7 +287,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 - (void)touchesMoved:(NSSet *)touches 
            withEvent:(UIEvent *)event{
     
-    if(!bInit) {
+    if(!bInit || !bSetup) {
         // if the glView is destroyed which also includes the OF app,
         // we no longer need to pass on these touch events.
         return; 
@@ -315,7 +319,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 - (void)touchesEnded:(NSSet *)touches 
            withEvent:(UIEvent *)event{
     
-    if(!bInit) {
+    if(!bInit || !bSetup) {
         // if the glView is destroyed which also includes the OF app,
         // we no longer need to pass on these touch events.
         return; 
@@ -350,7 +354,7 @@ static ofxiOSEAGLView * _instanceRef = nil;
 - (void)touchesCancelled:(NSSet *)touches 
                withEvent:(UIEvent *)event{
     
-    if(!bInit) {
+    if(!bInit || !bSetup) {
         // if the glView is destroyed which also includes the OF app,
         // we no longer need to pass on these touch events.
         return; 


### PR DESCRIPTION
This is a strange one really, it might have been around for a while (iOS 11, maybe 10). I noticed it recently and just guarded my own code with a bool, however after running a few old examples I see it breaks those so this is a critical.

Call stack: (bottom to top)
<img width="292" alt="screen shot 2018-03-02 at 12 44 14 pm" src="https://user-images.githubusercontent.com/830748/36879932-30b82020-1e1a-11e8-8a80-dad1c1c10440.png">

viewDidLoad calls startAnimation which calls draw view and this is now calling a first call on Creation (something that didn't happen previously in iOS).
<img width="804" alt="screen shot 2018-03-02 at 12 45 07 pm" src="https://user-images.githubusercontent.com/830748/36879980-76f3f870-1e1a-11e8-9e7d-e7f757a850c4.png">
(First called from here)


Just added a bool to guard calling the draw function that notify's update/draw if setup hasn't been called.