### PR TITLE
Fixed int division that needs to be floating point

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -304,7 +304,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 
     //this lets us detect if the window is running in a retina mode
 	if( framebufferW != currentW){
-        pixelScreenCoordScale = framebufferW / windowW;
+        pixelScreenCoordScale = (float)framebufferW / (float)windowW;
 		if( pixelScreenCoordScale < 1 ){
             pixelScreenCoordScale = 1;
         }


### PR DESCRIPTION
fixes the bug described in https://github.com/openframeworks/openFrameworks/issues/6032

Although it fixes this bug, it only checks for the horizontal framebuffersize and currentW, Not sure if it should also check for vertical difference. 