### PR TITLE
This change fixes an error message at the start of your application…

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -87,7 +87,7 @@ namespace{
 
     //--------------------------------------------------
     std::filesystem::path & defaultWorkingDirectory(){
-            static auto * defaultWorkingDirectory = new std::filesystem::path();
+            static auto * defaultWorkingDirectory = new std::filesystem::path(ofFilePath::getCurrentExeDir());
             return * defaultWorkingDirectory;
     }
 


### PR DESCRIPTION
…if you call `ofRestoreWorkingDirectoryToDefault();` in your `main` function.

IMPORTANT: only tested on Windows 10.