### PR TITLE
Fix ofx gui events propagation

### DIFF
--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -233,8 +233,6 @@ void ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter){
 void ofxGuiGroup::clear(){
 	collection.clear();
 	parameters.clear();
-//	there is no need for the following line as sizeChangedCB will handle it anyways, and change b.height.
-//	b.height = (bHeaderEnabled?headerRect.height:0) + spacing + spacingNextElement;
 	sizeChangedCB();
 }
 

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -233,8 +233,8 @@ void ofxGuiGroup::add(ofParameter <ofFloatColor> & parameter){
 void ofxGuiGroup::clear(){
 	collection.clear();
 	parameters.clear();
-	
-	b.height = (bHeaderEnabled?headerRect.height:0) + spacing + spacingNextElement;
+//	there is no need for the following line as sizeChangedCB will handle it anyways, and change b.height.
+//	b.height = (bHeaderEnabled?headerRect.height:0) + spacing + spacingNextElement;
 	sizeChangedCB();
 }
 
@@ -263,18 +263,19 @@ bool ofxGuiGroup::mousePressed(ofMouseEventArgs & args){
 	ofMouseEventArgs a = args;
 	for(std::size_t i = 0; i < collection.size(); i++){
 		if(collection[i]->mousePressed(a)){
+//			return true;
 			attended = true;
 		}
 	}
-	return attended;
+	return attended || b.inside(args);
 }
 
 bool ofxGuiGroup::mouseDragged(ofMouseEventArgs & args){
 	if(!isGuiDrawing())return false;
-	if(setValue(args.x, args.y, false)){
-		return true;
-	}
 	if(bGuiActive){
+		if(setValue(args.x, args.y, false)){
+			return true;
+		}
 		ofMouseEventArgs a = args;
 		for(std::size_t i = 0; i < collection.size(); i++){
 			if(collection[i]->mouseDragged(a)){
@@ -286,19 +287,25 @@ bool ofxGuiGroup::mouseDragged(ofMouseEventArgs & args){
 }
 
 bool ofxGuiGroup::mouseReleased(ofMouseEventArgs & args){
-	bGuiActive = false;
-	if(!isGuiDrawing())return false;
-	for(std::size_t k = 0; k < collection.size(); k++){
-		ofMouseEventArgs a = args;
-		if(collection[k]->mouseReleased(a)){
-			return true;
-		}
-	}
-	if(b.inside(ofPoint(args.x, args.y))){
-		return true;
-	}else{
+	if(!isGuiDrawing()){
+		bGuiActive = false;
 		return false;
 	}
+	if(bGuiActive){
+		bGuiActive = false;
+		for(std::size_t k = 0; k < collection.size(); k++){
+			ofMouseEventArgs a = args;
+			if(collection[k]->mouseReleased(a)){
+				return true;
+			}
+		}
+		if(b.inside(ofPoint(args.x, args.y))){
+			return true;
+		}else{
+			return false;
+		}
+	}
+	return false;
 }
 
 bool ofxGuiGroup::mouseScrolled(ofMouseEventArgs & args){

--- a/addons/ofxGui/src/ofxPanel.cpp
+++ b/addons/ofxGui/src/ofxPanel.cpp
@@ -119,12 +119,7 @@ bool ofxPanel::mousePressed(ofMouseEventArgs & args){
 }
 bool ofxPanel::mouseReleased(ofMouseEventArgs & args){
     this->bGrabbed = false;
-    if(ofxGuiGroup::mouseReleased(args)) return true;
-    if(isGuiDrawing() && b.inside(ofPoint(args.x,args.y))){
-    	return true;
-    }else{
-    	return false;
-    }
+	return ofxGuiGroup::mouseReleased(args);
 }
 
 bool ofxPanel::setValue(float mx, float my, bool bCheck){


### PR DESCRIPTION
fixed `ofxGuiGroup` events propagation.
When using an `ofEasyCam` and an `ofxPanel` or `ofxGuiGroup` object,if moving the camera by dragging the mouse and the mouse was released over the gui, then when trying to change something in the gui would also change the `ofEasyCam` object. 
This issue got reported [here](https://forum.openframeworks.cc/t/clicks-on-ofxgui-panel-params-pass-through-to-main-window/31368/3) 


Additionally, I changed all the instances of `ofPoint` and `ofVec*f` into glm.