### PR TITLE
remove std::move which prevents copy elision

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -173,7 +173,7 @@ void ofSetMainLoop(shared_ptr<ofMainLoop> newMainLoop) {
 
 //--------------------------------------
 int ofRunApp(ofBaseApp * OFSA){
-	mainLoop()->run(std::move(shared_ptr<ofBaseApp>(OFSA)));
+	mainLoop()->run(shared_ptr<ofBaseApp>(OFSA));
 	auto ret = ofRunMainLoop();
 #if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
 	ofExitCallback();


### PR DESCRIPTION
```
/Volumes/tool/ofw/libs/openFrameworks/app/ofAppRunner.cpp:176:18: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
```
cc @arturoc 
