### PR TITLE
ofxGui: Updating events to allow multiwindow functioning

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -138,8 +138,19 @@ void ofxBaseGui::unregisterMouseEvents(){
 	ofUnregisterMouseEvents(this, defaultEventsPriority);
 	bRegisteredForMouseEvents = false;
 }
-
+void ofxBaseGui::setEvents(ofCoreEvents & _events){
+	if(&_events != events){
+		bool wasMouseInputEnabled = bRegisteredForMouseEvents;// || !events;
+		unregisterMouseEvents();
+		events = &_events;
+		if (wasMouseInputEnabled) {
+			// note: this will set bMouseInputEnabled to true as a side-effect.
+			registerMouseEvents();
+		}
+	}
+}
 void ofxBaseGui::draw(){
+	setEvents(ofEvents());
 	if(needsRedraw){
 		generateDraw();
 		needsRedraw = false;

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -71,8 +71,8 @@ class ofxBaseGui {
 		static void loadFont(const ofTrueTypeFontSettings & fontSettings);
 		static void setUseTTF(bool bUseTTF);
 
-		void registerMouseEvents();
-		void unregisterMouseEvents();
+		virtual void registerMouseEvents();
+		virtual void unregisterMouseEvents();
 
 		virtual void sizeChangedCB();
 		virtual void setParent(ofxBaseGui * parent);
@@ -89,6 +89,7 @@ class ofxBaseGui {
 		virtual void mouseExited(ofMouseEventArgs &){
 		}
 
+		void setEvents(ofCoreEvents & events);
 	protected:
 		virtual void render() = 0;
 		virtual bool setValue(float mx, float my, bool bCheckBounds) = 0;
@@ -135,10 +136,11 @@ class ofxBaseGui {
 		static void loadStencilFromHex(ofImage & img, unsigned char * data);
 
 		void setNeedsRedraw();
-
+		ofCoreEvents * events = nullptr;
 	private:
 		bool needsRedraw;
 		unsigned long currentFrame;
 		bool bRegisteredForMouseEvents;
+	
 		//std::vector<ofEventListener> coreListeners;
 };


### PR DESCRIPTION
So currently if you try to use an ofxGui on a multiwindow app and draw it on a window other than the main window, you need to setup the gui before the main app setup is run, which is quite cumbersome.
Besides this, if you have an app and want to open a new window and draw in it an already setup gui the mouse events will not work. You need to disable and reenable mouse events while the window on which you want to draw the gui is the currently renderer window. 

So, the fix for this is quite simple and effective. It takes the same idea from the ofEasyCam events.
 
It stores a pointer to the ofEvents() and it checks against it on every draw call so if it changed it will reregister the mouse events.

This allows:
*  to avoid [this nasty line ](https://github.com/openframeworks/openFrameworks/blob/master/examples/windowing/multiWindowOneAppExample/src/main.cpp#L22)
* automatically switch to different windows. 
* even render the same gui on different windows at the same time while having mouse interactions on both.
@ofTheo @arturoc @bakercp @ofZach 

