### PR TITLE
fix to beginshape endshape not using actual color

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -104,6 +104,7 @@ void ofCairoRenderer::setup(string _filename, Type _type, bool multiPage_, bool 
 	page = 0;
 	b3D = b3D_;
 	multiPage = multiPage_;
+	setupGraphicDefaults();
 }
 
 void ofCairoRenderer::setupMemoryOnly(Type _type, bool multiPage_, bool b3D_, ofRectangle outputsize){


### PR DESCRIPTION
differently from other renderers it misses
```c++
	path.setUseShapeColor(false);
```
from initialization. this update closes this issue
https://github.com/openframeworks/openFrameworks/issues/6766
and I think it matches style of other renderers (setupGraphicDefaults in the end of setup)