### PR TITLE
bugfix macos arm fullscreen crash. closes #6685

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -252,7 +252,6 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
                     #ifdef TARGET_OSX
 					    //for OS X we need to set this first as the window size affects the window positon
 					    settings.setSize(mode->width, mode->height);
-						setWindowShape(settings.getWidth(), settings.getHeight());
                     #endif
 					setWindowPosition(settings.getPosition().x,settings.getPosition().y);
 					currentW = mode->width;
@@ -263,7 +262,6 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
                 #ifdef TARGET_OSX
 				    auto size = getScreenSize();
 					settings.setSize(size.x, size.y);
-					setWindowShape(settings.getWidth(), settings.getHeight());
                 #endif
 					currentW = settings.getWidth();
 					currentH = settings.getHeight();


### PR DESCRIPTION
Tested on a multi monitor setup and removing these lines, doesn't seem to change anything in a variety of scenarios. 
I think GLFW fixes since we added those lines have made them unnecessary. 

Removing the lines, lets OF start in fullscreen on Arm / M1 macs without crashing. 

Closes #6685 