### PR TITLE
modifier key bitmask fix.

### DIFF
--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -53,7 +53,7 @@ enum ofKey{
 	OF_KEY_SHIFT	=	 0x1,
 	OF_KEY_CONTROL	=	 0x2,
 	OF_KEY_ALT		=	 0x4,
-	OF_KEY_SUPER	=	 0x8,
+	OF_KEY_SUPER	=	 0x10,
 	OF_KEY_COMMAND  =    OF_KEY_SUPER,
 	OF_KEY_LEFT_SHIFT    =	 0xe60,
 	OF_KEY_RIGHT_SHIFT   =	 0xe61,

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -168,7 +168,7 @@ public:
 	/// Key modifiers
 	int modifiers = 0;
 
-	bool hasModifier(int modifier){
+	bool hasModifier(int modifier) const {
 		return modifiers & modifier;
 	}
 };

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -53,7 +53,7 @@ enum ofKey{
 	OF_KEY_SHIFT	=	 0x1,
 	OF_KEY_CONTROL	=	 0x2,
 	OF_KEY_ALT		=	 0x4,
-	OF_KEY_SUPER	=	 0x16,
+	OF_KEY_SUPER	=	 0x8,
 	OF_KEY_COMMAND  =    OF_KEY_SUPER,
 	OF_KEY_LEFT_SHIFT    =	 0xe60,
 	OF_KEY_RIGHT_SHIFT   =	 0xe61,


### PR DESCRIPTION
`0x16` is not a helpful (unique) bitmask when the others are `0x1`, `0x2`, `0x4`, etc.  It causes various other keys to be marked as triggered when the `OF_KEY_SUPER` or `OF_KEY_COMMAND` key is pressed.  Also, make the `hasModifiers` const correct for lots of reasons.