### PR TITLE
Converted ofxCvBlob points from ofPoint to ofDefaultVec3.

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvBlob.h
+++ b/addons/ofxOpenCv/src/ofxCvBlob.h
@@ -21,11 +21,11 @@ class ofxCvBlob {
         float               area;
         float               length;
         ofRectangle         boundingRect;
-        ofPoint             centroid;
+        ofDefaultVec3       centroid;
         bool                hole;
 
-        std::vector <ofPoint> pts;    // the contour of the blob
-        int                 nPts;   // number of pts;
+        std::vector<ofDefaultVec3> pts;    // the contour of the blob
+        int                        nPts;   // number of pts;
 
         //----------------------------------------
         ofxCvBlob() {


### PR DESCRIPTION
I'm assuming we're phasing out `ofPoint`...

In any case, I encountered an issue with the following code, which this change fixes:
```
ofxCvBlob blob = contourFinder.blobs[i];
ofPolyline polyline = ofPolyline(blob.pts);
```