### PR TITLE
Fix kerning issues in ofTrueTypeFont

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -725,7 +725,7 @@ bool ofTrueTypeFont::load(const ofTrueTypeFontSettings & _settings){
 
 
 	FT_Set_Char_Size( face.get(), settings.fontSize << 6, settings.fontSize << 6, settings.dpi, settings.dpi);
-	fontUnitScale = (float(settings.fontSize * settings.dpi)) / (72 * face->units_per_EM);
+	fontUnitScale = 1.0 / 64;// (float(settings.fontSize * settings.dpi)) / (72 * face->units_per_EM);
 	lineHeight = face->height * fontUnitScale;
 	ascenderHeight = face->ascender * fontUnitScale;
 	descenderHeight = face->descender * fontUnitScale;
@@ -1024,8 +1024,8 @@ void ofTrueTypeFont::drawChar(uint32_t c, float x, float y, bool vFlipped) const
 int ofTrueTypeFont::getKerning(uint32_t c, uint32_t prevC) const{
 	if(FT_HAS_KERNING( face )){
 		FT_Vector kerning;
-		FT_Get_Kerning(face.get(), FT_Get_Char_Index(face.get(), c), FT_Get_Char_Index(face.get(), prevC), FT_KERNING_UNFITTED, &kerning);
-		return kerning.x / 64;// *fontUnitScale;
+		FT_Get_Kerning(face.get(), FT_Get_Char_Index(face.get(), prevC), FT_Get_Char_Index(face.get(), c), FT_KERNING_UNFITTED, &kerning);
+		return kerning.x * fontUnitScale;
 	}else{
 		return 0;
 	}

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1025,7 +1025,7 @@ int ofTrueTypeFont::getKerning(uint32_t c, uint32_t prevC) const{
 	if(FT_HAS_KERNING( face )){
 		FT_Vector kerning;
 		FT_Get_Kerning(face.get(), FT_Get_Char_Index(face.get(), c), FT_Get_Char_Index(face.get(), prevC), FT_KERNING_UNFITTED, &kerning);
-		return kerning.x * fontUnitScale;
+		return kerning.x / 64;// *fontUnitScale;
 	}else{
 		return 0;
 	}


### PR DESCRIPTION
Freetype uses fixed point number for font calculation (26.6).

It means 26 bit integer and 6 bit decimal.

So we can not simply use the value of `FT_Get_Kerning` because we need to account for the .6

How to calculate?
We do bit shift to the right.

`pen_x += delta.x >> 6;`

This is same calculation as dividing by 64 (2^6=64).

See Simple Text Rendering: Kerning and Centering sesction in this page. https://www.freetype.org/freetype2/docs/tutorial/step2.html#section-4

Thanks to @hiroMTB for figuring this out.
