### PR TITLE
Fix flatNormals()

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1826,7 +1826,7 @@ void ofMesh_<V,N,C,T>::flatNormals() {
     if( getMode() == OF_PRIMITIVE_TRIANGLES) {
         
         // get copy original mesh data
-        auto numIndices = getIndices().size();
+        auto indices = getIndices();
         auto verts = getVertices();
         auto texCoords = getTexCoords();
         auto colors = getColors();
@@ -1836,12 +1836,12 @@ void ofMesh_<V,N,C,T>::flatNormals() {
         
         // add mesh data back, duplicating vertices and recalculating normals
         N normal;
-        for(ofIndexType i = 0; i < numIndices; i++) {
-            ofIndexType indexCurr = getIndex(i);
+        for(ofIndexType i = 0; i < indices.size(); i++) {
+            ofIndexType indexCurr = indices[i];
     
             if(i % 3 == 0) {
-                ofIndexType indexNext1 = getIndex(i + 1);
-                ofIndexType indexNext2 = getIndex(i + 2);
+                ofIndexType indexNext1 = indices[i + 1];
+                ofIndexType indexNext2 = indices[i + 2];
                 auto e1 = verts[indexCurr] - verts[indexNext1];
                 auto e2 = verts[indexNext2] - verts[indexNext1];
                 normal = glm::normalize(glm::cross(e1, e2));


### PR DESCRIPTION
flatNormals() doesn't work because indices gets reset by clear(), after which the indices are needed.  The simple fix is to make a local copy of indices.