### PR TITLE
PROJECT_CC and PROJECT_CXX fix

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
@@ -374,7 +374,7 @@ ifdef MAKEFILE_DEBUG
 endif
 
 ifdef PROJECT_CXX
-	CXX ?= $(PROJECT_CXX)
+	CXX = $(PROJECT_CXX)
 endif
 
 ifdef PLATFORM_CXX
@@ -382,7 +382,7 @@ ifdef PLATFORM_CXX
 endif
 
 ifdef PROJECT_CC
-	CC ?= $(PROJECT_CC)
+	CC = $(PROJECT_CC)
 endif
 
 ifdef PLATFORM_CC


### PR DESCRIPTION
changes to fix https://github.com/openframeworks/openFrameworks/issues/6534

I've studied the concatenation of make file includes to understand how CXX and CC variables were not being set per project when using PROJECT_CC and PROJECT_CXX
with this two changes it arrives at the end with the right variables set.

To understand better how variables were set I've added this in the end of my test project Makefile
```make
$(info -----------------)
$(info PROJECT_CC final is $(PROJECT_CC))
$(info PROJECT_CXX final is $(PROJECT_CXX))
$(info CC final is $(CC))
$(info CXX final is $(CXX))
$(info -----------------)
```

as the changes are isolated inside the ifdef PROJECT_CC / ifdef PROJECT_CXX it should not affect anything else