### PR TITLE
nightly script bug fix - needs to cd back to scripts/dev/

### DIFF
--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -107,6 +107,7 @@ echo
 
 mail -s "Nightly builds $lastversion OK." $REPORT_MAIL <<EOF
 Successfully created nightly builds for ${lastversion}
+cd $(cat ~/.ofprojectgenerator/config)/scripts/dev
 echo $currenthash>lasthash.txt
 
 $(if [ -f /home/ofadmin/logs/nightlybuilds.log ]; then cat /home/ofadmin/logs/nightlybuilds.log; fi)


### PR DESCRIPTION
Nightly script needs to cd back to the scripts/dev/ folder after successful build to write lasthash.txt to the correct location.  

Otherwise lasthash.txt in scripts/dev/ is not getting updated. 
