### PR TITLE
ofAVFoundationPlayer.mm Minor tweaks, avoid texture allocation every frame

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -495,8 +495,7 @@ void ofAVFoundationPlayer::initTextureCache() {
         ofLogError("ofAVFoundationPlayer") << "initTextureCache(): error creating texture cache from image " << err << ".";
     }
 	
-	// No need to unlock every frame of normal video
-	// CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
+    CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
 
 #ifdef TARGET_OF_IOS
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -433,13 +433,17 @@ void ofAVFoundationPlayer::initTextureCache() {
      *  so... we can use ofTexture::setUseExternalTextureID() to get around this.
      */
 
-    int videoTextureW = getWidth();
-    int videoTextureH = getHeight();
-    videoTexture.allocate(videoTextureW, videoTextureH, GL_RGBA);
+	if (!videoTexture.isAllocated()) {
+		int videoTextureW = getWidth();
+		int videoTextureH = getHeight();
+		videoTexture.allocate(videoTextureW, videoTextureH, GL_RGBA);
 
-    ofTextureData & texData = videoTexture.getTextureData();
-    texData.tex_t = 1.0f; // these values need to be reset to 1.0 to work properly.
-    texData.tex_u = 1.0f; // assuming this is something to do with the way ios creates the texture cache.
+		ofTextureData & texData = videoTexture.getTextureData();
+		texData.tex_t = 1.0f; // these values need to be reset to 1.0 to work properly.
+		texData.tex_u = 1.0f; // assuming this is something to do with the way ios creates the texture cache.
+		videoTexture.setTextureMinMagFilter(GL_LINEAR, GL_LINEAR);
+		videoTexture.setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
+	}
 
     CVReturn err;
     unsigned int textureCacheID;
@@ -481,8 +485,6 @@ void ofAVFoundationPlayer::initTextureCache() {
 #endif
 
     videoTexture.setUseExternalTextureID(textureCacheID);
-    videoTexture.setTextureMinMagFilter(GL_LINEAR, GL_LINEAR);
-    videoTexture.setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
     if(ofIsGLProgrammableRenderer() == false) {
         videoTexture.bind();
         glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
@@ -492,8 +494,9 @@ void ofAVFoundationPlayer::initTextureCache() {
     if(err) {
         ofLogError("ofAVFoundationPlayer") << "initTextureCache(): error creating texture cache from image " << err << ".";
     }
-
-    CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
+	
+	// No need to unlock every frame of normal video
+	// CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
 
 #ifdef TARGET_OF_IOS
 


### PR DESCRIPTION
comment out CVPixelBufferUnlockBaseAddress in every frame. not needed for normal video
Some minor changes to avoid allocating videoTexture every frame.