### PR TITLE
ofBaseHasPixels is already present

### DIFF
--- a/libs/openFrameworks/video/ofVideoBaseTypes.h
+++ b/libs/openFrameworks/video/ofVideoBaseTypes.h
@@ -100,8 +100,7 @@ public:
 class ofBaseVideoDraws:
 	virtual public ofBaseVideo,
 	public ofBaseDraws,
-	public ofBaseHasTexturePlanes,
-	virtual public ofBaseHasPixels{
+	public ofBaseHasTexturePlanes{
 public:
 	/// \brief Destroy the ofBaseVideoDraws.
 	virtual ~ofBaseVideoDraws(){}

--- a/libs/openFrameworks/video/ofVideoBaseTypes.h
+++ b/libs/openFrameworks/video/ofVideoBaseTypes.h
@@ -98,7 +98,7 @@ public:
 
 /// \brief A base class representing a drawable video source.
 class ofBaseVideoDraws:
-	virtual public ofBaseVideo,
+	public ofBaseVideo,
 	public ofBaseDraws,
 	public ofBaseHasTexturePlanes{
 public:


### PR DESCRIPTION
ofBaseHasPixels is already present, inherited by ofBaseVideo

doesn't make any difference and increases readability, helps visualizing the memory layout of the object