### PR TITLE
adding pugi parsing Options to ofXml (OF enum version)

### DIFF
--- a/libs/openFrameworks/utils/ofXml.cpp
+++ b/libs/openFrameworks/utils/ofXml.cpp
@@ -6,6 +6,7 @@ using namespace std;
 ofXml::ofXml()
 :doc(new pugi::xml_document){
 	xml = doc->root();
+	parsing_options = OF_PARSE_DEFAULT;	
 }
 
 ofXml::ofXml(std::shared_ptr<pugi::xml_document> doc, const pugi::xml_node & xml)
@@ -14,9 +15,13 @@ ofXml::ofXml(std::shared_ptr<pugi::xml_document> doc, const pugi::xml_node & xml
 
 }
 
+void ofXml::setParsingOptions(unsigned int l_parsing_options) {
+	parsing_options = l_parsing_options;
+}
+
 bool ofXml::load(const std::filesystem::path & file){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
-	if(auxDoc->load_file(ofToDataPath(file).c_str())){
+	if(auxDoc->load_file(ofToDataPath(file).c_str(), parsing_options)){
 		doc = auxDoc;
 		xml = doc->root();
 		return true;
@@ -32,7 +37,7 @@ bool ofXml::load(const ofBuffer & buffer){
 bool ofXml::parse(const std::string & xmlStr){
 	auto auxDoc = std::make_shared<pugi::xml_document>();
     #if ( defined(PUGIXML_VERSION) && PUGIXML_VERSION >= 150 )
-        if(auxDoc->load_string(xmlStr.c_str())){
+        if(auxDoc->load_string(xmlStr.c_str(), parsing_options)){
     #else
         if(auxDoc->load(xmlStr.c_str())){
     #endif

--- a/libs/openFrameworks/utils/ofXml.h
+++ b/libs/openFrameworks/utils/ofXml.h
@@ -4,6 +4,27 @@
 #include "pugixml.hpp"
 #include "ofParameter.h"
 
+enum ofXmlParsingOption: const unsigned int {
+	OF_PARSE_MINIMAL = pugi::parse_minimal,
+	OF_PARSE_DEFAULT = pugi::parse_default,
+	OF_PARSE_FULL = pugi::parse_full,
+
+	OF_PARSE_DECLARATION = pugi::parse_declaration,
+	OF_PARSE_DOCTYPE = pugi::parse_doctype,
+	OF_PARSE_PI = pugi::parse_pi,
+	OF_PARSE_COMMENTS = pugi::parse_comments,
+	OF_PARSE_CDATA = pugi::parse_cdata,
+	OF_PARSE_TRIM_PCDATA = pugi::parse_trim_pcdata,
+	OF_PARSE_WS_PCDATA = pugi::parse_ws_pcdata,
+	OF_PARSE_WS_PCDATA_SINGLE = pugi::parse_ws_pcdata_single,
+	OF_PARSE_EMBED_PCDATA = pugi::parse_embed_pcdata,
+	OF_PARSE_FRAGMENT = pugi::parse_fragment,
+	OF_PARSE_ESCAPES = pugi::parse_escapes,
+	OF_PARSE_EOL = pugi::parse_eol,
+	OF_PARSE_WCONV_ATTRIBUTE = pugi::parse_wconv_attribute,
+	OF_PARSE_WNORM_ATTRIBUTE = pugi::parse_wnorm_attribute
+};
+
 template<typename It>
 class ofXmlIterator;
 class ofXmlAttributeIterator;
@@ -101,6 +122,7 @@ public:
 	ofXml();
 
 	bool load(const std::filesystem::path & file);
+ 	void setParsingOptions(unsigned int l_parsing_options);	
 	bool load(const ofBuffer & buffer);
 	bool parse(const std::string & xmlStr);
 	bool save(const std::filesystem::path & file) const;
@@ -114,6 +136,8 @@ public:
 	ofXml appendChild(const ofXml & xml);
 	ofXml prependChild(const ofXml & xml);
 	bool removeChild(const ofXml & node);
+
+	unsigned int parsing_options;
 
 #if PUGIXML_VERSION>=170
 	ofXml appendChild(ofXml && xml);


### PR DESCRIPTION
Hi all,

this is a re-opened pull request after change requests from your side.
pugi offers parsing options like "pugi::parse_default | pugi::parse_comments" in case one wants comments not to be stripped etc. Added a variable, a setter and (as requested) OF-like enum decleration to be able to use them in ofXml. 

Would be used like this:
XML.setParsingOptions( OF_PARSE_DEFAULT | OF_PARSE_COMMENTS ); XML.load(pathToXML);

Hope I got this enum-thing done appropriately?

**Thanks for your awesome work!**
oe