### PR TITLE
ofColor::getLightness() - fix overflow error

### DIFF
--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -346,7 +346,7 @@ float ofColor_<PixelType>::getBrightness() const {
 
 template<typename PixelType>
 float ofColor_<PixelType>::getLightness() const {
-	return (r + g + b) / 3.f;
+	return r / 3. + g / 3. + b / 3.;
 }
 
 template<typename PixelType>

--- a/libs/openFrameworks/utils/ofThreadChannel.h
+++ b/libs/openFrameworks/utils/ofThreadChannel.h
@@ -278,6 +278,15 @@ public:
 		return queue.empty();
 	}
 
+
+	/// \brief Queries size of queue.
+	///
+	/// This call is only an approximation, since messages come from a different
+	/// thread.
+	size_t size() const {
+		return queue.size();
+	}
+
 private:
 	/// \brief The FIFO data queue.
 	std::queue<T> queue;


### PR DESCRIPTION
Sorry this also picked up the other commit on ofThreadChannel which is in a seperate PR