### PR TITLE
supress warning unused needsResizeCheck - RPI only

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -219,7 +219,10 @@ private:
 
 	int 			nFramesSinceWindowResized;
 	bool			bWindowNeedsShowing;
+	
+	#ifdef TARGET_RASPBERRY_PI 
 	bool			needsResizeCheck = false; /// Just for RPI at this point
+	#endif	
 
 	GLFWwindow* 	windowP;
 


### PR DESCRIPTION
RPI only variable, so it goes inside #ifdef macro
```
/Volumes/tool/ofw/libs/openFrameworks/app/ofAppGLFWWindow.h:222:9: warning: private field 'needsResizeCheck' is not used [-Wunused-private-field]
```