### PR TITLE
[[Need discussion]] makes ofRectangle `memcpy`able and slim.

### DIFF
--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -9,6 +9,12 @@ using namespace std;
 ofRectangle::ofRectangle() : position(), width(), height() {
 }
 
+ofRectangle::ofRectangle(const ofRectangle& rect)
+: position(rect.position)
+, width(rect.width)
+, height(rect.height)
+{}
+
 ofRectangle::ofRectangle(float px, float py, float w, float h) {
 	set(px,py,w,h);
 }
@@ -774,6 +780,13 @@ ofRectangle ofRectangle::mapClamp(const ofRectangle & coeff) const {
        );
 }
     
+//----------------------------------------------------------
+ofRectangle& ofRectangle::operator = (const ofRectangle& rect) {
+    position = rect.position;
+    width = rect.width;
+    height = rect.height;
+}
+
 
 //----------------------------------------------------------
 ofRectangle ofRectangle::operator + (const glm::vec3 & point){

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -785,6 +785,7 @@ ofRectangle& ofRectangle::operator = (const ofRectangle& rect) {
     position = rect.position;
     width = rect.width;
     height = rect.height;
+    return *this;
 }
 
 

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -6,8 +6,7 @@
 using namespace std;
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle() {
-    set(0,0,0,0);
+ofRectangle::ofRectangle() : position(), width(), height() {
 }
 
 ofRectangle::ofRectangle(float px, float py, float w, float h) {

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -6,40 +6,31 @@
 using namespace std;
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle() : x(position.x), y(position.y) {
+ofRectangle::ofRectangle() {
     set(0,0,0,0);
 }
 
-//----------------------------------------------------------
-ofRectangle::~ofRectangle(){}
-
-//----------------------------------------------------------
-ofRectangle::ofRectangle(float px, float py, float w, float h) : x(position.x), y(position.y) {
+ofRectangle::ofRectangle(float px, float py, float w, float h) {
 	set(px,py,w,h);
 }
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle(const glm::vec3& p, float w, float h) : x(position.x), y(position.y) {
+ofRectangle::ofRectangle(const glm::vec3& p, float w, float h) {
     set(p,w,h);
 }
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle(const glm::vec2& p, float w, float h) : x(position.x), y(position.y) {
+ofRectangle::ofRectangle(const glm::vec2& p, float w, float h) {
 	set(p,w,h);
 }
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle(const ofRectangle& rect) : x(position.x), y(position.y) {
-    set(rect);
-}
-
-//----------------------------------------------------------
-ofRectangle::ofRectangle(const glm::vec3& p0, const glm::vec3& p1) : x(position.x), y(position.y) {
+ofRectangle::ofRectangle(const glm::vec3& p0, const glm::vec3& p1) {
     set(p0,p1);
 }
 
 //----------------------------------------------------------
-ofRectangle::ofRectangle(const glm::vec2& p0, const glm::vec2& p1) : x(position.x), y(position.y) {
+ofRectangle::ofRectangle(const glm::vec2& p0, const glm::vec2& p1) {
 	set(p0,p1);
 }
 
@@ -784,12 +775,6 @@ ofRectangle ofRectangle::mapClamp(const ofRectangle & coeff) const {
        );
 }
     
-
-//----------------------------------------------------------
-ofRectangle& ofRectangle::operator = (const ofRectangle& rect) {
-    set(rect);
-	return *this;
-}
 
 //----------------------------------------------------------
 ofRectangle ofRectangle::operator + (const glm::vec3 & point){

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -122,7 +122,7 @@ public:
 
     /// \brief Construct a rectangle by copying another rectangle.
     /// \param rect The rectangle to copy.
-    ofRectangle(const ofRectangle& rect) = default;
+    ofRectangle(const ofRectangle& rect);
 
     /// \brief Construct a rectangle by defining two corners.
     ///
@@ -882,7 +882,7 @@ public:
     /// \brief Assignment operator.
     /// \param rect The rectangle to assign.
     /// \returns A reference to this rectangle.
-    ofRectangle& operator = (const ofRectangle& rect) = default;
+    ofRectangle& operator = (const ofRectangle& rect);
 
     /// \brief Returns a new ofRectangle where the x and y positions of the
 	/// rectangle are offset by the (x, y) coordinates of the glm::vec3.

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -134,7 +134,7 @@ public:
 	ofRectangle(const glm::vec2& p0, const glm::vec2& p1);
 
     /// \brief Destroy the rectangle.
-    ~ofRectangle() = default;
+    virtual ~ofRectangle() = default;
 
     /// \}
 

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -124,10 +124,6 @@ public:
     /// \param rect The rectangle to copy.
     ofRectangle(const ofRectangle& rect) = default;
 
-    /// \brief Construct a rectangle by copying another rectangle.
-    /// \param rect The rectangle to copy.
-    ofRectangle(ofRectangle&& rect) = default;
-    
     /// \brief Construct a rectangle by defining two corners.
     ///
 	/// \warning The z-components of the passed glm::vec3s are ignored.
@@ -888,11 +884,6 @@ public:
     /// \returns A reference to this rectangle.
     ofRectangle& operator = (const ofRectangle& rect) = default;
 
-    /// \brief Assignment operator.
-    /// \param rect The rectangle to assign.
-    /// \returns A reference to this rectangle.
-    ofRectangle& operator = (ofRectangle&& rect) = default;
-    
     /// \brief Returns a new ofRectangle where the x and y positions of the
 	/// rectangle are offset by the (x, y) coordinates of the glm::vec3.
     /// \param p The point to translate.

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -122,8 +122,12 @@ public:
 
     /// \brief Construct a rectangle by copying another rectangle.
     /// \param rect The rectangle to copy.
-    ofRectangle(const ofRectangle& rect);
+    ofRectangle(const ofRectangle& rect) = default;
 
+    /// \brief Construct a rectangle by copying another rectangle.
+    /// \param rect The rectangle to copy.
+    ofRectangle(ofRectangle&& rect) = default;
+    
     /// \brief Construct a rectangle by defining two corners.
     ///
 	/// \warning The z-components of the passed glm::vec3s are ignored.
@@ -134,7 +138,7 @@ public:
 	ofRectangle(const glm::vec2& p0, const glm::vec2& p1);
 
     /// \brief Destroy the rectangle.
-    virtual ~ofRectangle();
+    ~ofRectangle() = default;
 
     /// \}
 
@@ -882,8 +886,13 @@ public:
     /// \brief Assignment operator.
     /// \param rect The rectangle to assign.
     /// \returns A reference to this rectangle.
-    ofRectangle& operator = (const ofRectangle& rect);
+    ofRectangle& operator = (const ofRectangle& rect) = default;
 
+    /// \brief Assignment operator.
+    /// \param rect The rectangle to assign.
+    /// \returns A reference to this rectangle.
+    ofRectangle& operator = (ofRectangle&& rect) = default;
+    
     /// \brief Returns a new ofRectangle where the x and y positions of the
 	/// rectangle are offset by the (x, y) coordinates of the glm::vec3.
     /// \param p The point to translate.
@@ -923,14 +932,16 @@ public:
     ///
     /// \warning The z-component of this position is preserved and can be used
     /// but all ofRectangle operations will ignore the z-component.
-	glm::vec3 position{};
-
-    /// \brief The x position of the ofRectangle.
-    float& x;
-
-    /// \brief The y position of the ofRectangle.
-    float& y;
-
+    union {
+        glm::vec3 position;
+        struct {
+            /// \brief The x position of the ofRectangle.
+            float x;
+            /// \brief The y position of the ofRectangle.
+            float y;
+        };
+    };
+    
     /// \brief The width of the ofRectangle.
     float width;
 


### PR DESCRIPTION
* make slim from 40byte per object to 20byte per object.
* remove virutual from destructor.

## Pros:
This PR makes `ofRectangle ` to `memcpy`, `fwrite` and other low level memory operation friendly.
In addition, this makes less memory usage.
(`float &` use 4/8byte at 32/64bit env. but this PR makes these into `union` doesn't need memory.)

## Cons:
But, this PR removes `virtual` from destructor.
This makes what memory leak may occur in some code that inherit from ofRectangle and be use with polymorphism.