### PR TITLE
fix c++17 std::filesystem error.

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -438,22 +438,24 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 // Remove from here once everything is using std::filesystem::path
 #if OF_USING_STD_FS
 #	if __cplusplus < 201703L
+#       define OF_USE_EXPERIMENTAL_FS 1
 
-		namespace std {
-			namespace experimental{
-				namespace filesystem {
-					namespace v1 {
-						namespace __cxx11 {
-							class path;
-						}
-					}
+    namespace std {
+        namespace experimental{
+            namespace filesystem {
+                namespace v1 {
+                    namespace __cxx11 {
+                        class path;
+                    }
+                }
 
-					using v1::__cxx11::path;
-				}
-			}
-			namespace filesystem = experimental::filesystem;
-		}
+                using v1::__cxx11::path;
+            }
+        }
+        namespace filesystem = experimental::filesystem;
+    }
 #	else
+#       define OF_USE_EXPERIMENTAL_FS 0
 
 	namespace std {
 		namespace filesystem {

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -765,11 +765,23 @@ bool ofFile::isHidden() const {
 //------------------------------------------------------------------------------------------------------------
 void ofFile::setWriteable(bool flag){
 	try{
-		if(flag){
-			std::filesystem::permissions(myFile,std::filesystem::perms::owner_write | std::filesystem::perms::add_perms);
-		}else{
-			std::filesystem::permissions(myFile,std::filesystem::perms::owner_write | std::filesystem::perms::remove_perms);
-		}
+#if !OF_USING_STD_FS || (OF_USING_STD_FS && OF_USE_EXPERIMENTAL_FS)
+        if(flag){
+            std::filesystem::permissions(myFile,std::filesystem::perms::owner_write | std::filesystem::perms::add_perms);
+        }else{
+            std::filesystem::permissions(myFile,std::filesystem::perms::owner_write | std::filesystem::perms::remove_perms);
+        }
+#else
+        if(flag){
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_write,
+                                         std::filesystem::perm_options::add);
+        }else{
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_write,
+                                         std::filesystem::perm_options::remove);
+        }
+#endif
 	}catch(std::exception & e){
 		ofLogError() << "Couldn't set write permission on " << myFile << ": " << e.what();
 	}
@@ -784,11 +796,23 @@ void ofFile::setReadOnly(bool flag){
 //------------------------------------------------------------------------------------------------------------
 void ofFile::setReadable(bool flag){
 	try{
-		if(flag){
-			std::filesystem::permissions(myFile,std::filesystem::perms::owner_read | std::filesystem::perms::add_perms);
-		}else{
-			std::filesystem::permissions(myFile,std::filesystem::perms::owner_read | std::filesystem::perms::remove_perms);
-		}
+#if !OF_USING_STD_FS || (OF_USING_STD_FS && OF_USE_EXPERIMENTAL_FS)
+        if(flag){
+            std::filesystem::permissions(myFile,std::filesystem::perms::owner_read | std::filesystem::perms::add_perms);
+        }else{
+            std::filesystem::permissions(myFile,std::filesystem::perms::owner_read | std::filesystem::perms::remove_perms);
+        }
+#else
+        if(flag){
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_read,
+                                         std::filesystem::perm_options::add);
+        }else{
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_read,
+                                         std::filesystem::perm_options::remove);
+        }
+#endif
 	}catch(std::exception & e){
 		ofLogError() << "Couldn't set read permission on " << myFile << ": " << e.what();
 	}
@@ -798,11 +822,23 @@ void ofFile::setReadable(bool flag){
 void ofFile::setExecutable(bool flag){
 	try{
 #if OF_USING_STD_FS
-		if(flag){
-			std::filesystem::permissions(myFile, std::filesystem::perms::owner_exec | std::filesystem::perms::add_perms);
-		} else{
-			std::filesystem::permissions(myFile, std::filesystem::perms::owner_exec | std::filesystem::perms::remove_perms);
-		}
+#   if OF_USE_EXPERIMENTAL_FS
+        if(flag){
+            std::filesystem::permissions(myFile, std::filesystem::perms::owner_exec | std::filesystem::perms::add_perms);
+        } else{
+            std::filesystem::permissions(myFile, std::filesystem::perms::owner_exec | std::filesystem::perms::remove_perms);
+        }
+#   else
+        if(flag){
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_exec,
+                                         std::filesystem::perm_options::add);
+        } else{
+            std::filesystem::permissions(myFile,
+                                         std::filesystem::perms::owner_exec,
+                                         std::filesystem::perm_options::remove);
+        }
+#   endif
 #else
 		if(flag){
 			std::filesystem::permissions(myFile, std::filesystem::perms::owner_exe | std::filesystem::perms::add_perms);


### PR DESCRIPTION
added process switching with macro about std::filesystem::permissions.

cite:
* TS/experimental API
  * https://en.cppreference.com/w/cpp/experimental/fs/permissions
  * https://en.cppreference.com/w/cpp/experimental/fs/perms
* c++17 API
  * https://en.cppreference.com/w/cpp/filesystem/permissions
  * https://en.cppreference.com/w/cpp/filesystem/perms
  * https://en.cppreference.com/w/cpp/filesystem/perm_options