### PR TITLE
Fix ofx network

### DIFF
--- a/addons/ofxNetwork/src/ofxNetworkUtils.cpp
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.cpp
@@ -3,13 +3,18 @@
 #include "ofUtils.h"
 
 
-
-int ofxNetworkCheckErrno(const char* file, int line) {
+//-----------------------------------------------------------------
+int ofxNetworkGetLastError(){
 	#ifdef TARGET_WIN32
-		int	err	= WSAGetLastError();
+		return WSAGetLastError();
 	#else
-		int err = errno;
+		return errno;
 	#endif
+}
+
+
+//-----------------------------------------------------------------
+void ofxNetworkLogError(int err, const char* file, int line){
 	switch(err){
 	case 0:
 		break;
@@ -111,6 +116,12 @@ int ofxNetworkCheckErrno(const char* file, int line) {
 		ofLogVerbose("ofxNetwork") << file << ": " << line << " unknown error: " << err << " see errno.h for description of the error";
 		break;
 	}
+}
 
+
+//-----------------------------------------------------------------
+int ofxNetworkCheckErrno(const char* file, int line) {
+	int err = ofxNetworkGetLastError();
+	ofxNetworkLogError( err, file, line );
 	return err;
 }

--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -19,6 +19,48 @@
 #define OFXNETWORK_ERROR(name)	E ## name
 #endif
 
+/**
+ * @brief Log the latest network error and where it happened (file and line)
+ * 
+ */
 #define ofxNetworkCheckError() ofxNetworkCheckErrno(__FILE__, __LINE__)
+#define ofxNetworkLogLastError() ofxNetworkLogError(ofxNetworkGetLastError(), __FILE__, __LINE__)
 
+/**
+ * @brief returns error code from the last network function
+ * 
+ * @return int 
+ */
+int ofxNetworkGetLastError();
+
+
+/**
+ * @brief Logs the network error err using ofLogError.
+ * 
+ * @param err 
+ * @param file 
+ * @param line 
+ * @return int 
+ */
+
+
+/**
+ * @brief Logs the network error err using ofLogError.
+ * 
+ * @param err the network error
+ * @param file the file where the error happened, generally __FILE__
+ * @param line the line where the error happened, generally __LINE__
+ */
+void ofxNetworkLogError(int err, const char* file=__FILE__, int line=__LINE__-1);
+
+/**
+ * @brief 
+ * 
+ * @param file 
+ * @param line 
+ * @return int 
+ */
+//OF_DEPRECATED_MSG("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead", int ofxNetworkCheckErrno(const char* file, int line) );
 int ofxNetworkCheckErrno(const char* file, int line);
+
+

--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -24,24 +24,19 @@
  * 
  */
 #define ofxNetworkCheckError() ofxNetworkCheckErrno(__FILE__, __LINE__)
+
+/**
+ * @brief Log the latest network error and where it happened (file and line)
+ * 
+ */
 #define ofxNetworkLogLastError() ofxNetworkLogError(ofxNetworkGetLastError(), __FILE__, __LINE__)
 
 /**
  * @brief returns error code from the last network function
  * 
- * @return int 
+ * @return int the last network error
  */
 int ofxNetworkGetLastError();
-
-
-/**
- * @brief Logs the network error err using ofLogError.
- * 
- * @param err 
- * @param file 
- * @param line 
- * @return int 
- */
 
 
 /**
@@ -54,13 +49,14 @@ int ofxNetworkGetLastError();
 void ofxNetworkLogError(int err, const char* file=__FILE__, int line=__LINE__-1);
 
 /**
- * @brief 
+ * @brief Logs the last network error and returns it; 
  * 
- * @param file 
- * @param line 
- * @return int 
+ * @deprecated use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead
+ * 
+ * @param file the file where the error happened, generally __FILE__
+ * @param line the line where the error happened, generally __LINE__
+ * @return int the last network error
  */
-//OF_DEPRECATED_MSG("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead", int ofxNetworkCheckErrno(const char* file, int line) );
-int ofxNetworkCheckErrno(const char* file, int line);
+OF_DEPRECATED_MSG("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead", int ofxNetworkCheckErrno(const char* file, int line) );
 
 

--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -122,8 +122,8 @@ bool ofxTCPClient::send(string message){
 	message = partialPrevMsg + message + messageDelimiter;
 	message += (char)0; //for flash
 	int ret = TCPClient.SendAll( message.c_str(), message.length() );
-    int errorCode = 0;
-    if(ret<0) errorCode = ofxNetworkCheckError();
+	int errorCode = ofxNetworkGetLastError();
+	if( ret<0 ) ofxNetworkLogError(errorCode);
 	if( isClosingCondition(ret, errorCode) ){
 		ofLogWarning("ofxTCPClient") << "send(): client disconnected";
 		close();
@@ -161,8 +161,8 @@ bool ofxTCPClient::sendRawMsg(const char * msg, int size){
 	tmpBuffSend.append(messageDelimiter.c_str(),messageDelimiter.size());
 
     int ret = TCPClient.SendAll( tmpBuffSend.getData(), tmpBuffSend.size() );
-    int errorCode = 0;
-    if(ret<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+	if( ret<0 ) ofxNetworkLogError(errorCode);
 	if( isClosingCondition(ret, errorCode) ){
 		ofLogWarning("ofxTCPClient") << "sendRawMsg(): client disconnected";
 		close();
@@ -187,8 +187,8 @@ bool ofxTCPClient::sendRawMsg(const char * msg, int size){
 bool ofxTCPClient::sendRaw(string message){
 	if( message.length() == 0) return false;
     int ret = TCPClient.SendAll(message.c_str(), message.length());
-    int errorCode = 0;
-    if(ret<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+    if( ret<0 ) ofxNetworkLogError(errorCode);
 	if( isClosingCondition(ret, errorCode) ){
 		ofLogError("ofxTCPClient") << "sendRawBytes(): sending failed";
 		close();
@@ -202,8 +202,8 @@ bool ofxTCPClient::sendRaw(string message){
 bool ofxTCPClient::sendRawBytes(const char* rawBytes, const int numBytes){
 	if( numBytes <= 0) return false;
 	int ret = TCPClient.SendAll(rawBytes, numBytes);
-    int errorCode = 0;
-    if(ret<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+    if( ret<0 ) ofxNetworkLogError(errorCode);
 	if( isClosingCondition(ret, errorCode) ){
 		ofLogError("ofxTCPClient") << "sendRawBytes(): sending failed";
 		close();
@@ -255,8 +255,8 @@ string ofxTCPClient::receive(){
 		}
 
 		// check for connection reset or disconnection
-		int errorCode = 0;
-		if(length<0) errorCode = ofxNetworkCheckError();
+		int errorCode = ofxNetworkGetLastError();
+		if( length<0 ) ofxNetworkLogError(errorCode);
 		if(isClosingCondition(length,errorCode)){
 			close();
 			if(tmpStr.length()==0) {
@@ -323,8 +323,8 @@ int ofxTCPClient::receiveRawMsg(char * receiveBuffer, int numBytes){
 //--------------------------
 int ofxTCPClient::receiveRawBytes(char * receiveBuffer, int numBytes){
     messageSize = TCPClient.Receive(receiveBuffer, numBytes);
-    int errorCode = 0;
-    if(messageSize<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+    if(messageSize<0) ofxNetworkLogError(errorCode);
 	//	0 is not an error... -1 is
 	if(isClosingCondition(messageSize, errorCode)){
 		close();
@@ -335,8 +335,8 @@ int ofxTCPClient::receiveRawBytes(char * receiveBuffer, int numBytes){
 //--------------------------
 int ofxTCPClient::peekReceiveRawBytes(char * receiveBuffer, int numBytes){
     messageSize = TCPClient.PeekReceive(receiveBuffer, numBytes);
-    int errorCode = 0;
-    if(messageSize<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+    if(messageSize<0) ofxNetworkLogError(errorCode);
     if(isClosingCondition(messageSize, errorCode)){
 		close();
 	}
@@ -346,8 +346,8 @@ int ofxTCPClient::peekReceiveRawBytes(char * receiveBuffer, int numBytes){
 //--------------------------
 string ofxTCPClient::receiveRaw(){
     messageSize = TCPClient.Receive(tmpBuff, TCP_MAX_MSG_SIZE);
-    int errorCode = 0;
-    if(messageSize<0) errorCode = ofxNetworkCheckError();
+    int errorCode = ofxNetworkGetLastError();
+    if(messageSize<0) ofxNetworkLogError(errorCode);
 	if(isClosingCondition(messageSize, errorCode)){
 		close();
 	}else if(messageSize>=0 && messageSize<TCP_MAX_MSG_SIZE) {

--- a/addons/ofxNetwork/src/ofxTCPManager.cpp
+++ b/addons/ofxNetwork/src/ofxTCPManager.cpp
@@ -52,9 +52,9 @@ bool ofxTCPManager::Close()
 	#endif
 		{
 			//	if it's reported we're not/no longer a socket, let it fall through and be invalidated
-			int Error = ofxNetworkCheckError();
-			if ( Error != OFXNETWORK_ERROR(NOTSOCK) )
-			{
+			int err = ofxNetworkGetLastError();
+			if( err != OFXNETWORK_ERROR(NOTSOCK) ){
+				ofxNetworkLogError( err, __FILE__, __LINE__-2 );
 				return(false);
 			}
 		}
@@ -129,7 +129,7 @@ bool ofxTCPManager::Create()
 
 	bool ret = (m_hSocket != INVALID_SOCKET);
 
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 
 	return ret;
 }
@@ -141,7 +141,7 @@ bool ofxTCPManager::Listen(int iMaxConnections)
 	if (m_hSocket == INVALID_SOCKET) return(false);
 	m_iMaxConnections = iMaxConnections;
 	bool ret = (listen(m_hSocket, iMaxConnections)!= SOCKET_ERROR);
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 	return ret;
 }
 
@@ -158,13 +158,13 @@ bool ofxTCPManager::Bind(unsigned short usPort, bool bReuse)
 	if (bReuse) {
 		int enable = 1;
 		if (setsockopt(m_hSocket,SOL_SOCKET,SO_REUSEADDR,(char*)&enable,sizeof(int)) < 0){
-			ofxNetworkCheckError();
+			ofxNetworkLogLastError();
 			return false;
 		}
 	}
 
 	if (::bind(m_hSocket,(struct sockaddr*)&local,sizeof(local))){
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 	return true;
@@ -189,7 +189,7 @@ bool ofxTCPManager::Accept(ofxTCPManager& sConnect)
 	  FD_SET(m_hSocket, &fd);
 	  timeval tv= {(time_t)m_dwTimeoutAccept, 0};
 	  if(select(0, &fd, NULL, NULL, &tv) == 0) {
-		  ofxNetworkCheckError();
+		  ofxNetworkLogLastError();
 		  return(false);
 	  }
   }
@@ -197,7 +197,7 @@ bool ofxTCPManager::Accept(ofxTCPManager& sConnect)
   iSize= sizeof(sockaddr_in);
   sConnect.m_hSocket = accept(m_hSocket, (sockaddr*)&addr, &iSize);
   bool ret = (sConnect.m_hSocket != INVALID_SOCKET);
-  if(!ret && !m_closing) ofxNetworkCheckError();
+  if(!ret && !m_closing) ofxNetworkLogLastError();
   return ret;
 }
 
@@ -226,20 +226,24 @@ bool ofxTCPManager::Connect(const char *pAddrStr, unsigned short usPort)
 	}
 
     int ret = connect(m_hSocket, (sockaddr *)&addr_in, sizeof(sockaddr));
-    int err = 0;
-    if(ret<0) err = ofxNetworkCheckError();
-    // set a timeout
-    if (ret < 0 && (err == OFXNETWORK_ERROR(INPROGRESS) || err == OFXNETWORK_ERROR(WOULDBLOCK)) && m_dwTimeoutConnect != NO_TIMEOUT) {
-		ret = WaitSend(m_dwTimeoutConnect, 0);
-		if(ret == 0) {
-			socklen_t len = sizeof err;
-			if (getsockopt(m_hSocket, SOL_SOCKET, SO_ERROR, (char*)&err, &len)<0){
-				ret = SOCKET_ERROR;
-			}else if(err != 0) {
-				ret = SOCKET_ERROR;
-            } 
+    int err = ofxNetworkGetLastError(); int errline=__LINE__;
+	if( ret < 0 ){
+		// set a timeout
+		if ((err == OFXNETWORK_ERROR(INPROGRESS) || err == OFXNETWORK_ERROR(WOULDBLOCK)) && m_dwTimeoutConnect != NO_TIMEOUT) {
+			ret = WaitSend(m_dwTimeoutConnect, 0);
+			if(ret == 0) {
+				socklen_t len = sizeof err;
+				if (getsockopt(m_hSocket, SOL_SOCKET, SO_ERROR, (char*)&err, &len)<0){
+					ret = SOCKET_ERROR;
+				}else if(err != 0) {
+					ret = SOCKET_ERROR;
+				} 
+			}
+		}else{
+			ofxNetworkLogError( err, __FILE__, errline );
 		}
-    }
+	}
+    
 
 	if(m_dwTimeoutConnect != NO_TIMEOUT){
 		SetNonBlocking(wasBlocking);
@@ -312,7 +316,7 @@ bool ofxTCPManager::SetNonBlocking(bool useNonBlocking)
 
 	bool ret = (retVal >= 0);
 	if(!ret){
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		nonBlocking = prevNonBlocking;
 	}
 
@@ -500,7 +504,7 @@ bool ofxTCPManager::GetRemoteAddr(LPINETADDR pInetAddr)
 
 	iSize= sizeof(sockaddr);
 	bool ret = (getpeername(m_hSocket, (sockaddr *)pInetAddr, &iSize) != SOCKET_ERROR);
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 	return ret;
 }
 
@@ -517,7 +521,7 @@ bool ofxTCPManager::GetInetAddr(LPINETADDR pInetAddr)
 
 	iSize= sizeof(sockaddr);
 	bool ret = (getsockname(m_hSocket, (sockaddr *)pInetAddr, &iSize) != SOCKET_ERROR);
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 	return ret;
 }
 
@@ -558,7 +562,7 @@ int ofxTCPManager::GetReceiveBufferSize() {
 	int sizeBuffer=0;
 	size = sizeof(int);
 	int ret = getsockopt(m_hSocket, SOL_SOCKET, SO_RCVBUF, (char*)&sizeBuffer, &size);
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 	return sizeBuffer;
 }
 
@@ -568,7 +572,7 @@ bool ofxTCPManager::SetReceiveBufferSize(int sizeInByte) {
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_RCVBUF, (char*)&sizeInByte, sizeof(sizeInByte)) == 0){
 		return true;
 	}else{
-		 ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }
@@ -585,7 +589,7 @@ int ofxTCPManager::GetSendBufferSize() {
 	int sizeBuffer=0;
 	size = sizeof(int);
 	int ret = getsockopt(m_hSocket, SOL_SOCKET, SO_SNDBUF, (char*)&sizeBuffer, &size);
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 	return sizeBuffer;
 }
 
@@ -595,7 +599,7 @@ bool ofxTCPManager::SetSendBufferSize(int sizeInByte) {
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_SNDBUF, (char*)&sizeInByte, sizeof(sizeInByte)) == 0){
 		return true;
 	}else{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }

--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -48,7 +48,7 @@ bool ofxUDPManager::Close()
 		if(close(m_hSocket) == SOCKET_ERROR)
 	#endif
 	{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return(false);
 	}
 	m_hSocket= INVALID_SOCKET;
@@ -112,7 +112,7 @@ bool ofxUDPManager::Create()
 		#endif
 	}
 	bool ret = m_hSocket !=	INVALID_SOCKET;
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 	return ret;
 }
 
@@ -171,7 +171,7 @@ bool ofxUDPManager::SetNonBlocking(bool useNonBlocking)
 	#endif
 
 	bool ret=(retVal >= 0);
-	if(!ret) ofxNetworkCheckError();
+	if(!ret) ofxNetworkLogLastError();
 	return ret;
 }
 
@@ -183,7 +183,7 @@ bool ofxUDPManager::Bind(unsigned short usPort)
 	//Port MUST	be in Network Byte Order
 	saServer.sin_port =	htons(usPort);
 	int ret = ::bind(m_hSocket,(struct sockaddr*)&saServer,sizeof(struct sockaddr));
-	if(ret == SOCKET_ERROR) ofxNetworkCheckError();
+	if(ret == SOCKET_ERROR) ofxNetworkLogLastError();
 
 	return (ret == 0);
 }
@@ -205,7 +205,7 @@ bool ofxUDPManager::BindMcast(char *pMcast, unsigned short usPort)
 
 	if (setsockopt(m_hSocket, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char FAR*) &mreq, sizeof (mreq)) == SOCKET_ERROR)
 	{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 
@@ -249,7 +249,7 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	{
 #ifdef _DEBUG
 		ofLogError("ofxUDPManager") << "ConnectMcast(): couldn't bind to " << usPort;
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 #endif
 		return false;
 	}
@@ -259,7 +259,7 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	{
 #ifdef _DEBUG
 		ofLogWarning("ofxUDPManager") << "ConnectMcast(): couldn't set TTL; continuing anyway"; 
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 #endif
 	}
 
@@ -267,7 +267,7 @@ bool ofxUDPManager::ConnectMcast(char* pMcast, unsigned short usPort)
 	{
 #ifdef _DEBUG
 		ofLogError("ofxUDPManager") << " ConnectMcast(): couldn't connect to socket";
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 #endif
 		return false;
 	}
@@ -292,7 +292,7 @@ int	ofxUDPManager::Send(const char* pBuff,	const int iSize)
 	}
 
 	int ret = sendto(m_hSocket, (char*)pBuff,	iSize, 0, (sockaddr *)&saClient, sizeof(sockaddr));
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 	return ret;
 	//	return(send(m_hSocket, pBuff, iSize, 0));
 }
@@ -372,7 +372,7 @@ int	ofxUDPManager::PeekReceive()
 	{
 		//assert( Result == SOCKET_ERROR );
 		//	report error
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return SOCKET_ERROR;
 	}
 
@@ -420,9 +420,9 @@ int	ofxUDPManager::Receive(char* pBuff, const int iSize)
 		canGetRemoteAddress = false;
 
 		//	if the network error is WOULDBLOCK, then return 0 instead of SOCKET_ERROR as it's not really a problem, just no data.
-		int SocketError = ofxNetworkCheckError();
-		if ( SocketError == OFXNETWORK_ERROR(WOULDBLOCK) )
-			return 0;
+		int err = ofxNetworkGetLastError();
+		if( err == OFXNETWORK_ERROR(WOULDBLOCK) ) return 0;
+		ofxNetworkLogError( err, __FILE__, __LINE__-2);
 	}
 
 	return ret;
@@ -491,7 +491,7 @@ int	ofxUDPManager::GetMaxMsgSize()
 	#endif
 
 	int ret = getsockopt(m_hSocket, SOL_SOCKET, SO_MAX_MSG_SIZE, (char*)&sizeBuffer, &size);
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 	return sizeBuffer;
 }
 
@@ -509,7 +509,7 @@ int	ofxUDPManager::GetReceiveBufferSize()
 	#endif
 
 	int ret = getsockopt(m_hSocket, SOL_SOCKET, SO_RCVBUF, (char*)&sizeBuffer, &size);
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 	return sizeBuffer;
 }
 
@@ -521,7 +521,7 @@ bool ofxUDPManager::SetReceiveBufferSize(int sizeInByte)
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_RCVBUF, (char*)&sizeInByte, sizeof(sizeInByte)) == 0){
 		return true;
 	}else{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }
@@ -540,7 +540,7 @@ int	ofxUDPManager::GetSendBufferSize()
 	#endif
 
 	int ret = getsockopt(m_hSocket, SOL_SOCKET, SO_SNDBUF, (char*)&sizeBuffer, &size);
-	if(ret==-1) ofxNetworkCheckError();
+	if(ret==-1) ofxNetworkLogLastError();
 
 	return sizeBuffer;
 }
@@ -553,7 +553,7 @@ bool ofxUDPManager::SetSendBufferSize(int sizeInByte)
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_SNDBUF, (char*)&sizeInByte, sizeof(sizeInByte)) == 0){
 		return true;
 	}else{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }
@@ -570,7 +570,7 @@ bool ofxUDPManager::SetReuseAddress(bool allowReuse)
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on)) ==	0){
 		return true;
 	}else{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }
@@ -585,7 +585,7 @@ bool ofxUDPManager::SetEnableBroadcast(bool enableBroadcast)
 	if ( setsockopt(m_hSocket, SOL_SOCKET, SO_BROADCAST, (char*)&on, sizeof(on)) ==	0){
 		return true;
 	}else{
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 }
@@ -608,7 +608,7 @@ int ofxUDPManager::GetTTL()
 #ifdef _DEBUG
 		ofLogError("ofxUDPManager") << "GetTTL(): getsockopt failed";
 #endif
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return -1;
 	}
 
@@ -626,7 +626,7 @@ bool ofxUDPManager::SetTTL(int nTTL)
 #ifdef _DEBUG
 		ofLogError("ofxUDPManager") << "SetTTL(): setsockopt failed";
 #endif
-		ofxNetworkCheckError();
+		ofxNetworkLogLastError();
 		return false;
 	}
 

--- a/tests/addons/networkTcp/src/main.cpp
+++ b/tests/addons/networkTcp/src/main.cpp
@@ -129,7 +129,7 @@ public:
 
 
 		std::vector<char> messageReceived(messageSent.size()+1, 0);
-		int received = 0;
+		std::size_t received = 0;
 		do{
 			auto ret = server.receiveRawBytes(0, messageReceived.data() + received, messageSent.size());
 			ofxTest(ret>0, "received blocking from server");
@@ -164,7 +164,7 @@ public:
 		ofxTest(client.sendRawBytes(messageSent.c_str(), messageSent.size()), "send blocking from client");
 
 		std::vector<char> messageReceived(messageSent.size()+1, 0);
-		int received = 0;
+		std::size_t received = 0;
 		do{
 			auto ret = server.receiveRawBytes(0, messageReceived.data() + received, messageSent.size());
 			ofxTest(ret>0, "received blocking from server");
@@ -223,7 +223,7 @@ public:
 		auto now = ofGetElapsedTimeMillis();
 		// seems timers in the test servers are not very accurate so
 		// we test this with a margin of 500ms
-		ofxTestGt(now-then, 4500, "Connect waits 5s to timeout, waited: " + ofToString(now - then));
+		ofxTestGt(now-then, std::uint64_t(4500), "Connect waits 5s to timeout, waited: " + ofToString(now - then));
 		done.notify_all();
 		serverThread.join();
 	}

--- a/tests/addons/networkUdp/src/main.cpp
+++ b/tests/addons/networkUdp/src/main.cpp
@@ -25,7 +25,7 @@ class ofApp: public ofxUnitTestsApp{
 
 		ofxTest(client.Send(messageSent.c_str(), messageSent.size()), "client send non blocking");
 
-		auto received = 0;
+		std::size_t received = 0;
 		auto left = messageSent.size();
 		for(int i=0;i<10 && received<messageSent.size();i++){
 			auto ret = server.Receive(bufferReceive.data() + received, left);
@@ -124,7 +124,7 @@ class ofApp: public ofxUnitTestsApp{
 		ofxTestEq(ret,SOCKET_TIMEOUT,"socket receive timeout");
 		// seems timers in the test servers are not very accurate so
 		// we test this with a margin of 500ms
-        ofxTestGt(now-then, 4500, "socket receive timeouts after 5s");
+        ofxTestGt(now-then, std::uint64_t(4500), "socket receive timeouts after 5s");
 	}
 
     void testPortsStayBound(){


### PR DESCRIPTION
As proposed in #6457 

-   Deprecate ofxNetworkCheckError()
-   Add int ofxNetworkGetLastError() to return the last error
-   Add void ofxNetworkLogError(int err, const char* file, int line) to log an error that happened on line line in file file
-   Add ofxNetworkLogLastError() that is a shortcut for ofxNetworkLogError(ofxNetworkGetLastError(), __FILE__, __LINE__)
