### PR TITLE
add default member initialiser for position

### DIFF
--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -923,7 +923,7 @@ public:
     ///
     /// \warning The z-component of this position is preserved and can be used
     /// but all ofRectangle operations will ignore the z-component.
-	glm::vec3 position;
+	glm::vec3 position{};
 
     /// \brief The x position of the ofRectangle.
     float& x;


### PR DESCRIPTION
If `ofRectangle`s field `position.z` was not explicitly set, this would mean that garbage memory most likely remained stored in place of the .z coordinate of a rectangle's position.

Whilst this didn't affect any 2D operations, as soon as the rectangle in question was going to be drawn, its .z position would be fed straight into an ofMesh, and then a vertex shader, and all sorts of mayhem could happen.

Test this with `guiFromParametersExample` when opening the `ofxColorPicker` GUI element after selecting a colour...

By adding a default member initialiser to `.position`, the .z coordinate will receive default 0, which is what any 2D graphical element would be expected to be initialised with.

Fixes #6419 