### PR TITLE
Speed up image loading

### DIFF
--- a/libs/openFrameworks/gl/ofGLUtils.cpp
+++ b/libs/openFrameworks/gl/ofGLUtils.cpp
@@ -612,7 +612,7 @@ int ofGetGLInternalFormatFromPixelFormat(ofPixelFormat pixelFormat){
 		}
 #endif
 	default:
-		ofLogError("ofGLUtils") << "ofGetGLInternalFormatFromPixelFormat(): unknown OF pixel format"
+		ofLogError("ofGLUtils") << "ofGetGLInternalFormatFromPixelFormat(): unknown OF pixel format "
 						<< ofToString(pixelFormat) << ", returning GL_RGBA";
 		return GL_RGBA;
 	}
@@ -671,12 +671,12 @@ int ofGetGLFormatFromPixelFormat(ofPixelFormat pixelFormat){
 	default:
 #ifndef TARGET_OPENGLES
 		if(ofIsGLProgrammableRenderer()){
-			ofLogError("ofGLUtils") << "ofGetGLFormatFromPixelFormat(): unknown OF pixel format"
+			ofLogError("ofGLUtils") << "ofGetGLFormatFromPixelFormat(): unknown OF pixel format "
 				<< ofToString(pixelFormat) << ", returning GL_RED";
 			return GL_RED;
 		}else{
 #endif
-			ofLogError("ofGLUtils") << "ofGetGLFormatFromPixelFormat(): unknown OF pixel format"
+			ofLogError("ofGLUtils") << "ofGetGLFormatFromPixelFormat(): unknown OF pixel format "
 				<< ofToString(pixelFormat) << ", returning GL_LUMINANCE";
 			return GL_LUMINANCE;
 #ifndef TARGET_OPENGLES

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -207,7 +207,7 @@ static bool loadImage(ofPixels_<PixelType> & pix, const std::filesystem::path& _
 		return ofLoadImage(pix, ofLoadURL(_fileName.string()).data);
 	}
 
-	std::string fileName = ofToDataPath(_fileName);
+	std::string fileName = ofToDataPath(_fileName, true);
 	bool bLoaded = false;
 	FIBITMAP * bmp = nullptr;
 

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -520,6 +520,9 @@ void ofSetDataPathRoot(const std::filesystem::path& newRoot){
 
 //--------------------------------------------------
 string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
+    if (makeAbsolute && path.is_absolute())
+        return path.string();
+    
 	if (!enableDataPath)
         return path.string();
 


### PR DESCRIPTION
Currently `ofLoadImage` spends a large percentage of its time on `ofToDataPath` when loading lots of small images from disk.  These changes help speed this up when absolute paths are already known.

Before:
![instruments4](https://user-images.githubusercontent.com/300484/40454733-89f8c380-5eaf-11e8-8d60-3ea894ee1512.png)

After:
![instruments4](https://user-images.githubusercontent.com/300484/40454791-c9391626-5eaf-11e8-98ed-512edc808e6e.png)

This has only been tested a bit, so a code review thinking across platforms is probably a good idea.
