### PR TITLE
Fix ofx gui slider scrolling

### DIFF
--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -419,11 +419,15 @@ bool ofxInputField<Type>::mouseReleased(ofMouseEventArgs &){
 //-----------------------------------------------------------
 template<typename Type>
 bool ofxInputField<Type>::mouseScrolled(ofMouseEventArgs & mouse){
+	if(!isGuiDrawing() || insideSlider){
+		//when insideSlider it is the slider object who is in charge of handling the scrolling
+		return false;
+	}
 	if(b.inside(mouse)){
 		if(!bGuiActive){
-			if(mouse.y>0 || mouse.y<0){
+			if(mouse.scrollY>0 || mouse.scrollY<0){
 				double range = getRange(value.getMin(), value.getMax(), b.width);
-				Type newValue = value + ofMap(mouse.y,-1,1,-range, range);
+				Type newValue = value + ofMap(mouse.scrollY,-1,1,-range, range);
 				newValue = ofClamp(newValue,value.getMin(),value.getMax());
 				value = newValue;
 			}

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -192,11 +192,9 @@ bool ofxSlider<Type>::mouseScrolled(ofMouseEventArgs & args){
 		}else{
 			// the following will always return false as it is inside the slider.
 //			return input.mouseScrolled(args);
-		
 		}
-	}else{
-		return false;
 	}
+	return false;
 }
 
 

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -176,20 +176,26 @@ getRange(Type min, Type max, float width){
 
 template<typename Type>
 bool ofxSlider<Type>::mouseScrolled(ofMouseEventArgs & args){
-	if(state==Slider){
-		if(mouseInside){
-			if(args.scrollY>0 || args.scrollY<0){
-				double range = getRange(value.getMin(),value.getMax(),b.width);
-				Type newValue = value + ofMap(args.scrollY,-1,1,-range, range);
-				newValue = ofClamp(newValue,value.getMin(),value.getMax());
-				value = newValue;
+	if(isGuiDrawing()){
+		if(state==Slider){
+			if(mouseInside){
+				if(args.scrollY>0 || args.scrollY<0){
+					double range = getRange(value.getMin(),value.getMax(),b.width);
+					Type newValue = value + ofMap(args.scrollY,-1,1,-range, range);
+					newValue = ofClamp(newValue,value.getMin(),value.getMax());
+					value = newValue;
+				}
+				return true;
+			}else{
+				return false;
 			}
-			return true;
 		}else{
-			return false;
+			// the following will always return false as it is inside the slider.
+//			return input.mouseScrolled(args);
+		
 		}
 	}else{
-		return isGuiDrawing() && input.mouseScrolled(args);
+		return false;
 	}
 }
 


### PR DESCRIPTION
Fix for this issue https://github.com/openframeworks/openFrameworks/issues/6133

The scrolling was still being handled when the gui was not being drawn both in ofxSlider and ofxInputField. 

Tested using the code provided in the mentioned issue.

Also, 
there is some redundant code in ofxSlider.cpp and ofxInputField.cpp. Both have a function called `toRange(...)` which is identical in both. When the scroll callback is called this function  is called. Can't we move this function to the ofxBaseGui for instance? Also, the code used in the scroll callback in both ofxSlider and ofxInputField is quite similar, maybe moving this to ofxBaseGui might be better too. 


