### PR TITLE
Android Fix PS4/PS5 Controller KeyCodes to oF KeyPressed/KeyReleased

### DIFF
--- a/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
+++ b/addons/ofxAndroid/ofAndroidLib/src/cc/openframeworks/OFAndroid.java
@@ -858,8 +858,10 @@ public class OFAndroid {
            		return false;
            	}
         }
-
 		int unicodeChar = event.getUnicodeChar();
+		if(unicodeChar == 0 && keyCode < 256 && keyCode > 0) {
+			unicodeChar = keyCode;
+		}
 		return onKeyDown(keyCode, unicodeChar);
 	}
 	
@@ -871,6 +873,9 @@ public class OFAndroid {
 	 */
 	public static boolean keyUp(int keyCode, KeyEvent event) {
 		int unicodeChar = event.getUnicodeChar();
+		if(unicodeChar == 0 && keyCode < 256 && keyCode > 0) {
+			unicodeChar = keyCode;
+		}
 		return onKeyUp(keyCode, unicodeChar);
 	}
 


### PR DESCRIPTION
Basically current KeyCode parsing in OFAndroid layer parses keys into Unicode or kills them into 0: 

Problem: Controller Keycode: 22 becomes 0 passed back to **keyPressed** - Key should be 22 here:
<img width="747" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/830748/109816812-454b7600-7c85-11eb-9ac5-cbdd4c37d34a.png">
<img width="946" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/830748/109816819-47153980-7c85-11eb-8558-46b0909a6f7b.png">

Source of Problem:
<img width="422" alt="image" src="https://user-images.githubusercontent.com/830748/109817280-da4e6f00-7c85-11eb-9509-80c526e336c4.png">

Fix: Exclusion for Range >0 to < 256
PS5 ranges from 20-> 106

Android Supports Game Controllers for Accessibility and Games and these fall into the < 256 int range so using an exclusion for this range in the OFAndroid Layer that was zeroing out the KeyPressed / KeyReleased events for Hardware Controllers

