### PR TITLE
fix regular expression example

### DIFF
--- a/examples/strings/regularExpressionExample/src/ofApp.cpp
+++ b/examples/strings/regularExpressionExample/src/ofApp.cpp
@@ -63,7 +63,7 @@ void ofApp::draw(){
     while(getline(file,line)){
         if(line.empty() == false) {
             string minutes = grepStringInRegex(line, "[0-9]+:[0-9]+");
-            string sentence = grepStringInRegex(line, "[^0-9_:\\[\\]])");
+            string sentence = grepStringInRegex(line, "[^0-9_:\\[\\]]");
             ofDrawBitmapString("Time:"+minutes, 400, posY);
             ofDrawBitmapString("Sentence:"+sentence, 500, posY);
             posY += 20;


### PR DESCRIPTION
hello
the regex example was crashing on osx, m1.
i removed the closing parenthesis. i guess adding an opening one would work as well. not sure this example requires a capture group.

```
libc++abi.dylib: terminating with uncaught exception of type std::__1::regex_error: The parser did not consume the entire regular expression.
terminating with uncaught exception of type std::__1::regex_error: The parser did not consume the entire regular expression.
```