### PR TITLE
core: fix GLM warnings 

### DIFF
--- a/libs/openFrameworks/math/ofVectorMath.h
+++ b/libs/openFrameworks/math/ofVectorMath.h
@@ -18,7 +18,6 @@
 #include "glm/trigonometric.hpp"
 #include "glm/exponential.hpp"
 #include "glm/vector_relational.hpp"
-#include "glm/ext.hpp"
 
 #include "glm/gtc/constants.hpp"
 #include "glm/gtc/matrix_transform.hpp"


### PR DESCRIPTION
Fix #6496 fix class-memaccess warning on unused glm types