### PR TITLE
Bugfix VS build script

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -3,9 +3,9 @@
 
 //-------------------------------
 #define OF_VERSION_MAJOR 0
-#define OF_VERSION_MINOR 10
+#define OF_VERSION_MINOR 11
 #define OF_VERSION_PATCH 0
-#define OF_VERSION_PRE_RELEASE "stable"
+#define OF_VERSION_PRE_RELEASE "master"
 
 // Set to 1 for compatibility with old projects using ofVec instead of glm
 #ifndef OF_USE_LEGACY_VECTOR_MATH

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -147,8 +147,8 @@ for /d %%X in (..\..\examples\*) do (
 			echo.
 
 			if "%BUILD_TOOL%"=="msbuild" (
-				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Debug)
-				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Release)
+				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /maxcpucount /p:Configuration=Debug)
+				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /maxcpucount /p:Configuration=Release)
 			) else (
 				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
 				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -147,8 +147,8 @@ for /d %%X in (..\..\examples\*) do (
 			echo.
 
 			if "%BUILD_TOOL%"=="msbuild" (
-				if not "%CONFIGURATION%"=="release" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Debug)
-				if not "%CONFIGURATION%"=="debug" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Release)
+				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Debug)
+				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Release)
 			) else (
 				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
 				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -150,8 +150,8 @@ for /d %%X in (..\..\examples\*) do (
 				if not "%CONFIGURATION%"=="release" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Debug)
 				if not "%CONFIGURATION%"=="debug" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Release)
 			) else (
-				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Y\%%Z" /%ACTION% Debug /nologo)
-				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Y\%%Z" /%ACTION% Release /nologo))
+				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
+				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)
 		)
 		cd ../
 	)


### PR DESCRIPTION
Two fixes of VS build scripts.
- devenv ignores %PLATFORM% parameter. It compiles against win32 even %PLATFORM% is x64.
- msbuild ignores %ACTION% parameter. It can only excute "build" action even %ACTION% is clean.

One feature
- msbuild has /maxcpucount option to enable parallel compile.

Excute msbuild /? command for detailed available option
