### PR TITLE
update multi window example to draw w/2, h/2 instead of w/2, w/2.

### DIFF
--- a/examples/windowing/multiWindowExample/src/ofApp.cpp
+++ b/examples/windowing/multiWindowExample/src/ofApp.cpp
@@ -14,7 +14,7 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofSetColor(gui->color);
-	ofDrawCircle(ofGetWidth()*0.5,ofGetWidth()*0.5,gui->radius);
+	ofDrawCircle(ofGetWidth()*0.5,ofGetHeight()*0.5,gui->radius);
 	ofSetColor(0);
 	ofDrawBitmapString(ofGetFrameRate(),20,20);
 }

--- a/examples/windowing/multiWindowOneAppExample/src/ofApp.cpp
+++ b/examples/windowing/multiWindowOneAppExample/src/ofApp.cpp
@@ -23,7 +23,7 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
 	ofSetColor(color);
-	ofDrawCircle(ofGetWidth()*0.5,ofGetWidth()*0.5,radius);
+	ofDrawCircle(ofGetWidth()*0.5,ofGetHeight()*0.5,radius);
 	ofSetColor(0);
 	ofDrawBitmapString(ofGetFrameRate(),20,20);
 }


### PR DESCRIPTION
Had me confused for a bit when resizing the example, this way the circle stays in the centre even if the window is a non square one.