### PR TITLE
bugfix ofAppGLFWWindow requested monitor wasn't being clamped

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -215,6 +215,10 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 	if(settings.windowMode==OF_GAME_MODE){
 		int count;
 		GLFWmonitor** monitors = glfwGetMonitors(&count);
+		if( settings.monitor >= count ){
+			ofLogError("ofAppGLFWWindow") << "requested game mode monitor is: " << settings.monitor << " monitor count is: " << count;
+		}
+		settings.monitor = ofClamp(settings.monitor,0,count-1);
 		if(settings.isSizeSet()){
 			currentW = settings.getWidth();
 			currentH = settings.getHeight();
@@ -238,13 +242,17 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		if(settings.windowMode==OF_FULLSCREEN){
 			int count = 0;
 			auto monitors = glfwGetMonitors(&count);
+			if( settings.monitor >= count ){
+				ofLogError("ofAppGLFWWindow") << "requested fullscreen monitor is: " << settings.monitor << " monitor count is: " << count;
+			}
+			settings.monitor = ofClamp(settings.monitor,0,count-1);
+			
 			auto mode = glfwGetVideoMode(monitors[settings.monitor]);
 			currentW = mode->width;
 			currentH = mode->height;
 			if(!settings.isPositionSet()){
 				if(count > 0){
 					int x = 0, y = 0;
-					settings.monitor = ofClamp(settings.monitor,0,count-1);
 					glfwGetMonitorPos(monitors[settings.monitor],&x,&y);
 					settings.setPosition(glm::vec2(x,y));
 					setWindowPosition(settings.getPosition().x,settings.getPosition().y);


### PR DESCRIPTION
If you did:

```
ofGLFWWindowSettings settings;
settings.monitor = 1;
settings.windowMode = OF_FULLSCREEN;
```

With just one monitor the app would crash as settings.monitor was being used without being clamped  