### PR TITLE
ofParameter.h - lambda capture 'this' is not used

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -747,7 +747,7 @@ inline void ofParameter<ParameterType>::eventsSetValue(const ParameterType & v){
 			// Erase each invalid parent
 			obj->parents.erase(std::remove_if(obj->parents.begin(),
 											  obj->parents.end(),
-											  [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
+											  [](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
 							   obj->parents.end());
 
 			// notify all leftover (valid) parents of this object's changed value.


### PR DESCRIPTION
fix warning, remove capture this
```
/Volumes/tool/ofw/libs/openFrameworks/types/ofParameter.h:750:15: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
```