### PR TITLE
fix qbs project file broken because of wrong .qbs method return type

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
@@ -68,7 +68,7 @@ CppApplication{
         property string sourceDirectory: project.sourceDirectory;
         property string appname: parent.name
         configure: {
-            name = Helpers.parseConfig(sourceDirectory + "/config.make", "APPNAME", appname, "all");
+            name = Helpers.parseConfig(sourceDirectory + "/config.make", "APPNAME", appname, "all") + ""; // NOTE: we must add an empty String so that the result will be converted to String
             found = true;
         }
     }


### PR DESCRIPTION
When checking out openFrameworks from master, and opening the projectGenerator commandline `.qbs` file, QtCreator will refuse to open the project file because of an error in the `.qbs` file:

> :-1: warning: TypeError: /home/tim/Documents/dev/of/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs:65:5 Value assigned to property 'name' does not have type 'string'.

The error (the emoji courtesy of github's parser, not qt creator) appears because qbs can't figure out the name of the application. This value (`APPNAME`) is parsed name from the projectGenerator `config.make` file, but the parsing method appears to return an array of strings instead of a string value.

I can think of two approaches to fix this without too many unforseen consequences:

1. using the value at position 0 of the result, or
2. "duck-casting" the value to a string by appending an empty string.

With this PR I'm opting for the second one, since the first one might open a whole new can of worms.

I'm also adding a comment to the file here, to highlight the surprising need for the `""`s, which might otherwise look like a leftover.