### PR TITLE
define APPNAME earlier to fix msys2 copy dlls failing

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
@@ -3,12 +3,12 @@
 # define the OF_SHARED_MAKEFILES location
 OF_SHARED_MAKEFILES_PATH=$(OF_ROOT)/libs/openFrameworksCompiled/project/makefileCommon
 
-include $(OF_SHARED_MAKEFILES_PATH)/config.shared.mk
-
 # if APPNAME is not defined, set it to the project dir name
 ifndef APPNAME
 	APPNAME = $(shell basename `pwd`)
 endif
+
+include $(OF_SHARED_MAKEFILES_PATH)/config.shared.mk
 
 # Name TARGET
 ifeq ($(findstring Debug,$(MAKECMDGOALS)),Debug)


### PR DESCRIPTION
This fixes the copy_dlls make target on msys2 (windows)

fixes #6165