### PR TITLE
ofSoundBuffer: copying tick count and device id when calling copyTo

### DIFF
--- a/libs/openFrameworks/sound/ofSoundBuffer.cpp
+++ b/libs/openFrameworks/sound/ofSoundBuffer.cpp
@@ -186,10 +186,14 @@ void ofSoundBuffer::copyTo(ofSoundBuffer & soundBuffer, std::size_t nFrames, std
 	soundBuffer.resize(nFrames*outChannels);
 	soundBuffer.setNumChannels(outChannels);
 	soundBuffer.setSampleRate(samplerate);
+	soundBuffer.setTickCount(this->getTickCount());
+	soundBuffer.setDeviceID(this->getDeviceID());
 	copyTo(&soundBuffer[0], nFrames, outChannels, fromFrame, loop);
 }
 
 void ofSoundBuffer::copyTo(ofSoundBuffer & outBuffer, std::size_t fromFrame, bool loop) const{
+	outBuffer.setTickCount(this->getTickCount());
+	outBuffer.setDeviceID(this->getDeviceID());
 	copyTo(&outBuffer[0], outBuffer.getNumFrames(), outBuffer.getNumChannels(), fromFrame, loop);
 }
 


### PR DESCRIPTION
The tick count and device id were not being passed when copying the buffers which I think are very useful.