### PR TITLE
Add handling of double precision position data in PLY model loader

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1110,7 +1110,8 @@ void ofMesh_<V,N,C,T>::load(const std::filesystem::path& path){
 			continue;
 		}
 
-		if(state==VertexDef && (lineStr.find("property float x")==0 || lineStr.find("property float y")==0 || lineStr.find("property float z")==0)){
+		if(state==VertexDef && (lineStr.find("property float x")==0 || lineStr.find("property float y")==0 || lineStr.find("property float z")==0
+                || lineStr.find("property double x")==0 || lineStr.find("property double y")==0 || lineStr.find("property double z")==0)){
 			meshDefinition.push_back(Position);
 			vertexCoordsFound++;
 			continue;


### PR DESCRIPTION
If users try to load a PLY with double precision position data instead of float data, OF will act like its floating point precision, instead of silently loading the model incorrectly.
This was discussed in my forum post [here](https://forum.openframeworks.cc/t/solved-double-precision-ply-file/32506 ) It was suggested I make a PR so here we are. :) thanks.