### PR TITLE
Merge make43 msys2ccache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,12 +11,10 @@ environment:
       platform: x86
       BUILDER: MSYS2
       MSYSTEM: MINGW32
-      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       BUILDER: MSYS2
       MSYSTEM: MINGW64
-      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
 
   #VisualStudio Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -44,16 +42,10 @@ init:
 
 # - IF "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 
-cache:
-    - .ccache
-
 install:
 - if "%BUILDER%"=="VS" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/vs/install.sh")
 - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh")
 
-before_build:
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -z")
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")
 
 build_script:
 - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/build.sh")
@@ -72,6 +64,3 @@ test_script:
       cd scripts/ci/vs
       .\run_tests.bat
     }
-
-after_test:
-  - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")

--- a/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.addons.mk
@@ -96,7 +96,7 @@ define parse_addon
 	$(eval ADDON_SOURCES=$(PARSED_ADDONS_SOURCE_FILES)) \
 	$(eval PROCESS_NEXT=0) \
 	$(if $(wildcard $(addon)/addon_config.mk), \
-		$(foreach var_line, $(subst $(space),?,$(shell cat $(addon)/addon_config.mk | tr '\n' '\t')), \
+		$(foreach var_line, $(shell cat $(addon)/addon_config.mk | tr '\n ' '\t?'), \
 			$(eval unscaped_var_line=$(strip $(subst ?, ,$(var_line)))) \
 			$(if $(filter $(PROCESS_NEXT),1), $(eval $(unscaped_var_line))) \
 			$(if $(filter %:,$(unscaped_var_line)), \

--- a/scripts/ci/ccache.sh
+++ b/scripts/ci/ccache.sh
@@ -20,9 +20,11 @@ EOF2
     export CXX="$PWD/clang++.sh"
     export CC="$PWD/clang.sh"
 elif [ "$BUILDER" == "msys2" ]; then
-    echo "detected msys setting ccache as env var"
-    export CC="ccache /mingw32/bin/gcc"
-    export CXX="ccache /mingw32/bin/g++"
+#    echo "detected msys setting ccache as env var"
+#    export CC="ccache /mingw32/bin/gcc"
+#    export CXX="ccache /mingw32/bin/g++"
+#    USE_CCACHE="USE_CCACHE=1"
+    echo "ccache is disable in MSYS2"
 else
 	export PATH="/usr/lib/ccache:$PATH"
 fi

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -5,15 +5,15 @@ source $ROOT/scripts/ci/ccache.sh
 
 echo "**** Building OF core ****"
 cd $ROOT/libs/openFrameworksCompiled/project
-make USE_CCACHE=1 -j4 Debug
+make ${USE_CCACHE} -j4 Debug
 
 echo "**** Building emptyExample ****"
 cd $ROOT/scripts/templates/msys2
-make USE_CCACHE=1 -j4 Debug
+make ${USE_CCACHE} -j4 Debug
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
 cp scripts/templates/msys2/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
-make USE_CCACHE=1 -j4 Debug
+make ${USE_CCACHE} -j4 Debug

--- a/scripts/ci/msys2/run_tests.sh
+++ b/scripts/ci/msys2/run_tests.sh
@@ -12,7 +12,7 @@ for group in *; do
 				cd $test
 				cp ../../../scripts/templates/msys2/Makefile .
 				cp ../../../scripts/templates/msys2/config.make .
-				make USE_CCACHE=1 -j4 Debug
+				make ${USE_CCACHE} -j4 Debug
 				cd bin
 				binname=$(basename ${test})
                 #gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug


### PR DESCRIPTION
- remove use of ccache in MSYS2 appveryor build (fix #6565)
- fix "missing separator" error with make 4.3 (fix #6535)

Both fix in a single PR to have build pass on Appveyor 
Replace #6564