### PR TITLE
armv6: remove failing cd at end of install.sh

### DIFF
--- a/scripts/ci/linuxarmv6l/install.sh
+++ b/scripts/ci/linuxarmv6l/install.sh
@@ -66,4 +66,3 @@ cd $ROOT/raspbian/usr/lib
 relativeSoftLinks
 cd $ROOT/raspbian/usr/lib/arm-linux-gnueabihf
 relativeSoftLinks
-cd $ROOT/raspbian/usr/lib/gcc/arm-linux-gnueabihf/4.9


### PR DESCRIPTION
The `cd $ROOT/raspbian/usr/lib/gcc/arm-linux-gnueabihf/4.9` fails because the GCC version in `rpi_toolchain_gcc6.tar.bz2` is 6.3.0 and not 4.9.

Simply remove it because it is not needed and never did anything (no call to fix relative links after `cd`).

This change is against the stable branch because that's what I use. However, it should be applied to master as well.

Signed-off-by: Lucas Rangit MAGASWERAN <lucasrangit@gmail.com>