### PR TITLE
ofURLFileLoader: don't reuse CURL* handle

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -51,15 +51,12 @@ private:
 	ofThreadChannel<ofHttpResponse> responses;
 	ofThreadChannel<int> cancelRequestQueue;
 	set<int> cancelledRequests;
-	std::unique_ptr<CURL, void(*)(CURL*)> curl;
 };
 
-ofURLFileLoaderImpl::ofURLFileLoaderImpl()
-:curl(nullptr, nullptr){
+ofURLFileLoaderImpl::ofURLFileLoaderImpl() {
 	if(!curlInited){
 		 curl_global_init(CURL_GLOBAL_ALL);
 	}
-	curl = std::unique_ptr<CURL, void(*)(CURL*)>(curl_easy_init(), curl_easy_cleanup);
 }
 
 ofURLFileLoaderImpl::~ofURLFileLoaderImpl(){
@@ -178,6 +175,8 @@ namespace{
 }
 
 ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request) {
+	std::unique_ptr<CURL, void(*)(CURL*)> curl =
+		std::unique_ptr<CURL, void(*)(CURL*)>(curl_easy_init(), curl_easy_cleanup);
 	curl_slist *headers = nullptr;
 	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 0);
 	curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
fixes #6776

`ofLoadURLAsync` and `ofLoadURL` are called from different threads, however from https://curl.se/libcurl/c/threadsafe.html you can read that: "You must never share the same handle in multiple threads".

So here we fix this by creating a new handle for each request. I think the overhead is acceptable; it could be noticeable when downloading many small files though.

There might be a better way using:
``` C++ 
thread_local std::unique_ptr<CURL, void(*)(CURL*)> curl 
```
but I couldn't figure how to to it properly, sorry...
