### PR TITLE
Bugfix. Fixes broken video renderer for newer codec tools on Windows. closes #6765

### DIFF
--- a/libs/openFrameworks/video/ofDirectShowPlayer.cpp
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.cpp
@@ -615,11 +615,16 @@ class DirectShowVideo : public ISampleGrabberCB{
             IPin* pinOut = 0;
 
             hr = m_pGraph->FindFilterByName(L"Video Renderer", &m_pVideoRenderer);
-            if (FAILED(hr)){
-                printf("failed to find the video renderer\n");
-                tearDown();
-                return false;
-            }
+
+			if (FAILED(hr)) {
+				//newer graphs use Video Mixing Renderer 9
+				hr = m_pGraph->FindFilterByName(L"Video Mixing Renderer 9", &m_pVideoRenderer);
+				if (FAILED(hr)) {
+					printf("failed to find the video renderer\n");
+					tearDown();
+					return false;
+				}
+			}
 
             //we disconnect the video renderer window by finding the output pin of the sample grabber
             hr = m_pGrabberF->FindPin(L"Out", &pinOut);


### PR DESCRIPTION
Newer installs of K-Lite Codec tools are defaulting to a newer Directshow rendering pipeline, breaking video playback on Windows. This approach tries both the existing and newer approaches and only fails if it can't find either. 

Fixes #6765

Thanks to @nama-gatsuo for reporting and @hanasaan for the fix suggestion!