### PR TITLE
phong.frag: v_transformedNormal and eye should be re-normalized (#6221)

### DIFF
--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -65,7 +65,7 @@ static const string fragmentShader = R"(
         float d;            // distance from surface to light source
         vec3  VP;           // direction from surface to light position
         vec3  halfVector;   // direction of maximum highlights
-        vec3 eye = -v_eyePosition;
+        vec3 eye = -normalize(v_eyePosition);
 
         // Compute vector from surface to light position
         VP = vec3 (light.position.xyz) - ecPosition3;
@@ -124,7 +124,7 @@ static const string fragmentShader = R"(
         float pf;
         float d;            // distance from surface to light source
         vec3  VP;           // direction from surface to light position
-        vec3 eye = -v_eyePosition;
+        vec3 eye = -normalize(v_eyePosition);
         float spotEffect;
         float attenuation=1.0;
         vec3  halfVector;   // direction of maximum highlights
@@ -219,16 +219,18 @@ static const string fragmentShader = R"(
         vec3 diffuse = vec3(0.0,0.0,0.0);
         vec3 specular = vec3(0.0,0.0,0.0);
 
+		vec3 transformedNormal = normalize(v_transformedNormal);
+
         for( int i = 0; i < MAX_LIGHTS; i++ ){
             if(lights[i].enabled<0.5) continue;
             if(lights[i].type<0.5){
-                pointLight(lights[i], v_transformedNormal, v_eyePosition, ambient, diffuse, specular);
+                pointLight(lights[i], transformedNormal, v_eyePosition, ambient, diffuse, specular);
             }else if(lights[i].type<1.5){
-                directionalLight(lights[i], v_transformedNormal, ambient, diffuse, specular);
+                directionalLight(lights[i], transformedNormal, ambient, diffuse, specular);
             }else if(lights[i].type<2.5){
-                spotLight(lights[i], v_transformedNormal, v_eyePosition, ambient, diffuse, specular);
+                spotLight(lights[i], transformedNormal, v_eyePosition, ambient, diffuse, specular);
             }else{
-                areaLight(lights[i], v_transformedNormal, v_eyePosition, ambient, diffuse, specular);
+                areaLight(lights[i], transformedNormal, v_eyePosition, ambient, diffuse, specular);
             }
         }
 


### PR DESCRIPTION
Proposed bugfix for: #6221 phong.frag: v_transformedNormal and eye should be re-normalized

Changes to libs/openFrameworks/gl/shaders/phong.frag

line 68, function pointLight(...): vec3 eye normalized so that that eye direction is a normalized vector. This means that calculation of the halfVector (in line 82) should now be correct. Previously 'VP' was normalized but 'eye' was un-normalized, which resulted in incorrect calculation of the halfVector, and hence incorrect placement of specular highlights.

line 127, function spotLight(...): vec3 eye normalized so that that eye direction is a normalized vector. This means that calculation of the halfVector (in line 142) should now be correct. Previously 'VP' was normalized but 'eye' was un-normalized, which resulted in incorrect calculation of the halfVector, and hence incorrect placement of specular highlights.

lines 222-233, function main(void): vec3 transformedNormal calculated by normalizing the value of attribute v_transformedNormal. Interpollation of attributes during rasterization means that v_transformedNormal is not necessarily a unit vector, which can cause significant shading artefacts. Using the normalized value (transformedNormal instead of v_transformedNormal) for the light shaders appears to significantly improve the quality of specular highlight when there is smooth interpollation of the normals.

Code tested on Windows 10.
