### PR TITLE
Use the textureMatrix supplied from SurfaceTexture

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -106,6 +106,14 @@ void ofxAndroidVideoGrabber::Data::update(){
 	env->CallVoidMethod(javaVideoGrabber, getTextureMatrix, matrixJava);
 	jfloat* cfloats = env->GetFloatArrayElements(matrixJava, 0);
 	ofMatrix4x4 mat(cfloats);
+	if(mat(0,0) == -1){
+		mat.scale(-1,1,1);
+		mat.translate(1,0,0);
+	}
+	if(mat(1,1) == -1){
+		mat.scale(1,-1,1);
+		mat.translate(0,1,0);
+	}
 	texture.setTextureMatrix(mat);
 }
 
@@ -151,7 +159,6 @@ void ofxAndroidVideoGrabber::Data::loadTexture(){
 	texture.texData.tex_u = 1;
 	texture.texData.textureTarget = GL_TEXTURE_EXTERNAL_OES;
 	texture.texData.glInternalFormat = GL_RGBA;
-	texture.texData.bFlipTexture = true;
 
 
 }

--- a/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
+++ b/addons/ofxAndroid/src/ofxAndroidVideoGrabber.cpp
@@ -12,6 +12,7 @@
 #include "ofUtils.h"
 #include "ofVideoGrabber.h"
 #include "ofGLUtils.h"
+#include "ofMatrix4x4.h"
 
 using namespace std;
 


### PR DESCRIPTION
This fixes a bug where on some devices the camera preview wouldn’t appear correctly. In my case it had a green line a few pixels tall along the bottom edge of the preview.

Also, in my instance the texture matrix flipped the image, so I had to enable bFlipTexture. I don’t know if this is device dependent or not. I tested on two separate devices, a Saumsung Tab 2 and Nexus 5X.