### PR TITLE
fix undesired playback after load

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -751,6 +751,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 				// auto-play or play if started before beeing ready
 				if(bAutoPlayOnLoad || bPlayStateBeforeLoad) {
 					[self play];
+				} else {
+					[self pause];
 				}
 				
 				// update as soon is ready so pixels are loaded.


### PR DESCRIPTION
this PR will fix ofVideoPlayer start playback after load automatically on macOS.