### PR TITLE
improve typo in unloadSound deprecated message

### DIFF
--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -87,7 +87,7 @@ public:
 
     /// \brief Stops and unloads the current sound.
     void unload();
-    OF_DEPRECATED_MSG("Use load",void unloadSound());
+    OF_DEPRECATED_MSG("Use unload",void unloadSound());
     
     /// \brief Starts playback.
     void play();


### PR DESCRIPTION
Hello oF development team. This is a small changes.
I find a typo in `unloadSound`  deprecated message, and this PR may solved it.

Thanks.