### PR TITLE
ofArduino.h remove unused numEncoders

### DIFF
--- a/libs/openFrameworks/communication/ofArduino.h
+++ b/libs/openFrameworks/communication/ofArduino.h
@@ -789,7 +789,7 @@ private:
 
 	int _numSteppers;
 
-	int _numEncoders;
+	// int _numEncoders;
 
 	int _encoderID;
 


### PR DESCRIPTION
supress this warning
```
/Volumes/tool/ofw/libs/openFrameworks/communication/ofArduino.h:792:6: warning: private field '_numEncoders' is not used [-Wunused-private-field]

```
I've just commented it out, in the case somebody wants to actually implement