### PR TITLE
[CI] Optimize MSYS2 on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,9 @@
 version: 1.0.{build}
 
+platform:
+  - x86
+  - x64
+
 environment:
   global:
     APPVEYOR_OS_NAME: windows
@@ -11,67 +15,81 @@ environment:
   matrix:
   #MSYS2 Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
       BUILDER: MSYS2
-      MSYSTEM: MINGW32
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      BUILDER: MSYS2
-      MSYSTEM: MINGW64
   #VisualStudio Building
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x86
       BUILDER : VS
-      BITS: 32
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      platform: x64
-      BUILDER : VS
-      BITS: 64
 
 configuration: Debug
 shallow_clone: true
 clone_depth: 10
 
+
 init:
 # fix for https://github.com/appveyor/ci/issues/2571
 - del C:\Windows\System32\libssl-*.dll C:\Windows\system32\libcrypto-*.dll
 - del C:\Windows\SysWOW64\libssl-*.dll C:\Windows\SysWOW64\libcrypto-*.dll
-# Upgrade the MSYS2 system and all install packages
-- '%MSYS2_PATH%\usr\bin\pacman --noconfirm -Syu'
-# Install packages need by download_libs.sh scripts (VS and MSYS2)
-- '%MSYS2_PATH%\usr\bin\pacman --noconfirm -S --needed unzip rsync wget libopenssl mingw-w64-i686-openssl'
-- if "%BUILDER%"=="VS" set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%
 
-# - IF "%BUILDER%"=="VS" set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 
-cache:
+
+for:
+  -
+    matrix:
+      only:
+        - BUILDER: MSYS2
+    
+    cache:
     - .ccache
 
-install:
-- if "%BUILDER%"=="VS" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/vs/install.sh")
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh")
+    install:
+      - |-
+        set MSYSTEM=%platform:86=32%
+        set MSYSTEM=%MSYSTEM:x=MINGW%
+        cd C:\
+        ren msys64 msys64_old
+        C:\msys64_old\usr\bin\bash -lc "curl -L http://repo.msys2.org/distrib/msys2-x86_64-latest.tar.xz | xz -d | tar -xf -"
+        %MSYS2_PATH%\usr\bin\bash -lc "pacman --noconfirm -Syu"
+        %MSYS2_PATH%\usr\bin\pacman --noconfirm -S --needed unzip rsync wget libopenssl
+        cd "%APPVEYOR_BUILD_FOLDER%"
+        %MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/install.sh"
+        %MSYS2_PATH%\usr\bin\bash -lc "echo $PATH"
 
-before_build:
-#- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -z")
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")
+    before_build:
+      - |-
+        %MSYS2_PATH%\usr\bin\bash -lc "ccache -z"
+        %MSYS2_PATH%\usr\bin\bash -lc "ccache -s"
 
-build_script:
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/build.sh")
+    build_script:
+      - '%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/build.sh"'
 
-- ps: |
-    if ($env:BUILDER -eq "VS") {
-      msbuild libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-      msbuild examples/templates/emptyExample/emptyExample.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-      msbuild examples/templates/allAddonsExample/allAddonsExample.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-    }
+    test_script:
+      - '%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/run_tests.sh"'
 
-test_script:
-- if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/msys2/run_tests.sh")
-- ps: |
-    if ($env:BUILDER -eq "VS") {
-      cd scripts/ci/vs
-      .\run_tests.bat
-    }
+    after_test:
+      - '%MSYS2_PATH%\usr\bin\bash -lc "ccache -s"'
 
-after_test:
-  - if "%BUILDER%"=="MSYS2" (%MSYS2_PATH%\usr\bin\bash -lc "ccache -s")
+
+  -
+    matrix:
+      only:
+        - BUILDER: VS
+
+    install:
+      - |-
+        set BITS=%platform:86=32%
+        set BITS=%BITS:x=%
+        %MSYS2_PATH%\usr\bin\pacman --noconfirm -S --needed unzip rsync wget libopenssl
+        set PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin;%PATH%
+        %MSYS2_PATH%\usr\bin\bash -lc "scripts/ci/vs/install.sh"
+
+    build_script:
+      - |-
+          echo BITS=%BITS%
+          msbuild libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+          msbuild examples/templates/emptyExample/emptyExample.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+          msbuild examples/templates/allAddonsExample/allAddonsExample.vcxproj  /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+    test_script:
+      - |-
+        cd scripts/ci/vs
+        .\run_tests.bat


### PR DESCRIPTION
Reorganize YAML
 - setup `platform:` matrix
 - use `for:` to separate build logics MSYS2/VS - avoid `if BUILDER= ... ` statements

Reduce MSYS2 installation/upgrade time using a clean MSYS2 install.
For comparison :
 - baseline : upgrade current install and install OF packages : 10min or more
 - remove not needed package, upgrade, install OF packages : 7-8min 
 - clean install, upgrade, install OF packages : 4min  

With the additional gain of CCache, MSYS2 builds are around 15min for MINGW32 and 25min for MINGW64