### PR TITLE
Included missing header in ofImage.h required for instantination of of ofImage_::clone()

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -2,7 +2,6 @@
 #include "ofConstants.h"
 #include "ofAppRunner.h"
 #include "FreeImage.h"
-#include "ofGLUtils.h"
 
 #include "ofURLFileLoader.h"
 #include "uriparser/Uri.h"

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -5,6 +5,7 @@
 #include "ofPixels.h"
 #include "ofGLBaseTypes.h"
 #include "ofGraphicsConstants.h"
+#include "ofGLUtils.h"
 
 class ofFile;
 class ofBuffer;


### PR DESCRIPTION
Included missing header in ofImage.h required for instantination of ofImage_::clone().