### PR TITLE
disabled debugging when browsing versions, fixes #6687

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample AppStore.xcscheme
+++ b/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample AppStore.xcscheme
@@ -48,7 +48,7 @@
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
@@ -69,7 +69,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Debug.xcscheme
+++ b/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Debug.xcscheme
@@ -46,7 +46,7 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>
          <BuildableReference
@@ -65,7 +65,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Release.xcscheme
+++ b/scripts/templates/osx/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Release.xcscheme
@@ -46,7 +46,7 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
-      debugDocumentVersioning = "YES"
+      debugDocumentVersioning = "NO"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>
          <BuildableReference
@@ -65,7 +65,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
-      debugDocumentVersioning = "YES">
+      debugDocumentVersioning = "NO">
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"


### PR DESCRIPTION
this prevents xcode from passing unwanted args to the app which makes some command line arg parsers crash