### PR TITLE
Added missing ROOT variable to fedora install_dependencies.sh

### DIFF
--- a/scripts/linux/fedora/install_dependencies.sh
+++ b/scripts/linux/fedora/install_dependencies.sh
@@ -10,6 +10,8 @@ if [ $EUID != 0 ]; then
    exit 1
 fi
 
+ROOT=$(cd $(dirname $0); pwd -P)
+
 dnf install freeglut-devel alsa-lib-devel libXmu-devel libXxf86vm-devel gcc-c++ libraw1394-devel gstreamer1-devel gstreamer1-plugins-base-devel libudev-devel libtheora-devel libvorbis-devel openal-soft-devel libsndfile-devel python-lxml glew-devel flac-devel freeimage-devel cairo-devel pulseaudio-libs-devel openssl-devel libusbx-devel gtk2-devel libXrandr-devel libXi-devel opencv-devel libX11-devel assimp-devel rtaudio-devel boost-devel gtk3-devel glfw-devel uriparser-devel curl-devel pugixml-devel jack-audio-connection-kit-dbus poco-devel
 
 exit_code=$?


### PR DESCRIPTION
The script uses ROOT when modifies the ofxOpenCv addon. Without it the script fails.