### PR TITLE
Fixed title not being shown when calling ofSystemLoadDialog in macos

### DIFF
--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -362,7 +362,9 @@ ofFileDialogResult ofSystemLoadDialog(string windowTitle, bool bFolderSelection,
 		[loadDialog setResolvesAliases:YES];
 
 		if(!windowTitle.empty()) {
-			[loadDialog setTitle:[NSString stringWithUTF8String:windowTitle.c_str()]];
+			// changed from setTitle to setMessage
+			// https://stackoverflow.com/questions/36879212/title-bar-missing-in-nsopenpanel
+			[loadDialog setMessage:[NSString stringWithUTF8String:windowTitle.c_str()]];
 		}
 
 		if(!defaultPath.empty()) {


### PR DESCRIPTION
Macos only: Minor change that properly shows the title of the NSOpenPanel when calling ofSystemLoadDialog