### PR TITLE
AVFoundationVideoPlayer fix - set video position to a previous position than the playhead

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1229,10 +1229,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	time = CMTimeMaximum(time, kCMTimeZero);
 	time = CMTimeMinimum(time, duration);
 	
-	if (!bStream && (CMTimeCompare(time, videoSampleTime) < 0)) {
+// 	if (!bStream && (CMTimeCompare(time, videoSampleTime) < 0)) {
 		// if jumping back in time
 		//[self createAssetReaderWithTimeRange:CMTimeRangeMake(time, duration)];
-	}
+// 	}
 	
 	// set reader to real requested time
 	[_player seekToTime:time

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1231,7 +1231,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	
 	if (!bStream && (CMTimeCompare(time, videoSampleTime) < 0)) {
 		// if jumping back in time
-		[self createAssetReaderWithTimeRange:CMTimeRangeMake(time, duration)];
+		//[self createAssetReaderWithTimeRange:CMTimeRangeMake(time, duration)];
 	}
 	
 	// set reader to real requested time


### PR DESCRIPTION
this particular call of createAssetReaderWithTimeRange is exclusive if we seek a position of the video before the actual playhead.
but it creates a strange situation where videoSampleTime is not correctly updated and we got stuck outside the "while" loop that checks the video buffer for new content.
no video is displayed until the playhead goes to the previous position again.

This fix supress this function here, but  it is going to be called anyway in updateFromAssetReader, but this time videoSampleTime is correctly updated and video is displayed correctly with good performance.