### PR TITLE
videoGrabberExample - set the inverted pixels to actual grabber dimensions

### DIFF
--- a/examples/input_output/imageLoaderWebExample/src/ofApp.cpp
+++ b/examples/input_output/imageLoaderWebExample/src/ofApp.cpp
@@ -12,7 +12,7 @@ void ofApp::setup(){
 
 //--------------------------------------------------------------
 void ofApp::urlResponse(ofHttpResponse & response){
-	if(response.status==200 && response.request.name == "tsingy_forest"){
+	if(response.status==200 && response.request.name == "about"){
 		img.load(response.data);
 		loading=false;
 	}else{

--- a/examples/video/videoGrabberExample/src/ofApp.cpp
+++ b/examples/video/videoGrabberExample/src/ofApp.cpp
@@ -19,10 +19,10 @@ void ofApp::setup(){
     }
 
     vidGrabber.setDeviceID(0);
-    vidGrabber.setDesiredFrameRate(60);
+    vidGrabber.setDesiredFrameRate(30);
     vidGrabber.initGrabber(camWidth, camHeight);
 
-    videoInverted.allocate(camWidth, camHeight, OF_PIXELS_RGB);
+    videoInverted.allocate(vidGrabber.getWidth(), vidGrabber.getHeight(), OF_PIXELS_RGB);
     videoTexture.allocate(videoInverted);
     ofSetVerticalSync(true);
 }


### PR DESCRIPTION
current example was broken on macOS. 