### PR TITLE
bugfix changes the create_package script to call executable generated by DebugNoOF

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -189,7 +189,7 @@ function createProjectFiles {
         else
             pg_platform=$pkg_platform
         fi
-        ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples > /dev/null
+        ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator_debug --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples > /dev/null
     elif [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ]; then
         for example_group in $pkg_ofroot/examples/*; do
             for example in $example_group/*; do


### PR DESCRIPTION
Project generator seems to be compiling fine now after installing poco. 
This seems to be the last step to getting the nightlies to build again. 

compiling the PG with DebugNoOF produces bin/projectGenerator_debug but a few lines down the script calls bin/projectGenerator 
