### PR TITLE
fixes wrong OF_ROOT path for make files. closes #6650

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -195,6 +195,16 @@ function createProjectFiles {
             pg_platform=$pkg_platform
         fi
         ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator_debug --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples > /dev/null
+        
+        #fix config.make because the project generator is putting in the full path to the OF_ROOT as it is designed to do.
+        #in this case we actually don't want to set it as the default of ../../../ is fine.
+        for example_group in $pkg_ofroot/examples/*; do
+            for example in $example_group/*; do
+                if [ -d $example ]; then
+                    sed -i 's/^OF_ROOT =.*/# OF_ROOT = ..\/..\/..\//' $example/config.make
+                fi
+            done
+        done
     elif [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ]; then
         for example_group in $pkg_ofroot/examples/*; do
             for example in $example_group/*; do


### PR DESCRIPTION
The project generator was correctly setting the OF_ROOT path for the config.make files. 
For the nightly builds though and package generation this wasn't desired. 

Closes #6650