### PR TITLE
MSYS2 installation and compilation enhancements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,11 +31,10 @@ init:
 # fix for https://github.com/appveyor/ci/issues/2571
 - del C:\Windows\System32\libssl-*.dll C:\Windows\system32\libcrypto-*.dll
 - del C:\Windows\SysWOW64\libssl-*.dll C:\Windows\SysWOW64\libcrypto-*.dll
-# Upgrade the MSYS2 system
-- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Syu"'
-# Upgrade all packages if running with MSYS2
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Su")
-- '%MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Su --needed unzip rsync libopenssl mingw-w64-i686-openssl"'
+# Upgrade the MSYS2 system and all install packages
+- '%MSYS2_PATH%\usr\bin\pacman --noconfirm -Syu'
+# Install packages need by download_libs.sh scripts (VS and MSYS2)
+- '%MSYS2_PATH%\usr\bin\pacman --noconfirm -S --needed unzip rsync wget libopenssl mingw-w64-i686-openssl'
 - if "%BUILDER%"=="VS" set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%
 
 # - IF "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ cache:
 
 install:
 - if "%BUILDER%"=="VS" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/vs/install.sh")
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh --noconfirm")
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh")
 
 before_build:
 - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -z")

--- a/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
+++ b/libs/openFrameworksCompiled/project/msys2/config.msys2.default.mk
@@ -25,31 +25,20 @@
 #   core source code.
 ##########################################################################################
 
-PLATFORM_PROJECT_DEBUG_BIN_NAME=$(APPNAME)_debug
-PLATFORM_PROJECT_RELEASE_BIN_NAME=$(APPNAME)
-PLATFORM_RUN_COMMAND =
-#ifneq (,$(findstring MINMGW64_NT,$(PLATFORM_OS)))
-MSYS2_ROOT = /mingw32
+MINGW_PREFIX ?= /mingw32
 PLATFORM_CFLAGS += -std=gnu++14 -DUNICODE -D_UNICODE
 #PLATFORM_CFLAGS += -IC:/msys64/mingw32/include/gstreamer-1.0 -DOF_VIDEO_PLAYER_GSTREAMER
-PLATFORM_LDFLAGS += -lpthread
-ifndef DEBUG
-	PLATFORM_LDFLAGS += -mwindows
-endif
-#ifeq ($(PLATFORM_ARCH),x86_64)
 ifdef USE_CCACHE
-	CC = ccache $(MSYS2_ROOT)/bin/gcc
-	CXX = ccache $(MSYS2_ROOT)/bin/g++
+	CC = ccache $(MINGW_PREFIX)/bin/gcc
+	CXX = ccache $(MINGW_PREFIX)/bin/g++
 else
-	CC = $(MSYS2_ROOT)/bin/gcc
-	CXX = $(MSYS2_ROOT)/bin/g++
+	CC = $(MINGW_PREFIX)/bin/gcc
+	CXX = $(MINGW_PREFIX)/bin/g++
 endif
 FIND ?= /usr/bin/find
-PLATFORM_AR = $(MSYS2_ROOT)/bin/ar
-PLATFORM_LD = $(MSYS2_ROOT)/bin/ld
-PLATFORM_PKG_CONFIG = $(MSYS2_ROOT)/bin/pkg-config
-#endif
-#endif
+PLATFORM_AR = $(MINGW_PREFIX)/bin/ar
+PLATFORM_LD = $(MINGW_PREFIX)/bin/ld
+PLATFORM_PKG_CONFIG = $(MINGW_PREFIX)/bin/pkg-config
 
 
 PLATFORM_PROJECT_DEBUG_BIN_NAME=$(APPNAME)_debug.exe
@@ -78,8 +67,13 @@ endif
 # Note: Be sure to leave a leading space when using a += operator to add items to the list
 ##########################################################################################
 
+#PLATFORM_DEFINES = OF_USING_STD_FS
 ifeq ($(OF_USE_POCO),1)
-	PLATFORM_DEFINES = POCO_STATIC
+	PLATFORM_DEFINES += POCO_STATIC
+endif
+
+ifeq ($(MSYSTEM),MINGW64)
+	PLATFORM_DEFINES += OF_SOUND_PLAYER_OPENAL
 endif
 
 ##########################################################################################
@@ -132,6 +126,13 @@ endif
 
 
 #PLATFORM_LDFLAGS += -arch i386
+PLATFORM_LDFLAGS += -lpthread
+ifndef DEBUG
+	PLATFORM_LDFLAGS += -mwindows
+endif
+ifeq ($(findstring OF_USING_STD_FS, $(PLATFORM_DEFINES)),OF_USING_STD_FS)
+	PLATFORM_LDFLAGS += -lstdc++fs
+endif
 
 ##########################################################################################
 # PLATFORM OPTIMIZATION CFLAGS
@@ -190,6 +191,7 @@ PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openssl/%
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/boost/%
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/glfw/%
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/curl/%
+#PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/glm/%
 
 
 ##########################################################################################

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -8,12 +8,12 @@ cd $ROOT/libs/openFrameworksCompiled/project
 make USE_CCACHE=1 -j4 Debug
 
 echo "**** Building emptyExample ****"
-cd $ROOT/scripts/templates/linux64
+cd $ROOT/scripts/templates/msys2
 make USE_CCACHE=1 -j4 Debug
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
-cp scripts/templates/linux64/Makefile examples/templates/allAddonsExample/
-cp scripts/templates/linux64/config.make examples/templates/allAddonsExample/
+cp scripts/templates/msys2/Makefile examples/templates/allAddonsExample/
+cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
 make USE_CCACHE=1 -j4 Debug

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -13,11 +13,12 @@ function usage {
 }
 
 #Analyse script arguments
+confirm="yes"
 while [[ $# > 0 ]] ; do
 	arg=$1
 	shift
 	if [ "$arg" == "--noconfirm" ]; then
-		confirm=--noconfirm
+		confirm="no"
 		continue
 	fi
 	if [ "$arg" == "--help" ]; then
@@ -29,60 +30,27 @@ while [[ $# > 0 ]] ; do
 	exit 1
 done
 
+# List of MSYS packages to be installed
+msyspackages="make rsync unzip wget"
 
-#Install packages
-if [ -z ${confirm+x} ]; then
-	pacman -Su $confirm --needed ca-certificates
-	if [ -z ${APPVEYOR+x} ]; then
-		pacman -Su $confirm --needed wget rsync unzip make ${MINGW_PACKAGE_PREFIX}-ntldd-git
-	fi
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc \
-		${MINGW_PACKAGE_PREFIX}-glew \
-		${MINGW_PACKAGE_PREFIX}-freeglut \
-		${MINGW_PACKAGE_PREFIX}-FreeImage \
-		${MINGW_PACKAGE_PREFIX}-opencv \
-		${MINGW_PACKAGE_PREFIX}-assimp \
-		${MINGW_PACKAGE_PREFIX}-boost \
-		${MINGW_PACKAGE_PREFIX}-cairo \
-		${MINGW_PACKAGE_PREFIX}-gdb \
-		${MINGW_PACKAGE_PREFIX}-zlib \
-		${MINGW_PACKAGE_PREFIX}-tools \
-		${MINGW_PACKAGE_PREFIX}-pkg-config \
-		${MINGW_PACKAGE_PREFIX}-poco \
-		${MINGW_PACKAGE_PREFIX}-glfw \
-		${MINGW_PACKAGE_PREFIX}-libusb \
-		${MINGW_PACKAGE_PREFIX}-harfbuzz \
-		${MINGW_PACKAGE_PREFIX}-poco \
-		${MINGW_PACKAGE_PREFIX}-curl \
-		${MINGW_PACKAGE_PREFIX}-libxml2
+# List of MINGW packages to be installed (without prefix)
+mingwPackages="assimp boost cairo curl freeglut FreeImage gcc gdb glew glfw \
+			  harfbuzz libusb libxml2 ntldd-git opencv \
+			  pkg-config poco tools zlib"
+
+# Build the full list of packages adding prefix to MINGW packages
+packages=${msyspackages}
+for pkg in ${mingwPackages}; do
+	packages="$packages  $MINGW_PACKAGE_PREFIX-$pkg"
+done
+
+# Install packages
+if [[ "${confirm}" == "yes" ]]; then
+	for pkg in ${packages}; do
+		pacman -Su --confirm --needed ${pkg}
+	done
 else
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-harfbuzz
-	pacman -Su $confirm --needed ca-certificates
-	if [ -z ${APPVEYOR+x} ]; then
-		pacman -Su $confirm --needed wget
-		pacman -Su $confirm --needed rsync
-		pacman -Su $confirm --needed unzip
-		pacman -Su $confirm --needed make
-		pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-ntldd-git
-	fi
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gcc
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-glew
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-freeglut
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-FreeImage
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-opencv
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-assimp
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-boost
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-cairo
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-gdb
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-zlib
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-tools
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-pkg-config
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-glfw
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-libusb
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-poco
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-curl
-	pacman -Su $confirm --needed ${MINGW_PACKAGE_PREFIX}-libxml2
+	pacman -Su --noconfirm --needed ${packages}
 fi
 
 


### PR DESCRIPTION
Simplify MSYS2 packages installations.
Clean up package installation on appveyor.
Clean up MSYS2 makefile (and make it compatible with MINGW64)