### PR TITLE
update method for drawing slider bars

### DIFF
--- a/addons/ofxGui/src/ofxGuiUtils.h
+++ b/addons/ofxGui/src/ofxGuiUtils.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "ofColor.h"
+#include "ofRectangle.h"
+#include "ofVboMesh.h"
+
+namespace ofxGui {
+
+/*
+ * Internal helper to generate and cache rectangle meshes for ofxGui.
+ */
+class RectMesh {
+	ofColor     mColorFill = {};
+	ofRectangle mRect      = {};
+	ofVboMesh   mMesh      = {};
+	bool        isDirty    = true;
+	bool        mHasMesh   = false;
+
+  public:
+	void clear() {
+		mColorFill = {};
+		mRect      = {};
+		mMesh.clear();
+		mHasMesh = false;
+		isDirty  = false;
+	}
+
+	void draw() {
+
+		if ( isDirty && mHasMesh ) {
+			mMesh.clear();
+			mHasMesh = false;
+			isDirty  = false;
+		}
+
+		if ( mRect.width < 1.f || mRect.height < 1.f ) {
+			// We will not draw a mesh for rectangles
+			// which are smaller than one pixel for
+			// either w, or height.
+			return;
+		}
+
+		if ( mHasMesh == false ) {
+
+			mMesh.addVertex( mRect.getBottomLeft() );
+			mMesh.addVertex( mRect.getBottomRight() );
+			mMesh.addVertex( mRect.getTopLeft() );
+			mMesh.addVertex( mRect.getTopRight() );
+
+			mMesh.addColor( mColorFill );
+			mMesh.addColor( mColorFill );
+			mMesh.addColor( mColorFill );
+			mMesh.addColor( mColorFill );
+
+			mMesh.addIndex( 0 );
+			mMesh.addIndex( 1 );
+			mMesh.addIndex( 2 );
+			mMesh.addIndex( 2 );
+			mMesh.addIndex( 1 );
+			mMesh.addIndex( 3 );
+
+			mMesh.setMode( ofPrimitiveMode::OF_PRIMITIVE_TRIANGLES );
+			mHasMesh = true;
+		}
+
+		mMesh.draw();
+	}
+
+	void setFillColor( ofColor const &color ) {
+		isDirty |= ( color != mColorFill );
+		mColorFill = color;
+	}
+
+	void setExtents( ofRectangle const &rect ) {
+		isDirty |= ( rect != mRect );
+		mRect = rect;
+	}
+
+	void setExtents( float x, float y, float w, float h ) {
+		setExtents( {x, y, w, h} );
+	}
+};
+
+} // namespace ofxGui

--- a/addons/ofxGui/src/ofxGuiUtils.h
+++ b/addons/ofxGui/src/ofxGuiUtils.h
@@ -4,8 +4,6 @@
 #include "ofRectangle.h"
 #include "ofVboMesh.h"
 
-namespace ofxGui {
-
 /*
  * Internal helper to generate and cache rectangle meshes for ofxGui.
  */
@@ -80,5 +78,3 @@ class RectMesh {
 		setExtents( {x, y, w, h} );
 	}
 };
-
-} // namespace ofxGui

--- a/addons/ofxGui/src/ofxGuiUtils.h
+++ b/addons/ofxGui/src/ofxGuiUtils.h
@@ -7,7 +7,7 @@
 /*
  * Internal helper to generate and cache rectangle meshes for ofxGui.
  */
-class RectMesh {
+class ofxGuiRectMesh {
 	ofColor     mColorFill = {};
 	ofRectangle mRect      = {};
 	ofVboMesh   mMesh      = {};

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -20,66 +20,6 @@ namespace{
 }
 
 template<typename Type>
-void ofxSlider<Type>::ofxSlider::RectShape::clear(){
-	mColorFill    = {};
-	mRect         = {};
-	mMesh.clear();
-	mHasMesh      = false;
-}
-
-template<typename Type>
-void ofxSlider<Type>::ofxSlider::RectShape::draw(){
-
-	if (mRect.width < 1.f || mRect.height < 1.f ){
-		// We will not draw a mesh for rectangles
-		// which are smaller than one pixel for
-		// either w, or height.
-		return;
-	}
-
-	if ( mHasMesh == false ) {
-
-		auto const & r = mRect;
-
-		std::vector<glm::vec3> vertices {
-			r.getBottomLeft(),
-			r.getBottomRight(),
-			r.getTopLeft(),
-			r.getTopRight(),
-		};
-		std::vector<ofIndexType>indices {0,1,2,2,1,3};
-		std::vector<ofFloatColor> colors;
-		colors.resize(4,mColorFill);
-
-		mMesh.addVertices(vertices);
-		mMesh.addIndices(indices);
-		mMesh.addColors(colors);
-
-		mMesh.setMode(ofPrimitiveMode::OF_PRIMITIVE_TRIANGLES);
-		mHasMesh = true;
-	}
-
-	mMesh.draw();
-
-}
-
-template<typename Type>
-void ofxSlider<Type>::ofxSlider::RectShape::setFillColor(ofColor const & color){
-	mColorFill = color;
-}
-
-template<typename Type>
-void ofxSlider<Type>::ofxSlider::RectShape::setRectangle(ofRectangle const & rect){
-	mRect = rect;
-}
-
-template<typename Type>
-void ofxSlider<Type>::ofxSlider::RectShape::setRectangle(float x, float y, float w, float h){
-	setRectangle({x,y,w,h});
-}
-
-
-template<typename Type>
 ofxSlider<Type>::ofxSlider(){
 	bUpdateOnReleaseOnly = false;
 	bGuiActive = false;
@@ -275,11 +215,11 @@ void ofxSlider<Type>::generateDraw(){
 	bar.clear();
 
 	bg.setFillColor(thisBackgroundColor);
-	bg.setRectangle(b);
+	bg.setExtents(b);
 
 	float valAsPct = ofMap( value, value.getMin(), value.getMax(), 0, b.width-2, true );
 	bar.setFillColor(thisFillColor);
-	bar.setRectangle(b.x+1, b.y+1, valAsPct, b.height-2);
+	bar.setExtents(b.x+1, b.y+1, valAsPct, b.height-2);
 
 	generateText();
 	input.generateDraw();

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -20,6 +20,66 @@ namespace{
 }
 
 template<typename Type>
+void ofxSlider<Type>::ofxSlider::RectShape::clear(){
+	mColorFill    = {};
+	mRect         = {};
+	mMesh.clear();
+	mHasMesh      = false;
+}
+
+template<typename Type>
+void ofxSlider<Type>::ofxSlider::RectShape::draw(){
+
+	if (mRect.width < 1.f || mRect.height < 1.f ){
+		// We will not draw a mesh for rectangles
+		// which are smaller than one pixel for
+		// either w, or height.
+		return;
+	}
+
+	if ( mHasMesh == false ) {
+
+		auto const & r = mRect;
+
+		std::vector<glm::vec3> vertices {
+			r.getBottomLeft(),
+			r.getBottomRight(),
+			r.getTopLeft(),
+			r.getTopRight(),
+		};
+		std::vector<ofIndexType>indices {0,1,2,2,1,3};
+		std::vector<ofFloatColor> colors;
+		colors.resize(4,mColorFill);
+
+		mMesh.addVertices(vertices);
+		mMesh.addIndices(indices);
+		mMesh.addColors(colors);
+
+		mMesh.setMode(ofPrimitiveMode::OF_PRIMITIVE_TRIANGLES);
+		mHasMesh = true;
+	}
+
+	mMesh.draw();
+
+}
+
+template<typename Type>
+void ofxSlider<Type>::ofxSlider::RectShape::setFillColor(ofColor const & color){
+	mColorFill = color;
+}
+
+template<typename Type>
+void ofxSlider<Type>::ofxSlider::RectShape::setRectangle(ofRectangle const & rect){
+	mRect = rect;
+}
+
+template<typename Type>
+void ofxSlider<Type>::ofxSlider::RectShape::setRectangle(float x, float y, float w, float h){
+	setRectangle({x,y,w,h});
+}
+
+
+template<typename Type>
 ofxSlider<Type>::ofxSlider(){
 	bUpdateOnReleaseOnly = false;
 	bGuiActive = false;
@@ -215,13 +275,11 @@ void ofxSlider<Type>::generateDraw(){
 	bar.clear();
 
 	bg.setFillColor(thisBackgroundColor);
-	bg.setFilled(true);
-	bg.rectangle(b);
+	bg.setRectangle(b);
 
 	float valAsPct = ofMap( value, value.getMin(), value.getMax(), 0, b.width-2, true );
 	bar.setFillColor(thisFillColor);
-	bar.setFilled(true);
-	bar.rectangle(b.x+1, b.y+1, valAsPct, b.height-2);
+	bar.setRectangle(b.x+1, b.y+1, valAsPct, b.height-2);
 
 	generateText();
 	input.generateDraw();

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -56,7 +56,7 @@ public:
 
 private:
 
-	RectMesh bg, bar;
+	ofxGuiRectMesh bg, bar;
 
 protected:
 	virtual void render();

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -56,7 +56,7 @@ public:
 
 private:
 
-	ofxGui::RectMesh bg, bar;
+	RectMesh bg, bar;
 
 protected:
 	virtual void render();

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -54,6 +54,23 @@ public:
 
 	ofAbstractParameter & getParameter();
 
+private:
+
+	class RectShape {
+		ofColor     mColorFill;
+		ofRectangle mRect;
+		ofVboMesh   mMesh;
+		bool        mHasMesh = false;
+	public:
+		void clear();
+		void draw();
+		void setFillColor(ofColor const & color);
+		void setRectangle(float x, float y, float w, float h);
+		void setRectangle(ofRectangle const & rect);
+	};
+
+	RectShape bg, bar;
+
 protected:
 	virtual void render();
 	ofParameter<Type> value;
@@ -65,7 +82,7 @@ protected:
 	virtual void generateDraw();
 	virtual void generateText();
 	void valueChanged(Type & value);
-	ofPath bg, bar;
+
 	ofVboMesh textMesh;
 	ofxInputField<Type> input{ofxInputField<Type>::InsideSlider};
 

--- a/addons/ofxGui/src/ofxSlider.h
+++ b/addons/ofxGui/src/ofxSlider.h
@@ -3,6 +3,7 @@
 #include "ofxBaseGui.h"
 #include "ofParameter.h"
 #include "ofxInputField.h"
+#include "ofxGuiUtils.h"
 
 template<typename Type>
 class ofxSlider : public ofxBaseGui{
@@ -51,25 +52,11 @@ public:
 	virtual void setShape(ofRectangle r);
 	virtual void setShape(float x, float y, float w, float h);
 	
-
 	ofAbstractParameter & getParameter();
 
 private:
 
-	class RectShape {
-		ofColor     mColorFill;
-		ofRectangle mRect;
-		ofVboMesh   mMesh;
-		bool        mHasMesh = false;
-	public:
-		void clear();
-		void draw();
-		void setFillColor(ofColor const & color);
-		void setRectangle(float x, float y, float w, float h);
-		void setRectangle(ofRectangle const & rect);
-	};
-
-	RectShape bg, bar;
+	ofxGui::RectMesh bg, bar;
 
 protected:
 	virtual void render();


### PR DESCRIPTION
Instead of calling `ofPath` tessellation on each draw call for sliders, slider knows how to generate mesh for bar rectangles itself. The mesh is cached, and updated **iff** the slider value changes.

Rect mesh caching works similarly to the slider's internal caching of text meshes.

You might notice a slight performance improvement on GUIs with multiple sliders with this PR.

As an additional check/optimisation, slider fill rectangles with either width or height < 1 pixels will also not be drawn (they would not be visible anyway).

By *not* using `ofPath` (and by implication the tessellator) to draw the slider we avoid having to ask the tessellator to tessellate extremely small paths, in which case it had a tendency to throw its hands up in
despair or disgust (hard to tell from a stack trace) and cause crashes (see issue #6294).

Fixes issue #6294.