### PR TITLE
added camera and microphone permissions for mojave

### DIFF
--- a/scripts/templates/osx/openFrameworks-Info.plist
+++ b/scripts/templates/osx/openFrameworks-Info.plist
@@ -18,5 +18,9 @@
 	<string>1.0</string>
 	<key>CFBundleIconFile</key>
 	<string>${ICON}</string>
+	<key>NSCameraUsageDescription</key>    
+	<string>This app needs to access the camera</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs to access the microphone</string>
 </dict>
 </plist>


### PR DESCRIPTION
This should address the permissions issue for 10.14 users. 
Tagging #6149