### PR TITLE
Preload the 3d model resources to memory

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -17,6 +17,22 @@ ofxAssimpModelLoader::~ofxAssimpModelLoader(){
 }
 
 //------------------------------------------
+bool ofxAssimpModelLoader::preLoadModel(string modelName, bool optimize){
+    modelURI = modelName;
+    ofFile file2 = ofFile(modelName);
+    modelDirectory = file2.getEnclosingDirectory();
+    importModelFromAssimp(file2.getAbsolutePath().c_str(), optimize);
+
+    if (!scene) {
+        ofLogError("ofxAssimpModelLoader") << "loadModel(): " + (string) aiGetErrorString();
+        clear();
+        return false;
+    }
+
+    return true;
+}
+
+//------------------------------------------
 bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
     
     file.open(modelName, ofFile::ReadOnly, true); // Since it may be a binary file we should read it in binary -Ed
@@ -26,49 +42,45 @@ bool ofxAssimpModelLoader::loadModel(string modelName, bool optimize){
     }
 
     ofLogVerbose("ofxAssimpModelLoader") << "loadModel(): loading \"" << file.getFileName()
-		<< "\" from \"" << file.getEnclosingDirectory() << "\"";
-    
-    if(scene.get() != nullptr){
-        clear();
-		// we reset the shared_ptr explicitly here, to force the old 
-		// aiScene to be deleted **before** a new aiScene is created.
-		scene.reset();
-    }
-    
-    // sets various properties & flags to a default preference
-    unsigned int flags = initImportProperties(optimize);
-    
+                                         << "\" from \"" << file.getEnclosingDirectory() << "\"";
+
     // loads scene from file
-	std::string path = file.getAbsolutePath();
-	scene = shared_ptr<const aiScene>(aiImportFileExWithProperties(path.c_str(), flags, NULL, store.get()), aiReleaseImport);
-    
-    bool bOk = processScene();
-    return bOk;
+    std::string path = file.getAbsolutePath();
+    importModelFromAssimp(path.c_str(), optimize);
+    return processScene();
 }
 
+void ofxAssimpModelLoader::importModelFromAssimp(const char *filename, bool optimize) {
+    resetScene();
+    // sets various properties & flags to a default preference
+    unsigned int flags = initImportProperties(optimize);
+    scene = shared_ptr<const aiScene>(aiImportFileExWithProperties(filename, flags, NULL, store.get()), aiReleaseImport);
+}
 
 bool ofxAssimpModelLoader::loadModel(ofBuffer & buffer, bool optimize, const char * extension){
-    
     ofLogVerbose("ofxAssimpModelLoader") << "loadModel(): loading from memory buffer \"." << extension << "\"";
-    
-    if(scene.get() != nullptr){
-        clear();
-		// we reset the shared_ptr explicitly here, to force the old 
-		// aiScene to be deleted **before** a new aiScene is created.
-		scene.reset();
-    }
-    
-    // sets various properties & flags to a default preference
-    unsigned int flags = initImportProperties(optimize);
-    
-    // loads scene from memory buffer - note this will not work for multipart files (obj, md3, etc)
-    scene = shared_ptr<const aiScene>(aiImportFileFromMemoryWithProperties(buffer.getData(), buffer.size(), flags, extension, store.get()), aiReleaseImport);
-    
-    bool bOk = processScene();
-    return bOk;
+    importModelFromAssimp(buffer, optimize, extension);
+    return processScene();
 }
 
-unsigned int ofxAssimpModelLoader::initImportProperties(bool optimize) {    
+void ofxAssimpModelLoader::importModelFromAssimp(ofBuffer & buffer, bool optimize, const char *extension) {
+    resetScene();
+    // sets various properties & flags to a default preference
+    unsigned int flags = initImportProperties(optimize);
+    // loads scene from memory buffer - note this will not work for multipart files (obj, md3, etc)
+    scene = shared_ptr<const aiScene>(aiImportFileFromMemoryWithProperties(buffer.getData(), buffer.size(), flags, extension, store.get()), aiReleaseImport);
+}
+
+void ofxAssimpModelLoader::resetScene() {
+    if(scene.get() != nullptr){
+        clear();
+        // we reset the shared_ptr explicitly here, to force the old
+        // aiScene to be deleted **before** a new aiScene is created.
+        scene.reset();
+    }
+}
+
+unsigned int ofxAssimpModelLoader::initImportProperties(bool optimize) {
     store.reset(aiCreatePropertyStore(), aiReleasePropertyStore);
     
     // only ever give us triangles.
@@ -179,6 +191,7 @@ void ofxAssimpModelLoader::optimizeScene(){
 void ofxAssimpModelLoader::loadGLResources(){
 
 	ofLogVerbose("ofxAssimpModelLoader") << "loadGLResources(): starting";
+    preloadTextures();
 
     // create new mesh helpers for each mesh, will populate their data later.
     modelMeshes.resize(scene->mNumMeshes,ofxAssimpMeshHelper());
@@ -237,51 +250,7 @@ void ofxAssimpModelLoader::loadGLResources(){
         else
             meshHelper.twoSided = false;
 
-        // Load Textures
-        int texIndex = 0;
-        aiString texPath;
-
-        // TODO: handle other aiTextureTypes
-        if(AI_SUCCESS == mtl->GetTexture(aiTextureType_DIFFUSE, texIndex, &texPath)){
-            ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): loading image from \"" << texPath.data << "\"";
-            string modelFolder = file.getEnclosingDirectory();
-            string relTexPath = ofFilePath::getEnclosingDirectory(texPath.data,false);
-            string texFile = ofFilePath::getFileName(texPath.data);
-            string realPath = ofFilePath::join(ofFilePath::join(modelFolder, relTexPath), texFile);
-            
-            if(ofFile::doesFileExist(realPath) == false) {
-                ofLogError("ofxAssimpModelLoader") << "loadGLResource(): texture doesn't exist: \""
-					<< file.getFileName() + "\" in \"" << realPath << "\"";
-            }
-            
-            ofxAssimpTexture assimpTexture;
-            bool bTextureAlreadyExists = false;
-            for(size_t j = 0; j < textures.size(); j++) {
-                assimpTexture = textures[j];
-                if(assimpTexture.getTexturePath() == realPath) {
-                    bTextureAlreadyExists = true;
-                    break;
-                }
-            }
-            if(bTextureAlreadyExists) {
-                meshHelper.assimpTexture = assimpTexture;
-                ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): texture already loaded: \""
-					<< file.getFileName() + "\" from \"" << realPath << "\"";
-            } else {
-                ofTexture texture;
-                bool bTextureLoadedOk = ofLoadImage(texture, realPath);
-                if(bTextureLoadedOk) {
-                    textures.push_back(ofxAssimpTexture(texture, realPath));
-                    assimpTexture = textures.back();
-                    meshHelper.assimpTexture = assimpTexture;
-                    ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): texture loaded, dimensions: "
-						<< texture.getWidth() << "x" << texture.getHeight();
-                } else {
-                    ofLogError("ofxAssimpModelLoader") << "loadGLResource(): couldn't load texture: \""
-						<< file.getFileName() + "\" from \"" << realPath << "\"";
-                }
-            }
-        }
+        this->loadTexturesForMaterial(mtl, meshHelper);
 
         meshHelper.mesh = mesh;
         aiMeshToOfMesh(mesh, meshHelper.cachedMesh, &meshHelper);
@@ -302,50 +271,88 @@ void ofxAssimpModelLoader::loadGLResources(){
 			}
         }
 
+        this->loadVBOs(mesh, meshHelper);
+    }
 
-        int usage;
-        if(getAnimationCount()){
+    ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): finished";
+}
+
+bool ofxAssimpModelLoader::loadTexturesForMaterial(aiMaterial* mtl, ofxAssimpMeshHelper &meshHelper) {
+    // Load Textures
+    int texIndex = 0;
+    aiString texPath;
+    bool loaded = false;
+
+    // TODO: handle other aiTextureTypes
+    if(AI_SUCCESS == mtl->GetTexture(aiTextureType_DIFFUSE, texIndex, &texPath)){
+        ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): loading image from \"" << texPath.data << "\"";
+
+        for(size_t j = 0; j < textures.size(); j++) {
+            if(textures[j].getTexturePath() == texPath.data) {
+                if (!textures[j].isLoaded()) {
+                    loaded = textures[j].loadTextureFromTextureData();
+                } else {
+                    loaded = textures[j].reloadTextureFromTextureData();
+                }
+
+                if (!loaded) {
+                    ofLogError("ofxAssimpModelLoader") << "loadGLResource(): couldn't load pre-loaded texture: \""
+                                                       << modelURI + "\" from \"" << string(texPath.data) << "\"";
+                } else {
+                    meshHelper.assimpTexture = textures[j];
+                    ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): texture already loaded: \""
+                                                         << file.getFileName() + "\" from \"" << string(texPath.data) << "\"";
+                }
+
+                break;
+            }
+        }
+    }
+
+    return loaded;
+}
+
+void ofxAssimpModelLoader::loadVBOs(aiMesh* mesh, ofxAssimpMeshHelper& meshHelper) {
+    int usage;
+
+    if (getAnimationCount()) {
 #ifndef TARGET_OPENGLES
-        	if(!ofIsGLProgrammableRenderer()){
+        if(!ofIsGLProgrammableRenderer()){
         		usage = GL_STATIC_DRAW;
         	}else{
         		usage = GL_STREAM_DRAW;
         	}
 #else
-        	usage = GL_DYNAMIC_DRAW;
+        usage = GL_DYNAMIC_DRAW;
 #endif
-        }else{
-        	usage = GL_STATIC_DRAW;
-
-        }
-
-        meshHelper.vbo.setVertexData(&mesh->mVertices[0].x,3,mesh->mNumVertices,usage,sizeof(aiVector3D));
-        if(mesh->HasVertexColors(0)){
-        	meshHelper.vbo.setColorData(&mesh->mColors[0][0].r,mesh->mNumVertices,GL_STATIC_DRAW,sizeof(aiColor4D));
-        }
-        if(mesh->HasNormals()){
-        	meshHelper.vbo.setNormalData(&mesh->mNormals[0].x,mesh->mNumVertices,usage,sizeof(aiVector3D));
-        }
-        if (meshHelper.cachedMesh.hasTexCoords()){			
-			meshHelper.vbo.setTexCoordData(&meshHelper.cachedMesh.getTexCoords()[0].x, mesh->mNumVertices,GL_STATIC_DRAW,sizeof(ofVec2f));
-        }
-
-        meshHelper.indices.resize(mesh->mNumFaces * 3);
-        int j=0;
-        for (unsigned int x = 0; x < mesh->mNumFaces; ++x){
-			for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a){
-				meshHelper.indices[j++]=mesh->mFaces[x].mIndices[a];
-			}
-		}
-
-        meshHelper.vbo.setIndexData(&meshHelper.indices[0],meshHelper.indices.size(),GL_STATIC_DRAW);
-
-        //modelMeshes.push_back(meshHelper);
+    } else {
+        usage = GL_STATIC_DRAW;
     }
-    
 
+    meshHelper.vbo.setVertexData(&mesh->mVertices[0].x,3,mesh->mNumVertices,usage,sizeof(aiVector3D));
 
-    ofLogVerbose("ofxAssimpModelLoader") << "loadGLResource(): finished";
+    if(mesh->HasVertexColors(0)){
+        meshHelper.vbo.setColorData(&mesh->mColors[0][0].r,mesh->mNumVertices,GL_STATIC_DRAW,sizeof(aiColor4D));
+    }
+
+    if(mesh->HasNormals()){
+        meshHelper.vbo.setNormalData(&mesh->mNormals[0].x,mesh->mNumVertices,usage,sizeof(aiVector3D));
+    }
+
+    if (meshHelper.cachedMesh.hasTexCoords()){
+        meshHelper.vbo.setTexCoordData(&meshHelper.cachedMesh.getTexCoords()[0].x, mesh->mNumVertices,GL_STATIC_DRAW,sizeof(ofVec2f));
+    }
+
+    meshHelper.indices.resize(mesh->mNumFaces * 3);
+    int j=0;
+
+    for (unsigned int x = 0; x < mesh->mNumFaces; ++x) {
+        for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a) {
+            meshHelper.indices[j++]=mesh->mFaces[x].mIndices[a];
+        }
+    }
+
+    meshHelper.vbo.setIndexData(&meshHelper.indices[0],meshHelper.indices.size(),GL_STATIC_DRAW);
 }
 
 //-------------------------------------------
@@ -1040,6 +1047,103 @@ void ofxAssimpModelLoader::disableColors(){
 }
 
 //--------------------------------------------------------------
-void ofxAssimpModelLoader::disableMaterials(){
-	bUsingMaterials = false;
+void ofxAssimpModelLoader::disableMaterials() {
+    bUsingMaterials = false;
+}
+
+//-------------------------------------------
+void ofxAssimpModelLoader::preloadTextures(){
+    for (unsigned int i = 0; i < scene->mNumMeshes; ++i) {
+        ofLogVerbose("ofxAssimpModelLoader") << "preloadTextures(): textures for mesh mesh " << i;
+        // current mesh
+        aiMesh* mesh = scene->mMeshes[i];
+        aiMaterial* mtl = scene->mMaterials[mesh->mMaterialIndex];
+
+        // Load Textures
+        int texIndex = 0;
+        aiString texPath;
+
+        if(AI_SUCCESS == mtl->GetTexture(aiTextureType_DIFFUSE, texIndex, &texPath)) {
+            ofLogVerbose("ofxAssimpModelLoader") << "preloadTextures(): loading image from \"" << texPath.data << "\"";
+            string realPath;
+            if (ofFile::isPathURL(texPath.data)) {
+                realPath = texPath.data;
+            } else {
+                string relTexPath = ofFilePath::getEnclosingDirectory(texPath.data,false);
+                string texFile = ofFilePath::getFileName(texPath.data);
+                realPath = modelDirectory + relTexPath  + texFile;
+            }
+
+            bool bTextureAlreadyExists = false;
+            for(int j=0; j<textures.size(); j++) {
+                if( textures[j].getTexturePath() == texPath.data) {
+                    ofLogVerbose("ofxAssimpModelLoader") << "preloadTextures(): Strings are equal!";
+                    bTextureAlreadyExists = true;
+                    ofLogVerbose("ofxAssimpModelLoader") << "preloadTextures(): texture \"" << texPath.data << "\" already loaded, skipping..";
+                    break;
+                }
+            }
+
+            if(!bTextureAlreadyExists) {
+                if(ofFile::doesFileExist(realPath) == false && !ofFile::isPathURL(texPath.data)) {
+                    ofLogError("ofxAssimpModelLoader") << "preloadTextures(): texture doesn't exist: \""
+                                                       << modelURI + "\" in \"" << realPath << "\"";
+                }
+                this->preloadTexture(realPath, string(texPath.data));
+            }
+        }
+    }
+}
+
+//-------------------------------------------
+void ofxAssimpModelLoader::preloadTexture(string texURL, string texPathString){
+    ofBuffer textureData;
+
+    if (ofFile::isPathURL(aiString(texURL).data)) {
+        textureData = ofLoadURL(texURL).data;
+    } else {
+        ofFile file;
+        file.open(texURL);
+
+        if(!file.exists()) {
+            ofLogError("ofxAssimpModelLoader") << "preloadTexturedModel(): failed to load texture file: \"" << texURL << "\"";
+            return;
+        }
+
+        textureData = file.readToBuffer();
+    }
+    textures.push_back(ofxAssimpTexture(textureData, texPathString));
+}
+
+//------------------------------------------
+bool ofxAssimpModelLoader::loadModelGLResources() {
+    return processScene();
+}
+
+//-------------------------------------------
+bool ofxAssimpModelLoader::reloadModelGLResources() {
+    bool ok = this->reloadModelVBOs();
+
+    for (unsigned int i = 0; i < scene->mNumMeshes; ++i) {
+        aiMesh *mesh = scene->mMeshes[i];
+        ofxAssimpMeshHelper &meshHelper = modelMeshes[i];
+        aiMaterial *mtl = scene->mMaterials[mesh->mMaterialIndex];
+        ok = this->loadTexturesForMaterial(mtl, meshHelper) && ok;
+    }
+
+    return ok;
+}
+
+bool ofxAssimpModelLoader::reloadModelVBOs() {
+    for (unsigned int i = 0; i < scene->mNumMeshes; ++i){
+        ofLogVerbose("ofxAssimpModelLoader") << "reloadModelVBOs(): reloading mesh " << i << " VBOs";
+
+        aiMesh* mesh = scene->mMeshes[i];
+        ofxAssimpMeshHelper & meshHelper = modelMeshes[i];
+
+        meshHelper.vbo.clear();
+        this->loadVBOs(mesh, meshHelper);
+
+    }
+    return true;
 }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -29,8 +29,21 @@ class ofxAssimpModelLoader{
         ~ofxAssimpModelLoader();
         ofxAssimpModelLoader();
 
+        // Pre-loads model from file or url into a buffer but does not initialize OpenGL resources (for load in background thread)
+        bool preLoadModel(string modelName, bool optimize=false);
+        // Pre-loads all model's textures without creating any GL resource
+        void preloadTextures();
+        // Pre-loads texture from texURL (file or URL) with texPath identifier inside the model.
+        void preloadTexture(string texURL, string texPath);
+
+        // Loads model's OpenGL resoruces
+        bool loadModelGLResources();
+        // Reloads model's OpenGL Resources (Textures)
+        bool reloadModelGLResources();
+
 		bool loadModel(std::string modelName, bool optimize=false);
         bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
+		bool loadTexturesForMaterial(aiMaterial* mtl, ofxAssimpMeshHelper &meshHelper);
         void createEmptyModel();
         void createLightsFromAiModel();
         void optimizeScene();
@@ -119,16 +132,28 @@ class ofxAssimpModelLoader{
         void updateBones();
         void updateModelMatrix();
     
+        bool reloadModelTextures();
+        bool reloadModelVBOs();
+
         // ai scene setup
         unsigned int initImportProperties(bool optimize);
         bool processScene();
+		void resetScene();
 
         // Initial VBO creation, etc
         void loadGLResources();
     
         // updates the *actual GL resources* for the current animation
         void updateGLResources();
-    
+
+		// Imports the model from a file path
+		void importModelFromAssimp(const char * filename, bool optimize);
+		// Imports the model from a buffer
+		void importModelFromAssimp(ofBuffer & buffer, bool optimize, const char * extension);
+
+        // Load VBOs
+        void loadVBOs(aiMesh* mesh, ofxAssimpMeshHelper& meshHelper);
+
         void getBoundingBoxWithMinVector( aiVector3D* min, aiVector3D* max);
         void getBoundingBoxForNode(const ofxAssimpMeshHelper & mesh,  aiVector3D* min, aiVector3D* max);
 
@@ -160,4 +185,7 @@ class ofxAssimpModelLoader{
         // the main Asset Import scene that does the magic.
 		std::shared_ptr<const aiScene> scene;
 		std::shared_ptr<aiPropertyStore> store;
+
+        std::string modelURI; // url or path of the model file
+        std::string modelDirectory;
 };

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
@@ -11,12 +11,24 @@
 using namespace std;
 
 ofxAssimpTexture::ofxAssimpTexture() {
-    texturePath = "";
+    this->texture.clear();
+    this->texturePath = "";
+    this->loaded = false;
+    this->textureData = NULL;
 }
 
 ofxAssimpTexture::ofxAssimpTexture(ofTexture texture, string texturePath) {
     this->texture = texture;
     this->texturePath = texturePath;
+    this->loaded = true;
+}
+
+ofxAssimpTexture::ofxAssimpTexture(const ofBuffer &texData, string texturePath) {
+    this->texture.clear();
+    this->texturePath = texturePath;
+    this->loaded = false;
+    this->textureData = new ofPixels();
+    this->bTextureDataLoaded = ofLoadImage(*(this->textureData), texData);
 }
 
 ofTexture & ofxAssimpTexture::getTextureRef() {
@@ -29,4 +41,35 @@ string ofxAssimpTexture::getTexturePath() {
 
 bool ofxAssimpTexture::hasTexture() {
     return texture.isAllocated();
+}
+
+bool ofxAssimpTexture::isLoaded() {
+    return loaded;
+}
+
+bool ofxAssimpTexture::loadTextureFromTextureData() {
+    if (loaded || !bTextureDataLoaded) {
+        return false;
+    }
+
+    this->texture.allocate(*(this->textureData));
+    this->texture.loadData(*(this->textureData));
+    this->loaded = true;
+
+    return true;
+}
+
+bool ofxAssimpTexture::reloadTextureFromTextureData() {
+    if (loaded) {
+        this->texture.clear();
+    }
+
+    if (!bTextureDataLoaded) {
+        return false;
+    }
+
+    this->texture.allocate(*(this->textureData));
+    this->texture.loadData(*(this->textureData));
+
+    return true;
 }

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
@@ -9,6 +9,7 @@
 
 #include "ofConstants.h"
 #include "ofTexture.h"
+#include "ofImage.h"
 
 class ofxAssimpTexture {
 
@@ -16,14 +17,23 @@ public:
     
     ofxAssimpTexture();
 	ofxAssimpTexture(ofTexture texture, std::string texturePath);
+	ofxAssimpTexture(const ofBuffer &texData, std::string texturePath);
 
     ofTexture & getTextureRef();
 	std::string getTexturePath();
     bool hasTexture();
     
+	bool isLoaded();
+
+	bool loadTextureFromTextureData();
+	bool reloadTextureFromTextureData();
+
 private:
     
     ofTexture texture;
 	std::string texturePath;
-    
+	ofPixels *textureData;
+	bool loaded;
+	bool bTextureDataLoaded;
+
 };

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "ofUtils.h"
 #include "ofLog.h"
+#include <uriparser/Uri.h>
 
 
 #ifdef TARGET_OSX
@@ -1037,6 +1038,24 @@ bool ofFile::doesFileExist(const std::filesystem::path& _fPath, bool bRelativeTo
 		tmp.openFromCWD(_fPath,ofFile::Reference);
 	}
 	return !_fPath.empty() && tmp.exists();
+}
+
+//------------------------------------------------------------------------------------------------------------
+bool ofFile::isPathURL(string path){
+	UriUriA uri;
+	UriParserStateA state;
+	state.uri = &uri;
+
+	if (uriParseUriA(&state, path.c_str()) != URI_SUCCESS) {
+		ofLogError("ofFileUtils") << "isPathURL(): malformed uri when loading image from uri " << path;
+		uriFreeUriMembersA(&uri);
+		return false;
+	}
+
+	std::string scheme(uri.scheme.first, uri.scheme.afterLast);
+	uriFreeUriMembersA(&uri);
+
+	return scheme == "http" || scheme == "https";
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -807,6 +807,8 @@ public:
 	/// \returns true if the path was removed successfully
 	static bool removeFile(const std::filesystem::path& path, bool bRelativeToData = true);
 
+	static bool isPathURL(std::string path);
+
 private:
 	bool isWriteMode();
 	bool openStream(Mode _mode, bool binary);


### PR DESCRIPTION
The aim of these modifications is to allow to preload the 3D model resources to memory from a background thread, improving the 3D model loading process performance.