### PR TITLE
Bugfix msys2 ci not working on mingw64

### DIFF
--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -16,4 +16,9 @@ cd $ROOT
 cp scripts/templates/msys2/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
+
+# this is maybe a fix for some weird issues where the linker runs out of address space
+echo "PROJECT_CFLAGS = -fpic -mmode=medium" >> config.make
+echo "PROJECT_OPTIMIZATION_CFLAGS_DEBUG = -Os" >> config.make
+
 make ${USE_CCACHE} -j4 Debug

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -18,7 +18,7 @@ cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
 
 # this is maybe a fix for some weird issues where the linker runs out of address space
-echo "PROJECT_CFLAGS = -fpic -mmode=medium" >> config.make
+echo "PROJECT_CFLAGS = -fpic -mcmodel=medium" >> config.make
 echo "PROJECT_OPTIMIZATION_CFLAGS_DEBUG = -Os" >> config.make
 
 make ${USE_CCACHE} -j4 Debug

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -5,22 +5,15 @@ source $ROOT/scripts/ci/ccache.sh
 
 echo "**** Building OF core ****"
 cd $ROOT/libs/openFrameworksCompiled/project
-make ${USE_CCACHE} -j4 Debug
+make ${USE_CCACHE} -j4 Release
 
 echo "**** Building emptyExample ****"
 cd $ROOT/scripts/templates/msys2
-make ${USE_CCACHE} -j4 Debug
+make ${USE_CCACHE} -j4 Release
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
 cp scripts/templates/msys2/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
-
-# this is maybe a fix for some weird issues where the linker runs out of address space
-if [ "$MSYSTEM" == "MINGW64" ]; then
-    echo "PROJECT_CFLAGS = -fpic -mcmodel=medium" >> config.make
-    echo "PROJECT_OPTIMIZATION_CFLAGS_DEBUG = -Os" >> config.make
-fi
-
-make ${USE_CCACHE} -j4 Debug
+make ${USE_CCACHE} -j4 Release

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -18,7 +18,9 @@ cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
 
 # this is maybe a fix for some weird issues where the linker runs out of address space
-echo "PROJECT_CFLAGS = -fpic -mcmodel=medium" >> config.make
-echo "PROJECT_OPTIMIZATION_CFLAGS_DEBUG = -Os" >> config.make
+if [ "$MSYSTEM" == "MINGW64" ]; then
+    echo "PROJECT_CFLAGS = -fpic -mcmodel=medium" >> config.make
+    echo "PROJECT_OPTIMIZATION_CFLAGS_DEBUG = -Os" >> config.make
+fi
 
 make ${USE_CCACHE} -j4 Debug

--- a/scripts/ci/msys2/run_tests.sh
+++ b/scripts/ci/msys2/run_tests.sh
@@ -12,11 +12,11 @@ for group in *; do
 				cd $test
 				cp ../../../scripts/templates/msys2/Makefile .
 				cp ../../../scripts/templates/msys2/config.make .
-				make ${USE_CCACHE} -j4 Debug
+				make ${USE_CCACHE} -j4 Release
 				cd bin
 				binname=$(basename ${test})
                 #gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug
-				./${binname}_debug.exe
+				./${binname}.exe
 				errorcode=$?
 				if [[ $errorcode -ne 0 ]]; then
 					exit $errorcode


### PR DESCRIPTION
Closes #6683
I think this might be just a CI bug. Seems to be solved by switching to Release ( I think the Debug build of allAddonsExample is taking up too much linker address space ) 

@oxillo if you don't get the errors on desktop then I think this is a safe enough CI fix. 