### PR TITLE
MSYS2 : Remove setup of PATH env var in install_dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ PLATFORM/IDE SPECIFIC
 ### makefiles
 - makefiles: addon data not being copied(#2903).
 
+### msys2
+- setup : removed automatic setup of PATH environment variable(#5740). Move instructions to setup PATY to documentation.
+- documentation : fix typo (#6211) and insist on the use of MINGW32 shell. 
+
 ADDONS
 ------
 ### ofxOpenCv

--- a/docs/msys2.md
+++ b/docs/msys2.md
@@ -1,43 +1,122 @@
 [openFrameworks](http://openframeworks.cc/) | [Documentation table of contents](table_of_contents.md)
 
+
 MSYS2
 =====
 
-Installing MSYS2 
+Installing msys2
 ----------------
 
-First, install MSYS2 using the [one-click installer](https://msys2.github.io/) or 
+First, install MSYS2 using the [one-click installer](https://msys2.github.io/) or
 directly unzipping the archive from their [repository](http://sourceforge.net/projects/msys2/files/Base/x86_64/)
+
+If you have an old install of MSYS2 (before 2018), it's recommended to do a fresh install.
 
 If you are going to use QtCreator you should install msys2 in the default install folder, c:\msys64
 
-Open a **MINGW32** shell (`C:\msys64\mingw32.exe`) and update the system packages :
 
-    pacman --noconfirm  --needed -Syu
-	
-Close the shell and open a new one to update the remaining packages :
 
-    pacman --noconfirm -Su
+Now, let's update the MSYS2 installation.
+From an MSYS2 shell (it can be MSYS, MINGW32 or MINGW64), run :
 
-You are now ready to install openFrameworks.	
+```sh
+pacman -Syu --noconfirm --needed
+```
+
+If some system files are updated, you may be requested to close the shell.
+If that happens, close the shell as instructed and open a new one to update the remaining packages using the same command :
+
+```sh
+pacman -Syu --noconfirm --needed
+```
+
+You are now ready to install openFrameworks.
 
 
 Installing openFrameworks
 -------------------------
 
-Download and unzip the msys2 version of oF.
+**IMPORTANT**
+MSYS2 comes in 3 flavors : MSYS (msys2.exe), MINGW32 (mingw32.exe), MINGW64 (mingw64.exe).
+This really important to remember as many problems with running OF with MSYS2 come from using the wrong flavor.
+As of today, only **MINGW32** is supported.
+So you must use the mingw32.exe shell to run oF.
 
-Open an **MINGW32** shell and install OF dependencies :
+For the following instructions, it assumed that MSYS2 is installed in `C:\msys64`.
+If it has been installed elsewhere, adapt the instructions to reflect your MSYS2 installation path
 
-    cd your_oF_directory/scripts/msys2
-    ./install_dependencies.sh
-	
-Then compile oF libraries with :
+Download and unzip the **qt creator / msys2** version of oF. 
+**DO NOT INSTALL** oF in a folder having space or other special character.
 
-	cd your_oF_directory/libs/openFrameworksCompiled/project
+Open an **MINGW32** shell (`C:\msys64\mingw32.exe` ) and install OF dependencies:
+
+```sh
+cd your_oF_directory/scripts/msys2
+./install_dependencies.sh
+```
+
+Open an **MINGW32** shell (run `C:\msys64\mingw32.exe`) and compile oF libraries:
+
+    cd your_oF_directory/libs/openFrameworksCompiled/project
     make
 
-You can speed-up compilation using parallel build `make -j${NUMBER_OF_PROCESSORS}`
+You can speed-up compilation using parallel build `make -j4` or the number of cores you want it to use
+
+
+Setting the PATH variable
+-------------------------
+
+Setting the PATH variable is an optional step but is also the cause of many trouble.
+
+As of v0.10.1, the install_dependencies.sh script does it in an wrong way!
+
+### Why would you need to set the PATH variable ?
+
+__To be able to run my oF application by double clicking on it.__
+
+To run, the application needs to have the dll it was compiled with.
+If the required dll is not found at the location of your application, Windows will traverse the folders in your PATH to find it.
+If `C:\msys64\mingw32\bin` is included in your PATH, it will hopefully find the right dll.
+However, it may find a dll with a matching name in a different folder that is not compatible...  
+It may also happen that, after an MSYS2 update, it finds a newer version in `C:\msys64\mingw32\bin` that is also incompatible...
+
+The solution is to copy all the needed dlls in the application folder.
+This can be easily done with the command : 
+
+```sh
+make copy_dlls
+```
+This will also ease the installation of the application on a different computer....
+
+
+__To compile oF in IDE (Qt Creator or VS Code )__
+
+These softwares will try to detect compiler programs (gcc, make) by scanning the PATH variable.
+So it's an easy way to setup up your IDE.
+There may also be some settings in the IDE to configure where to find the programs.
+That gives you better control.
+As in the previous point, relying on the PATH variable to find the programs may result in unexpected behaviours (for example, using Windows C:\Windows\System32\find.exe instead of MSYS2 C:\msys64\usr\bin\find.exe)
+
+It may be interesting to write a wrapper batch file to lauch your IDE where you set the PATH to use.
+This way you do not pollute your PATH system-wide.
+
+### I've decided to use the PATH variable. How do I set it ?
+
+You can find how to set the PATH in windows here: http://www.computerhope.com/issues/ch000549.htm
+
+You'll need to add `c:\msys64\mingw32\bin` and `c:\msys64\usr\bin` to your PATH in **that order**.
+There are two ways:
+
+1. Either add them via 'Environment Variables' from the Control Panel > System > Advanced System Settings.
+2. Or you can also set the PATH from the command line: open a Windows cmd prompt and set you user PATH.
+```
+setx PATH "c:\msys64\mingw32\bin;c:\msys64\usr\bin;%PATH%"
+```
+
+Don't forget to logoff/logon as PATH is updated at logon.
+
+That's all, now go to the your_oF_directory/examples folder, where you will find
+the examples, and have fun!
 
 
 Running examples
@@ -49,8 +128,7 @@ Compile the example (for example the 3DPrimitivesExample)
 
 At this point, `make run` to launch. 
 
-In order to be able to run the file by double-clicking on it, you must make sure that mingw32 dlls can be found from your PATH
-
+To be able to double-click on the exe file to run it, run `make copy_dlls` (if you haven't set the PATH!)
 
 Makefile
 --------
@@ -58,11 +136,12 @@ Makefile
 Every example has a Makefile you can configure using the files config.make
 and addons.make.
 
-config.make: This file has options to add search paths, libraries, etc., the 
+config.make: This file has options to add search paths, libraries, etc., the
 syntax is the usual syntax in makefiles, there's help comments inside the file.
 
-addons.make: if you want to use an addon which is inside the addons folder, just 
+addons.make: if you want to use an addon which is inside the addons folder, just
 add its name in a new line in this file.
+
 
 Dlls
 ----
@@ -74,6 +153,7 @@ Windows applications compiled with msys2 need some system dlls to run. If you ar
 from the msys2 terminal and it'll copy the necesary dlls to the project bin folder. Now you can copy that bin folder to any computer and it will run right away without having to install msys2.
 
 This is still experimental so if you find any problem please [report it on github](https://github.com/openframeworks/openFrameworks/new?title=Problem%20with%20msys2%20dlls)
+
 
 QtCreator
 ---------

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -29,14 +29,6 @@ while [[ $# > 0 ]] ; do
 	exit 1
 done
 
-NOT_HAS_PATH=$(cmd /c "echo %PATH%" | grep mingw32\\bin > /dev/null; echo $?)
-if [ "$NOT_HAS_PATH" -ne "0" ]; then
-	cd /
-	MSYS2_ROOT=$(pwd)
-	MSYS2_ROOT=$(cygpath -w $MSYS2_ROOT)
-	setx PATH "%PATH%;${MSYS2_ROOT}mingw32\\bin;${MSYS2_ROOT}usr\\bin\\"
-	echo "set path to ${MSYS2_ROOT}mingw32\\bin;${MSYS2_ROOT}usr\\bin\\"
-fi
 
 #Install packages
 if [ -z ${confirm+x} ]; then


### PR DESCRIPTION
Fix #5740 : It's better not to modify user environment without him knowing. Moreover, setting PATH is optional. So move instructions to documentation

Fix #6211 : documentation typo