### PR TITLE
Fixes multitouch confusion on iOS

### DIFF
--- a/scripts/templates/ios/src/main.mm
+++ b/scripts/templates/ios/src/main.mm
@@ -1,7 +1,7 @@
 #include "ofApp.h"
 
 int main() {
-    
+
     //  here are the most commonly used iOS window settings.
     //------------------------------------------------------
     ofiOSWindowSettings settings;
@@ -17,7 +17,8 @@ int main() {
     settings.depthType = ofxiOSRendererDepthFormat::DEPTH_NONE; // depth format (16/24) if depth enabled
     settings.stencilType = ofxiOSRendererStencilFormat::STENCIL_NONE; // stencil mode
     settings.windowMode = OF_FULLSCREEN;
+    settings.enableMultiTouch = false; // enables multitouch support and updates touch.id etc.
     ofCreateWindow(settings);
-    
+
 	return ofRunApp(new ofApp);
 }


### PR DESCRIPTION
Multitouch was never broken on iOS - it had to be enabled from the main.mm file. What made it confusing was that `settings.enableMultiTouch` was not present in the template to begin with, so just added it! Makes life slightly easier :)