### PR TITLE
ofxTruetypeFont: Added index property to ofxTryutypeSettings 

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -364,11 +364,11 @@ static std::string linuxFontPathByName(const std::string& fontname){
 #endif
 
 //-----------------------------------------------------------
-static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename){
+static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face, std::filesystem::path & filename, int index){
 	std::filesystem::path fontname = _fontname;
 	filename = ofToDataPath(_fontname,true);
 	ofFile fontFile(filename,ofFile::Reference);
-	int fontID = 0;
+	int fontID = index;
 	if(!fontFile.exists()){
 #ifdef TARGET_LINUX
         filename = linuxFontPathByName(fontname.string());
@@ -717,7 +717,7 @@ bool ofTrueTypeFont::load(const ofTrueTypeFontSettings & _settings){
 
 	//--------------- load the library and typeface
 	FT_Face loadFace;
-    if(!loadFontFace(settings.fontName, loadFace, settings.fontName)){
+    if(!loadFontFace(settings.fontName, loadFace, settings.fontName, settings.index)){
 		return false;
 	}
 	face = std::shared_ptr<struct FT_FaceRec_>(loadFace,FT_Done_Face);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -132,6 +132,7 @@ struct ofTrueTypeFontSettings{
     bool                      contours = false;
     float                     simplifyAmt = 0.3f;
     int                       dpi = 0;
+    int                       index = 0;
     ofTrueTypeFontDirection direction = OF_TTF_LEFT_TO_RIGHT;
     std::vector<ofUnicode::range> ranges;
 


### PR DESCRIPTION
Index property allows to use single file fonts with several styles. The index defines the "style" to be loaded. This shouldn't break anything . It is just exposing this feature
