### PR TITLE
Bugfix - last commit hash written before build successful.

### DIFF
--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -49,7 +49,6 @@ if [ "$currenthash" = "$lasthash" ]; then
     exit 0
 fi
 
-echo $currenthash>lasthash.txt
 ./create_package.sh linux64 $lastversion master gcc4
 ./create_package.sh linux64 $lastversion master gcc5
 ./create_package.sh linux64 $lastversion master gcc6
@@ -108,6 +107,7 @@ echo
 
 mail -s "Nightly builds $lastversion OK." $REPORT_MAIL <<EOF
 Successfully created nightly builds for ${lastversion}
+echo $currenthash>lasthash.txt
 
 $(if [ -f /home/ofadmin/logs/nightlybuilds.log ]; then cat /home/ofadmin/logs/nightlybuilds.log; fi)
 EOF


### PR DESCRIPTION
This isn't the cause of the current nightly build errors, but it hides the actual cause. 

Because lasthash.txt is written before the build is successful it means it's not trying to do the build each night even though the actual packages are older than the last commit.  

Moving it to the end of the script will mean that our log file will show the real error messages preventing the build.