### PR TITLE
Storing render surface stack on fbo.begin() to restore at fbo.end().

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1293,6 +1293,11 @@ void ofGLProgrammableRenderer::unbind(const ofShader & shader){
 void ofGLProgrammableRenderer::begin(const ofFbo & fbo, ofFboMode mode){
 	pushView();
     pushStyle();
+    ofBaseDraws* currentRenderSurface = const_cast<ofBaseDraws*>(matrixStack.getCurrentRenderSurface());
+    if(currentRenderSurface)
+    {
+        renderSurfaceStack.push_back(currentRenderSurface);
+    }
     if(mode & OF_FBOMODE_MATRIXFLIP){
         matrixStack.setRenderSurface(fbo);
     }else{
@@ -1310,7 +1315,15 @@ void ofGLProgrammableRenderer::begin(const ofFbo & fbo, ofFboMode mode){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::end(const ofFbo & fbo){
 	unbind(fbo);
-	matrixStack.setRenderSurface(*window);
+    if(renderSurfaceStack.size() > 0)
+    {
+        matrixStack.setRenderSurface(*renderSurfaceStack.back());
+        renderSurfaceStack.pop_back();
+    }
+    else
+    {
+        matrixStack.setRenderSurface(*window);
+    }
 	uploadMatrices();
 	popStyle();
 	popView();

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -320,4 +320,5 @@ private:
 	std::deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
     GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
+    std::vector<ofBaseDraws*> renderSurfaceStack;   ///render surface stack to restore
 };

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -460,6 +460,11 @@ void ofGLRenderer::unbind(const ofShader & shader){
 void ofGLRenderer::begin(const ofFbo & fbo, ofFboMode mode){
 	pushView();
 	pushStyle();
+    ofBaseDraws* currentRenderSurface = const_cast<ofBaseDraws*>(matrixStack.getCurrentRenderSurface());
+    if(currentRenderSurface)
+    {
+        renderSurfaceStack.push_back(currentRenderSurface);
+    }
     if(mode & OF_FBOMODE_MATRIXFLIP){
         matrixStack.setRenderSurface(fbo);
     }else{
@@ -485,7 +490,15 @@ void ofGLRenderer::begin(const ofFbo & fbo, ofFboMode mode){
 //----------------------------------------------------------
 void ofGLRenderer::end(const ofFbo & fbo){
 	unbind(fbo);
-	matrixStack.setRenderSurface(*window);
+    if(renderSurfaceStack.size() > 0)
+    {
+        matrixStack.setRenderSurface(*renderSurfaceStack.back());
+        renderSurfaceStack.pop_back();
+    }
+    else
+    {
+        matrixStack.setRenderSurface(*window);
+    }
 	popStyle();
 	popView();
 }

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -249,5 +249,5 @@ private:
 	std::deque<GLuint> framebufferIdStack;	///< keeps track of currently bound framebuffers
 	GLuint defaultFramebufferId;		///< default GL_FRAMEBUFFER_BINDING, windowing frameworks might want to set this to their MSAA framebuffer, defaults to 0
 	GLuint currentFramebufferId;		///< the framebuffer id currently bound to the GL_FRAMEBUFFER target
-
+    std::vector<ofBaseDraws*> renderSurfaceStack;   ///render surface stack to restore
 };

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -56,6 +56,16 @@ void ofMatrixStack::setRenderSurface(const ofAppBaseWindow & window){
 	setOrientation(orientation,vFlipped);
 }
 
+const ofBaseDraws* ofMatrixStack::getCurrentRenderSurface()
+{
+    return currentRenderSurface;
+}
+
+const ofAppBaseWindow* ofMatrixStack::getCurrentWindow()
+{
+    return currentWindow;
+}
+
 void ofMatrixStack::setOrientation(ofOrientation _orientation, bool vFlip){
 	vFlipped = vFlip;
 	orientation = _orientation;

--- a/libs/openFrameworks/utils/ofMatrixStack.h
+++ b/libs/openFrameworks/utils/ofMatrixStack.h
@@ -26,6 +26,8 @@ public:
 	void setRenderSurface(const ofBaseDraws & fbo);
 	void setRenderSurfaceNoMatrixFlip(const ofBaseDraws & fbo);
 	void setRenderSurface(const ofAppBaseWindow & window);
+    const ofBaseDraws* getCurrentRenderSurface();
+    const ofAppBaseWindow* getCurrentWindow();
 
 	void setOrientation(ofOrientation orientation, bool vFlip);
 	ofOrientation getOrientation() const;


### PR DESCRIPTION
By this change, you can use nested fbo:
fbo.begin();
fbo.begin();
fbo.end();
fbo.end();
