### PR TITLE
add msys2 64bit builds to nightly and release scripts.

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -335,7 +335,11 @@ function createPackage {
     elif [ "$pkg_platform" = "linuxarmv7l" ]; then
         scripts/linux/download_libs.sh -a armv7l
     elif [ "$pkg_platform" = "msys2" ]; then
-        scripts/msys2/download_libs.sh
+        if [ "$libs_abi" = "64" ]; then
+            scripts/msys2/download_libs.sh -a 64
+        else
+            scripts/msys2/download_libs.sh
+        fi
     elif [ "$pkg_platform" = "vs2015" ]; then
         scripts/dev/download_libs.sh -p vs2015
     elif [ "$pkg_platform" = "vs2017" ]; then
@@ -624,12 +628,12 @@ function createPackage {
         COPYFILE_DISABLE=true tar czf of_v${pkg_version}_${pkg_platform}${libs_abi}_release.tar.gz of_v${pkg_version}_${pkg_platform}${libs_abi}_release
         rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_release
     else
-        echo "compressing package to of_v${pkg_version}_${pkg_platform}_release.zip"
+        echo "compressing package to of_v${pkg_version}_${pkg_platform}${libs_abi}_release.zip"
         cd $pkg_ofroot/..
-        mkdir of_v${pkg_version}_${pkg_platform}_release
-        mv ${pkgfolder}/* of_v${pkg_version}_${pkg_platform}_release
-        zip --symlinks -r of_v${pkg_version}_${pkg_platform}_release.zip of_v${pkg_version}_${pkg_platform}_release > /dev/null
-        rm -Rf of_v${pkg_version}_${pkg_platform}_release
+        mkdir of_v${pkg_version}_${pkg_platform}${libs_abi}_release
+        mv ${pkgfolder}/* of_v${pkg_version}_${pkg_platform}${libs_abi}_release
+        zip --symlinks -r of_v${pkg_version}_${pkg_platform}${libs_abi}_release.zip of_v${pkg_version}_${pkg_platform}${libs_abi}_release > /dev/null
+        rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_release
     fi
 }
 

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -88,6 +88,11 @@ if [ "$version" == "" ]; then
     exit 1
 fi
 
+if [ "$platform" == "msys2" ] && ! ([ "$libs_abi" == "mingw32" ] || [ "$libs_abi" == "mingw64" ]); then
+    echo ./create_package.sh : libs_abi must be \'mingw32\' or \'mingw64\' for \'msys2\' platform
+    exit 1
+fi
+
 echo
 echo
 echo
@@ -335,7 +340,7 @@ function createPackage {
     elif [ "$pkg_platform" = "linuxarmv7l" ]; then
         scripts/linux/download_libs.sh -a armv7l
     elif [ "$pkg_platform" = "msys2" ]; then
-        if [ "$libs_abi" = "64" ]; then
+        if [ "$libs_abi" = "mingw64" ]; then
             scripts/msys2/download_libs.sh -a 64
         else
             scripts/msys2/download_libs.sh
@@ -628,12 +633,17 @@ function createPackage {
         COPYFILE_DISABLE=true tar czf of_v${pkg_version}_${pkg_platform}${libs_abi}_release.tar.gz of_v${pkg_version}_${pkg_platform}${libs_abi}_release
         rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_release
     else
-        echo "compressing package to of_v${pkg_version}_${pkg_platform}${libs_abi}_release.zip"
+        if [ "$libs_abi" = "" ]; then
+            pkg_name=of_v${pkg_version}_${pkg_platform}_release
+        else
+            pkg_name=of_v${pkg_version}_${pkg_platform}_${libs_abi}_release
+        fi 
+        echo "compressing package to ${pkg_name}.zip"
         cd $pkg_ofroot/..
-        mkdir of_v${pkg_version}_${pkg_platform}${libs_abi}_release
-        mv ${pkgfolder}/* of_v${pkg_version}_${pkg_platform}${libs_abi}_release
-        zip --symlinks -r of_v${pkg_version}_${pkg_platform}${libs_abi}_release.zip of_v${pkg_version}_${pkg_platform}${libs_abi}_release > /dev/null
-        rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_release
+        mkdir ${pkg_name}
+        mv ${pkgfolder}/* ${pkg_name}
+        zip --symlinks -r ${pkg_name}.zip ${pkg_name} > /dev/null
+        rm -Rf ${pkg_name}
     fi
 }
 

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -171,7 +171,7 @@ elif [ "$ARCH" == "" ] && [ "$PLATFORM" == "vs2017" ]; then
           openFrameworksLibs_${VER}_${PLATFORM}_64_3.zip \
           openFrameworksLibs_${VER}_${PLATFORM}_64_4.zip"
 elif [ "$PLATFORM" == "msys2" ]; then
-    PKGS="openFrameworksLibs_${VER}_${PLATFORM}_${ARCH}_.zip"
+    PKGS="openFrameworksLibs_${VER}_${PLATFORM}_mingw${ARCH}.zip"
 elif [ "$PLATFORM" == "vs2015" ] || [ "$PLATFORM" == "vs2017" ]; then
     PKGS="openFrameworksLibs_${VER}_${PLATFORM}_${ARCH}_1.zip \
           openFrameworksLibs_${VER}_${PLATFORM}_${ARCH}_2.zip \

--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -53,6 +53,7 @@ fi
 ./create_package.sh linux64 $lastversion master gcc5
 ./create_package.sh linux64 $lastversion master gcc6
 ./create_package.sh msys2 $lastversion master
+./create_package.sh msys2 $lastversion master 64
 ./create_package.sh vs2017 $lastversion master
 ./create_package.sh ios $lastversion master
 ./create_package.sh osx $lastversion master
@@ -70,6 +71,7 @@ mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc4_release.tar.gz /var/
 mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc5_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linux64gcc5_nightly.tar.gz
 mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc6_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linux64gcc6_nightly.tar.gz
 mv /var/www/versions/nightly/of_v${lastversion}_msys2_release.zip /var/www/versions/nightly/of_v${lastversion}_msys2_nightly.zip
+mv /var/www/versions/nightly/of_v${lastversion}_msys264_release.zip /var/www/versions/nightly/of_v${lastversion}_msys264_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_vs2017_release.zip /var/www/versions/nightly/of_v${lastversion}_vs2017_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_ios_release.zip /var/www/versions/nightly/of_v${lastversion}_ios_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_osx_release.zip /var/www/versions/nightly/of_v${lastversion}_osx_nightly.zip

--- a/scripts/dev/nightlybuilds.sh
+++ b/scripts/dev/nightlybuilds.sh
@@ -52,8 +52,8 @@ fi
 ./create_package.sh linux64 $lastversion master gcc4
 ./create_package.sh linux64 $lastversion master gcc5
 ./create_package.sh linux64 $lastversion master gcc6
-./create_package.sh msys2 $lastversion master
-./create_package.sh msys2 $lastversion master 64
+./create_package.sh msys2 $lastversion master mingw32
+./create_package.sh msys2 $lastversion master mingw64
 ./create_package.sh vs2017 $lastversion master
 ./create_package.sh ios $lastversion master
 ./create_package.sh osx $lastversion master
@@ -70,8 +70,8 @@ mv *.zip /var/www/versions/nightly
 mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc4_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linux64gcc4_nightly.tar.gz
 mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc5_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linux64gcc5_nightly.tar.gz
 mv /var/www/versions/nightly/of_v${lastversion}_linux64gcc6_release.tar.gz /var/www/versions/nightly/of_v${lastversion}_linux64gcc6_nightly.tar.gz
-mv /var/www/versions/nightly/of_v${lastversion}_msys2_release.zip /var/www/versions/nightly/of_v${lastversion}_msys2_nightly.zip
-mv /var/www/versions/nightly/of_v${lastversion}_msys264_release.zip /var/www/versions/nightly/of_v${lastversion}_msys264_nightly.zip
+mv /var/www/versions/nightly/of_v${lastversion}_msys2_mingw32_release.zip /var/www/versions/nightly/of_v${lastversion}_msys2_mingw32_nightly.zip
+mv /var/www/versions/nightly/of_v${lastversion}_msys2_mingw64_release.zip /var/www/versions/nightly/of_v${lastversion}_msys2_mingw64_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_vs2017_release.zip /var/www/versions/nightly/of_v${lastversion}_vs2017_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_ios_release.zip /var/www/versions/nightly/of_v${lastversion}_ios_nightly.zip
 mv /var/www/versions/nightly/of_v${lastversion}_osx_release.zip /var/www/versions/nightly/of_v${lastversion}_osx_nightly.zip

--- a/scripts/dev/release.sh
+++ b/scripts/dev/release.sh
@@ -56,8 +56,8 @@ cd $(cat ~/.ofprojectgenerator/config)/scripts/dev
 ./create_package.sh linux64 $version $branch gcc6
 ./create_package.sh linuxarmv6l $version $branch
 ./create_package.sh linuxarmv7l $version $branch
-./create_package.sh msys2 $version $branch
-./create_package.sh msys2 $version $branch 64
+./create_package.sh msys2 $version $branch mingw32
+./create_package.sh msys2 $version $branch mingw64
 ./create_package.sh vs2017 $version $branch
 ./create_package.sh ios $version $branch
 ./create_package.sh osx $version $branch

--- a/scripts/dev/release.sh
+++ b/scripts/dev/release.sh
@@ -57,6 +57,7 @@ cd $(cat ~/.ofprojectgenerator/config)/scripts/dev
 ./create_package.sh linuxarmv6l $version $branch
 ./create_package.sh linuxarmv7l $version $branch
 ./create_package.sh msys2 $version $branch
+./create_package.sh msys2 $version $branch 64
 ./create_package.sh vs2017 $version $branch
 ./create_package.sh ios $version $branch
 ./create_package.sh osx $version $branch

--- a/scripts/msys2/install_dependencies.sh
+++ b/scripts/msys2/install_dependencies.sh
@@ -31,7 +31,7 @@ while [[ $# > 0 ]] ; do
 done
 
 # List of MSYS packages to be installed
-msyspackages="make rsync unzip wget"
+msyspackages="make rsync zip unzip wget"
 
 # List of MINGW packages to be installed (without prefix)
 mingwPackages="assimp boost cairo curl freeglut FreeImage gcc gdb glew glfw \


### PR DESCRIPTION
This should work for nightly builds and releases. 
@oxillo maybe you could test the generated package and let us know if it works okay for you?

( msys2 64bit build ) 
http://ci.openframeworks.cc/versions/v0.11.0/of_v0.11.0_msys264_release.zip 