### PR TITLE
ofGetUnixTime() returns 64bit uint now #6738

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -375,8 +375,8 @@ uint64_t ofGetSystemTimeMicros( ) {
 }
 
 //--------------------------------------------------
-unsigned int ofGetUnixTime(){
-	return (unsigned int)time(nullptr);
+uint64_t ofGetUnixTime(){
+	return static_cast<uint64_t>(time(nullptr));
 }
 
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -68,7 +68,7 @@ int ofGetHours();
 /// Resolution is in seconds.
 ///
 /// \returns the number of seconds since Midnight, January 1, 1970 (epoch time).
-unsigned int ofGetUnixTime();
+uint64_t ofGetUnixTime();
 
 /// \brief Get the system time in milliseconds.
 /// \returns the system time in milliseconds.


### PR DESCRIPTION
#6738 ofGetUnixTime() returns uint64_t instead of int