### PR TITLE
emscripten  DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR

### DIFF
--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -1,3 +1,34 @@
+
+Skip to content
+Pull requests
+Issues
+Marketplace
+Explore
+@Jonathhhan
+Learn Git and GitHub without any code!
+
+Using the Hello World guide, you’ll start a branch, write comments, and open a pull request.
+openframeworks /
+openFrameworks
+
+541
+7.5k
+
+    2.4k
+
+Code
+Issues 820
+Pull requests 89
+Actions
+Projects 0
+Wiki
+Security
+Insights
+openFrameworks/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+Arturo Castro emscripten: fix problems with latest versions c070afc on 26 Jun 2019
+@arturoc
+@frauzufall
+284 lines (245 sloc) 13.2 KB
 ################################################################################
 # CONFIGURE CORE PLATFORM MAKEFILE
 #   This file has linux common rules for all the platforms (x86_64, i386,armv6l
@@ -64,7 +95,7 @@ PLATFORM_REQUIRED_ADDONS = ofxEmscripten
 ################################################################################
 
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
-PLATFORM_CXXFLAGS = -Wall -std=c++14 -Wno-warn-absolute-paths     
+PLATFORM_CFLAGS = -Wall -std=c++14 -Wno-warn-absolute-paths
 
 
 ################################################################################
@@ -90,7 +121,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl,--as-needed -Wl,--gc-sections --preload-file bin/data@data --emrun --bind  --profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_MEMORY=1920MB -s  ASSERTIONS=2 -s SAFE_HEAP=1 -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0 -s ERROR_ON_UNDEFINED_SYMBOLS=0  -s DEMANGLE_SUPPORT=1
+PLATFORM_LDFLAGS = -Wl,--as-needed -Wl,--gc-sections --preload-file bin/data@data --emrun -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 
@@ -282,3 +313,18 @@ afterplatform: $(TARGET_NAME)
 	@echo "     "
 	@emrun --list_browsers 2>/dev/null
 	@echo
+
+    © 2020 GitHub, Inc.
+    Terms
+    Privacy
+    Security
+    Status
+    Help
+
+    Contact GitHub
+    Pricing
+    API
+    Training
+    Blog
+    About
+

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -64,7 +64,7 @@ PLATFORM_REQUIRED_ADDONS = ofxEmscripten
 ################################################################################
 
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
-PLATFORM_CFLAGS = -Wall -std=c++14 -Wno-warn-absolute-paths
+PLATFORM_CXXFLAGS = -Wall -std=c++14 -Wno-warn-absolute-paths     
 
 
 ################################################################################
@@ -90,7 +90,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl,--as-needed -Wl,--gc-sections --preload-file bin/data@data --emrun
+PLATFORM_LDFLAGS = -Wl,--as-needed -Wl,--gc-sections --preload-file bin/data@data --emrun --bind  --profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_MEMORY=1920MB -s  ASSERTIONS=2 -s SAFE_HEAP=1 -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=0 -s ERROR_ON_UNDEFINED_SYMBOLS=0  -s DEMANGLE_SUPPORT=1
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -1,34 +1,3 @@
-
-Skip to content
-Pull requests
-Issues
-Marketplace
-Explore
-@Jonathhhan
-Learn Git and GitHub without any code!
-
-Using the Hello World guide, you’ll start a branch, write comments, and open a pull request.
-openframeworks /
-openFrameworks
-
-541
-7.5k
-
-    2.4k
-
-Code
-Issues 820
-Pull requests 89
-Actions
-Projects 0
-Wiki
-Security
-Insights
-openFrameworks/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
-Arturo Castro emscripten: fix problems with latest versions c070afc on 26 Jun 2019
-@arturoc
-@frauzufall
-284 lines (245 sloc) 13.2 KB
 ################################################################################
 # CONFIGURE CORE PLATFORM MAKEFILE
 #   This file has linux common rules for all the platforms (x86_64, i386,armv6l
@@ -313,18 +282,3 @@ afterplatform: $(TARGET_NAME)
 	@echo "     "
 	@emrun --list_browsers 2>/dev/null
 	@echo
-
-    © 2020 GitHub, Inc.
-    Terms
-    Privacy
-    Security
-    Status
-    Help
-
-    Contact GitHub
-    Pricing
-    API
-    Training
-    Blog
-    About
-


### PR DESCRIPTION
Hi, 
I hope I did the pull request the right way...
You need to set the flag DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR to 0 to make Open Frameworks work with the latest fastcomp Emscripten (1.39.6).
I also added some additional flags but they are mainly for debugging...
https://github.com/Jonathhhan/openFrameworks/blob/patch-release/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
I am not able to change the template.html so that it is possible to use the flag DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 which would be even nicer.
Here is the topic from the forum: https://forum.openframeworks.cc/t/latest-emscripten-doesnt-work-on-examples/30463/54