### PR TITLE
Move functions about data path from ofUtils to ofFileUtils.

### DIFF
--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -127,18 +127,19 @@ void ofInit(){
 	signal(SIGABRT, &ofSignalHandler);  // abort signal
 #endif
 
-        of::priv::initutils();
+    of::priv::initutils();
+    of::priv::initfileutils();
 
-	#ifdef WIN32_HIGH_RES_TIMING
-		timeBeginPeriod(1);		// ! experimental, sets high res time
-								// you need to call timeEndPeriod.
-								// if you quit the app other than "esc"
-								// (ie, close the console, kill the process, etc)
-								// at exit wont get called, and the time will
-								// remain high res, that could mess things
-								// up on your system.
-								// info here:http://www.geisswerks.com/ryan/FAQS/timing.html
-	#endif
+#ifdef WIN32_HIGH_RES_TIMING
+    timeBeginPeriod(1);		// ! experimental, sets high res time
+                            // you need to call timeEndPeriod.
+                            // if you quit the app other than "esc"
+                            // (ie, close the console, kill the process, etc)
+                            // at exit wont get called, and the time will
+                            // remain high res, that could mess things
+                            // up on your system.
+                            // info here:http://www.geisswerks.com/ryan/FAQS/timing.html
+#endif
 
 #ifdef TARGET_LINUX
 	if(std::locale().name() == "C"){

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -16,6 +16,49 @@
 
 using namespace std;
 
+namespace{
+    bool enableDataPath = true;
+
+    //--------------------------------------------------
+    string defaultDataPath(){
+    #if defined TARGET_OSX
+        try{
+            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
+        }catch(...){
+            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
+        }
+    #elif defined TARGET_ANDROID
+        return string("sdcard/");
+    #else
+        try{
+            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).make_preferred().string();
+        }catch(...){
+            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
+        }
+    #endif
+    }
+
+    //--------------------------------------------------
+    std::filesystem::path & defaultWorkingDirectory(){
+            static auto * defaultWorkingDirectory = new std::filesystem::path(ofFilePath::getCurrentExeDir());
+            return * defaultWorkingDirectory;
+    }
+
+    //--------------------------------------------------
+    std::filesystem::path & dataPathRoot(){
+            static auto * dataPathRoot = new std::filesystem::path(defaultDataPath());
+            return *dataPathRoot;
+    }
+}
+
+namespace of{
+    namespace priv{
+        void initfileutils(){
+            defaultWorkingDirectory() = std::filesystem::absolute(std::filesystem::current_path());
+        }
+    }
+}
+
 
 //------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------
@@ -1797,3 +1840,112 @@ string ofFilePath::makeRelative(const std::filesystem::path & from, const std::f
 
 	return ret.string();
 }
+
+//--------------------------------------------------
+void ofEnableDataPath(){
+    enableDataPath = true;
+}
+
+//--------------------------------------------------
+void ofDisableDataPath(){
+    enableDataPath = false;
+}
+
+//--------------------------------------------------
+bool ofRestoreWorkingDirectoryToDefault(){
+    try{
+        std::filesystem::current_path(defaultWorkingDirectory());
+        return true;
+    }catch(...){
+        return false;
+    }
+}
+
+//--------------------------------------------------
+void ofSetDataPathRoot(const std::filesystem::path& newRoot){
+    dataPathRoot() = newRoot;
+}
+
+//--------------------------------------------------
+string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
+    if (makeAbsolute && path.is_absolute())
+        return path.string();
+    
+    if (!enableDataPath)
+        return path.string();
+
+    bool hasTrailingSlash = !path.empty() && path.generic_string().back()=='/';
+
+    // if our Current Working Directory has changed (e.g. file open dialog)
+#ifdef TARGET_WIN32
+    if (defaultWorkingDirectory() != std::filesystem::current_path()) {
+        // change our cwd back to where it was on app load
+        bool ret = ofRestoreWorkingDirectoryToDefault();
+        if(!ret){
+            ofLogWarning("ofUtils") << "ofToDataPath: error while trying to change back to default working directory " << defaultWorkingDirectory();
+        }
+    }
+#endif
+
+    // this could be performed here, or wherever we might think we accidentally change the cwd, e.g. after file dialogs on windows
+    const auto  & dataPath = dataPathRoot();
+    std::filesystem::path inputPath(path);
+    std::filesystem::path outputPath;
+
+    // if path is already absolute, just return it
+    if (inputPath.is_absolute()) {
+        try {
+            auto outpath = std::filesystem::canonical(inputPath).make_preferred();
+            if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
+                return ofFilePath::addTrailingSlash(outpath.string());
+            }else{
+                return outpath.string();
+            }
+        }
+        catch (...) {
+            return inputPath.string();
+        }
+    }
+
+    // here we check whether path already refers to the data folder by looking for common elements
+    // if the path begins with the full contents of dataPathRoot then the data path has already been added
+    // we compare inputPath.toString() rather that the input var path to ensure common formatting against dataPath.toString()
+    auto dirDataPath = dataPath.string();
+    // also, we strip the trailing slash from dataPath since `path` may be input as a file formatted path even if it is a folder (i.e. missing trailing slash)
+    dirDataPath = ofFilePath::addTrailingSlash(dirDataPath);
+
+    auto relativeDirDataPath = ofFilePath::makeRelative(std::filesystem::current_path().string(),dataPath.string());
+    relativeDirDataPath  = ofFilePath::addTrailingSlash(relativeDirDataPath);
+
+    if (inputPath.string().find(dirDataPath) != 0 && inputPath.string().find(relativeDirDataPath)!=0) {
+        // inputPath doesn't contain data path already, so we build the output path as the inputPath relative to the dataPath
+        if(makeAbsolute){
+            outputPath = dirDataPath / inputPath;
+        }else{
+            outputPath = relativeDirDataPath / inputPath;
+        }
+    } else {
+        // inputPath already contains data path, so no need to change
+        outputPath = inputPath;
+    }
+
+    // finally, if we do want an absolute path and we don't already have one
+    if(makeAbsolute){
+        // then we return the absolute form of the path
+        try {
+            auto outpath = std::filesystem::canonical(std::filesystem::absolute(outputPath)).make_preferred();
+            if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
+                return ofFilePath::addTrailingSlash(outpath.string());
+            }else{
+                return outpath.string();
+            }
+        }
+        catch (std::exception &) {
+            return std::filesystem::absolute(outputPath).string();
+        }
+    }else{
+        // or output the relative path
+        return outputPath.string();
+    }
+}
+

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -1868,11 +1868,13 @@ void ofSetDataPathRoot(const std::filesystem::path& newRoot){
 
 //--------------------------------------------------
 string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
-    if (makeAbsolute && path.is_absolute())
+    if (makeAbsolute && path.is_absolute()) {
         return path.string();
+    }
     
-    if (!enableDataPath)
+    if (!enableDataPath) {
         return path.string();
+    }
 
     bool hasTrailingSlash = !path.empty() && path.generic_string().back()=='/';
 

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1162,3 +1162,56 @@ private:
 	bool showHidden;
 
 };
+
+/// \section Data Path
+/// \brief Enable the use of the data path.
+///
+/// This function causes ofToDataPath() to respect the relative path set
+/// with ofSetDataPathRoot().  This is enabled by default.
+void ofEnableDataPath();
+
+/// \brief Disable the use of the data path.
+///
+/// This function causes ofToDataPath() to ignore the relative path set
+/// with ofSetDataPathRoot().
+void ofDisableDataPath();
+
+/// \brief Make a path relative to the location of the data/ folder.
+///
+/// This funtion returns path unchanged if ofDisableDataPath() was called first.
+///
+/// By default, a relative path is returned. Users requiring absolute paths for
+/// (e.g. for non-openFrameworks functions), can specify that an absolute path
+/// be returned.
+///
+/// \param path The path to make relative to the data/ folder.
+/// \param absolute Set to true to return an absolute path.
+/// \returns the new path, unless paths were disabled with ofDisableDataPath().
+std::string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
+
+/// \brief Reset the working directory to the platform default.
+///
+/// The default working directory is where the application was started from
+/// or the exe directory in case of osx bundles. GLUT might change the default
+/// working directory to the resources directory in the bundle in osx. This
+/// will restore it to the exe dir or whatever was the current dir when the
+/// application was started
+bool ofRestoreWorkingDirectoryToDefault();
+
+/// \brief Set the relative path to the data/ folder from the executable.
+///
+/// This method can be useful when users want to embed the data as a resource
+/// folder within an *.app bundle on OSX or perhaps work from a shared data
+/// folder in the user's Documents directory.
+///
+/// \warning The provided path must have a trailing slash (/).
+/// \param root The path to the data/ folder relative to the app executable.
+void ofSetDataPathRoot(const std::filesystem::path& root);
+
+/*! \cond PRIVATE */
+namespace of{
+namespace priv{
+    void initfileutils();
+}
+}
+/*! \endcond */

--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -1,6 +1,5 @@
 #include "ofUtils.h"
 #include "ofImage.h"
-#include "ofFileUtils.h"
 #include "ofLog.h"
 #include "ofAppBaseWindow.h"
 #include "ofMainLoop.h"
@@ -63,45 +62,9 @@
 
 using namespace std;
 
-namespace{
-	bool enableDataPath = true;
-
-    //--------------------------------------------------
-    string defaultDataPath(){
-    #if defined TARGET_OSX
-        try{
-            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
-        }catch(...){
-            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
-        }
-    #elif defined TARGET_ANDROID
-        return string("sdcard/");
-    #else
-        try{
-            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).make_preferred().string();
-        }catch(...){
-            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
-        }
-    #endif
-    }
-
-    //--------------------------------------------------
-    std::filesystem::path & defaultWorkingDirectory(){
-            static auto * defaultWorkingDirectory = new std::filesystem::path(ofFilePath::getCurrentExeDir());
-            return * defaultWorkingDirectory;
-    }
-
-    //--------------------------------------------------
-    std::filesystem::path & dataPathRoot(){
-            static auto * dataPathRoot = new std::filesystem::path(defaultDataPath());
-            return *dataPathRoot;
-    }
-}
-
 namespace of{
 namespace priv{
 	void initutils(){
-        defaultWorkingDirectory() = std::filesystem::absolute(std::filesystem::current_path());
         ofResetElapsedTimeCounter();
         ofSeedRandom();
     }
@@ -492,115 +455,6 @@ int ofGetWeekday(){
 	local   =*(localtime(&curr));
 	return local.tm_wday;
 }
-
-//--------------------------------------------------
-void ofEnableDataPath(){
-	enableDataPath = true;
-}
-
-//--------------------------------------------------
-void ofDisableDataPath(){
-	enableDataPath = false;
-}
-
-//--------------------------------------------------
-bool ofRestoreWorkingDirectoryToDefault(){
-    try{
-        std::filesystem::current_path(defaultWorkingDirectory());
-        return true;
-    }catch(...){
-        return false;
-    }
-}
-
-//--------------------------------------------------
-void ofSetDataPathRoot(const std::filesystem::path& newRoot){
-	dataPathRoot() = newRoot;
-}
-
-//--------------------------------------------------
-string ofToDataPath(const std::filesystem::path & path, bool makeAbsolute){
-    if (makeAbsolute && path.is_absolute())
-        return path.string();
-    
-	if (!enableDataPath)
-        return path.string();
-
-    bool hasTrailingSlash = !path.empty() && path.generic_string().back()=='/';
-
-	// if our Current Working Directory has changed (e.g. file open dialog)
-#ifdef TARGET_WIN32
-	if (defaultWorkingDirectory() != std::filesystem::current_path()) {
-		// change our cwd back to where it was on app load
-		bool ret = ofRestoreWorkingDirectoryToDefault();
-		if(!ret){
-			ofLogWarning("ofUtils") << "ofToDataPath: error while trying to change back to default working directory " << defaultWorkingDirectory();
-		}
-	}
-#endif
-
-	// this could be performed here, or wherever we might think we accidentally change the cwd, e.g. after file dialogs on windows
-	const auto  & dataPath = dataPathRoot();
-	std::filesystem::path inputPath(path);
-	std::filesystem::path outputPath;
-
-	// if path is already absolute, just return it
-	if (inputPath.is_absolute()) {
-		try {
-            auto outpath = std::filesystem::canonical(inputPath).make_preferred();
-            if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
-                return ofFilePath::addTrailingSlash(outpath.string());
-            }else{
-                return outpath.string();
-            }
-		}
-		catch (...) {
-            return inputPath.string();
-		}
-	}
-
-	// here we check whether path already refers to the data folder by looking for common elements
-	// if the path begins with the full contents of dataPathRoot then the data path has already been added
-	// we compare inputPath.toString() rather that the input var path to ensure common formatting against dataPath.toString()
-    auto dirDataPath = dataPath.string();
-	// also, we strip the trailing slash from dataPath since `path` may be input as a file formatted path even if it is a folder (i.e. missing trailing slash)
-    dirDataPath = ofFilePath::addTrailingSlash(dirDataPath);
-
-    auto relativeDirDataPath = ofFilePath::makeRelative(std::filesystem::current_path().string(),dataPath.string());
-    relativeDirDataPath  = ofFilePath::addTrailingSlash(relativeDirDataPath);
-
-    if (inputPath.string().find(dirDataPath) != 0 && inputPath.string().find(relativeDirDataPath)!=0) {
-		// inputPath doesn't contain data path already, so we build the output path as the inputPath relative to the dataPath
-	    if(makeAbsolute){
-            outputPath = dirDataPath / inputPath;
-	    }else{
-            outputPath = relativeDirDataPath / inputPath;
-	    }
-	} else {
-		// inputPath already contains data path, so no need to change
-		outputPath = inputPath;
-	}
-
-    // finally, if we do want an absolute path and we don't already have one
-	if(makeAbsolute){
-	    // then we return the absolute form of the path
-	    try {
-            auto outpath = std::filesystem::canonical(std::filesystem::absolute(outputPath)).make_preferred();
-            if(std::filesystem::is_directory(outpath) && hasTrailingSlash){
-                return ofFilePath::addTrailingSlash(outpath.string());
-            }else{
-                return outpath.string();
-            }
-	    }
-	    catch (std::exception &) {
-            return std::filesystem::absolute(outputPath).string();
-	    }
-	}else{
-		// or output the relative path
-        return outputPath.string();
-	}
-}
-
 
 //----------------------------------------
 template<>

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ofConstants.h"
-#include "ofFileUtils.h"
 #include "utf8.h"
 #include <bitset> // For ofToBinary.
 #include <chrono>
@@ -207,52 +206,6 @@ int ofGetDay();
 ///
 /// \returns the current weekday [0-6].
 int ofGetWeekday();
-
-/// \section Data Path
-/// \brief Enable the use of the data path.
-///
-/// This function causes ofToDataPath() to respect the relative path set
-/// with ofSetDataPathRoot().  This is enabled by default.
-void ofEnableDataPath();
-
-/// \brief Disable the use of the data path.
-///
-/// This function causes ofToDataPath() to ignore the relative path set
-/// with ofSetDataPathRoot().
-void ofDisableDataPath();
-
-/// \brief Make a path relative to the location of the data/ folder.
-///
-/// This funtion returns path unchanged if ofDisableDataPath() was called first.
-///
-/// By default, a relative path is returned. Users requiring absolute paths for
-/// (e.g. for non-openFrameworks functions), can specify that an absolute path
-/// be returned.
-///
-/// \param path The path to make relative to the data/ folder.
-/// \param absolute Set to true to return an absolute path.
-/// \returns the new path, unless paths were disabled with ofDisableDataPath().
-std::string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
-
-/// \brief Reset the working directory to the platform default.
-///
-/// The default working directory is where the application was started from
-/// or the exe directory in case of osx bundles. GLUT might change the default
-/// working directory to the resources directory in the bundle in osx. This
-/// will restore it to the exe dir or whatever was the current dir when the
-/// application was started
-bool ofRestoreWorkingDirectoryToDefault();
-
-/// \brief Set the relative path to the data/ folder from the executable.
-///
-/// This method can be useful when users want to embed the data as a resource
-/// folder within an *.app bundle on OSX or perhaps work from a shared data
-/// folder in the user's Documents directory.
-///
-/// \warning The provided path must have a trailing slash (/).
-/// \param root The path to the data/ folder relative to the app executable.
-void ofSetDataPathRoot(const std::filesystem::path& root);
-
 
 /// \section Vectors
 /// \brief Randomly reorder the values in a vector.
@@ -1148,11 +1101,9 @@ private:
 };
 
 
-
 /*! \cond PRIVATE */
 namespace of{
 namespace priv{
-    void setWorkingDirectoryToDefault();
     void initutils();
     void endutils();
 }


### PR DESCRIPTION
This PR make solve little complexity about ofUtils and ofFileUtils references each other.

those functions and private variable are moved from ofUtils to ofFileUtils.
(and remove declaration of `setWorkingDirectoryToDefault` has no implementation...)

```cpp
namespace {
    bool enableDataPath = true;
    string defaultDataPath();
    std::filesystem::path & defaultWorkingDirectory();
    std::filesystem::path & dataPathRoot();
}
void ofEnableDataPath();
void ofDisableDataPath();
std::string ofToDataPath(const std::filesystem::path & path, bool absolute=false);
bool ofRestoreWorkingDirectoryToDefault();
void ofSetDataPathRoot(const std::filesystem::path& root);
```

and those line is moved from `of::priv::initutils()` to new private function `of::priv::initfileutils()`.

```cpp
        defaultWorkingDirectory() = std::filesystem::absolute(std::filesystem::current_path());
```

and add line to call this function after `of::priv::initutils() called` in ofAppRunner.

This is not needed absolutely. but I think this update makes a sense. because, ofToDataPath and other functions are about Files, and these are in ofFileUtils is better.

In some situations, maybe this update will break backwards compatibility when using `ofToDataPath` without including ofFileUtils only including ofUtils and other headers too.
If needed, I will add `#include ofFileUtils` in ofUtils.h for backwards compatibility.