### PR TITLE
ofEventListeners: added size() method.

### DIFF
--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -415,9 +415,7 @@ public:
 		listeners.emplace_back(std::move(listener));
 	}
 
-	OF_DEPRECATED_MSG("Don't use this method. If you need granular control over each listener, then use individual ofEventListener instances for each.", void unsubscribe(std::size_t pos){
-		listeners[pos].unsubscribe();
-	})
+	OF_DEPRECATED_MSG("Don't use this method. If you need granular control over each listener, then use individual ofEventListener instances for each.", void unsubscribe(std::size_t pos));
 
 	void unsubscribeAll(){
 		listeners.clear();
@@ -429,7 +427,9 @@ public:
 private:
 	std::deque<ofEventListener> listeners;
 };
-
+void ofEventListeners::unsubscribe(std::size_t pos){
+	listeners[pos].unsubscribe();
+}
 
 // -------------------------------------
 // ofEvent main implementation

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -415,14 +415,17 @@ public:
 		listeners.emplace_back(std::move(listener));
 	}
 
-	void unsubscribe(std::size_t pos){
+	OF_DEPRECATED_MSG("Don't use this method. If you need granular control over each listener, then use individual ofEventListener instances for each.", void unsubscribe(std::size_t pos){
 		listeners[pos].unsubscribe();
-	}
+	})
 
 	void unsubscribeAll(){
 		listeners.clear();
 	}
 
+    size_t size() const {
+        return listeners.size();
+    }
 private:
 	std::deque<ofEventListener> listeners;
 };

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -427,7 +427,8 @@ public:
 private:
 	std::deque<ofEventListener> listeners;
 };
-void ofEventListeners::unsubscribe(std::size_t pos){
+
+inline void ofEventListeners::unsubscribe(std::size_t pos){
 	listeners[pos].unsubscribe();
 }
 

--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -423,8 +423,8 @@ public:
 		listeners.clear();
 	}
 
-    size_t size() const {
-        return listeners.size();
+    bool empty() const {
+        return listeners.size() == 0 ;
     }
 private:
 	std::deque<ofEventListener> listeners;


### PR DESCRIPTION
This allows to things, checking not being out of bounds when removing a listener and checking if there are any registered listeners. 
@arturoc @bakercp 