### PR TITLE
ofCairoRenderer reordering fields to supress warning

### DIFF
--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -184,6 +184,8 @@ private:
 
 	// 3d transformation
 	bool b3D;
+	of3dGraphics graphics3d;
+
 	glm::mat4 projection;
 	glm::mat4 modelView;
 	ofRectangle viewportRect, originalViewport;
@@ -203,6 +205,5 @@ private:
 
 	ofStyle currentStyle;
 	std::deque <ofStyle> styleHistory;
-	of3dGraphics graphics3d;
 	ofPath path;
 };


### PR DESCRIPTION
```
/Volumes/tool/ofw/libs/openFrameworks/graphics/ofCairoRenderer.cpp:22:2: warning: field 'graphics3d' will be initialized after field 'projection' [-Wreorder-ctor]
```