### PR TITLE
fixes ofImage grabScreen and resize getting swapped R and B.

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -1193,7 +1193,6 @@ void ofImage_<PixelType>::changeTypeOfPixels(ofPixels_<PixelType> &pix, ofImageT
 	FIBITMAP * convertedBmp = nullptr;
 
     ofPixelFormat oldPixFormat = pix.getPixelFormat();
-    int oldNumChannels = pix.getNumChannels();
 
 	switch (newType){
 		case OF_IMAGE_GRAYSCALE:
@@ -1214,17 +1213,14 @@ void ofImage_<PixelType>::changeTypeOfPixels(ofPixels_<PixelType> &pix, ofImageT
     putBmpIntoPixels(convertedBmp, pix, false);
     
     // if we started with BGRA or BGR pixels make sure we end up with similar
-    // when we add or drop  a channel
-    if( oldNumChannels >= 3 && pix.getNumChannels() >= 3 ){
-        if( oldPixFormat == OF_PIXELS_BGR || oldPixFormat == OF_PIXELS_BGRA ){
-            ofPixelFormat fixedFormat = pix.getPixelFormat();
-            if( fixedFormat == OF_PIXELS_RGBA ){
-                fixedFormat = OF_PIXELS_BGRA;
-            }else if( fixedFormat == OF_PIXELS_RGB ){
-                fixedFormat = OF_PIXELS_BGR;
-            }
-            pix.setFromPixels(pix.getData(),pix.getWidth(),pix.getHeight(), fixedFormat);
+    if( pix.getNumChannels() >= 3 && ( oldPixFormat == OF_PIXELS_BGR || oldPixFormat == OF_PIXELS_BGRA ) ){
+        ofPixelFormat fixedFormat = pix.getPixelFormat();
+        if( fixedFormat == OF_PIXELS_RGBA ){
+            fixedFormat = OF_PIXELS_BGRA;
+        }else if( fixedFormat == OF_PIXELS_RGB ){
+            fixedFormat = OF_PIXELS_BGR;
         }
+        pix.setFromPixels(pix.getData(),pix.getWidth(),pix.getHeight(), fixedFormat);
     }
 
 	if (bmp != nullptr) {

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -95,7 +95,7 @@ FIBITMAP* getBmpFromPixels(const ofPixels_<PixelType> &pix){
 
 //----------------------------------------------------
 template<typename PixelType>
-void putBmpIntoPixels(FIBITMAP * bmp, ofPixels_<PixelType>& pix, bool swapOnLittleEndian = true) {
+void putBmpIntoPixels(FIBITMAP * bmp, ofPixels_<PixelType>& pix, bool swapOnLittleEndian = true, bool bUsePassedPixelFormat = false) {
 
 	// convert to correct type depending on type of input bmp and PixelType
 	FIBITMAP* bmpConverted = nullptr;
@@ -138,15 +138,19 @@ void putBmpIntoPixels(FIBITMAP * bmp, ofPixels_<PixelType>& pix, bool swapOnLitt
 
 
 	ofPixelFormat pixFormat;
-    if(channels==1) pixFormat=OF_PIXELS_GRAY;
-    if(swapRG){
-		if(channels==3) pixFormat=OF_PIXELS_BGR;
-		if(channels==4) pixFormat=OF_PIXELS_BGRA;
-	}else{
-		if(channels==3) pixFormat=OF_PIXELS_RGB;
-		if(channels==4) pixFormat=OF_PIXELS_RGBA;
+    if( bUsePassedPixelFormat ){
+        pixFormat = pix.getPixelFormat();
+    }else{
+        if(channels==1) pixFormat=OF_PIXELS_GRAY;
+        if(swapRG){
+            if(channels==3) pixFormat=OF_PIXELS_BGR;
+            if(channels==4) pixFormat=OF_PIXELS_BGRA;
+        }else{
+            if(channels==3) pixFormat=OF_PIXELS_RGB;
+            if(channels==4) pixFormat=OF_PIXELS_RGBA;
+        }
     }
-
+    
 	// ofPixels are top left, FIBITMAP is bottom left
 	FreeImage_FlipVertical(bmp);
 
@@ -364,6 +368,9 @@ static bool saveImage(const ofPixels_<PixelType> & _pix, const std::filesystem::
 	}
 	if(fif==FIF_JPEG && (_pix.getNumChannels()==4 || _pix.getBitsPerChannel() > 8)){
 		ofPixels pix3 = _pix;
+        if( pix3.getPixelFormat() == OF_PIXELS_BGRA ){
+            pix3.swapRgb();
+        }
 		pix3.setNumChannels(3);
 		return saveImage(pix3,_fileName,qualityLevel);
 	}
@@ -457,6 +464,9 @@ static bool saveImage(const ofPixels_<PixelType> & _pix, ofBuffer & buffer, ofIm
 
 	if(format==OF_IMAGE_FORMAT_JPEG && (_pix.getNumChannels()==4 || _pix.getBitsPerChannel() > 8)){
 		ofPixels pix3 = _pix;
+        if( pix3.getPixelFormat() == OF_PIXELS_BGRA ){
+            pix3.swapRgb();
+        }
 		pix3.setNumChannels(3);
 		return saveImage(pix3,buffer,format,qualityLevel);
 	}
@@ -1164,7 +1174,7 @@ void ofImage_<PixelType>::resizePixels(ofPixels_<PixelType> &pix, int newWidth, 
 	FIBITMAP * convertedBmp			= nullptr;
 
 	convertedBmp = FreeImage_Rescale(bmp, newWidth, newHeight, FILTER_BICUBIC);
-    putBmpIntoPixels(convertedBmp, pix, false);
+    putBmpIntoPixels(convertedBmp, pix, false, true);
 
 	if (bmp != nullptr)				FreeImage_Unload(bmp);
 	if (convertedBmp != nullptr)		FreeImage_Unload(convertedBmp);
@@ -1181,6 +1191,9 @@ void ofImage_<PixelType>::changeTypeOfPixels(ofPixels_<PixelType> &pix, ofImageT
 
 	FIBITMAP * bmp = getBmpFromPixels(pix);
 	FIBITMAP * convertedBmp = nullptr;
+
+    ofPixelFormat oldPixFormat = pix.getPixelFormat();
+    int oldNumChannels = pix.getNumChannels();
 
 	switch (newType){
 		case OF_IMAGE_GRAYSCALE:
@@ -1199,6 +1212,20 @@ void ofImage_<PixelType>::changeTypeOfPixels(ofPixels_<PixelType> &pix, ofImageT
 	}
 
     putBmpIntoPixels(convertedBmp, pix, false);
+    
+    // if we started with BGRA or BGR pixels make sure we end up with similar
+    // when we add or drop  a channel
+    if( oldNumChannels >= 3 && pix.getNumChannels() >= 3 ){
+        if( oldPixFormat == OF_PIXELS_BGR || oldPixFormat == OF_PIXELS_BGRA ){
+            ofPixelFormat fixedFormat = pix.getPixelFormat();
+            if( fixedFormat == OF_PIXELS_RGBA ){
+                fixedFormat = OF_PIXELS_BGRA;
+            }else if( fixedFormat == OF_PIXELS_RGB ){
+                fixedFormat = OF_PIXELS_BGR;
+            }
+            pix.setFromPixels(pix.getData(),pix.getWidth(),pix.getHeight(), fixedFormat);
+        }
+    }
 
 	if (bmp != nullptr) {
 		FreeImage_Unload(bmp);


### PR DESCRIPTION
closes #6528

Also address another edge case where changing the number of channels for `OF_IMAGE_COLOR` or `OF_IMAGE_COLOR_ALPHA` can assumer RGB(A) when BGR(A) 

