### PR TITLE
bugfix. fixes error with Xcode build due to depracted function error.

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -31,7 +31,7 @@ bool ofXml::load(const ofBuffer & buffer){
 
 bool ofXml::parse(const std::string & xmlStr){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load(xmlStr.c_str())){
+	if(auxDoc->load_string(xmlStr.c_str())){
 		doc = auxDoc;
 		xml = doc->root();
 		return true;

--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -31,7 +31,11 @@ bool ofXml::load(const ofBuffer & buffer){
 
 bool ofXml::parse(const std::string & xmlStr){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load_string(xmlStr.c_str())){
+    #if ( defined(PUGIXML_VERSION) && PUGIXML_VERSION >= 150 )
+        if(auxDoc->load_string(xmlStr.c_str())){
+    #else
+        if(auxDoc->load(xmlStr.c_str())){
+    #endif
 		doc = auxDoc;
 		xml = doc->root();
 		return true;


### PR DESCRIPTION
This is an error I saw in the nightly. 
Just switching the deprecated function to the replacement function name. 