### PR TITLE
Add jack-audio-connection-kit-dbus as Fedora dep

### DIFF
--- a/scripts/linux/fedora/install_dependencies.sh
+++ b/scripts/linux/fedora/install_dependencies.sh
@@ -10,7 +10,7 @@ if [ $EUID != 0 ]; then
    exit 1
 fi
 
-dnf install freeglut-devel alsa-lib-devel libXmu-devel libXxf86vm-devel gcc-c++ libraw1394-devel gstreamer1-devel gstreamer1-plugins-base-devel libudev-devel libtheora-devel libvorbis-devel openal-soft-devel libsndfile-devel python-lxml glew-devel flac-devel freeimage-devel cairo-devel pulseaudio-libs-devel openssl-devel libusbx-devel gtk2-devel libXrandr-devel libXi-devel opencv-devel libX11-devel assimp-devel rtaudio-devel boost-devel gtk3-devel glfw-devel uriparser-devel curl-devel pugixml-devel
+dnf install freeglut-devel alsa-lib-devel libXmu-devel libXxf86vm-devel gcc-c++ libraw1394-devel gstreamer1-devel gstreamer1-plugins-base-devel libudev-devel libtheora-devel libvorbis-devel openal-soft-devel libsndfile-devel python-lxml glew-devel flac-devel freeimage-devel cairo-devel pulseaudio-libs-devel openssl-devel libusbx-devel gtk2-devel libXrandr-devel libXi-devel opencv-devel libX11-devel assimp-devel rtaudio-devel boost-devel gtk3-devel glfw-devel uriparser-devel curl-devel pugixml-devel jack-audio-connection-kit-dbus
 
 exit_code=$?
 if [ $exit_code != 0 ]; then


### PR DESCRIPTION
Add `jack-audio-connection-kit-dbus` as a Fedora dependency.
On a fresh system the projectGenerator reports "projectGenerator: error while loading shared libraries: libjack.so.0: cannot open shared object file: No such file or directory".

Installing `jack-audio-connection-kit-dbus` fixes this issue at least on Fedora 29.