### PR TITLE
bugfix for mojave permissions issues with camera. closes #6193

### DIFF
--- a/scripts/templates/osx/openFrameworks-Info.plist
+++ b/scripts/templates/osx/openFrameworks-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>cc.openFrameworks.ofapp</string>
+	<string>cc.openFrameworks.${EXECUTABLE_NAME}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
@@ -18,7 +18,7 @@
 	<string>1.0</string>
 	<key>CFBundleIconFile</key>
 	<string>${ICON}</string>
-	<key>NSCameraUsageDescription</key>    
+	<key>NSCameraUsageDescription</key>
 	<string>This app needs to access the camera</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs to access the microphone</string>


### PR DESCRIPTION
This should solve the permissions issues in #6193 as all apps made from OF were being treated as the same app by the system.  

This makes each App's bundle ID unique which fixed the issue of another OF app interfering with the camera permissions on 10.14.  