### PR TITLE
Fix easy cam auto distance

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -70,6 +70,9 @@ void ofEasyCam::reset(){
 	rot = {0,0,0};
 	translate = {0,0,0};
 
+	if(bAutoDistance){
+		bDistanceSet = false;
+	}
 	bApplyInertia = false;
 	currentTransformType = TRANSFORM_NONE;
 }
@@ -506,4 +509,10 @@ bool ofEasyCam:: hasInteraction(TransformType type, int mouseButton, int key){
 //----------------------------------------
 void ofEasyCam::removeAllInteractions(){
 	interactions.clear();
+}
+//----------------------------------------
+void ofEasyCam::onPositionChanged(){
+	if(!bDistanceSet && bAutoDistance){
+		bDistanceSet = true;
+	}
 }

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -178,6 +178,8 @@ public:
 	bool hasInteraction(TransformType type, int mouseButton, int key = -1);
 	bool hasInteraction(int mouseButton, int key);
 	void removeAllInteractions();
+protected:
+	virtual void onPositionChanged() ;
 private:
 	void setDistance(float distance, bool save);
 


### PR DESCRIPTION
when calling `setPosition(..)` on an `ofEasyCam` object during setup, by default it will no go to this position as it will get over riden by the auto distance function of it. Now, once calling `setPosition(..) ` during setup, auto distance is disabled and the camera will get positioned where it needs to be.