### PR TITLE
ofxOscSender.setup() fix

### DIFF
--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -59,7 +59,10 @@ bool ofxOscSender::setup(const ofxOscSenderSettings &settings){
 	osc::UdpTransmitSocket *socket = nullptr;
 	try{
 		osc::IpEndpointName name = osc::IpEndpointName(settings.host.c_str(), settings.port);
-		if (!name.address) return false;
+		if (!name.address){
+    			ofLogError("ofxOscSender") << "bad host? " << settings.host;
+    			return false;
+		}
 		socket = new osc::UdpTransmitSocket(name, settings.broadcast);
 		sendSocket.reset(socket);
 	}

--- a/addons/ofxOsc/src/ofxOscSender.cpp
+++ b/addons/ofxOsc/src/ofxOscSender.cpp
@@ -59,6 +59,7 @@ bool ofxOscSender::setup(const ofxOscSenderSettings &settings){
 	osc::UdpTransmitSocket *socket = nullptr;
 	try{
 		osc::IpEndpointName name = osc::IpEndpointName(settings.host.c_str(), settings.port);
+		if (!name.address) return false;
 		socket = new osc::UdpTransmitSocket(name, settings.broadcast);
 		sendSocket.reset(socket);
 	}


### PR DESCRIPTION
as mentioned here: https://forum.openframeworks.cc/t/ofxoscsender-falls-back-on-localhost/32442/2
and discussed there: https://github.com/bltzr/openFrameworks/commit/93ccf317e4377dd754655fb91956a3efe0c43b76 with @danomatika 

when providing an unavailable host to ofxOscSender.setup() it was falling back to localhost, which prevented from knowing that the connection to the desired host failed.

those 2 commits fix that, and post an error message when the endpoint cannot be reached