### PR TITLE
Bugfix ofParameter change name

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -483,3 +483,15 @@ void ofxBaseGui::disableHiDpi(){
 bool ofxBaseGui::isHiDpiEnabled(){
 	return hiDpiScale == 2;
 }
+
+void ofxBaseGui::nameChanged( std::string& )
+{
+	auto& p = getParameter();
+
+	setNeedsRedraw();
+	
+}
+void ofxBaseGui::setNameListener()
+{
+ 	nameChangeListener = getParameter().nameChangedEvent().newListener(this, &ofxBaseGui::nameChanged);
+}

--- a/addons/ofxGui/src/ofxBaseGui.h
+++ b/addons/ofxGui/src/ofxBaseGui.h
@@ -142,10 +142,17 @@ class ofxBaseGui {
 
 		void setNeedsRedraw();
 		ofCoreEvents * events = nullptr;
+		
+		void setNameListener();
+	
 	private:
 		bool needsRedraw;
 		unsigned long currentFrame;
 		bool bRegisteredForMouseEvents;
+	
+		ofEventListener nameChangeListener;
+	
+		void nameChanged( std::string& );
 	
 		//std::vector<ofEventListener> coreListeners;
 };

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -26,7 +26,7 @@ ofxButton* ofxButton::setup(ofParameter<void> _bVal, float width, float height){
 	registerMouseEvents();
 
 	value.addListener(this,&ofxButton::valueChanged);
-
+	setNameListener();
 	return this;
 }
 
@@ -43,7 +43,7 @@ ofxButton* ofxButton::setup(const std::string& toggleName, float width, float he
 	registerMouseEvents();
 
 	value.addListener(this,&ofxButton::valueChanged);
-
+	setNameListener();
 	return this;
 }
 

--- a/addons/ofxGui/src/ofxColorPicker.cpp
+++ b/addons/ofxGui/src/ofxColorPicker.cpp
@@ -168,6 +168,8 @@ ofxColorPicker_<ColorType> * ofxColorPicker_<ColorType>::setup(ofParameter<ofCol
     listener = color.newListener(colorChanged);
 	setShape(b.x, b.y, w, h);
 	colorChanged(color.get());//needs this so the color wheel shows the correct color once setup.
+	setNameListener();
+	
 	return this;
 }
 template<class ColorType>

--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -131,6 +131,7 @@ ofxGuiGroup * ofxGuiGroup::setup(const ofParameterGroup & _parameters, const std
 	parameters = _parameters;
 	registerMouseEvents();
 
+	setNameListener();
 	setNeedsRedraw();
 
 	return this;

--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -148,6 +148,7 @@ ofxInputField<Type>* ofxInputField<Type>::setup(ofParameter<Type> _val, float wi
 	listeners.push(value.newListener(this,&ofxInputField::valueChanged));
 	listeners.push(ofEvents().charEvent.newListener(this, &ofxInputField<Type>::charPressed, OF_EVENT_ORDER_BEFORE_APP));
 	listeners.push(ofEvents().keyPressed.newListener(this, &ofxInputField<Type>::keyPressed, OF_EVENT_ORDER_BEFORE_APP));
+	setNameListener();
 	return this;
 }
 

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -57,7 +57,7 @@ ofxSlider<Type>* ofxSlider<Type>::setup(ofParameter<Type> _val, float width, flo
 
 	value.addListener(this,&ofxSlider::valueChanged);
 	registerMouseEvents();
-
+	setNameListener();
 	input.setup(_val, width, height);
 	return this;
 }

--- a/addons/ofxGui/src/ofxSliderGroup.cpp
+++ b/addons/ofxGui/src/ofxSliderGroup.cpp
@@ -29,6 +29,7 @@ ofxVecSlider_<VecType> * ofxVecSlider_<VecType>::setup(ofParameter<VecType> valu
     }
 
     sliderChanging = false;
+	setNameListener();
     return this;
 
 }
@@ -154,7 +155,7 @@ ofxColorSlider_<ColorType> * ofxColorSlider_<ColorType>::setup(ofParameter<ofCol
 	add(&picker);
 	listeners.push(picker.getParameter().template cast<ofColor_<ColorType>>().newListener(this, & ofxColorSlider_::changeValue));
 
-
+	setNameListener();
 	sliderChanging = false;
 	minimize();
     return this;
@@ -294,7 +295,7 @@ ofxRectangleSlider * ofxRectangleSlider::setup(ofParameter<ofRectangle> value, f
         add(createGuiElement<ofxSlider<float>>(h, width, height));
         listeners.push(h.newListener(this, & ofxRectangleSlider::changeSlider));
 
-
+	setNameListener();
     sliderChanging = false;
     return this;
 

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -22,7 +22,7 @@ ofxToggle * ofxToggle::setup(ofParameter<bool> _bVal, float width, float height)
 	value.addListener(this,&ofxToggle::valueChanged);
 	registerMouseEvents();
 	setNeedsRedraw();
-
+	setNameListener();
 	return this;
 
 }

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -83,26 +83,14 @@ void ofParameter<void>::setName(const string & name){
     std::string oldName = getEscapedName();
 	obj->name = name;
     
-    // Notify all parents, if there are any.
-    if(!obj->parents.empty())
-    {
-        // Erase each invalid parent
-        obj->parents.erase(std::remove_if(obj->parents.begin(),
-                                          obj->parents.end(),
-                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
-                           obj->parents.end());
+	ofParameterGroup::changeChildName(this, obj->parents, oldName, getEscapedName());
+	
+}
 
-        // notify all leftover (valid) parents of this object's changed value.
-        // this can't happen in the same iterator as above, because a notified listener
-        // might perform similar cleanups that would corrupt our iterator
-        // (which appens for example if the listener calls getFirstParent on us)
-        for(auto & parent: obj->parents){
-            auto p = parent.lock();
-            if(p){
-                p->notifyParameterNameChanged(oldName, getEscapedName());
-            }
-        }
-    }
+
+ofEvent<std::string>& ofParameter<void>::nameChangedEvent()
+{
+	return obj->nameChangedEvent;
 }
 
 string ofParameter<void>::getName() const{
@@ -131,11 +119,8 @@ void ofParameter<void>::trigger(){
     // Notify all parents, if there are any.
     if(!obj->parents.empty())
     {
-        // Erase each invalid parent
-        obj->parents.erase(std::remove_if(obj->parents.begin(),
-                                          obj->parents.end(),
-                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
-                           obj->parents.end());
+		// Erase each invalid parent
+		ofParameterGroup::checkAndRemoveExpiredParents(obj->parents);
         
         // notify all leftover (valid) parents of this object's changed value.
         // this can't happen in the same iterator as above, because a notified listener
@@ -156,10 +141,7 @@ void ofParameter<void>::trigger(const void * sender){
     if(!obj->parents.empty())
     {
         // Erase each invalid parent
-        obj->parents.erase(std::remove_if(obj->parents.begin(),
-                                          obj->parents.end(),
-                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
-                           obj->parents.end());
+		ofParameterGroup::checkAndRemoveExpiredParents(obj->parents);
         
         // notify all leftover (valid) parents of this object's changed value.
         // this can't happen in the same iterator as above, because a notified listener

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -80,7 +80,29 @@ ofParameter<void>::ofParameter(const string& name)
 }
 
 void ofParameter<void>::setName(const string & name){
+    std::string oldName = getEscapedName();
 	obj->name = name;
+    
+    // Notify all parents, if there are any.
+    if(!obj->parents.empty())
+    {
+        // Erase each invalid parent
+        obj->parents.erase(std::remove_if(obj->parents.begin(),
+                                          obj->parents.end(),
+                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
+                           obj->parents.end());
+
+        // notify all leftover (valid) parents of this object's changed value.
+        // this can't happen in the same iterator as above, because a notified listener
+        // might perform similar cleanups that would corrupt our iterator
+        // (which appens for example if the listener calls getFirstParent on us)
+        for(auto & parent: obj->parents){
+            auto p = parent.lock();
+            if(p){
+                p->notifyParameterNameChanged(oldName, getEscapedName());
+            }
+        }
+    }
 }
 
 string ofParameter<void>::getName() const{

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -432,6 +432,13 @@ void ofParameterGroup::Value::notifyParameterChanged(ofAbstractParameter & param
 	}),parents.end());
 }
 
+void ofParameterGroup::Value::notifyParameterNameChanged(const std::string oldName, const std::string newName){
+    if(oldName != newName){
+        parametersIndex[newName] = parametersIndex[oldName];
+        parametersIndex.erase(oldName);
+    }
+}
+
 const ofParameterGroup ofParameterGroup::getFirstParent() const{
 	auto first = std::find_if(obj->parents.begin(),obj->parents.end(),[](const weak_ptr<Value> & p){return p.lock()!=nullptr;});
 	if(first!=obj->parents.end()){


### PR DESCRIPTION
As discussed in #6576 and PlaymodesStudio/openframeworks#1 this PR fixes the issue when a parameter changed it's name.
It adds an event dispatched by ofParameter when the name is changed to its parents, which can also be captured externally.
Also adds implementations for ofxGui capturing those events and updating the gui accordingly.
cc @roymacdonald 