### PR TITLE
ofGLRenderer.cpp - Removing duplicate include ofMesh.h

### DIFF
--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -1,7 +1,6 @@
 #include "ofGLRenderer.h"
 #include "ofMesh.h"
 #include "ofPath.h"
-#include "ofMesh.h"
 #include "of3dPrimitives.h"
 #include "ofBitmapFont.h"
 #include "ofGLUtils.h"


### PR DESCRIPTION
I'll make another PR to remove it from another file too.
just wondering, there is an include guard in ofMesh.h

https://github.com/openframeworks/openFrameworks/blob/7d7993550c2f9b00a985769dfaab3825abb975e5/libs/openFrameworks/3d/ofMesh.h#L1-L5
maybe it is there because of this duplication here?