### PR TITLE
set default AA numSamples to 0 for GLFW window for RPi. closes #6497

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -32,7 +32,12 @@ public:
 	:ofGLWindowSettings(settings){}
 #endif
 
+#ifdef TARGET_RASPBERRY_PI
+	int numSamples = 0;
+#else
 	int numSamples = 4;
+#endif
+
 	bool doubleBuffering = true;
 	int redBits = 8;
 	int greenBits = 8;


### PR DESCRIPTION
set default AA numSamples to 0 for GLFW window for RPi. closes #6497