### PR TITLE
add latomic flag for legacy RPi builds.

### DIFF
--- a/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
+++ b/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
@@ -55,12 +55,12 @@ ifneq (,$(wildcard $(RPI_ROOT)/etc/os-release))
 	VER_ID = $(shell grep -oP '(?<=^VERSION_ID=).+' $(RPI_ROOT)/etc/os-release | tr -d '"')
 endif
 
-#check if we are newer than 8 and use the new system
+#check if we are newer than Stretch and use the new system
 ifeq ($(shell expr $(VER_ID) \>= 9), 1)
+	# comment the line below if you want to use the non X window based system - currently compatible with RPi 1-3 only 
 	USE_PI_LEGACY = 0
+	USE_ATOMIC = 1
 endif
-
-$(info VER ID IS $(VER_ID)) 
 
 # defines used inside openFrameworks libs.
 PLATFORM_DEFINES += TARGET_RASPBERRY_PI
@@ -184,7 +184,7 @@ PLATFORM_LIBRARIES += dl
 
 PLATFORM_LDFLAGS += -pthread
 
-ifeq ($(USE_PI_LEGACY), 0)
+ifdef USE_ATOMIC
 	PLATFORM_LDFLAGS += -latomic
 endif 
 

--- a/libs/openFrameworksCompiled/project/linuxarmv7l/config.linuxarmv7l.raspberry2.mk
+++ b/libs/openFrameworksCompiled/project/linuxarmv7l/config.linuxarmv7l.raspberry2.mk
@@ -55,9 +55,11 @@ ifneq (,$(wildcard $(RPI_ROOT)/etc/os-release))
 	VER_ID = $(shell grep -oP '(?<=^VERSION_ID=).+' $(RPI_ROOT)/etc/os-release | tr -d '"')
 endif
 
-#check if we are newer than 8 and use the new system
+#check if we are newer than Stretch and use the new system
 ifeq ($(shell expr $(VER_ID) \>= 9), 1)
+	# comment the line below if you want to use the non X window based system - currently compatible with RPi 1-3 only 
 	USE_PI_LEGACY = 0
+	USE_ATOMIC = 1
 endif
 
 $(info VER ID IS $(VER_ID)) 
@@ -187,7 +189,7 @@ PLATFORM_LIBRARIES += dl
 
 PLATFORM_LDFLAGS += -pthread
 
-ifeq ($(USE_PI_LEGACY), 0)
+ifdef USE_ATOMIC
 	PLATFORM_LDFLAGS += -latomic
 endif 
 


### PR DESCRIPTION
This lets people use the older legacy approach for Rpi without getting atomic linking errors. 