### PR TITLE
Bugfix windowing examples

### DIFF
--- a/examples/windowing/multiWindowExample/src/main.cpp
+++ b/examples/windowing/multiWindowExample/src/main.cpp
@@ -7,14 +7,12 @@
 int main( ){
 	ofGLFWWindowSettings settings;
 
-	settings.width = 600;
-	settings.height = 600;
+    settings.setSize(600, 600);
 	settings.setPosition(ofVec2f(300,0));
 	settings.resizable = true;
 	shared_ptr<ofAppBaseWindow> mainWindow = ofCreateWindow(settings);
 
-	settings.width = 300;
-	settings.height = 300;
+    settings.setSize(300, 300);
 	settings.setPosition(ofVec2f(0,0));
 	settings.resizable = false;
 	shared_ptr<ofAppBaseWindow> guiWindow = ofCreateWindow(settings);

--- a/examples/windowing/multiWindowOneAppExample/src/main.cpp
+++ b/examples/windowing/multiWindowOneAppExample/src/main.cpp
@@ -5,14 +5,12 @@
 //========================================================================
 int main( ){
 	ofGLFWWindowSettings settings;
-	settings.width = 600;
-	settings.height = 600;
+    settings.setSize(600, 600);
 	settings.setPosition(ofVec2f(300,0));
 	settings.resizable = true;
 	shared_ptr<ofAppBaseWindow> mainWindow = ofCreateWindow(settings);
 
-	settings.width = 300;
-	settings.height = 300;
+    settings.setSize(300, 300);
 	settings.setPosition(ofVec2f(0,0));
 	settings.resizable = false;
 	// uncomment next line to share main's OpenGL resources with gui


### PR DESCRIPTION
fixes #5958.
Replaced settings.width = w; settings.height =h by settings.setSize( w, h )