### PR TITLE
ofGetUnixTime() return changed to size_t from uint

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -375,8 +375,8 @@ uint64_t ofGetSystemTimeMicros( ) {
 }
 
 //--------------------------------------------------
-unsigned int ofGetUnixTime(){
-	return (unsigned int)time(nullptr);
+size_t ofGetUnixTime(){
+	return static_cast<size_t>(time(nullptr));
 }
 
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -68,7 +68,7 @@ int ofGetHours();
 /// Resolution is in seconds.
 ///
 /// \returns the number of seconds since Midnight, January 1, 1970 (epoch time).
-unsigned int ofGetUnixTime();
+size_t ofGetUnixTime();
 
 /// \brief Get the system time in milliseconds.
 /// \returns the system time in milliseconds.


### PR DESCRIPTION
As discussed on Issue #6738, make ofGetUnixTime() return size_t to hopefully avoid troubles in 2038.