### PR TITLE
ofUtils.cpp warning  [-Wmisleading-indentation]

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -520,11 +520,13 @@ void ofSetDataPathRoot(const std::filesystem::path& newRoot){
 
 //--------------------------------------------------
 string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
-    if (makeAbsolute && path.is_absolute())
-        return path.string();
+	if (makeAbsolute && path.is_absolute()) {
+		return path.string();
+	}
     
-	if (!enableDataPath)
-        return path.string();
+	if (!enableDataPath) {
+		return path.string();
+	}
 
     bool hasTrailingSlash = !path.empty() && path.generic_string().back()=='/';
 


### PR DESCRIPTION
this PR fixes this warning and note 
```c++
/home/pi/ofw2/libs/openFrameworks/utils/ofUtils.cpp:523:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if (makeAbsolute && path.is_absolute())
     ^~
/home/pi/ofw2/libs/openFrameworks/utils/ofUtils.cpp:526:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  if (!enableDataPath)
  ^~
```