### PR TITLE
Freeimage flags

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -223,9 +223,9 @@ static bool loadImage(ofPixels_<PixelType> & pix, const std::filesystem::path& _
 	if((fif != FIF_UNKNOWN) && FreeImage_FIFSupportsReading(fif)) {
 		if(fif == FIF_JPEG) {
 			int option = getJpegOptionFromImageLoadSetting(settings);
-			bmp = FreeImage_Load(fif, fileName.c_str(), option);
+			bmp = FreeImage_Load(fif, fileName.c_str(), option | settings.freeImageFlags);
 		} else {
-			bmp = FreeImage_Load(fif, fileName.c_str(), 0);
+			bmp = FreeImage_Load(fif, fileName.c_str(), 0 | settings.freeImageFlags);
 		}
 
 		if (bmp != nullptr){
@@ -271,9 +271,9 @@ static bool loadImage(ofPixels_<PixelType> & pix, const ofBuffer & buffer, const
 	//make the image!!
 	if(fif == FIF_JPEG) {
 		int option = getJpegOptionFromImageLoadSetting(settings);
-		bmp = FreeImage_LoadFromMemory(fif, hmem, option);
+		bmp = FreeImage_LoadFromMemory(fif, hmem, option | settings.freeImageFlags);
 	} else {
-		bmp = FreeImage_LoadFromMemory(fif, hmem, 0);
+		bmp = FreeImage_LoadFromMemory(fif, hmem, settings.freeImageFlags);
 	}
 
 	if( bmp != nullptr ){

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -126,6 +126,7 @@ struct ofImageLoadSettings {
 	bool exifRotate = false;
 	bool grayscale = false;
 	bool separateCMYK = false;
+    int freeImageFlags = 0;
 };
 
 //----------------------------------------------------

--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -346,7 +346,7 @@ float ofColor_<PixelType>::getBrightness() const {
 
 template<typename PixelType>
 float ofColor_<PixelType>::getLightness() const {
-	return (r + g + b) / 3.f;
+	return r / 3. + g / 3. + b / 3.;
 }
 
 template<typename PixelType>

--- a/libs/openFrameworks/utils/ofThreadChannel.h
+++ b/libs/openFrameworks/utils/ofThreadChannel.h
@@ -278,6 +278,15 @@ public:
 		return queue.empty();
 	}
 
+
+	/// \brief Queries size of queue.
+	///
+	/// This call is only an approximation, since messages come from a different
+	/// thread.
+	size_t size() const {
+		return queue.size();
+	}
+
 private:
 	/// \brief The FIFO data queue.
 	std::queue<T> queue;


### PR DESCRIPTION
allow the user to send their own flags to freeimage when loading an image through ofLoadImage