### PR TITLE
MSYS2 : (re)enable ccache in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,18 +5,19 @@ environment:
     APPVEYOR_OS_NAME: windows
     CHERE_INVOKING: 1
     MSYS2_PATH: c:\msys64
+    #CCACHE settings : Appveyor cache is limited to 1G so we limit CCACHE to 2G and expect 50% compression...
+    CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
+    CCACHE_MAXSIZE: 2G
   matrix:
   #MSYS2 Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
       BUILDER: MSYS2
       MSYSTEM: MINGW32
-      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       BUILDER: MSYS2
       MSYSTEM: MINGW64
-      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
   #VisualStudio Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,11 +11,12 @@ environment:
       platform: x86
       BUILDER: MSYS2
       MSYSTEM: MINGW32
+      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x64
       BUILDER: MSYS2
       MSYSTEM: MINGW64
-
+      CCACHE_DIR: "%APPVEYOR_BUILD_FOLDER%\\.ccache"
   #VisualStudio Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       platform: x86
@@ -42,10 +43,16 @@ init:
 
 # - IF "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 
+cache:
+    - .ccache
+
 install:
 - if "%BUILDER%"=="VS" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/vs/install.sh")
 - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh")
 
+before_build:
+#- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -z")
+- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")
 
 build_script:
 - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/build.sh")
@@ -64,3 +71,6 @@ test_script:
       cd scripts/ci/vs
       .\run_tests.bat
     }
+
+after_test:
+  - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")

--- a/scripts/ci/ccache.sh
+++ b/scripts/ci/ccache.sh
@@ -19,12 +19,9 @@ EOF2
 
     export CXX="$PWD/clang++.sh"
     export CC="$PWD/clang.sh"
-elif [ "$BUILDER" == "msys2" ]; then
-#    echo "detected msys setting ccache as env var"
-#    export CC="ccache /mingw32/bin/gcc"
-#    export CXX="ccache /mingw32/bin/g++"
-#    USE_CCACHE="USE_CCACHE=1"
-    echo "ccache is disable in MSYS2"
+elif [ "$BUILDER" == "MSYS2" ]; then
+    echo "detected msys setting ccache as env var"
+    USE_CCACHE="USE_CCACHE=1"
 else
 	export PATH="/usr/lib/ccache:$PATH"
 fi

--- a/scripts/ci/msys2/install.sh
+++ b/scripts/ci/msys2/install.sh
@@ -4,4 +4,6 @@ ROOT=$(pwd -P)
 
 $ROOT/scripts/msys2/install_dependencies.sh --noconfirm
 $ROOT/scripts/msys2/download_libs.sh --silent
-pacman -S --noconfirm ccache
+if [[ $MINGW_PACKAGE_PREFIX ]]; then 
+    pacman -S --noconfirm $MINGW_PACKAGE_PREFIX-ccache
+fi


### PR DESCRIPTION
Fix #6565 - use mingw(32|64) version of ccache instead of msys version.

Revert disabling of ccache in #6566 

Remove duplicate use of setting ccache (by setting CXX in ccache.sh) and by using USE_CCACHE and setting PLATFORM_CXX in msys2 makefile. makefile solution (with USE_CCACHE) has been retained.

