### PR TITLE
Add useful ofParameter constructor

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -484,6 +484,7 @@ public:
 	ofParameter(const ParameterType & v);
 	ofParameter(const std::string& name, const ParameterType & v);
 	ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+    ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable);
 
 	const ParameterType & get() const;
 	const ParameterType * operator->() const;
@@ -616,6 +617,14 @@ private:
 		,bInNotify(false)
 		,serializable(true){}
 
+        Value(std::string name, ParameterType v, ParameterType min, ParameterType max, bool serializable)
+        :name(name)
+        ,value(v)
+        ,min(min)
+        ,max(max)
+        ,bInNotify(false)
+        ,serializable(serializable){}
+        
 		std::string name;
 		ParameterType value;
 		ParameterType min, max;
@@ -661,6 +670,10 @@ ofParameter<ParameterType>::ofParameter(const std::string& name, const Parameter
 :obj(std::make_shared<Value>(name, v, min, max))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
+template<typename ParameterType>
+ofParameter<ParameterType>::ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable)
+:obj(std::make_shared<Value>(name, v, min, max, serializable))
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 template<typename ParameterType>
 inline ofParameter<ParameterType> & ofParameter<ParameterType>::operator=(const ofParameter<ParameterType> & v){

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -1102,6 +1102,7 @@ public:
 	ofReadOnlyParameter(const ParameterType & v);
 	ofReadOnlyParameter(const std::string& name, const ParameterType & v);
 	ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+    ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable);
 
 	const ParameterType & get() const;
 	const ParameterType * operator->() const;
@@ -1226,6 +1227,9 @@ template<typename ParameterType,typename Friend>
 inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)
 :parameter(name,v,min,max){}
 
+template<typename ParameterType,typename Friend>
+inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable)
+:parameter(name,v,min,max,serializable){}
 
 template<typename ParameterType,typename Friend>
 inline const ParameterType & ofReadOnlyParameter<ParameterType,Friend>::get() const{

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -1115,6 +1115,7 @@ public:
 //	ofReadOnlyParameter(ofReadOnlyParameter<ParameterType,Friend> & p);
 	ofReadOnlyParameter(const ParameterType & v);
 	ofReadOnlyParameter(const std::string& name, const ParameterType & v);
+    ofReadOnlyParameter(const std::string& name, const ParameterType & v, bool serializable);
 	ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
     ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable);
 
@@ -1237,6 +1238,10 @@ inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const Para
 template<typename ParameterType,typename Friend>
 inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v)
 :parameter(name,v){}
+
+template<typename ParameterType,typename Friend>
+inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v, bool serializable)
+:parameter(name,v, serializable){}
 
 template<typename ParameterType,typename Friend>
 inline ofReadOnlyParameter<ParameterType,Friend>::ofReadOnlyParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max)

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -1177,6 +1177,7 @@ protected:
 	
 	ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value);
 	ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max);
+    ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max, bool serializable);
 
 	void setMin(const ParameterType & min);
 	void setMax(const ParameterType & max);
@@ -1468,6 +1469,11 @@ inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<Parameter
 	return *this;
 }
 
+template<typename ParameterType,typename Friend>
+inline ofReadOnlyParameter<ParameterType,Friend> & ofReadOnlyParameter<ParameterType,Friend>::set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max, bool serializable){
+    parameter.set(name,value,min,max,serializable);
+    return *this;
+}
 
 template<typename ParameterType,typename Friend>
 inline void ofReadOnlyParameter<ParameterType,Friend>::setMin(const ParameterType & min){

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -483,6 +483,7 @@ public:
 	ofParameter(const ofParameter<ParameterType> & v);
 	ofParameter(const ParameterType & v);
 	ofParameter(const std::string& name, const ParameterType & v);
+    ofParameter(const std::string& name, const ParameterType & v, bool serializable);
 	ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
     ofParameter(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable);
 
@@ -610,6 +611,14 @@ private:
 		,bInNotify(false)
 		,serializable(true){}
 
+        Value(std::string name, ParameterType v, bool serializable)
+        :name(name)
+        ,value(v)
+        ,min(of::priv::TypeInfo<ParameterType>::min())
+        ,max(of::priv::TypeInfo<ParameterType>::max())
+        ,bInNotify(false)
+        ,serializable(serializable){}
+
 		Value(std::string name, ParameterType v, ParameterType min, ParameterType max)
 		:name(name)
 		,value(v)
@@ -664,6 +673,11 @@ ofParameter<ParameterType>::ofParameter(const ParameterType & v)
 template<typename ParameterType>
 ofParameter<ParameterType>::ofParameter(const std::string& name, const ParameterType & v)
 :obj(std::make_shared<Value>(name, v))
+,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
+
+template<typename ParameterType>
+ofParameter<ParameterType>::ofParameter(const std::string& name, const ParameterType & v, bool serializable)
+:obj(std::make_shared<Value>(name, v, serializable))
 ,setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)){}
 
 template<typename ParameterType>

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -558,6 +558,7 @@ public:
 	ofParameter<ParameterType> & set(const ParameterType & v);
 	ofParameter<ParameterType> & set(const std::string& name, const ParameterType & v);
 	ofParameter<ParameterType> & set(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
+    ofParameter<ParameterType> & set(const std::string& name, const ParameterType & v, const ParameterType & min, const ParameterType & max, bool serializable);
 
 	ofParameter<ParameterType> & setWithoutEventNotifications(const ParameterType & v);
 
@@ -700,6 +701,16 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::set(const std::string& 
 	setMin(min);
 	setMax(max);
 	return *this;
+}
+
+template<typename ParameterType>
+ofParameter<ParameterType> & ofParameter<ParameterType>::set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max, bool serializable){
+    setName(name);
+    set(value);
+    setMin(min);
+    setMax(max);
+    setSerializable(serializable);
+    return *this;
 }
 
 template<typename ParameterType>


### PR DESCRIPTION
Right now we are able to initialize ofParameter like below in ofApp.h.
```
ofParameter<int>  fps{"FPS", 0, 0, 120};
ofParameter<bool> bFullscreen{"Fullscreen", false};
ofParameterGroup  grp{"general settings", fps, bFullscreen};
```
The first parameter (e.g. "FPS") is the name of parameter then initial value, min and max.
This is very useful because we can write in header file and reduce code in ofApp.cpp file.
I'm using this often in my project since I found this syntax in Entropy project(for example [here](https://github.com/Entropy/Entropy/blob/master/Projects/EntropyRender/src/entropy/render/PostEffects.h)), 

It would be nicer if we could initialize "serializable" variable as well in same manner. With this PR we can write this way and reduce .setSerializable(false) in ofApp.cpp to avoid saving parameter to xml (or json).

```
ofParameter<int>  fps{"FPS", 0, 0, 120, false};
ofParameter<bool> bFullscreen{"Fullscreen", false, false};
ofParameterGroup  grp{"general settings", fps, bFullscreen};
```

*Same to ofReadOnlyParameter