### PR TITLE
Add translate, rotate and scale to ofPolyline

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -349,6 +349,20 @@ public:
     /// points removed.
 	void simplify(float tolerance=0.3f);
 
+        /// \}
+	/// \name Transform polyline
+	/// \{
+
+        void translate(const glm::vec3 & p);
+	void rotate(float az, const glm::vec3& axis );
+	void translate(const glm::vec2 & p);
+	void rotate(float az, const glm::vec2& axis );
+
+	/// \brief Change the size of the ofPolyline
+	/// These changes are non-reversible, so for instance
+	/// scaling by 0,0 zeros out all data.
+	void scale(float x, float y);
+
 	/// \}
 	/// \name Polyline State
 	/// \{

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -787,6 +787,47 @@ void ofPolyline_<T>::simplify(float tol){
 
 //--------------------------------------------------
 template<class T>
+void ofPolyline_<T>::translate(const glm::vec3 & p){
+    for(auto & point : points){
+        point += p;
+    }
+    flagHasChanged();
+}
+
+//--------------------------------------------------
+template<class T>
+void ofPolyline_<T>::translate(const glm::vec2 &p){
+    translate(glm::vec3(p, 0.0));
+}
+
+//--------------------------------------------------
+template<class T>
+void ofPolyline_<T>::rotate(float az, const glm::vec3 &axis){
+    auto radians = ofDegToRad(az);
+    for(auto & point : points){
+        point = glm::rotate(toGlm(point), radians, axis);
+    }
+    flagHasChanged();
+}
+
+//--------------------------------------------------
+template<class T>
+void ofPolyline_<T>::rotate(float az, const glm::vec2 &axis){
+    rotate(az, glm::vec3(axis, 0.0));
+}
+
+//--------------------------------------------------
+template<class T>
+void ofPolyline_<T>::scale(float x, float y){
+    for(auto & point : points){
+        point.x *= x;
+        point.y *= y;
+    }
+    flagHasChanged();
+}
+
+//--------------------------------------------------
+template<class T>
 void ofPolyline_<T>::draw() const{
 	ofGetCurrentRenderer()->draw(*this);
 }


### PR DESCRIPTION
Based on ofPath methods.

To consider for both ofPath and ofPolyline:
* scale uses float but translate and rotate uses glm::vec
* it might nice to be able to set the origin for rotate and scale, instead of using (0,0,0)
* rotating in 2D is not convenient: you need to specify glm::vec3(0.0, 0.0, 1.0) as axis. Add `rotate(float az)` for 2D rotations?
* az == azimuth? use `deg` instead? or `rotateDeg()` + `rotateRad()`?

