### PR TITLE
fix copy_dlls make target when there's only a debug build

### DIFF
--- a/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
+++ b/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
@@ -54,6 +54,12 @@ PLATFORM_PROJECT_RELEASE_BIN_NAME=$(APPNAME).exe
 PLATFORM_PROJECT_RELEASE_TARGET = bin/$(PLATFORM_PROJECT_RELEASE_BIN_NAME)
 PLATFORM_PROJECT_DEBUG_TARGET = bin/$(PLATFORM_PROJECT_DEBUG_BIN_NAME)
 PLATFORM_RUN_COMMAND = cd bin;./$(BIN_NAME)
+ifneq ("$(wildcard $(PLATFORM_PROJECT_RELEASE_TARGET))","")
+	PLATFORM_PROJECT_EXISTING_TARGET=$(PLATFORM_PROJECT_RELEASE_TARGET)
+else
+	PLATFORM_PROJECT_EXISTING_TARGET=$(PLATFORM_PROJECT_DEBUG_TARGET)
+endif
+
 
 ##########################################################################################
 # PLATFORM DEFINES
@@ -282,7 +288,7 @@ PLATFORM_LIBRARY_SEARCH_PATHS =
 copy_dlls:
 	@echo "     copying dlls to bin"
 
-	@ntldd --recursive $(PLATFORM_PROJECT_RELEASE_TARGET) | grep -F "mingw32" | cut -d">" -f2 |cut -d" " -f2 >dlllist
+	@ntldd --recursive $(PLATFORM_PROJECT_EXISTING_TARGET) | grep -F "mingw32" | cut -d">" -f2 |cut -d" " -f2 >dlllist
 	@while read -r dll; do \
 		test -e "$$dll" && cp "$$dll" ./bin; \
     done <dlllist


### PR DESCRIPTION
A simple workaround for a missing release build. Test first if release build exists otherwise use the debug build

fixes #6045