### PR TITLE
ofOpenALSoundPlayer: fix conflicting forward declaration in newer versions

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -23,10 +23,10 @@
 
 using namespace std;
 
-ALCdevice * ofOpenALSoundPlayer::alDevice = 0;
-ALCcontext * ofOpenALSoundPlayer::alContext = 0;
+static ALCdevice * alDevice = nullptr;
+static ALCcontext * alContext = nullptr;
 vector<float> ofOpenALSoundPlayer::window;
-float ofOpenALSoundPlayer::windowSum=0;
+float ofOpenALSoundPlayer::windowSum = 0.f;
 
 
 kiss_fftr_cfg ofOpenALSoundPlayer::systemFftCfg=0;
@@ -40,7 +40,7 @@ static set<ofOpenALSoundPlayer*> & players(){
 }
 
 void ofOpenALSoundUpdate(){
-	alcProcessContext(ofOpenALSoundPlayer::alContext);
+	alcProcessContext(alContext);
 }
 
 // ----------------------------------------------------------------------------

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -9,12 +9,6 @@
 
 
 typedef unsigned int ALuint;
-/** Opaque device handle */
-typedef struct ALCdevice_struct ALCdevice;
-/** Opaque context handle */
-typedef struct ALCcontext_struct ALCcontext;
-
-
 
 #include "kiss_fft.h"
 #include "kiss_fftr.h"
@@ -123,8 +117,6 @@ class ofOpenALSoundPlayer : public ofBaseSoundPlayer, public ofThread {
 		float speed; // -n to n, 1 = normal, -1 backwards
 		unsigned int length; // in samples;
 
-		static ALCdevice * alDevice;
-		static ALCcontext * alContext;
 		static std::vector<float> window;
 		static float windowSum;
 


### PR DESCRIPTION
Declare statics inside cpp to avoid forward declaration