### PR TITLE
small improovement for getResampledBySpacing

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -505,7 +505,7 @@ ofPolyline_<T> ofPolyline_<T>::getResampledBySpacing(float spacing) const {
     if(spacing==0 || size() == 0) return *this;
 	ofPolyline_ poly;
     float totalLength = getPerimeter();
-    for(float f=0; f<totalLength; f += spacing) {
+    for(float f=0; f<totalLength+spacing*0.99; f += spacing) {
         poly.lineTo(getPointAtLength(f));
     }
     


### PR DESCRIPTION
To avoid bigger gaps at the end of the resampled polyline, adding almost a full spacing will help adding a rather small last space than a big one. The last point is replaced anyway.