### PR TITLE
[android] add maven url to comply with v4:25

### DIFF
--- a/scripts/templates/android/build.gradle
+++ b/scripts/templates/android/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven{ url "https://maven.google.com" }
     }
 }
 


### PR DESCRIPTION
Hi
Just hit the same error as the one below, and it seems that project generator uses the template under oF directory.
I have added the line to comply with com.android.support:support-v4:25.+ and tested with 
android studio 3.5 that it builds and runs.
https://forum.openframeworks.cc/t/android-error-failed-to-resolve-com-android-support25/32436