### PR TITLE
fix data type on texture load from int32_t* and uint32_t*

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -557,7 +557,7 @@ void ofTexture::loadData(const uint16_t * data, int w, int h, int glFormat){
 //----------------------------------------------------------
 void ofTexture::loadData(const uint32_t * data, int w, int h, int glFormat){
 	ofSetPixelStoreiAlignment(GL_UNPACK_ALIGNMENT,w,2,ofGetNumChannelsFromGLFormat(glFormat));
-	loadData(data, w, h, glFormat, GL_SHORT);
+	loadData(data, w, h, glFormat, GL_UNSIGNED_INT);
 }
 
 //----------------------------------------------------------
@@ -575,7 +575,7 @@ void ofTexture::loadData(const int16_t * data, int w, int h, int glFormat){
 //----------------------------------------------------------
 void ofTexture::loadData(const int32_t * data, int w, int h, int glFormat){
 	ofSetPixelStoreiAlignment(GL_UNPACK_ALIGNMENT,w,2,ofGetNumChannelsFromGLFormat(glFormat));
-	loadData(data, w, h, glFormat, GL_SHORT);
+	loadData(data, w, h, glFormat, GL_INT);
 }
 
 //----------------------------------------------------------


### PR DESCRIPTION
`ofTexture::loadData` with `int32_t*` and `uint32_t*`inputs sets the type in the call to `glTexSubImage2D` incorrectly to `GL_SHORT`, causing corruption.