### PR TITLE
Fix 6722 of easy cam copy

### DIFF
--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -35,8 +35,8 @@ ofCamera::ofCamera(const ofCamera & camera) :
 	vFlip(vFlip),
 	renderer(renderer)
 { 
-
 }
+
 //----------------------------------------
 ofCamera::~ofCamera() {}
 

--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -24,6 +24,20 @@ vFlip(false)
 }
 
 //----------------------------------------
+ofCamera::ofCamera(const ofCamera & camera) :
+	isOrtho(camera.isOrtho),
+	fov(camera.fov),
+	nearClip(camera.nearClip),
+	farClip(camera.farClip),
+	lensOffset(lensOffset),
+	forceAspectRatio(forceAspectRatio),
+	aspectRatio(aspectRatio),
+	vFlip(vFlip),
+	renderer(renderer)
+{ 
+
+}
+//----------------------------------------
 ofCamera::~ofCamera() {}
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofCamera.h
+++ b/libs/openFrameworks/3d/ofCamera.h
@@ -20,6 +20,9 @@ public:
     /// \brief Construct a default camera.
 	ofCamera();
 
+	/// \brief Copy constructor
+	ofCamera(const ofCamera & camera);
+
     /// \brief Destroy the camera.
     virtual ~ofCamera();
 	

--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -23,52 +23,7 @@ ofEasyCam::ofEasyCam(){
     addInteraction(TRANSFORM_TRANSLATE_XY, OF_MOUSE_BUTTON_LEFT,doTranslationKey);
 	addInteraction(TRANSFORM_ROTATE, OF_MOUSE_BUTTON_LEFT);
 	addInteraction(TRANSFORM_TRANSLATE_Z, OF_MOUSE_BUTTON_RIGHT);
-	addInteraction(TRANSFORM_TRANSLATE_XY, OF_MOUSE_BUTTON_MIDDLE);
-	
-}
-
-//----------------------------------------
-ofEasyCam::ofEasyCam(const ofEasyCam & easyCam) :
-	target(easyCam.target),
-	bEnableMouseMiddleButton(easyCam.bEnableMouseMiddleButton),
-	bApplyInertia(easyCam.bApplyInertia),	
-	bInsideArcball(easyCam.bInsideArcball),
-	bMouseInputEnabled(easyCam.bMouseInputEnabled),
-	bDistanceSet(easyCam.bDistanceSet),
-	bAutoDistance(easyCam.bAutoDistance),
-	bEventsSet(easyCam.bEventsSet),
-	bIsScrolling(easyCam.bIsScrolling),
-	lastDistance(easyCam.lastDistance),	
-	drag(easyCam.drag),
-	rot(easyCam.rot),
-	translate(easyCam.translate),
-	sensitivityTranslate(easyCam.sensitivityTranslate),
-	sensitivityRot(easyCam.sensitivityRot),
-	sensitivityScroll(easyCam.sensitivityScroll),
-	prevMouse(easyCam.prevMouse),
-	mouseVel(easyCam.mouseVel),
-	doTranslationKey(easyCam.doTranslationKey),
-	lastTap(easyCam.lastTap),
-	curRot(easyCam.curRot),
-	lastPressAxisX(easyCam.lastPressAxisX),
-	lastPressAxisY(easyCam.lastPressAxisY),
-	lastPressAxisZ(easyCam.lastPressAxisZ),
-	lastPressPosition(easyCam.lastPressPosition),
-	lastPressOrientation(easyCam.lastPressOrientation),
-	lastPressMouse(easyCam.lastPressMouse),
-	viewport(easyCam.viewport),
-	controlArea(easyCam.controlArea),
-	bRelativeYAxis(easyCam.bRelativeYAxis),
-	doInertia(easyCam.doInertia),
-	upAxis(easyCam.upAxis),	
-	mouseAtScroll(easyCam.mouseAtScroll),
-	prevFarClip(easyCam.prevFarClip), 
-	prevNearClip(easyCam.prevNearClip),	
-	currentTransformType(easyCam.currentTransformType),
-	interactions(easyCam.interactions),
-	events(easyCam.events)
-	//listeners(easyCam.listeners) // does not copy event listeners, not necessary and generally a bad idea
-{ 
+	addInteraction(TRANSFORM_TRANSLATE_XY, OF_MOUSE_BUTTON_MIDDLE);	
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -26,6 +26,51 @@ ofEasyCam::ofEasyCam(){
 	addInteraction(TRANSFORM_TRANSLATE_XY, OF_MOUSE_BUTTON_MIDDLE);
 	
 }
+
+//----------------------------------------
+ofEasyCam::ofEasyCam(const ofEasyCam & easyCam) :
+	target(easyCam.target),
+	bEnableMouseMiddleButton(easyCam.bEnableMouseMiddleButton),
+	bApplyInertia(easyCam.bApplyInertia),	
+	bInsideArcball(easyCam.bInsideArcball),
+	bMouseInputEnabled(easyCam.bMouseInputEnabled),
+	bDistanceSet(easyCam.bDistanceSet),
+	bAutoDistance(easyCam.bAutoDistance),
+	bEventsSet(easyCam.bEventsSet),
+	bIsScrolling(easyCam.bIsScrolling),
+	lastDistance(easyCam.lastDistance),	
+	drag(easyCam.drag),
+	rot(easyCam.rot),
+	translate(easyCam.translate),
+	sensitivityTranslate(easyCam.sensitivityTranslate),
+	sensitivityRot(easyCam.sensitivityRot),
+	sensitivityScroll(easyCam.sensitivityScroll),
+	prevMouse(easyCam.prevMouse),
+	mouseVel(easyCam.mouseVel),
+	doTranslationKey(easyCam.doTranslationKey),
+	lastTap(easyCam.lastTap),
+	curRot(easyCam.curRot),
+	lastPressAxisX(easyCam.lastPressAxisX),
+	lastPressAxisY(easyCam.lastPressAxisY),
+	lastPressAxisZ(easyCam.lastPressAxisZ),
+	lastPressPosition(easyCam.lastPressPosition),
+	lastPressOrientation(easyCam.lastPressOrientation),
+	lastPressMouse(easyCam.lastPressMouse),
+	viewport(easyCam.viewport),
+	controlArea(easyCam.controlArea),
+	bRelativeYAxis(easyCam.bRelativeYAxis),
+	doInertia(easyCam.doInertia),
+	upAxis(easyCam.upAxis),	
+	mouseAtScroll(easyCam.mouseAtScroll),
+	prevFarClip(easyCam.prevFarClip), 
+	prevNearClip(easyCam.prevNearClip),	
+	currentTransformType(easyCam.currentTransformType),
+	interactions(easyCam.interactions),
+	events(easyCam.events)
+	//listeners(easyCam.listeners) // does not copy event listeners, not necessary and generally a bad idea
+{ 
+}
+
 //----------------------------------------
 void ofEasyCam::update(ofEventArgs & args){
 	if(this->viewport.isZero()){

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -14,8 +14,11 @@ public:
     /// \brief Create a default camera.
 	ofEasyCam();
 
-    /// \brief Copy constructor for ofEasyCam
-	ofEasyCam(const ofEasyCam & cam);
+    /// \brief Default copy constructor.
+	ofEasyCam(const ofEasyCam & )            = default;
+
+    /// \brief Default assignment copy constructor.
+	ofEasyCam &operator=(const ofEasyCam & ) = default;
 
 	/// \}
 	/// \name Rendering

--- a/libs/openFrameworks/3d/ofEasyCam.h
+++ b/libs/openFrameworks/3d/ofEasyCam.h
@@ -14,6 +14,9 @@ public:
     /// \brief Create a default camera.
 	ofEasyCam();
 
+    /// \brief Copy constructor for ofEasyCam
+	ofEasyCam(const ofEasyCam & cam);
+
 	/// \}
 	/// \name Rendering
 	/// \{
@@ -273,6 +276,11 @@ private:
 	struct interaction{
 		interaction():mouseButton(0), key(-1), transformType(TRANSFORM_NONE){}
 		interaction(TransformType type, int _mouseButton, int _key = -1):mouseButton(_mouseButton), key(_key), transformType(type){}
+		interaction(interaction& interaction) : 
+			mouseButton(interaction.mouseButton),
+			key(interaction.key),
+			transformType(interaction.transformType) {}
+    
 		int mouseButton;
 		int key;
 		TransformType transformType;


### PR DESCRIPTION
Added a copy constructor for ofCamera and ofEasyCam

Not sure if this is useful to other people but used this quite a bit in some of my own projects.

Please note ofEasyCam copy constructor does not copy the listeners, this wasn't necessary for my own projects and seemed like a bad idea.