### PR TITLE
Fix for ofAVFoundationGrabber.mm setDevice(...) after close() 

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationGrabber.mm
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.mm
@@ -496,6 +496,9 @@ std::vector <ofVideoDevice> ofAVFoundationGrabber::listDevices() const{
 }
 
 void ofAVFoundationGrabber::setDeviceID(int deviceID) {
+	if( grabber == nil ){
+		grabber = [OSXVideoGrabber alloc];
+	}
 	[grabber setDevice:deviceID];
 	device = deviceID;
 }


### PR DESCRIPTION
Fix for a bug outlined in this forum post : https://forum.openframeworks.cc/t/changing-the-camera-input-while-the-app-is-running/7622/5

If you attempt to set the device ID after you have called close() on the grabber, the grabber object no longer exists, and any subsequent calls to setup() will use the default device (id=0). I have added a check that reallocates the OSXVideoGrabber if necessary.