### PR TITLE
Fixes #6381 based on @LYHSH code snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ ADDONS
 ### ofxSVG
 - added support for the SVG "use" command, a common feature that allows multiple instances of the same graphic elements. Also fixed an issue where line weights less that 1 unit would not render. This increased compatibility can be disabled if required by using the ofxSVG::setImprovedCompatibilityMode(bool mode) method. [commit](https://github.com/openframeworks/openFrameworks/commit/)
 
-###ofxGui
+### ofxGui
 - Added check to update header color when color is changed from external source (fixes #6381)
 --------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ ADDONS
  
 ### ofxSVG
 - added support for the SVG "use" command, a common feature that allows multiple instances of the same graphic elements. Also fixed an issue where line weights less that 1 unit would not render. This increased compatibility can be disabled if required by using the ofxSVG::setImprovedCompatibilityMode(bool mode) method. [commit](https://github.com/openframeworks/openFrameworks/commit/)
-- 
+
+###ofxGui
+-Added check to update header color when color is changed from external source (fixed #6381)
 --------------------------------------
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CORE
 - ofPolyline::removeVertex( ... ) added.
 
 ### utils
-- ofXML - provided access to the underlying pugi::xml_node method "getParent()" 
+- ofXML - provided access to the underlying pugi::xml_node method "getParent()"
 
 PLATFORM/IDE SPECIFIC
 -----------------
@@ -17,18 +17,18 @@ PLATFORM/IDE SPECIFIC
 ### msys2
 - add 64 bits support.
 - setup : removed automatic setup of PATH environment variable(#5740). Move instructions to setup PATH to documentation.
-- documentation : fix typo (#6211) and insist on the use of MINGW32 shell. 
+- documentation : fix typo (#6211) and insist on the use of MINGW32 shell.
 
 ADDONS
 ------
 ### ofxOpenCv
 - added support for OpenCV4 : deprecated C functions replaced by their C++ counterpart. Also fix issue due to incorrect pkg-config package [commit](https://github.com/openframeworks/openFrameworks/commit/)
- 
+
 ### ofxSVG
 - added support for the SVG "use" command, a common feature that allows multiple instances of the same graphic elements. Also fixed an issue where line weights less that 1 unit would not render. This increased compatibility can be disabled if required by using the ofxSVG::setImprovedCompatibilityMode(bool mode) method. [commit](https://github.com/openframeworks/openFrameworks/commit/)
 
 ###ofxGui
--Added check to update header color when color is changed from external source (fixed #6381)
+- Added check to update header color when color is changed from external source (fixes #6381)
 --------------------------------------
 
 ```

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -205,6 +205,9 @@ void ofxColorSlider_<ColorType>::changeValue(ofColor_<ColorType> & value){
             collection[i]->setTextColor( p/range > 0.75 ? ofFloatColor(0.) : ofFloatColor(1.));
         }
 	}
+    if(isMinimized()){
+        setHeaderBackgroundColor(value);
+    }
 }
 
 template<class ColorType>


### PR DESCRIPTION
Fixes #6381 

Adds a check to update header colors value when the header is minimised. Minimum viable code to test it works.

```
//in ofApp.h
ofParameter<ofColor> color;
ofxPanel gui;

//---

//.cpp
//--------------------------------------------------------------
void ofApp::setup(){
    gui.setup();
    gui.add(color.set(ofColor(255, 0, 0)));
}

//--------------------------------------------------------------
void ofApp::update(){    
    float blue = 255 * sin(ofDegToRad(ofGetFrameNum()/1.0));
    color = ofColor(color->r, color->g, abs(blue));
}

//--------------------------------------------------------------
void ofApp::draw(){
    ofSetColor(color);  
    ofDrawCircle(ofGetWidth()/2, ofGetHeight()/2, 100);        
    gui.draw();
}

```