### PR TITLE
fixed ofxGuiSlider text input positioning error

### DIFF
--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -105,6 +105,7 @@ bool ofxSlider<Type>::mousePressed(ofMouseEventArgs & mouse){
 			if(b.inside(mouse)){
 				state = Input;
 				auto mouseLeft = mouse;
+				input.setShape(b);
 				mouseLeft.button = OF_MOUSE_BUTTON_LEFT;
 				input.mousePressed(mouseLeft);
 				return true;


### PR DESCRIPTION
the text input field of the ofxGuiSlider not positioned correctly as a side effect of commit b9612146dcb1bb74b2cfa95613ef175632119e70  .

Please merge @ofZach @arturoc @ofTheo 