### PR TITLE
This change fixes a const-correctness problem…

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -843,7 +843,7 @@ void ofFbo::begin(bool setupScreen) const{
 }
 
 
-void ofFbo::begin(ofFboMode mode){
+void ofFbo::begin(ofFboMode mode) const{
     auto renderer = settings.renderer.lock();
     if(renderer){
         renderer->begin(*this, mode);
@@ -1115,11 +1115,14 @@ void ofFbo::updateTexture(int attachmentPoint) {
 
 		auto renderer = settings.renderer.lock();
 		if(renderer){
+			GLint readBuffer;
+			glGetIntegerv(GL_READ_BUFFER, &readBuffer);
+			
 			renderer->bindForBlitting(*this,*this,attachmentPoint);
 			glBlitFramebuffer(0, 0, settings.width, settings.height, 0, 0, settings.width, settings.height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 			renderer->unbind(*this);
-		
-			glReadBuffer(GL_BACK);
+			
+			glReadBuffer(readBuffer);
 		}
 
 		if(!ofIsGLProgrammableRenderer()){

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -149,7 +149,7 @@ public:
     ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
     ///           method instead.
     /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-    void begin(ofFboMode mode = OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP);
+    void begin(ofFboMode mode = OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP) const;
 
 	/// \brief    Ends the current framebuffer render context.
 	/// \sa       void begin(bool setupScreen=true) const;


### PR DESCRIPTION
…with `ofFbo::begin(bool)` and also fixes an issue with `ofbo::updateTexture(int)` where the original read buffer wasn't restored properly after blitting.

IMPORTANT: only tested on Windows 10.