### PR TITLE
Fix regex when ofShader int define is set to 0.

### DIFF
--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -353,19 +353,19 @@ bool ofShader::setupShaderFromSource(ofShader::Source && source){
 	// parse for includes
 	source.expandedSource = parseForIncludes( source.source, source.directoryPath );
 
-    // parse and set defines
-    for(auto & define: source.intDefines){
-        const auto & name = define.first;
-        const auto & value = define.second;
-		std::regex re_define("#define[ \t]+" + name + "[ \t]+(([1-9][0-9]*)|(0[xX][0-9a-fA-F]+))");
-        source.expandedSource = std::regex_replace(source.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
-    }
+	// parse and set defines
+	for (auto& define : source.intDefines) {
+		const auto& name = define.first;
+		const auto& value = define.second;
+		std::regex re_define("#define[ \t]+" + name + "[ \t]+(([1-9][0-9]*)|(0([xX][0-9a-fA-F]+)?))");
+		source.expandedSource = std::regex_replace(source.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
+	}
 
-    for(auto & define: source.floatDefines){
-        const auto & name = define.first;
-        const auto & value = define.second;
+	for (auto& define : source.floatDefines) {
+		const auto& name = define.first;
+		const auto& value = define.second;
 		std::regex re_define("#define[ \t]+" + name + "[ \t]+[0-9]*(\\.[0-9]*f?)?");
-        source.expandedSource = std::regex_replace(source.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
+		source.expandedSource = std::regex_replace(source.expandedSource, re_define, "#define " + name + " " + std::to_string(value));
 	}
 
 	// store source code (that's the expanded source with all includes copied in)


### PR DESCRIPTION
Regex did not work when #define was originally set to `0` (because of the hex format). This is now fixed.
Also made this block of code use tabs like the rest of the file.