### PR TITLE
ofSoundBuffer getChannel fix

### DIFF
--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -501,7 +501,7 @@ void ofSoundBuffer::getChannel(ofSoundBuffer & targetBuffer, std::size_t sourceC
 	targetBuffer.setNumChannels(1);
 	targetBuffer.setSampleRate(samplerate);
 	if(channels == 1){
-		copyTo(targetBuffer, getNumFrames(), 0, 0);
+		copyTo(targetBuffer, getNumFrames(), 1, 0);
 	}else{
 		// fetch samples from only one channel
 		targetBuffer.resize(getNumFrames());


### PR DESCRIPTION
ofSoundBuffer::checkSizeAndChannelsConsistency is crashing when calling ofSoundBuffer::getChannel with channels = 1 