### PR TITLE
Xcode 9.4 Default Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,22 +72,22 @@ matrix:
           - libstdc++6
 
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.4
     compiler: clang
     env: TARGET="osx"
 
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.4
     compiler: clang
     env: TARGET="osx" OPT="makefiles"
 
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.4
     compiler: clang
     env: TARGET="ios"
 
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.4
     compiler: clang
     env: TARGET="tvos"
 


### PR DESCRIPTION
Keep Travis Using Latest Default Xcode (also Travis has updated most to latest Xcode).

https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce