### PR TITLE
fix buffer overflow in linear interpolation of audio buffer with loop

### DIFF
--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -376,7 +376,6 @@ void ofSoundBuffer::linearResampleTo(ofSoundBuffer &outBuffer, std::size_t fromF
 					b = buffer[intPosition+inChannels+j];
 					*resBufferPtr++ = ofLerp(a,b,remainder);
 				}
-				resBufferPtr+=inChannels;
 				position += increment;
 				intPosition = position;
 			}


### PR DESCRIPTION
write pointer is incremented twice, removed the unnecessary increment