### PR TITLE
Correctly parse escaped linker flags in addons for QTCreator.

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -460,6 +460,10 @@ Module{
             for(var addon in allAddons){
                 var addonPath = allAddons[addon];
                 config_ldflags = config_ldflags.concat(Helpers.parseAddonConfig(addonPath, "ADDON_LDFLAGS", [], platform))
+
+                // Remove linker escapes https://doc.qt.io/qbs/qml-qbsmodules-cpp.html#linkerFlags-prop
+                config_ldflags = config_ldflags.map(function(element){ return element.replace("-Wl,","") })
+                config_ldflags = config_ldflags.map(function(element){ return element.replace("-Xlinker,","") })
             }
 
             // libs


### PR DESCRIPTION
Currently when dealing with complex addon_config.mk files, QTCreator was failing in situations like this:

```make
	ADDON_LDFLAGS  += -Wl,--start-group
	ADDON_LDFLAGS  += /opt/intel/mkl/lib/intel64/libmkl_intel_lp64.a
	ADDON_LDFLAGS  += /opt/intel/mkl/lib/intel64/libmkl_sequential.a
	ADDON_LDFLAGS  += /opt/intel/mkl/lib/intel64/libmkl_core.a
	ADDON_LDFLAGS  += -Wl,--end-group
	ADDON_LDFLAGS  += -lpthread -lm -ldl
```

While makefile works fine, QTCreator/QBS failed when linker flags were already escaped (-Wl, or -Xlinker,).

According to the documentation, linker flags should not be escaped.

https://doc.qt.io/qbs/qml-qbsmodules-cpp.html#linkerFlags-prop

So, this PR fixes that for addons.