### PR TITLE
fixed addTrailingSlash on std filesystem

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1641,12 +1641,17 @@ string ofFilePath::getPathForDirectory(const std::filesystem::path& path){
 	// if a trailing slash is missing from a path, this will clean it up
 	// if it's a windows-style "\" path it will add a "\"
 	// if it's a unix-style "/" path it will add a "/"
-	auto sep = std::filesystem::path("/").make_preferred();
+#if OF_USING_STD_FS && !OF_USE_EXPERIMENTAL_FS
+    if(path.string().empty()) return "";
+    return (path / "").string();
+#else
+    auto sep = std::filesystem::path("/").make_preferred();
     if(!path.empty() && ofToString(path.string().back())!=sep.string()){
         return (path / sep).string();
-	}else{
+    }else{
         return path.string();
-	}
+    }
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1609,7 +1609,7 @@ string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
 
 //------------------------------------------------------------------------------------------------------------
 string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
-#if OF_USING_STD_FS
+#if OF_USING_STD_FS && !OF_USE_EXPERIMENTAL_FS
     if(_path.string().empty()) return "";
     return (std::filesystem::path(_path).make_preferred() / "").string();
 #else

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1609,6 +1609,10 @@ string ofFilePath::addLeadingSlash(const std::filesystem::path& _path){
 
 //------------------------------------------------------------------------------------------------------------
 string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
+#if OF_USING_STD_FS
+    if(_path.string().empty()) return "";
+    return (std::filesystem::path(_path).make_preferred() / "").string();
+#else
     auto path = std::filesystem::path(_path).make_preferred().string();
 	auto sep = std::filesystem::path("/").make_preferred();
 	if(!path.empty()){
@@ -1617,6 +1621,7 @@ string ofFilePath::addTrailingSlash(const std::filesystem::path& _path){
 		}
 	}
 	return path;
+#endif
 }
 
 


### PR DESCRIPTION
on std::filesystem (not std::experimental::filesystem), `addTrailingSlash` is broken.
because, `std::filesystem::path("/hoge") / std::filesystem::path("/")` returns `std::filesystem::path("/")`.
so, this bug causes the wrong behavior of `ofToDataPath`.

ref: https://wandbox.org/permlink/QzINUEPwoDVOjYWr

this PR fixes it.
