### PR TITLE
Bugfix networkTcpClientExample

### DIFF
--- a/addons/ofxAndroid/src/ofxAndroidUtils.h
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.h
@@ -59,7 +59,6 @@ bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodNam
 bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodName, std::string methodSignature, ...);
 bool ofxJavaCallBoolMethod(jobject object, std::string className, std::string methodName, std::string methodSignature, ...);
 
-void ofxAndroidPauseApp();
 void ofxAndroidAlertBox(std::string msg);
 int ofxAndroidProgressBox(std::string msg);
 void ofxAndroidDismissProgressBox(int id);

--- a/addons/ofxAndroid/src/ofxAndroidUtils.h
+++ b/addons/ofxAndroid/src/ofxAndroidUtils.h
@@ -59,6 +59,7 @@ bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodNam
 bool ofxJavaCallBoolMethod(jobject object, jclass classID, std::string methodName, std::string methodSignature, ...);
 bool ofxJavaCallBoolMethod(jobject object, std::string className, std::string methodName, std::string methodSignature, ...);
 
+void ofxAndroidPauseApp();
 void ofxAndroidAlertBox(std::string msg);
 int ofxAndroidProgressBox(std::string msg);
 void ofxAndroidDismissProgressBox(int id);

--- a/examples/communication/networkTcpClientExample/src/ofApp.cpp
+++ b/examples/communication/networkTcpClientExample/src/ofApp.cpp
@@ -82,9 +82,9 @@ void ofApp::keyPressed(int key){
 		}else{
 			msgTx += (char) key;
 		}
-		tcpClient.send(msgTx);
 		if (!msgTx.empty() && msgTx.back() == '\n') {
-			msgTx.clear();
+            tcpClient.send(msgTx);
+            msgTx.clear();
 		}
 	}
 }


### PR DESCRIPTION
send message when user hit return key.
Otherwise it send strange strings like

input 
1111\n

output
1 11 111 1111