### PR TITLE
[ofParameterGroup] removed parameterIndex

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -266,7 +266,6 @@ private:
 
 		void notifyParameterChanged(ofAbstractParameter & param);
 
-		std::map<std::string,std::size_t> parametersIndex;
 		std::vector<std::shared_ptr<ofAbstractParameter> > parameters;
 		std::string name;
 		bool serializable;


### PR DESCRIPTION
This pull request is for addressing the issue described on #6576.

This removes the usage of parameterIndex as does not keep track of the changes in names of ofParameters inside the group.

I have also used the already implemented methods to avoid code duplication. (used `contains()`or `getPosition()`).

Worried about performance with this change, I run the unitTest for parameter and found that the change in time is negligible. (About 300 microseconds for both current implementation and this branch).

I can edit the [parameter test](https://github.com/openframeworks/openFrameworks/tree/patch-release/tests/types/parameters) to show the fix if that is needed.

Eduard