### PR TITLE
adding pugi parsing Options to ofXml

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -6,6 +6,7 @@ using namespace std;
 ofXml::ofXml()
 :doc(new pugi::xml_document){
 	xml = doc->root();
+	parsing_options = pugi::parse_default;
 }
 
 ofXml::ofXml(std::shared_ptr<pugi::xml_document> doc, const pugi::xml_node & xml)
@@ -14,9 +15,13 @@ ofXml::ofXml(std::shared_ptr<pugi::xml_document> doc, const pugi::xml_node & xml
 
 }
 
+void ofXml::setParsingOptions(unsigned int l_parsing_options) {
+	parsing_options = l_parsing_options;
+}
+
 bool ofXml::load(const std::filesystem::path & file){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load_file(ofToDataPath(file).c_str())){
+	if(auxDoc->load_file(ofToDataPath(file).c_str(), parsing_options)){
 		doc = auxDoc;
 		xml = doc->root();
 		return true;
@@ -31,7 +36,7 @@ bool ofXml::load(const ofBuffer & buffer){
 
 bool ofXml::parse(const std::string & xmlStr){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load(xmlStr.c_str())){
+	if(auxDoc->load(xmlStr.c_str(), parsing_options)){
 		doc = auxDoc;
 		xml = doc->root();
 		return true;

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -102,6 +102,8 @@ public:
 
 	bool load(const std::filesystem::path & file);
 	bool load(const ofBuffer & buffer);
+
+	void setParsingOptions(unsigned int l_parsing_options);
 	bool parse(const std::string & xmlStr);
 	bool save(const std::filesystem::path & file) const;
 	void clear();
@@ -114,6 +116,8 @@ public:
 	ofXml appendChild(const ofXml & xml);
 	ofXml prependChild(const ofXml & xml);
 	bool removeChild(const ofXml & node);
+
+	unsigned int parsing_options;
 
 #if PUGIXML_VERSION>=170
 	ofXml appendChild(ofXml && xml);


### PR DESCRIPTION
pugi offers parsing options like "pugi::parse_default | pugi::parse_comments" in case we want comments not to be stripped etc. Added a variable and a setter to be able to use them in ofXml.
Not sure if I did in accordance to your coding guidelines, but anyway it's just a proposal. Would be great to have for me. 

Would be used like this:
`XML.setParsingOptions(pugi::parse_default | pugi::parse_comments);
XML.load(pathToXML);`


**Thanks for your awesome work!**
oe