### PR TITLE
Fix ofLineSegmentIntersection test between line and rectangle.

### DIFF
--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -441,13 +441,13 @@ bool ofLineSegmentIntersection(const vectype& line1Start, const vectype& line1En
 	compareB = diffLB.x*line2Start.y - diffLB.y*line2Start.x;
 	if (
 		(
-			( ( diffLA.x*line2Start.y - diffLA.y*line2Start.x ) < compareA ) ^
-			( ( diffLA.x*line2End.y - diffLA.y*line2End.x ) < compareA )
+			( ( diffLA.x*line2Start.y - diffLA.y*line2Start.x ) <= compareA ) ^
+			( ( diffLA.x*line2End.y - diffLA.y*line2End.x ) <= compareA )
 		)
 		&&
 		(
-			( ( diffLB.x*line1Start.y - diffLB.y*line1Start.x ) < compareB ) ^
-			( ( diffLB.x*line1End.y - diffLB.y*line1End.x) < compareB )
+			( ( diffLB.x*line1Start.y - diffLB.y*line1Start.x ) <= compareB ) ^
+			( ( diffLB.x*line1End.y - diffLB.y*line1End.x) <= compareB )
 		)
 	)
 	{


### PR DESCRIPTION
There is currently an edge case where ofLineSegmentIntersection incorrectly returns false if the line's end points sit directly on the edges of the rectangle. This commit should fix that.

Example code to prove this : 
```
	ofRectangle rect(0,0,800,800);
	glm::vec2 p1(400,0);
	glm::vec2 p2(400,800);
	glm::vec2 p3(0,400);
	glm::vec2 p4(800,400);

	ofLogNotice((rect.intersects(p1, p2)) ? "TRUE" : "FALSE");
	ofLogNotice((rect.intersects(p3, p4)) ? "TRUE" : "FALSE");
```

Both tests should return true, previously they returned false. 

Hope this helps! 