### PR TITLE
More efficient way for ofNode::getGlobalOrientation (3~x faster)

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -561,8 +561,8 @@ glm::vec3 ofNode::getGlobalPosition() const {
 
 //----------------------------------------
 glm::quat ofNode::getGlobalOrientation() const {
-	auto rot = glm::scale(getGlobalTransformMatrix(), 1.f/getGlobalScale());
-	return glm::toQuat(rot);
+	if (parent) return parent->getGlobalOrientation() * getOrientationQuat();
+	return getOrientationQuat();
 }
 
 //----------------------------------------


### PR DESCRIPTION
The second one in https://github.com/openframeworks/openFrameworks/issues/6025.