### PR TITLE
Fix XCode release schemes

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@ fi
 				</array>
 				<key>MACOSX_DEPLOYMENT_TARGET</key>
 				<string>10.9</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
 				<key>OTHER_CODE_SIGN_FLAGS</key>
 				<string>--deep</string>
 				<key>OTHER_CPLUSPLUSFLAGS</key>
@@ -3081,6 +3083,8 @@ fi
 				</array>
 				<key>MACOSX_DEPLOYMENT_TARGET</key>
 				<string>10.9</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>				
 				<key>OTHER_CODE_SIGN_FLAGS</key>
 				<string>--deep</string>
 				<key>OTHER_CPLUSPLUSFLAGS</key>


### PR DESCRIPTION
XCode Release and Release Rosetta both generates Universal identical apps right now.
This pull request keeps Release behavior similar to Debug, compiling Apple Silicon or Intel code depending on the scheme selection.
I think the absence of this key turned the default to NO, so it was building other architectures together causing some issues on addons based in a specific architecture.

More details of this issue here:
https://github.com/openframeworks/openFrameworks/issues/6784#issuecomment-975544869