### PR TITLE
not prefixing frameworks with the global addons path

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -500,7 +500,7 @@ Module{
             for(var addon in allAddons){
                 var addonPath = allAddons[addon];
                 var addonFrameworks = [];
-                addonFrameworks = Helpers.parseAddonConfig(addonPath, "ADDON_FRAMEWORKS", addonFrameworks, platform, addonPath+"/");
+                addonFrameworks = Helpers.parseAddonConfig(addonPath, "ADDON_FRAMEWORKS", addonFrameworks, platform);
                 frameworks = frameworks.concat(addonFrameworks);
             }
 


### PR DESCRIPTION
qt creator prefixed osx frameworks with the global addons path. 
`:-1: error: framework not found /Users/thomasgeissl/libs/oF/addons/ofxMidi/CoreMIDI
`