### PR TITLE
Fix ofx slider group listeners removal

### DIFF
--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -109,6 +109,9 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 		}else if(type == typeid(ofParameter <ofFloatColor> ).name()){
 			auto p = _parameters.getFloatColor(i);
 			add(p);
+		}else if(type == typeid(ofParameter <ofRectangle> ).name()){
+			auto p = _parameters.getRectangle(i);
+			add(p);
 		}else if(_parameters[i].valueType() == typeid(string).name()){
 			if(_parameters[i].isReadOnly()){
 				auto p = _parameters.get(i).castReadOnly<std::string, void>();

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -12,20 +12,20 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     ofxGuiGroup::setup(value.getName(), "", 0, 0);
     
     parameters.clear();
-    
+	listeners.unsubscribeAll();
     const string names[4] = {"x", "y", "z", "w"};
     
     this->value.makeReferenceTo(value);
-    this->value.addListener(this, & ofxVecSlider_::changeValue);
+	listeners.push(this->value.newListener(this, & ofxVecSlider_::changeValue));
 
     VecType val = value;
     VecType min = value.getMin();
     VecType max = value.getMax();
-    
+
 	for (size_t i = 0; i < dim(); i++) {
     	ofParameter<float> p(names[i], val[i], min[i], max[i]);
-        add(createGuiElement<ofxSlider<float>>(p, width, height));
-        p.addListener(this, & ofxVecSlider_::changeSlider);
+		add(createGuiElement<ofxSlider<float>>(p, width, height));
+        listeners.push(p.newListener(this, & ofxVecSlider_::changeSlider));
     }
 
     sliderChanging = false;
@@ -137,11 +137,12 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
     ofColor_<ColorType> max = value.getMax();
 
 	picker.setup(value, width, width * 9. / 11.);
-
+	
+	listeners.unsubscribeAll();
     for (int i=0; i<4; i++) {
     	ofParameter<ColorType> p(names[i], val[i], min[i], max[i]);
         add(createGuiElement<ofxSlider<ColorType>>(p, width, height));
-        p.addListener(this, & ofxColorSlider_::changeSlider);
+		listeners.push(p.newListener(this, & ofxColorSlider_::changeSlider));
 		collection[i]->setFillColor(value.get());
         float range = p.getMax()-p.getMin();
         if(range == 0){
@@ -151,7 +152,7 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
         }
     }
 	add(&picker);
-	picker.getParameter().template cast<ofColor_<ColorType>>().addListener(this, & ofxColorSlider_::changeValue);
+	listeners.push(picker.getParameter().template cast<ofColor_<ColorType>>().newListener(this, & ofxColorSlider_::changeValue));
 
 
 	sliderChanging = false;
@@ -263,8 +264,9 @@ ofxRectangleSlider * ofxRectangleSlider::setup(ofParameter<ofRectangle> value, f
     
 //    const string names[4] = {"x", "y", "width", "height"};
 	
+	listeners.unsubscribeAll();
     this->value.makeReferenceTo(value);
-    this->value.addListener(this, & ofxRectangleSlider::changeValue);
+    listeners.push(this->value.newListener(this, & ofxRectangleSlider::changeValue));
 
     ofRectangle val = value;
     ofRectangle min = value.getMin();
@@ -278,19 +280,19 @@ ofxRectangleSlider * ofxRectangleSlider::setup(ofParameter<ofRectangle> value, f
 //    }
     	ofParameter<float> x("x", val.x, min.x, max.x);
         add(createGuiElement< ofxSlider<float> >(x, width, height));
-        x.addListener(this, & ofxRectangleSlider::changeSlider);
+        listeners.push(x.newListener(this, & ofxRectangleSlider::changeSlider));
 	
 		ofParameter<float> y("y", val.y, min.y, max.y);
         add(createGuiElement<ofxSlider<float>>(y, width, height));
-        y.addListener(this, & ofxRectangleSlider::changeSlider);
+        listeners.push(y.newListener(this, & ofxRectangleSlider::changeSlider));
 
     	ofParameter<float> w("width", val.width, min.width, max.width);
         add(createGuiElement<ofxSlider<float>>(w, width, height));
-        w.addListener(this, & ofxRectangleSlider::changeSlider);
+        listeners.push(w.newListener(this, & ofxRectangleSlider::changeSlider));
 
 		ofParameter<float> h("height", val.height, min.height, max.height);
         add(createGuiElement<ofxSlider<float>>(h, width, height));
-        h.addListener(this, & ofxRectangleSlider::changeSlider);
+        listeners.push(h.newListener(this, & ofxRectangleSlider::changeSlider));
 
 
     sliderChanging = false;

--- a/addons/ofxGui/src/ofxSliderGroup.h
+++ b/addons/ofxGui/src/ofxSliderGroup.h
@@ -26,6 +26,7 @@ protected:
 	static size_t dim();
     ofParameter<VecType> value;
     bool sliderChanging;
+	ofEventListeners listeners;
 };
 
 typedef ofxVecSlider_<ofDefaultVec3> ofxVec3Slider;
@@ -58,6 +59,7 @@ protected:
 	ofColor originalHeaderBackground;
 	ofColor originalHeaderText;
 	ofxColorPicker_<ColorType> picker;
+	ofEventListeners listeners;
 };
 typedef ofxColorSlider_<unsigned char> ofxColorSlider;
 typedef ofxColorSlider_<unsigned short> ofxShortColorSlider;
@@ -84,4 +86,5 @@ protected:
     bool sliderChanging;
     void changeSlider(const void * parameter, float & value);
 	void changeValue(ofRectangle & value);
+	ofEventListeners listeners;
 };


### PR DESCRIPTION
 ofxGui:: ofxSliderGroup: properly removing listeners which could lead to a crash when dynamically creating ofxGui objects
    ofxGuiGroup: added missing creation of sliders for an ofParameter<ofRectangle> when adding an ofParameterGRoup containing it