### PR TITLE
bugfix findHaarObjects. fixes constant push back to blobs every frame.

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
@@ -257,6 +257,10 @@ int ofxCvHaarFinder::findHaarObjects(const ofxCvGrayscaleImage& input,
 	}
 
 #else
+    if (!blobs.empty()){
+        blobs.clear();
+    }
+    
 	if( cascade.empty() )
 		return 0;
 	


### PR DESCRIPTION
This fixes the broken cameraLensOffsetExample listed in #6412 

Old CV Haar approach clears the blobs vector before adding to it. 
New approach forgot to clear the vector making the blobs vector increase in size continuously. 