### PR TITLE
Fix teardown order

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -71,6 +71,8 @@ ofAppGLFWWindow::~ofAppGLFWWindow(){
 
 void ofAppGLFWWindow::close(){
 	if(windowP){
+		
+
 		glfwSetMouseButtonCallback( windowP, nullptr );
 		glfwSetCursorPosCallback( windowP, nullptr );
 		glfwSetCursorEnterCallback( windowP, nullptr );
@@ -84,6 +86,12 @@ void ofAppGLFWWindow::close(){
 #endif
 		//hide the window before we destroy it stops a flicker on OS X on exit.
 		glfwHideWindow(windowP);
+
+		// We must ensure renderer is destroyed *before* glfw destroys the window in glfwDestroyWindow, 
+		// as `glfwDestroyWindow` at least on Windows has the effect of unloading OpenGL, making all 
+		// calls to OpenGL illegal.
+		currentRenderer.reset();
+
 		glfwDestroyWindow(windowP);
 		windowP = nullptr;
 		events().disable();

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -135,8 +135,9 @@ void ofMainLoop::loopOnce(){
 	if(bShouldClose) return;
 	for(auto i = windowsApps.begin(); !windowsApps.empty() && i != windowsApps.end();){
 		if(i->first->getWindowShouldClose()){
-			i->first->close();
+			auto window = i->first;
 			windowsApps.erase(i++); ///< i now points at the window after the one which was just erased
+			window->close();
 		}else{
 			currentWindow = i->first;
 			i->first->makeCurrent();


### PR DESCRIPTION
Ensures teardown order for a tuple of <app,renderer,window> is the following: 

1. app
2. renderer
3. window