### PR TITLE
bugfix. iOS fixes reversed touches when not using hardware orientation.

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -223,12 +223,12 @@ static ofxiOSEAGLView * _instanceRef = nil;
             touchPointOriented.y = ofGetHeight() - touchPoint.y;
             break;
             
-        case OF_ORIENTATION_90_LEFT:
+        case OF_ORIENTATION_90_RIGHT:
             touchPointOriented.x = touchPoint.y;
             touchPointOriented.y = ofGetHeight() - touchPoint.x;
             break;
             
-        case OF_ORIENTATION_90_RIGHT:
+        case OF_ORIENTATION_90_LEFT:
             touchPointOriented.x = ofGetWidth() - touchPoint.y;
             touchPointOriented.y = touchPoint.x;
             break;

--- a/addons/ofxiOS/src/core/ofxiOSGLKView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSGLKView.mm
@@ -230,12 +230,12 @@ static ofxiOSGLKView * _instanceRef = nil;
             touchPointOriented.y = ofGetHeight() - touchPoint.y;
             break;
             
-        case OF_ORIENTATION_90_LEFT:
+        case OF_ORIENTATION_90_RIGHT:
             touchPointOriented.x = touchPoint.y;
             touchPointOriented.y = ofGetHeight() - touchPoint.x;
             break;
             
-        case OF_ORIENTATION_90_RIGHT:
+        case OF_ORIENTATION_90_LEFT:
             touchPointOriented.x = ofGetWidth() - touchPoint.y;
             touchPointOriented.y = touchPoint.x;
             break;


### PR DESCRIPTION
 closes #6317