### PR TITLE
fix downloader to check if $2 is set first before testing its value.

### DIFF
--- a/scripts/dev/downloader.sh
+++ b/scripts/dev/downloader.sh
@@ -18,7 +18,10 @@ downloader() {
 	then printDownloaderHelp; fi
 
     	SILENTARGS="";
-    	if [ "$2" == "-s" ]; then
+        if [ $# -ge 2  ]; then
+            SILENTARGS=$2
+        fi
+        if [[ "${SILENTARGS}" == "-s" ]]; then
 		if command -v curl 2>/dev/null; then 
     			curl -LO --retry 20 -O -s $@; 
     		else 


### PR DESCRIPTION
The nightly build script was broken by #5848 because $2 ( for silent args ) wasn't been checked if set before testings its value.
I tried a few different solutions that felt like they should of worked but didn't.
These changes fixes the downloader function.