### PR TITLE
ofAVFoundationVideoPlayer - Add autorelease to dispatch_async

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -191,6 +191,9 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	}
 	
 	dispatch_async(queue, ^{
+		@autoreleasepool {
+		}
+		
 		[asset loadValuesAsynchronouslyForKeys:[NSArray arrayWithObject:kTracksKey] completionHandler:^{
 			
 			NSError * error = nil;


### PR DESCRIPTION
I've noticed in XCode the video player create lots of threads and release few. 
This change allows the program to release threads over time.