### PR TITLE
changing CURLOPT_SSL_VERIFYHOST argument

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -180,7 +180,7 @@ namespace{
 ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request) {
 	curl_slist *headers = nullptr;
 	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0);
-	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0);
+	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 2);
 	curl_easy_setopt(curl.get(), CURLOPT_URL, request.url.c_str());
 
 	// always follow redirections


### PR DESCRIPTION
Some https requests fail on mac (and perhaps other platforms) when the verify option is set to 0. Changing it to 2 seems to resolve issue.