### PR TITLE
AVFoundationPlayer - set speed, frame/position when beeing ready to play

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -82,6 +82,8 @@ typedef enum _playerLoopType{
     BOOL bSampleAudio; // default to NO
 	BOOL bIsUnloaded;
 	BOOL bStream;
+	int frameBeforeReady;
+	float positionBeforeReady;
 	
 	NSLock* asyncLock;
 	NSCondition* deallocCond;

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -178,6 +178,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	bReady = NO;
 	bLoaded = NO;
 	bPlayStateBeforeLoad = NO;
+	frameBeforeReady = 0;
+	positionBeforeReady = 0.F;
 	
 	// going to load
 	dispatch_semaphore_t sema = dispatch_semaphore_create(0);

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -80,6 +80,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 		bSeeking = NO;
 		bSampleVideo = YES;
 		bIsUnloaded = NO;
+		frameBeforeReady = 0;
+		positionBeforeReady = 0.F;
 		
 		// do not sample audio by default
 		// we are lacking interfaces for audiodata
@@ -728,12 +730,29 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 				bReady = true;
 				
-				[self setVolume:volume]; // set volume for current video.
+				// set volume for current video
+				[self setVolume:volume];
+				
+				// set speed for current video
+				[self setSpeed:speed];
+				
+				// set start-frame
+				if (frameBeforeReady > 0) {
+					[self setFrame:frameBeforeReady];
+				}
+				
+				// set start-position
+				if (positionBeforeReady > 0.F) {
+					[self setPosition:positionBeforeReady];
+				}
+				
+				// auto-play or play if started before beeing ready
 				if(bAutoPlayOnLoad || bPlayStateBeforeLoad) {
 					[self play];
 				}
 				
-				[self update]; // update as soon is ready so pixels are loaded.
+				// update as soon is ready so pixels are loaded.
+				[self update];
 
 				
 			} else if ([self.playerItem status] == AVPlayerItemStatusUnknown) {
@@ -1323,6 +1342,9 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	if ([self isReady]) {
 		double time = [self getDurationInSec] * position;
 		[self seekToTime:CMTimeMakeWithSeconds(time, NSEC_PER_SEC)];
+	} else {
+		positionBeforeReady = position;
+		frameBeforeReady = 0;
 	}
 }
 
@@ -1330,6 +1352,9 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	if ([self isReady]) {
 		float position = frame / (float)[self getDurationInFrames];
 		[self setPosition:position];
+	} else {
+		frameBeforeReady = frame;
+		positionBeforeReady = 0.F;
 	}
 }
 
@@ -1366,6 +1391,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (void)setSpeed:(float)value {
 	
+	speed = value;
+
 	if(![self isReady]) {
 		return;
 	}
@@ -1406,8 +1433,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	if (value < 0.0) {
 		bWasPlayingBackwards = YES;
 	}
-	
-	speed = value;
+		
 	[_player setRate:value];
 }
 


### PR DESCRIPTION
at the moment AVFoundation player does not allow setting frame/position and speed before the player is ready. isReady is handled internally only - users do not have a way to know when the movie is ready to play.

proposing these changes so frame/position and speed can be set before the video is ready to play.