### PR TITLE
Preload the 3d model resources to memory

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -99,6 +99,7 @@ bool ofxAssimpModelLoader::processScene() {
             ofLogVerbose("ofxAssimpModelLoader") << "loadMode(): no animations";
         }       
         
+        ofAddListener(ofEvents().exit,this,&ofxAssimpModelLoader::onAppExit);
         return true;
     }else{
         ofLogError("ofxAssimpModelLoader") << "loadModel(): " + (string) aiGetErrorString();
@@ -374,6 +375,7 @@ void ofxAssimpModelLoader::clear(){
     textures.clear();
 
     updateModelMatrix();
+    ofRemoveListener(ofEvents().exit,this,&ofxAssimpModelLoader::onAppExit);
 }
 
 //------------------------------------------- update.
@@ -1042,4 +1044,12 @@ void ofxAssimpModelLoader::disableColors(){
 //--------------------------------------------------------------
 void ofxAssimpModelLoader::disableMaterials(){
 	bUsingMaterials = false;
+}
+
+// automatic destruction on app exit makes the app crash because of some bug in assimp
+// this is a hack to clear every object on the exit callback of the application
+// FIXME: review when there's an update of assimp
+//-------------------------------------------
+void ofxAssimpModelLoader::onAppExit(ofEventArgs & args){
+    clear();
 }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -19,6 +19,7 @@
 #include "ofxAssimpTexture.h"
 #include "ofMesh.h"
 #include "ofPoint.h"
+#include "ofMain.h"
 
 struct aiScene;
 struct aiNode;
@@ -114,6 +115,7 @@ class ofxAssimpModelLoader{
 		const aiScene * getAssimpScene();
          
     protected:
+        void onAppExit(ofEventArgs & args);
         void updateAnimations();
         void updateMeshes(aiNode * node, ofMatrix4x4 parentMatrix);
         void updateBones();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -30,8 +30,21 @@ class ofxAssimpModelLoader{
         ~ofxAssimpModelLoader();
         ofxAssimpModelLoader();
 
+        // Pre-loads model from file or url into a buffer but does not initialize OpenGL resources (for load in background thread)
+        bool preLoadModel(string modelName, bool optimize=false);
+        // Pre-loads all model's textures without creating any GL resource
+        void preloadTextures();
+        // Pre-loads texture from texURL (file or URL) with texPath identifier inside the model.
+        void preloadTexture(string texURL, string texPath);
+
+        // Loads model's OpenGL resoruces
+        bool loadModelGLResources();
+        // Reloads model's OpenGL Resources (Textures)
+        bool reloadModelGLResources();
+
 		bool loadModel(std::string modelName, bool optimize=false);
         bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
+		bool loadTexturesForMaterial(aiMaterial* mtl, ofxAssimpMeshHelper &meshHelper);
         void createEmptyModel();
         void createLightsFromAiModel();
         void optimizeScene();
@@ -121,16 +134,28 @@ class ofxAssimpModelLoader{
         void updateBones();
         void updateModelMatrix();
     
+        bool reloadModelTextures();
+        bool reloadModelVBOs();
+
         // ai scene setup
         unsigned int initImportProperties(bool optimize);
         bool processScene();
+		void resetScene();
 
         // Initial VBO creation, etc
         void loadGLResources();
     
         // updates the *actual GL resources* for the current animation
         void updateGLResources();
-    
+
+		// Imports the model from a file path
+		void importModelFromAssimp(const char * filename, bool optimize);
+		// Imports the model from a buffer
+		void importModelFromAssimp(ofBuffer & buffer, bool optimize, const char * extension);
+
+        // Load VBOs
+        void loadVBOs(aiMesh* mesh, ofxAssimpMeshHelper& meshHelper);
+
         void getBoundingBoxWithMinVector( aiVector3D* min, aiVector3D* max);
         void getBoundingBoxForNode(const ofxAssimpMeshHelper & mesh,  aiVector3D* min, aiVector3D* max);
 
@@ -162,4 +187,7 @@ class ofxAssimpModelLoader{
         // the main Asset Import scene that does the magic.
 		std::shared_ptr<const aiScene> scene;
 		std::shared_ptr<aiPropertyStore> store;
+
+        std::string modelURI; // url or path of the model file
+        std::string modelDirectory;
 };

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
@@ -11,12 +11,24 @@
 using namespace std;
 
 ofxAssimpTexture::ofxAssimpTexture() {
-    texturePath = "";
+    this->texture.clear();
+    this->texturePath = "";
+    this->loaded = false;
+    this->textureData = NULL;
 }
 
 ofxAssimpTexture::ofxAssimpTexture(ofTexture texture, string texturePath) {
     this->texture = texture;
     this->texturePath = texturePath;
+    this->loaded = true;
+}
+
+ofxAssimpTexture::ofxAssimpTexture(const ofBuffer &texData, string texturePath) {
+    this->texture.clear();
+    this->texturePath = texturePath;
+    this->loaded = false;
+    this->textureData = new ofPixels();
+    this->bTextureDataLoaded = ofLoadImage(*(this->textureData), texData);
 }
 
 ofTexture & ofxAssimpTexture::getTextureRef() {
@@ -29,4 +41,35 @@ string ofxAssimpTexture::getTexturePath() {
 
 bool ofxAssimpTexture::hasTexture() {
     return texture.isAllocated();
+}
+
+bool ofxAssimpTexture::isLoaded() {
+    return loaded;
+}
+
+bool ofxAssimpTexture::loadTextureFromTextureData() {
+    if (loaded || !bTextureDataLoaded) {
+        return false;
+    }
+
+    this->texture.allocate(*(this->textureData));
+    this->texture.loadData(*(this->textureData));
+    this->loaded = true;
+
+    return true;
+}
+
+bool ofxAssimpTexture::reloadTextureFromTextureData() {
+    if (loaded) {
+        this->texture.clear();
+    }
+
+    if (!bTextureDataLoaded) {
+        return false;
+    }
+
+    this->texture.allocate(*(this->textureData));
+    this->texture.loadData(*(this->textureData));
+
+    return true;
 }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
@@ -9,6 +9,7 @@
 
 #include "ofConstants.h"
 #include "ofTexture.h"
+#include "ofImage.h"
 
 class ofxAssimpTexture {
 
@@ -16,14 +17,23 @@ public:
     
     ofxAssimpTexture();
 	ofxAssimpTexture(ofTexture texture, std::string texturePath);
+	ofxAssimpTexture(const ofBuffer &texData, std::string texturePath);
 
     ofTexture & getTextureRef();
 	std::string getTexturePath();
     bool hasTexture();
     
+	bool isLoaded();
+
+	bool loadTextureFromTextureData();
+	bool reloadTextureFromTextureData();
+
 private:
     
     ofTexture texture;
 	std::string texturePath;
-    
+	ofPixels *textureData;
+	bool loaded;
+	bool bTextureDataLoaded;
+
 };

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "ofUtils.h"
 #include "ofLog.h"
+#include <uriparser/Uri.h>
 
 
 #ifdef TARGET_OSX
@@ -1037,6 +1038,24 @@ bool ofFile::doesFileExist(const std::filesystem::path& _fPath, bool bRelativeTo
 		tmp.openFromCWD(_fPath,ofFile::Reference);
 	}
 	return !_fPath.empty() && tmp.exists();
+}
+
+//------------------------------------------------------------------------------------------------------------
+bool ofFile::isPathURL(string path){
+	UriUriA uri;
+	UriParserStateA state;
+	state.uri = &uri;
+
+	if (uriParseUriA(&state, path.c_str()) != URI_SUCCESS) {
+		ofLogError("ofFileUtils") << "isPathURL(): malformed uri when loading image from uri " << path;
+		uriFreeUriMembersA(&uri);
+		return false;
+	}
+
+	std::string scheme(uri.scheme.first, uri.scheme.afterLast);
+	uriFreeUriMembersA(&uri);
+
+	return scheme == "http" || scheme == "https";
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -807,6 +807,8 @@ public:
 	/// \returns true if the path was removed successfully
 	static bool removeFile(const std::filesystem::path& path, bool bRelativeToData = true);
 
+	static bool isPathURL(std::string path);
+
 private:
 	bool isWriteMode();
 	bool openStream(Mode _mode, bool binary);


### PR DESCRIPTION
The aim of these modifications is to allow to preload the 3D model resources to memory from a background thread, improving the 3D model loading process performance.