### PR TITLE
Remove install_name_tool steps for fmod 

### DIFF
--- a/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
+++ b/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
@@ -394,7 +394,6 @@ afterplatform: $(TARGET_NAME)
 ifneq ($(USE_FMOD),0)
 	@mkdir -p bin/$(BIN_NAME).app/Contents/Frameworks
 	@cp $(OF_LIBS_PATH)/*/lib/$(PLATFORM_LIB_SUBPATH)/*.$(SHARED_LIB_EXTENSION) bin/$(BIN_NAME).app/Contents/Frameworks/;
-	@install_name_tool -add_rpath "@executable_path/../Frameworks" bin/$(BIN_NAME).app/Contents/MacOS/$(BIN_NAME);
 endif
 
 	@echo

--- a/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/ofApp.qbs
@@ -127,7 +127,7 @@ CppApplication{
                     if( product.consoleApplication ){
                         return FileInfo.joinPaths(product.destinationDirectory, input.fileName);
                     }else{
-                        return FileInfo.joinPaths(product.destinationDirectory, product.targetName + ".app", "Contents/MacOS", input.fileName);
+                        return FileInfo.joinPaths(product.destinationDirectory, product.targetName + ".app", "Contents/Frameworks", input.fileName);
                     }
                 }
 

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -3393,7 +3393,8 @@ fi
 rsync -aved "$ICON_FILE" "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/"
 # Copy libfmod and change install directory for fmod to run
 rsync -aved "$OF_PATH/libs/fmod/lib/osx/libfmod.dylib" "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/";
-install_name_tool -change @rpath/libfmod.dylib @executable_path/../Frameworks/libfmod.dylib "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME";
+# Not needed as we now call install_name_tool -id @loader_path/../Frameworks/libfmod.dylib libfmod.dylib on the dylib directly which prevents the need for calling every post build - keeping here for reference and possible legacy usage 
+# install_name_tool -change @rpath/libfmod.dylib @executable_path/../Frameworks/libfmod.dylib "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME";
 
 echo "$GCC_PREPROCESSOR_DEFINITIONS";
 </string>


### PR DESCRIPTION
Removed install_name_tool fmod post build step as fmod dylib now has correct path. 
Update qbs template to look for dylibs in Contents/Frameworks/

This should allow Xcode, Makefiles and QT Creator to compile without needing install_name_tool steps