### PR TITLE
fix: ambiguous byte conflict with windows header

### DIFF
--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -7,8 +7,6 @@
 #include <condition_variable>
 #include <mutex>
 
-using namespace std;
-
 #ifdef TARGET_WIN32
 #include <winuser.h>
 #include <commdlg.h>
@@ -18,6 +16,8 @@ using namespace std;
 #include <shlobj.h>
 #include <tchar.h>
 #include <stdio.h>
+
+using namespace std;
 
 #endif
 

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -17,7 +17,6 @@
 #include <tchar.h>
 #include <stdio.h>
 
-using namespace std;
 
 #endif
 
@@ -253,6 +252,8 @@ void resetLocale(std::locale locale){
 #ifdef TARGET_EMSCRIPTEN
 #include <emscripten/emscripten.h>
 #endif
+
+using namespace std;
 
 //------------------------------------------------------------------------------
 ofFileDialogResult::ofFileDialogResult(){


### PR DESCRIPTION
A really small PR.

There is conflict with windows header and the definition of byte symbol.