### PR TITLE
Fixed bug: crash when call ofVAArgsToString("%d", 0);

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1072,7 +1072,10 @@ string ofVAArgsToString(const char * format, ...){
 	return s;
 }
 
-string ofVAArgsToString(const char * format, va_list args){
+template <typename VAList>
+auto ofVAArgsToString(const char * format, VAList args)
+    -> typename std::enable_if<std::is_same<va_list, VAList>::value, string>::type
+{
 	char buf[256];
 	size_t n = std::vsnprintf(buf, sizeof(buf), format, args);
 

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1050,6 +1050,23 @@ size_t ofUTF8Length(const std::string & str){
 	}
 }
 
+//------------------------------------------------
+std::string ofVAListToString(const char * format, va_list args) {
+    char buf[256];
+    size_t n = std::vsnprintf(buf, sizeof(buf), format, args);
+
+    // Static buffer large enough?
+    if (n < sizeof(buf)) {
+        return{ buf, n };
+    }
+
+    // Static buffer too small
+    std::string s(n + 1, 0);
+    std::vsnprintf(const_cast<char*>(s.data()), s.size(), format, args);
+
+    return s;
+}
+
 //--------------------------------------------------
 string ofVAArgsToString(const char * format, ...){
 	va_list args;
@@ -1068,25 +1085,6 @@ string ofVAArgsToString(const char * format, ...){
 	va_start(args, format);
 	std::vsnprintf(const_cast<char*>(s.data()), s.size(), format, args);
 	va_end(args);
-
-	return s;
-}
-
-template <typename VAList>
-auto ofVAArgsToString(const char * format, VAList args)
-    -> typename std::enable_if<std::is_same<va_list, VAList>::value, string>::type
-{
-	char buf[256];
-	size_t n = std::vsnprintf(buf, sizeof(buf), format, args);
-
-	// Static buffer large enough?
-	if (n < sizeof(buf)) {
-		return{ buf, n };
-	}
-
-	// Static buffer too small
-	std::string s(n + 1, 0);
-	std::vsnprintf(const_cast<char*>(s.data()), s.size(), format, args);
 
 	return s;
 }

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -638,7 +638,9 @@ std::string ofVAArgsToString(const char * format, ...);
 /// \param format A printf-style format string.
 /// \param args A variable argument list.
 /// \returns A string representation of the argument list.
-std::string ofVAArgsToString(const char * format, va_list args);
+template <typename VAList>
+auto  ofVAArgsToString(const char * format, VAList args)
+    -> typename std::enable_if<std::is_same<va_list, VAList>::value, std::string>::type;
 
 /// \section String Conversion
 /// \brief Convert a value to a string.

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -631,6 +631,12 @@ size_t ofUTF8Length(const std::string & utf8);
 
 /// \brief Convert a variable length argument to a string.
 /// \param format A printf-style format string.
+/// \param args A variable argument list.
+/// \returns A string representation of the argument list.
+std::string ofVAListToString(const char * format, va_list args);
+
+/// \brief Convert a variable length argument to a string.
+/// \param format A printf-style format string.
 /// \returns A string representation of the argument list.
 std::string ofVAArgsToString(const char * format, ...);
 
@@ -640,7 +646,10 @@ std::string ofVAArgsToString(const char * format, ...);
 /// \returns A string representation of the argument list.
 template <typename VAList>
 auto  ofVAArgsToString(const char * format, VAList args)
-    -> typename std::enable_if<std::is_same<va_list, VAList>::value, std::string>::type;
+    -> typename std::enable_if<std::is_same<va_list, VAList>::value, std::string>::type
+{
+    return ofVAListToString(format, args);
+}
 
 /// \section String Conversion
 /// \brief Convert a value to a string.

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -7,7 +7,7 @@
 #include <iomanip>  //for setprecision
 #include <algorithm>
 #include <sstream>
-
+#include <type_traits>
 
 /// \section Elapsed Time
 /// \brief Reset the elapsed time counter.


### PR DESCRIPTION
when call `ofVAArgsToString("%d", 0);`, second argument `0` will be interpreted to null pointer of `va_list`.
and function overload will be resolved to `auto ofVAArgsToString(const char * format, va_list args)` and crush.

this PR will fix this problem.