### PR TITLE
fix gui parameter group example

### DIFF
--- a/examples/gui/parameterGroupExample/src/CirclesRenderer.cpp
+++ b/examples/gui/parameterGroupExample/src/CirclesRenderer.cpp
@@ -17,7 +17,7 @@ void CirclesRenderer::setup(string name){
 	parameters.setName(name);
 	parameters.add(size.set("size",10,0,100));
 	parameters.add(number.set("number",2,1,20));
-	parameters.add(position.set("position",ofVec2f(ofGetWidth()*.5,ofGetHeight()*.5),ofVec2f(0,0),ofVec2f(ofGetWidth(),ofGetHeight())));
+	parameters.add(position.set("position",glm::vec2(ofGetWidth()*.5,ofGetHeight()*.5),glm::vec2(0,0),glm::vec2(ofGetWidth(),ofGetHeight())));
 
 	color.set("color",ofColor(127),ofColor(0,0),ofColor(255));
 

--- a/examples/gui/parameterGroupExample/src/CirclesRenderer.h
+++ b/examples/gui/parameterGroupExample/src/CirclesRenderer.h
@@ -29,7 +29,7 @@ public:
 	ofParameterGroup parameters;
 	ofParameter<float> size;
 	ofParameter<int> number;
-	ofParameter<ofVec2f> position;
+	ofParameter<glm::vec2> position;
 
 	ofParameter<ofColor> color;
 


### PR DESCRIPTION
As reported in the forum, an example has the old syntax.

https://forum.openframeworks.cc/t/of-v0-10-0-ofxgui-ofparameter-ofvec2f-ofvec3f-not-working/29959/4