### PR TITLE
fix `conflicting declaration` OpenGL on some linux distros

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -177,7 +177,7 @@ enum ofTargetPlatform{
 	#endif
 	#include <unistd.h>
 	#include "GL/glew.h"
-	#include <OpenGL/gl.h>
+	//#include <OpenGL/gl.h>
 	#include <ApplicationServices/ApplicationServices.h>
 
 	#if defined(__LITTLE_ENDIAN__)

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -124,7 +124,7 @@ enum ofTargetPlatform{
 	#define GLEW_STATIC
 	#define GLEW_NO_GLU
 	#include "GL/glew.h"
-    #include "GL/wglew.h"
+	#include "GL/wglew.h"
 	#define __WINDOWS_DS__
 	#define __WINDOWS_MM__
 	#if (_MSC_VER)       // microsoft visual studio
@@ -177,7 +177,6 @@ enum ofTargetPlatform{
 	#endif
 	#include <unistd.h>
 	#include "GL/glew.h"
-	//#include <OpenGL/gl.h>
 	#include <ApplicationServices/ApplicationServices.h>
 
 	#if defined(__LITTLE_ENDIAN__)
@@ -205,11 +204,8 @@ enum ofTargetPlatform{
 		#define EGL_EGLEXT_PROTOTYPES
 		#include "EGL/egl.h"
 		#include "EGL/eglext.h"
-	#else // normal linux
-		// #define GL_GLEXT_PROTOTYPES
-		#include <GL/glew.h>
-		// #include <GL/gl.h>
-		// #include <GL/glext.h>  
+	#else // desktop linux
+		#include <GL/glew.h> 
 	#endif
 
 	// for some reason, this isn't defined at compile time,

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -206,7 +206,7 @@ enum ofTargetPlatform{
 		#include "EGL/egl.h"
 		#include "EGL/eglext.h"
 	#else // normal linux
-		#define GL_GLEXT_PROTOTYPES
+		// #define GL_GLEXT_PROTOTYPES
 		#include <GL/glew.h>
 		// #include <GL/gl.h>
 		// #include <GL/glext.h>  

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -208,7 +208,7 @@ enum ofTargetPlatform{
 	#else // normal linux
 		#define GL_GLEXT_PROTOTYPES
 		#include <GL/glew.h>
-		#include <GL/gl.h>
+		// #include <GL/gl.h>
 		// #include <GL/glext.h>  
 	#endif
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -209,7 +209,7 @@ enum ofTargetPlatform{
 		#define GL_GLEXT_PROTOTYPES
 		#include <GL/glew.h>
 		#include <GL/gl.h>
-		#include <GL/glext.h>
+		// #include <GL/glext.h>  
 	#endif
 
 	// for some reason, this isn't defined at compile time,


### PR DESCRIPTION
reported from here.
https://forum.openframeworks.cc/t/arch-linux-compilation-error-after-updating-the-system/31097

and solution?.
https://github.com/mupen64plus/mupen64plus-video-z64/pull/16


