### PR TITLE
Change ofPath: flagShapeChanged() and hasChanged() from private to public

### DIFF
--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -393,10 +393,12 @@ private:
 	void addCommand(const Command & command);
 	void generatePolylinesFromCommands();
 
+public:
 	// only needs to be called when path is modified externally
 	void flagShapeChanged();
 	bool hasChanged();
 
+private:
 	// path description
 	//vector<ofSubPath>		paths;
 	std::vector<Command> 	commands;


### PR DESCRIPTION
ofPath::flagShapeChanged() could be really useful when paths are changed externally (the workaround is to call ofPath::getCommands() only so that ofPath::flagShapeChanged is called), and ofPath::hasChanged doesn't get called at all anywhere in OF, so making it public doesn't hurt the internals. Also, making it public mirrors the behavior of ofMesh::hasChanged.