### PR TITLE
Fix. Added openCv C++ headers.

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvConstants.h
+++ b/addons/ofxOpenCv/src/ofxCvConstants.h
@@ -8,6 +8,7 @@
 #endif 
 
 #include "cv.h"
+#include "opencv2/opencv.hpp"
 #include <vector>
 #include "ofMain.h"
 


### PR DESCRIPTION
Added openCv's C++ headers which got removed in because of some changes in opencv.
This is addressing what's discussed [here](https://forum.openframeworks.cc/t/ofx-does-not-recognize-native-opencv-functions/31609)
As noted in that thread,

> ofxOpenCv is only including the C header #include "cv.h", while ofxCv includes the C++ one #include "opencv2/opencv.hpp"

> OF 0.9.8 used opencv 2.4.8 where the cv.h file included the C++ headers, as you can see [here](https://github.com/opencv/opencv/blob/2.4.8/include/opencv/cv.h#L63-L72), while OF 0.10 uses opencv 3.1 which does not include those headers as you can see [here](https://github.com/opencv/opencv/blob/3.1.0/include/opencv/cv.h#L63-L67) 