### PR TITLE
ofSoundBuffer::copy from was not being set properly

### DIFF
--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -34,9 +34,9 @@ ofSoundBuffer::ofSoundBuffer(short * shortBuffer, std::size_t numFrames, std::si
 	checkSizeAndChannelsConsistency("constructor");
 }
 
-void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
+void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int _sampleRate) {
 	this->channels = numChannels;
-	setSampleRate(sampleRate);
+	setSampleRate(_sampleRate);
 	buffer.resize(numFrames * numChannels);
 	for(std::size_t i = 0; i < size(); i++){
 		buffer[i] = shortBuffer[i]/float(numeric_limits<short>::max());
@@ -44,9 +44,9 @@ void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, s
 	checkSizeAndChannelsConsistency("copyFrom");
 }
 
-void ofSoundBuffer::copyFrom(const float * floatBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
+void ofSoundBuffer::copyFrom(const float * floatBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int _sampleRate) {
 	this->channels = numChannels;
-	setSampleRate(sampleRate);
+	setSampleRate(_sampleRate);
 	buffer.assign(floatBuffer, floatBuffer + (numFrames * numChannels));
 	checkSizeAndChannelsConsistency("copyFrom");
 }

--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -36,7 +36,7 @@ ofSoundBuffer::ofSoundBuffer(short * shortBuffer, std::size_t numFrames, std::si
 
 void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
 	this->channels = numChannels;
-	setSampleRate(samplerate);
+	setSampleRate(sampleRate);
 	buffer.resize(numFrames * numChannels);
 	for(std::size_t i = 0; i < size(); i++){
 		buffer[i] = shortBuffer[i]/float(numeric_limits<short>::max());
@@ -46,7 +46,7 @@ void ofSoundBuffer::copyFrom(const short * shortBuffer, std::size_t numFrames, s
 
 void ofSoundBuffer::copyFrom(const float * floatBuffer, std::size_t numFrames, std::size_t numChannels, unsigned int sampleRate) {
 	this->channels = numChannels;
-	setSampleRate(samplerate);
+	setSampleRate(sampleRate);
 	buffer.assign(floatBuffer, floatBuffer + (numFrames * numChannels));
 	checkSizeAndChannelsConsistency("copyFrom");
 }


### PR DESCRIPTION
there was a small type that was making `ofSoundBuffer::copyFrom` not to set the samplerate to the value passed as argument.
ofSoundBuffer's variable for the sample rate is called `samplerate`while the argument passed to the copyFrom function was called `sampleRate`. The function was setting the sample rate using `samplerate` thus it would never actually set it to the argument passed. This PR fixes this issue.