### PR TITLE
Fix issue in ofSerial during Win32 enumeration

### DIFF
--- a/libs/openFrameworks/communication/ofSerial.cpp
+++ b/libs/openFrameworks/communication/ofSerial.cpp
@@ -69,9 +69,10 @@ void ofSerial::enumerateWin32Ports(){
 
 			 char * begin = nullptr;
 			 char * end = nullptr;
-			 begin = strstr((char *)dataBuf, "COM");
+			 begin = strstr((char *)dataBuf, "(COM");
 
 			 if(begin){
+				 begin++;	// get rid of the (
 				 end = strstr(begin, ")");
 				 if(end){
 					 *end = 0;   // get rid of the )...


### PR DESCRIPTION
This fix a bug occurring if the device's friendly name contains "COM" string.
For instance, if the device's friendly name is "Virtual COM Port (COM15)", then
enumeration will return the following device path : "COM Port (COM15" instead
of "COM15"