### PR TITLE
Add option to create console window in QtCreator wizards

### DIFF
--- a/scripts/qtcreator/templates/wizards/openFrameworks/qtcreator.qbs
+++ b/scripts/qtcreator/templates/wizards/openFrameworks/qtcreator.qbs
@@ -45,6 +45,9 @@ Project{
         of.frameworks: []       // osx only, additional frameworks to link with the project
         of.staticLibraries: []  // static libraries
         of.dynamicLibraries: [] // dynamic libraries
+        
+        // create a console window when the application start
+        consoleApplication: %{ConsoleWindow}
 
         // other flags can be set through the cpp module: http://doc.qt.io/qbs/cpp-module.html
         // eg: this will enable ccache when compiling

--- a/scripts/qtcreator/templates/wizards/openFrameworks/wizard.json
+++ b/scripts/qtcreator/templates/wizards/openFrameworks/wizard.json
@@ -106,6 +106,24 @@
             ]
         },
         {
+            "trDisplayName": "Console windows",
+            "trShortTitle": "Console",
+            "typeId": "Fields",
+            "data" :
+            [
+                {
+                    "name": "ConsoleWindow",
+                    "trDisplayName": "Create a console window when application start",
+                    "type": "CheckBox",
+                    "data": {
+                        "checkedValue": "true",
+                        "uncheckedValue": "false",
+                        "checked": "false"
+                    }
+                }
+            ]
+        },
+        {
             "trDisplayName": "Addons",
             "trShortTitle": "Addons",
             "typeId": "Fields",

--- a/scripts/qtcreator/templates/wizards/openFrameworksUpdate/qtcreator_update.qbs
+++ b/scripts/qtcreator/templates/wizards/openFrameworksUpdate/qtcreator_update.qbs
@@ -40,6 +40,9 @@ Project{
         of.frameworks: []       // osx only, additional frameworks to link with the project
         of.staticLibraries: []  // static libraries
         of.dynamicLibraries: [] // dynamic libraries
+        
+        // create a console window when the application start
+        consoleApplication: %{ConsoleWindow}
 
         // other flags can be set through the cpp module: http://doc.qt.io/qbs/cpp-module.html
         // eg: this will enable ccache when compiling

--- a/scripts/qtcreator/templates/wizards/openFrameworksUpdate/qtcreator_update_no_addons.qbs
+++ b/scripts/qtcreator/templates/wizards/openFrameworksUpdate/qtcreator_update_no_addons.qbs
@@ -34,6 +34,9 @@ Project{
         of.frameworks: []       // osx only, additional frameworks to link with the project
         of.staticLibraries: []  // static libraries
         of.dynamicLibraries: [] // dynamic libraries
+        
+        // create a console window when the application start
+        consoleApplication: %{ConsoleWindow}
 
         // other flags can be set through the cpp module: http://doc.qt.io/qbs/cpp-module.html
         // eg: this will enable ccache when compiling

--- a/scripts/qtcreator/templates/wizards/openFrameworksUpdate/wizard.json
+++ b/scripts/qtcreator/templates/wizards/openFrameworksUpdate/wizard.json
@@ -123,6 +123,24 @@
             ]
         },
         {
+            "trDisplayName": "Console windows",
+            "trShortTitle": "Console",
+            "typeId": "Fields",
+            "data" :
+            [
+                {
+                    "name": "ConsoleWindow",
+                    "trDisplayName": "Create a console window when application start",
+                    "type": "CheckBox",
+                    "data": {
+                        "checkedValue": "true",
+                        "uncheckedValue": "false",
+                        "checked": "false"
+                    }
+                }
+            ]
+        },
+        {
             "trDisplayName": "Kit Selection",
             "trShortTitle": "Kits",
             "typeId": "Kits",


### PR DESCRIPTION
Discussed here: https://github.com/openframeworks/openFrameworks/issues/6103

Add a new page in the QtCreator wizards (for new project and update project) with a checkbox named "Create a console window when application start"
![wizard](https://user-images.githubusercontent.com/2719976/43964817-f1981c1a-9cbd-11e8-9e36-8f8c281871d4.png)

It will add a new line in the qbs file:
```
        // create a console window when the application start
        consoleApplication: false
```

Tested with OF 0.10.0, msys, QtCreator 4.6.1, Windows 7

I'm not experimented with pull requests, hope this is right.