### PR TITLE
Turn off software flow control in serial device [Linux]

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -368,6 +368,7 @@ bool ofSerial::setup(string portName, int baud){
 		options.c_oflag &= (tcflag_t) ~(OPOST);
 		options.c_cflag |= CS8;
 		#if defined( TARGET_LINUX )
+            options.c_iflag &= ~(IXON | IXOFF | IXANY); // turn off software xon/xoff flow ctrl
 			options.c_cflag |= CRTSCTS;
 			options.c_lflag &= ~(ICANON | ECHO | ISIG);
 		#endif


### PR DESCRIPTION
I believe this only affects Linux (and by extension Rasberry Pi). I'm not 100% sure how it affects Windows or Mac so this patch is Linux only.

After having trouble receiving data from an Arduino, I investigated.
Basically I was sending 30 bytes from OF to an Arduino, and then sending the same data back to check if everything was being received correctly. The Arduino seemed to be receiving the right number of bytes, but OF was dropping bytes occasionally while receiving.

I tried playing around with baud rates to no avail.
I then came across this forum post:
https://forum.openframeworks.cc/t/simple-arduino-serial-openframework-missing-bytes/30260/4

I manged to get the correct results using Processing, and after running the Processing equivalent, it somehow set the correct serial flags and it would then work in OF.

Turns out we aren't turning off the serial flow control flags (XON/XOFF), which appear as ASCII bytes 17 and 19, hence the reason for the behaviour in the above post. It appears hardware flow control is being turned on anyway through

```
options.c_cflag |= CRTSCTS;
```

so it doesn't make any sense to have them both turned on.

This is a critical bug that has very likely been affecting the Linux serial port for years. I never was able to use @kylemcdonald 's DMX addon on Linux because of flickering, and I'm guessing this might have been the problem.

https://en.wikipedia.org/wiki/Software_flow_control
https://stackoverflow.com/questions/6947413/how-to-open-read-and-write-from-serial-port-in-c


