### PR TITLE
bugfix. fixes errors if legacy vector math is enabled. closes #6463

### DIFF
--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -7,6 +7,10 @@
 #include "glm/fwd.hpp"
 #include <deque>
 
+#include "ofVec2f.h"
+#include "ofVec3f.h"
+#include "ofVec4f.h"
+
 /// \file
 /// ofPolyLine allows you to combine multiple points into a single vector data
 /// object that can be drawn to the screen, manipulated point by point, and


### PR DESCRIPTION
Wasn't as bad as it initially seemed. 
Just needed the non forward decelerations in ofPolyline. 

Closes #6463 