### PR TITLE
remove line break from ofGetVersionInfo() end

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1162,7 +1162,6 @@ string ofGetVersionInfo(){
 		sstr << "-" << OF_VERSION_PRE_RELEASE;
 	}
 
-	sstr << std::endl;
 	return sstr.str();
 }
 


### PR DESCRIPTION
remove line break from ofGetVersionInfo() so I can make this kind of comparsion
```c++
if (ofGetVersionInfo() == "0.10.1-stable") {
	largura += 4;
}
```
instead of
```c++
if (ofGetVersionInfo() == "0.10.1-stable\n") {
	largura += 4;
}

```