### PR TITLE
added range for CJKSymbolAndPunctuation and added to CJK ranges

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -48,6 +48,7 @@ const ofUnicode::range ofUnicode::BlockElement {0x2580, 0x259F};
 const ofUnicode::range ofUnicode::GeometricShapes {0x25A0, 0x25FF};
 const ofUnicode::range ofUnicode::MiscSymbols {0x2600, 0x26FF};
 const ofUnicode::range ofUnicode::Dingbats {0x2700, 0x27BF};
+const ofUnicode::range ofUnicode::CJKSymbolAndPunctuation {0x3001, 0x303F};
 const ofUnicode::range ofUnicode::Hiragana {0x3040, 0x309F};
 const ofUnicode::range ofUnicode::Katakana {0x30A0, 0x30FF};
 const ofUnicode::range ofUnicode::HangulCompatJamo {0x3130, 0x318F};
@@ -88,6 +89,7 @@ const std::initializer_list<ofUnicode::range> ofAlphabet::Emoji {
 const std::initializer_list<ofUnicode::range> ofAlphabet::Japanese {
 	ofUnicode::Space,
 	ofUnicode::IdeographicSpace,
+	ofUnicode::CJKSymbolAndPunctuation,
 	ofUnicode::Hiragana,
 	ofUnicode::Katakana,
 	ofUnicode::KatakanaPhoneticExtensions,
@@ -98,6 +100,7 @@ const std::initializer_list<ofUnicode::range> ofAlphabet::Japanese {
 const std::initializer_list<ofUnicode::range> ofAlphabet::Chinese {
 	ofUnicode::Space,
 	ofUnicode::IdeographicSpace,
+	ofUnicode::CJKSymbolAndPunctuation,
 	ofUnicode::CJKLettersAndMonths,
 	ofUnicode::CJKUnified
 };
@@ -105,6 +108,7 @@ const std::initializer_list<ofUnicode::range> ofAlphabet::Chinese {
 const std::initializer_list<ofUnicode::range> ofAlphabet::Korean {
 	ofUnicode::Space,
 	ofUnicode::IdeographicSpace,
+	ofUnicode::CJKSymbolAndPunctuation,
 	ofUnicode::HangulJamo,
 	ofUnicode::HangulCompatJamo,
 	ofUnicode::HangulExtendedA,

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -78,6 +78,7 @@ public:
 	static const range GeometricShapes;
 	static const range MiscSymbols;
 	static const range Dingbats;
+	static const range CJKSymbolAndPunctuation;
 	static const range Hiragana;
 	static const range Katakana;
 	static const range HangulCompatJamo;


### PR DESCRIPTION
added ranges for CJK Symbols and Punctuation.
ref: https://en.wikipedia.org/wiki/CJK_Symbols_and_Punctuation

for example "、" means like "," and "。" means like "." .
In Japanese, basically those are needed.
and I don't know Chinese and Korean enough, but maybe those are needed too.