### PR TITLE
ofxOsc - Excluding a include folder for macOs

### DIFF
--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -78,7 +78,5 @@ vs:
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/posix/%
 	ADDON_DEFINES = OSC_HOST_LITTLE_ENDIAN
-	
-osx:
-	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32/%
+
 	

--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -63,7 +63,7 @@ common:
 	# when parsing the file system looking for sources exclude this for all or
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
-
+ 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32/%
 	# when parsing the file system looking for include paths exclude this for all or
 	# a specific platform
 	# ADDON_INCLUDES_EXCLUDE =

--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -63,7 +63,7 @@ common:
 	# when parsing the file system looking for sources exclude this for all or
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
- 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32/%
+ 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
 	# when parsing the file system looking for include paths exclude this for all or
 	# a specific platform
 	# ADDON_INCLUDES_EXCLUDE =

--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -78,3 +78,7 @@ vs:
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/posix/%
 	ADDON_DEFINES = OSC_HOST_LITTLE_ENDIAN
+	
+osx:
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	


### PR DESCRIPTION
so the compiler doesn't search here
```
-I/Volumes/tool/ofw/addons/ofxOsc/libs/oscpack/src/ip/win32
```