### PR TITLE
Upgrade MSYS2 packages in appveyor (including GCC)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,11 +3,14 @@ version: 1.0.{build}
 environment:
   global:
     APPVEYOR_OS_NAME: windows
+    CHERE_INVOKING: 1
+    MSYS2_PATH: c:\msys64
   matrix:
   #MSYS2 Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       BUILDER: MSYS2
+      MSYSTEM: MINGW32
       CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
 
   #VisualStudio Building
@@ -28,10 +31,6 @@ init:
 # fix for https://github.com/appveyor/ci/issues/2571
 - del C:\Windows\System32\libssl-*.dll C:\Windows\system32\libcrypto-*.dll
 - del C:\Windows\SysWOW64\libssl-*.dll C:\Windows\SysWOW64\libcrypto-*.dll
-- set MSYS2_PATH=c:\msys64
-- set CHERE_INVOKING=1
-- if "%BUILDER%_%PLATFORM%"=="MSYS2_x86" set MSYSTEM=MINGW32
-- if "%BUILDER%_%PLATFORM%"=="MSYS2_x64" set MSYSTEM=MINGW64
 - '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm --needed -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel"'
 - '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -S --needed unzip rsync libopenssl mingw-w64-i686-openssl"'
 - if "%BUILDER%"=="VS" set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,11 @@ init:
 # fix for https://github.com/appveyor/ci/issues/2571
 - del C:\Windows\System32\libssl-*.dll C:\Windows\system32\libcrypto-*.dll
 - del C:\Windows\SysWOW64\libssl-*.dll C:\Windows\SysWOW64\libcrypto-*.dll
-- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm --needed -Sy bash pacman pacman-mirrors msys2-runtime msys2-runtime-devel"'
-- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -S --needed unzip rsync libopenssl mingw-w64-i686-openssl"'
+# Upgrade the MSYS2 system
+- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Syu"'
+# Upgrade all packages if running with MSYS2
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Su")
+- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Su --needed unzip rsync libopenssl mingw-w64-i686-openssl"'
 - if "%BUILDER%"=="VS" set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%
 
 # - IF "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -51,7 +51,6 @@ if [ -z ${confirm+x} ]; then
 		${MINGW_PACKAGE_PREFIX}-assimp \
 		${MINGW_PACKAGE_PREFIX}-boost \
 		${MINGW_PACKAGE_PREFIX}-cairo \
-		${MINGW_PACKAGE_PREFIX}-clang \
 		${MINGW_PACKAGE_PREFIX}-gdb \
 		${MINGW_PACKAGE_PREFIX}-zlib \
 		${MINGW_PACKAGE_PREFIX}-tools \
@@ -81,7 +80,6 @@ else
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-assimp
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-boost
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-cairo
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-clang
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-gdb
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-zlib
 	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-tools

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -40,11 +40,12 @@ fi
 
 #Install packages
 if [ -z ${confirm+x} ]; then
-	pacman -S $confirm --needed ca-certificates
+	pacman -Su $confirm --needed ca-certificates
 	if [ -z ${APPVEYOR+x} ]; then
-		pacman -S $confirm --needed wget rsync unzip make ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-ntldd-git
+		pacman -Su $confirm --needed wget rsync unzip make ${MINGW_PACKAGE_PREFIX}-ntldd-git
 	fi
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew \
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc \
+		${MINGW_PACKAGE_PREFIX}-glew \
 		${MINGW_PACKAGE_PREFIX}-freeglut \
 		${MINGW_PACKAGE_PREFIX}-FreeImage \
 		${MINGW_PACKAGE_PREFIX}-opencv \
@@ -63,38 +64,38 @@ if [ -z ${confirm+x} ]; then
 		${MINGW_PACKAGE_PREFIX}-curl \
 		${MINGW_PACKAGE_PREFIX}-libxml2
 else
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-harfbuzz
-	pacman -S $confirm --needed ca-certificates
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-harfbuzz
+	pacman -Su $confirm --needed ca-certificates
 	if [ -z ${APPVEYOR+x} ]; then
-		pacman -S $confirm --needed wget
-		pacman -S $confirm --needed rsync
-		pacman -S $confirm --needed unzip
-		pacman -S $confirm --needed make
-		pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc
-		pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-ntldd-git
+		pacman -Su $confirm --needed wget
+		pacman -Su $confirm --needed rsync
+		pacman -Su $confirm --needed unzip
+		pacman -Su $confirm --needed make
+		pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-ntldd-git
 	fi
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-freeglut
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-FreeImage
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-opencv
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-assimp
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-boost
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-cairo
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-gdb
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-zlib
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-tools
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-pkg-config
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glfw
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-libusb
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-curl
-	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-libxml2
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-freeglut
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-FreeImage
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-opencv
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-assimp
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-boost
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-cairo
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gdb
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-zlib
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-tools
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-pkg-config
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-glfw
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-libusb
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-curl
+	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-libxml2
 fi
 
 
 # this would install gstreamer which can be used in mingw too
-#pacman -Sy ${MINGW_PACKAGE_PREFIX}-gst-libav ${MINGW_PACKAGE_PREFIX}-gst-plugins-bad ${MINGW_PACKAGE_PREFIX}-gst-plugins-base ${MINGW_PACKAGE_PREFIX}-gst-plugins-good ${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly ${MINGW_PACKAGE_PREFIX}-gstreamer
+#pacman -Su ${MINGW_PACKAGE_PREFIX}-gst-libav ${MINGW_PACKAGE_PREFIX}-gst-plugins-bad ${MINGW_PACKAGE_PREFIX}-gst-plugins-base ${MINGW_PACKAGE_PREFIX}-gst-plugins-good ${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly ${MINGW_PACKAGE_PREFIX}-gstreamer
 
 exit_code=$?
 if [ $exit_code != 0 ]; then

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -38,65 +38,65 @@ if [ "$NOT_HAS_PATH" -ne "0" ]; then
 	echo "set path to ${MSYS2_ROOT}mingw32\\bin;${MSYS2_ROOT}usr\\bin\\"
 fi
 
-arch=i686
+#Install packages
 if [ -z ${confirm+x} ]; then
 	pacman -S $confirm --needed ca-certificates
 	if [ -z ${APPVEYOR+x} ]; then
-		pacman -S $confirm --needed wget rsync unzip make mingw-w64-$arch-gcc mingw-w64-$arch-ntldd-git
+		pacman -S $confirm --needed wget rsync unzip make ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-ntldd-git
 	fi
-	pacman -S $confirm --needed mingw-w64-$arch-glew \
-		mingw-w64-$arch-freeglut \
-		mingw-w64-$arch-FreeImage \
-		mingw-w64-$arch-opencv \
-		mingw-w64-$arch-assimp \
-		mingw-w64-$arch-boost \
-		mingw-w64-$arch-cairo \
-		mingw-w64-$arch-clang \
-		mingw-w64-$arch-gdb \
-		mingw-w64-$arch-zlib \
-		mingw-w64-$arch-tools \
-		mingw-w64-$arch-pkg-config \
-		mingw-w64-$arch-poco \
-		mingw-w64-$arch-glfw \
-		mingw-w64-$arch-libusb \
-		mingw-w64-$arch-harfbuzz \
-		mingw-w64-$arch-poco \
-		mingw-w64-$arch-curl \
-		mingw-w64-$arch-libxml2
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew \
+		${MINGW_PACKAGE_PREFIX}-freeglut \
+		${MINGW_PACKAGE_PREFIX}-FreeImage \
+		${MINGW_PACKAGE_PREFIX}-opencv \
+		${MINGW_PACKAGE_PREFIX}-assimp \
+		${MINGW_PACKAGE_PREFIX}-boost \
+		${MINGW_PACKAGE_PREFIX}-cairo \
+		${MINGW_PACKAGE_PREFIX}-clang \
+		${MINGW_PACKAGE_PREFIX}-gdb \
+		${MINGW_PACKAGE_PREFIX}-zlib \
+		${MINGW_PACKAGE_PREFIX}-tools \
+		${MINGW_PACKAGE_PREFIX}-pkg-config \
+		${MINGW_PACKAGE_PREFIX}-poco \
+		${MINGW_PACKAGE_PREFIX}-glfw \
+		${MINGW_PACKAGE_PREFIX}-libusb \
+		${MINGW_PACKAGE_PREFIX}-harfbuzz \
+		${MINGW_PACKAGE_PREFIX}-poco \
+		${MINGW_PACKAGE_PREFIX}-curl \
+		${MINGW_PACKAGE_PREFIX}-libxml2
 else
-	pacman -S $confirm --needed mingw-w64-$arch-harfbuzz
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-harfbuzz
 	pacman -S $confirm --needed ca-certificates
 	if [ -z ${APPVEYOR+x} ]; then
 		pacman -S $confirm --needed wget
 		pacman -S $confirm --needed rsync
 		pacman -S $confirm --needed unzip
 		pacman -S $confirm --needed make
-		pacman -S $confirm --needed mingw-w64-$arch-gcc
-		pacman -S $confirm --needed mingw-w64-$arch-ntldd-git
+		pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc
+		pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-ntldd-git
 	fi
-	pacman -S $confirm --needed mingw-w64-$arch-glew
-	pacman -S $confirm --needed mingw-w64-$arch-freeglut
-	pacman -S $confirm --needed mingw-w64-$arch-FreeImage
-	pacman -S $confirm --needed mingw-w64-$arch-opencv
-	pacman -S $confirm --needed mingw-w64-$arch-assimp
-	pacman -S $confirm --needed mingw-w64-$arch-boost
-	pacman -S $confirm --needed mingw-w64-$arch-cairo
-	pacman -S $confirm --needed mingw-w64-$arch-clang
-	pacman -S $confirm --needed mingw-w64-$arch-gdb
-	pacman -S $confirm --needed mingw-w64-$arch-zlib
-	pacman -S $confirm --needed mingw-w64-$arch-tools
-	pacman -S $confirm --needed mingw-w64-$arch-pkg-config
-	pacman -S $confirm --needed mingw-w64-$arch-poco
-	pacman -S $confirm --needed mingw-w64-$arch-glfw
-	pacman -S $confirm --needed mingw-w64-$arch-libusb
-	pacman -S $confirm --needed mingw-w64-$arch-poco
-	pacman -S $confirm --needed mingw-w64-$arch-curl
-	pacman -S $confirm --needed mingw-w64-$arch-libxml2
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-freeglut
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-FreeImage
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-opencv
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-assimp
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-boost
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-cairo
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-clang
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-gdb
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-zlib
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-tools
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-pkg-config
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-glfw
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-libusb
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-curl
+	pacman -S $confirm --needed ${MINGW_PACKAGE_PREFIX}-libxml2
 fi
 
 
 # this would install gstreamer which can be used in mingw too
-#pacman -Sy mingw-w64-$arch-gst-libav mingw-w64-$arch-gst-plugins-bad mingw-w64-$arch-gst-plugins-base mingw-w64-$arch-gst-plugins-good mingw-w64-$arch-gst-plugins-ugly mingw-w64-$arch-gstreamer
+#pacman -Sy ${MINGW_PACKAGE_PREFIX}-gst-libav ${MINGW_PACKAGE_PREFIX}-gst-plugins-bad ${MINGW_PACKAGE_PREFIX}-gst-plugins-base ${MINGW_PACKAGE_PREFIX}-gst-plugins-good ${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly ${MINGW_PACKAGE_PREFIX}-gstreamer
 
 exit_code=$?
 if [ $exit_code != 0 ]; then


### PR DESCRIPTION
Fix #6330.
Version of GCC included in appveyor image is older than the one used to build openframeworks.
This results in an error when loading the Dlls at runtime.
install_dependencies.sh upgraded to use the MINGW_PACKAGE_PREFIX env variable defined by MSYS environment instead of the custom made mingw-w64-$arch. That should make install_denpendencies compatible with MINGW64 with no changes.
