### PR TITLE
Bugfix VS buildscript

### DIFF
--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -147,8 +147,8 @@ for /d %%X in (..\..\examples\*) do (
 			echo.
 
 			if "%BUILD_TOOL%"=="msbuild" (
-				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Debug)
-				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Release)
+				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /maxcpucount /p:Configuration=Debug)
+				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /maxcpucount /p:Configuration=Release)
 			) else (
 				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
 				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -147,8 +147,8 @@ for /d %%X in (..\..\examples\*) do (
 			echo.
 
 			if "%BUILD_TOOL%"=="msbuild" (
-				if not "%CONFIGURATION%"=="release" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Debug)
-				if not "%CONFIGURATION%"=="debug" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Release)
+				if not "%CONFIGURATION%"=="release" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Debug)
+				if not "%CONFIGURATION%"=="debug" (msbuild %%Z /t:%ACTION% /nologo /noautoresponse /p:Configuration=Release)
 			) else (
 				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
 				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -150,8 +150,8 @@ for /d %%X in (..\..\examples\*) do (
 				if not "%CONFIGURATION%"=="release" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Debug)
 				if not "%CONFIGURATION%"=="debug" (msbuild /nologo /noautoresponse %%Z /p:Configuration=Release)
 			) else (
-				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Y\%%Z" /%ACTION% Debug /nologo)
-				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Y\%%Z" /%ACTION% Release /nologo))
+				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
+				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)
 		)
 		cd ../
 	)

--- a/scripts/vs/setupCommandLine.cmd
+++ b/scripts/vs/setupCommandLine.cmd
@@ -152,6 +152,7 @@ for /d %%X in (..\..\examples\*) do (
 			) else (
 				if not "%CONFIGURATION%"=="release" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Debug|%PLATFORM%" /nologo)
 				if not "%CONFIGURATION%"=="debug" (%BUILD_TOOL% "%CD%\%%X\%%Z" /%ACTION% "Release|%PLATFORM%" /nologo)
+			)
 		)
 		cd ../
 	)


### PR DESCRIPTION
Two fixes and one new feature of VS build scripts.

Fixes
- `devenv` ignores %PLATFORM% parameter. It compiles against win32 even %PLATFORM% is x64.
- `msbuild` ignores %ACTION% parameter. It can only excute "build" action even %ACTION% is clean, etc.

Feature
- Use `/maxcpucount` option to enable parallel compile.

More info
Excute `msbuild /?` command for available options.