### PR TITLE
fix testAllExamples.sh

### DIFF
--- a/scripts/linux/testAllExamples.sh
+++ b/scripts/linux/testAllExamples.sh
@@ -1,40 +1,25 @@
 #!/bin/bash
 
 export LC_ALL=C
-cd ../../examples
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OF_ROOT=$SCRIPT_DIR/../..
 
-for category in $( ls . )
+# parameters
+THREADS=""
+BUILD_TYPE="Release"
+for arg in "$@"
 do
-    if [ "$category" = "android" -o "$category" = "ios" -o "$category" = "gles" ]; then
-            continue
+    if [[ $arg == -j* ]]; then
+        THREADS=$arg
+    elif [[ $arg == "Debug" ]] || [[ $arg == "Release" ]]; then
+        BUILD_TYPE=$arg
     fi
-    cd $category
-    for example in $( ls . )
-    do
-        if [[ "$example" == osx* ]]
-        then
-            continue
-        fi    
-        echo "-----------------------------------------------------------------"
-        echo "building " + $example
-        cd $example
-        make Debug
-        ret=$?
-        if [ $ret -ne 0 ]; then
-          echo error compiling $example
-          exit
-        fi
-        make Release
-        ret=$?
-        if [ $ret -ne 0 ]; then
-          echo error compiling $example
-          exit
-        fi
-        cd bin
-        ./$example
-        cd ../../
-        echo "-----------------------------------------------------------------"
-        echo ""
-    done
-    cd ..
 done
+
+# ignore all example categories we do not want
+# match all subdirectories that end on "Example"
+# enter them, clean, compile and run    
+find $OF_ROOT/examples \
+    -type d \( -name android -o -name ios -o -name gles \) -prune -false \
+    -o -type d -name '*Example' \
+    -exec bash -c "cd {} && make clean && make $BUILD_TYPE $THREADS && make Run$BUILD_TYPE" \;


### PR DESCRIPTION
testAllExamples.sh stumbled over README.md (and eventual qtCreator build-* directories), and then failed.
This fixes it and adds multithreaded compile

#6742