### PR TITLE
change Xcode settings about indentation from space to tab

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -1,5654 +1,1361 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>15594EFE15C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>15594F7C15C5697C00727FF2</string>
-				<string>15594F7815C5697C00727FF2</string>
-				<string>15594F7E15C5697C00727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>app</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594EFF15C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>15594FA915C56C9500727FF2</string>
-				<string>15594FA815C56C9500727FF2</string>
-				<string>15594FAA15C56C9500727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>events</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0015C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9008001C204EDC0F00DC786A</string>
-				<string>9008001B204EDC0E00DC786A</string>
-				<string>15594F0815C55AC900727FF2</string>
-				<string>15594F0515C55AC900727FF2</string>
-				<string>15594F0915C55AC900727FF2</string>
-				<string>15594F0615C55AC900727FF2</string>
-				<string>15594F0A15C55AC900727FF2</string>
-				<string>15594F0715C55AC900727FF2</string>
-				<string>15594F0B15C55AC900727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>gl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0115C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>671C0AF01770246200DF03B3</string>
-				<string>671C0AF11770246200DF03B3</string>
-				<string>671C0AF21770246200DF03B3</string>
-				<string>671C0AF31770246200DF03B3</string>
-				<string>678C3D19176F04F800D1CC68</string>
-				<string>678C3D1A176F04F800D1CC68</string>
-				<string>678C3D1B176F04F800D1CC68</string>
-				<string>678C3D1C176F04F800D1CC68</string>
-				<string>66EA462717A6D396009BB12A</string>
-				<string>66EA462817A6D396009BB12A</string>
-				<string>66EA462917A6D396009BB12A</string>
-				<string>66EA462A17A6D396009BB12A</string>
-				<string>678C3D1D176F04F800D1CC68</string>
-				<string>678C3D1E176F04F800D1CC68</string>
-				<string>678C3D1F176F04F800D1CC68</string>
-				<string>678C3D20176F04F800D1CC68</string>
-				<string>678C3D21176F04F800D1CC68</string>
-				<string>678C3D22176F04F800D1CC68</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>sound</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0215C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>15594FB615C56D1E00727FF2</string>
-				<string>15594FAF15C56D1E00727FF2</string>
-				<string>67D48ED11C103BAE00F719BC</string>
-				<string>67D48ED21C103BAE00F719BC</string>
-				<string>9252B7EF1CDA2A6100A8032B</string>
-				<string>9252B7F01CDA2A6100A8032B</string>
-				<string>15594FB715C56D1E00727FF2</string>
-				<string>15594FB015C56D1E00727FF2</string>
-				<string>15594FB815C56D1E00727FF2</string>
-				<string>15594FB115C56D1E00727FF2</string>
-				<string>15594FB915C56D1E00727FF2</string>
-				<string>15594FB215C56D1E00727FF2</string>
-				<string>15594FBA15C56D1E00727FF2</string>
-				<string>15594FB315C56D1E00727FF2</string>
-				<string>15594FBB15C56D1E00727FF2</string>
-				<string>15594FB415C56D1E00727FF2</string>
-				<string>15594FBC15C56D1E00727FF2</string>
-				<string>15594FB515C56D1E00727FF2</string>
-				<string>15594FBD15C56D1E00727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>utils</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0315C55A5700727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>15594FA215C56BB700727FF2</string>
-				<string>15594FA015C56BB700727FF2</string>
-				<string>15594FA115C56BB700727FF2</string>
-				<string>15594F9F15C56BB700727FF2</string>
-				<string>1594366315CF5F420087B684</string>
-				<string>1594366115CF5F420087B684</string>
-				<string>1594366215CF5F420087B684</string>
-				<string>1594366015CF5F420087B684</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>video</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0515C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>EAGLView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0615C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ES1Renderer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0715C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ES2Renderer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0815C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>EAGLView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0915C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ES1Renderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0A15C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ES2Renderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0B15C55AC900727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ESRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F0C15C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0515C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F0D15C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0615C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F0E15C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0715C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F0F15C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0815C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F1015C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0915C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F1115C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0A15C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F1215C55AC900727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F0B15C55AC900727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F7815C5697C00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofAppiOSWindow.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F7C15C5697C00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofAppiOSWindow.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F7E15C5697C00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSApp.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8115C5697C00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F7815C5697C00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F8515C5697C00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F7C15C5697C00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F8715C5697C00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F7E15C5697C00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F8A15C56A4E00727FF2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>15594F8F15C56A8A00727FF2</string>
-				<string>15594F8C15C56A8A00727FF2</string>
-				<string>15594F8E15C56A8A00727FF2</string>
-				<string>15594F8B15C56A8A00727FF2</string>
-				<string>90080017204EDB5500DC786A</string>
-				<string>90080018204EDB5500DC786A</string>
-				<string>90080015204EDA4600DC786A</string>
-				<string>90080013204EDA1300DC786A</string>
-				<string>15594F9015C56A8A00727FF2</string>
-				<string>15594F8D15C56A8A00727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>core</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8B15C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSEAGLView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8C15C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSAppDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8D15C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8E15C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSEAGLView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F8F15C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F9015C56A8A00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594F9115C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F8B15C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9215C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F8C15C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9315C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F8D15C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9415C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F8E15C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9515C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F8F15C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9615C56A8A00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F9015C56A8A00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594F9F15C56BB700727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>AVFoundationVideoGrabber.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FA015C56BB700727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AVFoundationVideoPlayer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FA115C56BB700727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVFoundationVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FA215C56BB700727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVFoundationVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FA315C56BB700727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594F9F15C56BB700727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FA415C56BB700727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FA015C56BB700727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FA515C56BB700727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FA115C56BB700727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FA615C56BB700727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FA215C56BB700727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FA815C56C9500727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSAlerts.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FA915C56C9500727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAlerts.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FAA15C56C9500727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAlertsListener.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FAC15C56C9500727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FA815C56C9500727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FAD15C56C9500727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FA915C56C9500727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FAE15C56C9500727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FAA15C56C9500727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FAF15C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSCoreLocation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB015C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSExternalDisplay.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB115C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB215C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSImagePicker.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB315C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSKeyboard.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB415C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSMapKit.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB515C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSMapKitDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB615C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSCoreLocation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB715C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSExternalDisplay.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB815C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FB915C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSImagePicker.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FBA15C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSKeyboard.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FBB15C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FBC15C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKitDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FBD15C56D1E00727FF2</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKitListener.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>15594FBE15C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FAF15C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FBF15C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB015C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC015C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB115C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC115C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB215C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC215C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB315C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC315C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB415C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC415C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB515C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC515C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB615C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC615C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB715C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC715C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB815C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC815C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FB915C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FC915C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FBA15C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FCA15C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FBB15C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FCB15C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FBC15C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15594FCC15C56D1E00727FF2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>15594FBD15C56D1E00727FF2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1594366015CF5F420087B684</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSVideoGrabber.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1594366115CF5F420087B684</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSVideoPlayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1594366215CF5F420087B684</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1594366315CF5F420087B684</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1594366415CF5F420087B684</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1594366015CF5F420087B684</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1594366515CF5F420087B684</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1594366115CF5F420087B684</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1594366615CF5F420087B684</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1594366215CF5F420087B684</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1594366715CF5F420087B684</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1594366315CF5F420087B684</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>15BC775215A5C31F00772525</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSExtensions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>19C28FACFE9D520D11CA2CBB</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BB24DED610DA7A3F00E9C588</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>1D30AB110D05D00D00671497</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>1DF5F4DF0D08C38300B7A737</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>288765FC0DF74451002DB57D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>29B97313FDCFA39411CA2CEA</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0920</string>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>C01FCF4E08A954540054247B</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>English</string>
-				<string>Japanese</string>
-				<string>French</string>
-				<string>German</string>
-			</array>
-			<key>mainGroup</key>
-			<string>29B97314FDCFA39411CA2CEA</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>BB24DE5C10DA7A3F00E9C588</string>
-			</array>
-		</dict>
-		<key>29B97314FDCFA39411CA2CEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E41D3E9013B38BE900A75A5D</string>
-				<string>E41D3E9113B38BE900A75A5D</string>
-				<string>E41D3E9213B38BE900A75A5D</string>
-				<string>E41D3E9313B38BE900A75A5D</string>
-				<string>BB16F26B0F2B646B00518274</string>
-				<string>E4F76D69176CB27200798745</string>
-				<string>BB16E9930F2B1E5900518274</string>
-				<string>19C28FACFE9D520D11CA2CBB</string>
-			</array>
-			<key>indentWidth</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>CustomTemplate</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-			<key>tabWidth</key>
-			<string>4</string>
-			<key>usesTabs</key>
-			<string>0</string>
-		</dict>
-		<key>29B97323FDCFA39411CA2CEA</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>99752D321BF21EEE0026316A</string>
-				<string>5E2E99DC10ED147800587639</string>
-				<string>901808B8205362D7004A7774</string>
-				<string>BBE5EAB70F49AD8400F28951</string>
-				<string>BB16EBD80F2B2AB500518274</string>
-				<string>BB16EBD10F2B2A9500518274</string>
-				<string>1DF5F4DF0D08C38300B7A737</string>
-				<string>1D30AB110D05D00D00671497</string>
-				<string>288765FC0DF74451002DB57D</string>
-				<string>53F323EA10A20EDB00E0DAE4</string>
-				<string>5326AEA710A23A0500278DE6</string>
-				<string>53DA338912DF8F4500C622CE</string>
-				<string>53DA338D12DF8F5000C622CE</string>
-				<string>53DA338F12DF8F5000C622CE</string>
-				<string>53DA339112DF8F5000C622CE</string>
-				<string>67D48ECF1C10399900F719BC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>core frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5326AEA710A23A0500278DE6</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreLocation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreLocation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>53DA338912DF8F4500C622CE</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AVFoundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AVFoundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>53DA338A12DF8F4500C622CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53DA338912DF8F4500C622CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53DA338D12DF8F5000C622CE</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreAudio.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreAudio.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>53DA338E12DF8F5000C622CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53DA338D12DF8F5000C622CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53DA338F12DF8F5000C622CE</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreMedia.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreMedia.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>53DA339012DF8F5000C622CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53DA338F12DF8F5000C622CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53DA339112DF8F5000C622CE</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreVideo.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreVideo.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>53DA339212DF8F5000C622CE</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53DA339112DF8F5000C622CE</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>53F323EA10A20EDB00E0DAE4</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>OpenAL.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/OpenAL.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>5E2E99DC10ED147800587639</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>MapKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/MapKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>5E2E99DD10ED147800587639</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5E2E99DC10ED147800587639</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6678E97219FEB2DF00C00581</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundBuffer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6678E97319FEB2DF00C00581</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundBuffer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6678E97419FEB2DF00C00581</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>6678E97619FEB2DF00C00581</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6678E97219FEB2DF00C00581</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6678E97719FEB2DF00C00581</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6678E97319FEB2DF00C00581</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6678E97819FEB2DF00C00581</key>
-		<dict>
-			<key>fileRef</key>
-			<string>6678E97419FEB2DF00C00581</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66EA462717A6D396009BB12A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofxOpenALSoundPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66EA462817A6D396009BB12A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxOpenALSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66EA462917A6D396009BB12A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>SoundEngine.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66EA462A17A6D396009BB12A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundEngine.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>66EA462B17A6D396009BB12A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66EA462717A6D396009BB12A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66EA462C17A6D396009BB12A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66EA462817A6D396009BB12A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66EA462D17A6D396009BB12A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66EA462917A6D396009BB12A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>66EA462E17A6D396009BB12A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>66EA462A17A6D396009BB12A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>6711091F19D3EAC6005D095F</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>671C0AF01770246200DF03B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>671C0AF11770246200DF03B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AVSoundPlayer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>671C0AF21770246200DF03B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>671C0AF31770246200DF03B3</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundPlayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>671C0AF41770246200DF03B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>671C0AF01770246200DF03B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>671C0AF51770246200DF03B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>671C0AF11770246200DF03B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>671C0AF61770246200DF03B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>671C0AF21770246200DF03B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>671C0AF71770246200DF03B3</key>
-		<dict>
-			<key>fileRef</key>
-			<string>671C0AF31770246200DF03B3</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67509ABA17979781003A3A29</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofXml.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67509ABB17979781003A3A29</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofXml.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67509ABC17979781003A3A29</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67509ABA17979781003A3A29</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67509ABD17979781003A3A29</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67509ABB17979781003A3A29</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F7E19F8990D00DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofFpsCounter.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F7F19F8990D00DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFpsCounter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8019F8990D00DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofThreadChannel.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8119F8990D00DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTimer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8219F8990D00DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTimer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8319F8990D00DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F7E19F8990D00DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8419F8990D00DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F7F19F8990D00DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8519F8990D00DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F8019F8990D00DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8619F8990D00DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F8119F8990D00DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8719F8990D00DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F8219F8990D00DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8819F8996300DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBufferObject.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8919F8996300DBE7AA</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBufferObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67833F8A19F8996300DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F8819F8996300DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67833F8B19F8996300DBE7AA</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67833F8919F8996300DBE7AA</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D19176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1A176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundStream.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1B176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundStreamDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1C176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundStreamDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1D176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundInputStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1E176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundInputStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D1F176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundOutputStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D20176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundOutputStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D21176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D22176F04F800D1CC68</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>678C3D23176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D19176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D24176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1A176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D25176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1B176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D26176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1C176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D27176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1D176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D28176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1E176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D29176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D1F176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D2A176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D20176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D2B176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D21176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>678C3D2C176F04F800D1CC68</key>
-		<dict>
-			<key>fileRef</key>
-			<string>678C3D22176F04F800D1CC68</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67D48ECF1C10399900F719BC</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreMotion.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreMotion.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>67D48ED01C10399900F719BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67D48ECF1C10399900F719BC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67D48ED11C103BAE00F719BC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSCoreMotion.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67D48ED21C103BAE00F719BC</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSCoreMotion.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>67D48ED31C103BAE00F719BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67D48ED11C103BAE00F719BC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>67D48ED41C103BAE00F719BC</key>
-		<dict>
-			<key>fileRef</key>
-			<string>67D48ED21C103BAE00F719BC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CC21FE45BAC004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBaseApp.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CC31FE45BAC004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CC21FE45BAC004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CC41FE45BB7004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CC51FE45BB7004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CC41FE45BB7004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CC61FE45BCD004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGraphicsBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CC71FE45BCD004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphicsBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CC81FE45BCD004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphicsConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CC91FE45BCD004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>ofPolyline.inl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CCA1FE45BCD004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CC61FE45BCD004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CCB1FE45BCD004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CC71FE45BCD004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CCC1FE45BCD004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CC81FE45BCD004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CCD1FE45BD9004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>ofMesh.inl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CCE1FE45BF2004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CCF1FE45BF2004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CD01FE45BF2004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CCE1FE45BF2004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CD11FE45BF2004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CCF1FE45BF2004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>69433CD21FE45E41004D5B73</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMathConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>69433CD31FE45E41004D5B73</key>
-		<dict>
-			<key>fileRef</key>
-			<string>69433CD21FE45E41004D5B73</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>860B024C17A96D840032B827</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOS.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>860B024D17A96D840032B827</key>
-		<dict>
-			<key>fileRef</key>
-			<string>860B024C17A96D840032B827</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90080013204EDA1300DC786A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSGLKViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90080014204EDA1300DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90080013204EDA1300DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90080015204EDA4600DC786A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSGLKViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90080016204EDA4B00DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90080015204EDA4600DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90080017204EDB5500DC786A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSGLKView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90080018204EDB5500DC786A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSGLKView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90080019204EDB5500DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90080017204EDB5500DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9008001A204EDB5500DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90080018204EDB5500DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9008001B204EDC0E00DC786A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>EAGLKView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9008001C204EDC0F00DC786A</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>EAGLKView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9008001D204EDC0F00DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9008001B204EDC0E00DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9008001E204EDC0F00DC786A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9008001C204EDC0F00DC786A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>901808B8205362D7004A7774</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>GLKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/GLKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>901808B9205362D7004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>901808B8205362D7004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9252B7EF1CDA2A6100A8032B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSEventAdapter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9252B7F01CDA2A6100A8032B</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSEventAdapter.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9252B7F11CDA2A6100A8032B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9252B7EF1CDA2A6100A8032B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9252B7F21CDA2A6100A8032B</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9252B7F01CDA2A6100A8032B</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D86F1BDDCD440002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8701BDDCD440002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D86F1BDDCD440002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>99752D321BF21EEE0026316A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>GameController.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/GameController.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>99752D331BF21EEE0026316A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>99752D321BF21EEE0026316A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9979E8171A1B9883007E55D1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofWindowSettings.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9979E8181A1B9883007E55D1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9979E8171A1B9883007E55D1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9979E8261A1CDBD4007E55D1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMainLoop.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9979E8271A1CDBD4007E55D1</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMainLoop.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9979E8281A1CDBD4007E55D1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9979E8261A1CDBD4007E55D1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9979E8291A1CDBD4007E55D1</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9979E8271A1CDBD4007E55D1</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB16E9930F2B1E5900518274</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BBE5E94E0F497BD800F28951</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>libs</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BB16EBD10F2B2A9500518274</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>OpenGLES.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/OpenGLES.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>BB16EBD80F2B2AB500518274</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>QuartzCore.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/QuartzCore.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>BB16F26B0F2B646B00518274</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BB24E02310DA7C6100E9C588</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>addons</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BB24DE5C10DA7A3F00E9C588</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>BB24DED210DA7A3F00E9C588</string>
-			<key>buildPhases</key>
-			<array>
-				<string>BB24DE5D10DA7A3F00E9C588</string>
-				<string>BB24DEB110DA7A3F00E9C588</string>
-				<string>BB24DEC910DA7A3F00E9C588</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>iPhone+OF Static Library</string>
-			<key>productName</key>
-			<string>Static Library</string>
-			<key>productReference</key>
-			<string>BB24DED610DA7A3F00E9C588</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>BB24DE5D10DA7A3F00E9C588</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E4F76E1A176CB27200798745</string>
-				<string>E4F76E1C176CB27200798745</string>
-				<string>E4F76E1E176CB27200798745</string>
-				<string>E4F76E20176CB27200798745</string>
-				<string>E4F76E22176CB27200798745</string>
-				<string>E4F76E24176CB27200798745</string>
-				<string>67833F8419F8990D00DBE7AA</string>
-				<string>E4F76E25176CB27200798745</string>
-				<string>90080019204EDB5500DC786A</string>
-				<string>E4F76E2F176CB27200798745</string>
-				<string>E4F76E30176CB27200798745</string>
-				<string>E4F76E37176CB27200798745</string>
-				<string>E4F76E38176CB27200798745</string>
-				<string>67D48ED31C103BAE00F719BC</string>
-				<string>E4F76E3A176CB27200798745</string>
-				<string>E4F76E3C176CB27200798745</string>
-				<string>E4F76E3E176CB27200798745</string>
-				<string>69433CD31FE45E41004D5B73</string>
-				<string>E4F76E40176CB27200798745</string>
-				<string>E4F76E42176CB27200798745</string>
-				<string>E4F76E44176CB27200798745</string>
-				<string>9252B7F11CDA2A6100A8032B</string>
-				<string>E4F76E46176CB27200798745</string>
-				<string>E4F76E4A176CB27200798745</string>
-				<string>E4F76E4C176CB27200798745</string>
-				<string>E4F76E4E176CB27200798745</string>
-				<string>E4F76E50176CB27200798745</string>
-				<string>E4F76E52176CB27200798745</string>
-				<string>E4F76E56176CB27200798745</string>
-				<string>E4F76E58176CB27200798745</string>
-				<string>E4F76E5A176CB27200798745</string>
-				<string>E4F76E5C176CB27200798745</string>
-				<string>69433CCB1FE45BCD004D5B73</string>
-				<string>E4F76E5E176CB27200798745</string>
-				<string>E4F76E60176CB27200798745</string>
-				<string>E4F76E62176CB27200798745</string>
-				<string>E4F76E64176CB27200798745</string>
-				<string>E4F76E66176CB27200798745</string>
-				<string>E4F76E68176CB27200798745</string>
-				<string>E4F76E6A176CB27200798745</string>
-				<string>69433CC51FE45BB7004D5B73</string>
-				<string>E4F76E6C176CB27200798745</string>
-				<string>69433CCC1FE45BCD004D5B73</string>
-				<string>E4F76E6E176CB27200798745</string>
-				<string>9979E8291A1CDBD4007E55D1</string>
-				<string>E4F76E6F176CB27200798745</string>
-				<string>E4F76E71176CB27200798745</string>
-				<string>E4F76E72176CB27200798745</string>
-				<string>9008001E204EDC0F00DC786A</string>
-				<string>67833F8519F8990D00DBE7AA</string>
-				<string>E4F76E73176CB27200798745</string>
-				<string>E4F76E81176CB27200798745</string>
-				<string>E4F76E83176CB27200798745</string>
-				<string>9957D8701BDDCD440002D53C</string>
-				<string>E4F76E87176CB27200798745</string>
-				<string>E4F76E89176CB27200798745</string>
-				<string>E4F76E8B176CB27200798745</string>
-				<string>E4F76E8D176CB27200798745</string>
-				<string>6678E97819FEB2DF00C00581</string>
-				<string>E4F76E8F176CB27200798745</string>
-				<string>E4F76E90176CB27200798745</string>
-				<string>E4F76E91176CB27200798745</string>
-				<string>9979E8181A1B9883007E55D1</string>
-				<string>E4F76E93176CB27200798745</string>
-				<string>E4F76E95176CB27200798745</string>
-				<string>E4F76E97176CB27200798745</string>
-				<string>E4F76E98176CB27200798745</string>
-				<string>E4F76E9A176CB27200798745</string>
-				<string>E4F76E9C176CB27200798745</string>
-				<string>E4F76E9E176CB27200798745</string>
-				<string>E4F76EA0176CB27200798745</string>
-				<string>E4F76EB6176CB27200798745</string>
-				<string>67833F8B19F8996300DBE7AA</string>
-				<string>E4F76EB8176CB27200798745</string>
-				<string>15594F0F15C55AC900727FF2</string>
-				<string>15594F1015C55AC900727FF2</string>
-				<string>15594F1115C55AC900727FF2</string>
-				<string>15594F1215C55AC900727FF2</string>
-				<string>15594F8515C5697C00727FF2</string>
-				<string>15594F8715C5697C00727FF2</string>
-				<string>15594F9415C56A8A00727FF2</string>
-				<string>15594F9515C56A8A00727FF2</string>
-				<string>15594F9615C56A8A00727FF2</string>
-				<string>6678E97719FEB2DF00C00581</string>
-				<string>15594FA515C56BB700727FF2</string>
-				<string>15594FA615C56BB700727FF2</string>
-				<string>15594FAD15C56C9500727FF2</string>
-				<string>15594FAE15C56C9500727FF2</string>
-				<string>15594FC515C56D1E00727FF2</string>
-				<string>15594FC615C56D1E00727FF2</string>
-				<string>15594FC715C56D1E00727FF2</string>
-				<string>15594FC815C56D1E00727FF2</string>
-				<string>15594FC915C56D1E00727FF2</string>
-				<string>15594FCA15C56D1E00727FF2</string>
-				<string>69433CD11FE45BF2004D5B73</string>
-				<string>15594FCB15C56D1E00727FF2</string>
-				<string>90080016204EDA4B00DC786A</string>
-				<string>15594FCC15C56D1E00727FF2</string>
-				<string>1594366615CF5F420087B684</string>
-				<string>1594366715CF5F420087B684</string>
-				<string>678C3D23176F04F800D1CC68</string>
-				<string>678C3D25176F04F800D1CC68</string>
-				<string>678C3D27176F04F800D1CC68</string>
-				<string>678C3D29176F04F800D1CC68</string>
-				<string>678C3D2B176F04F800D1CC68</string>
-				<string>671C0AF41770246200DF03B3</string>
-				<string>671C0AF61770246200DF03B3</string>
-				<string>67833F8719F8990D00DBE7AA</string>
-				<string>67509ABD17979781003A3A29</string>
-				<string>66EA462C17A6D396009BB12A</string>
-				<string>66EA462E17A6D396009BB12A</string>
-				<string>860B024D17A96D840032B827</string>
-			</array>
-			<key>isa</key>
-			<string>PBXHeadersBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BB24DEB110DA7A3F00E9C588</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>E4F76E19176CB27200798745</string>
-				<string>E4F76E1B176CB27200798745</string>
-				<string>E4F76E1D176CB27200798745</string>
-				<string>E4F76E1F176CB27200798745</string>
-				<string>E4F76E23176CB27200798745</string>
-				<string>E4F76E2E176CB27200798745</string>
-				<string>67833F8319F8990D00DBE7AA</string>
-				<string>E4F76E36176CB27200798745</string>
-				<string>E4F76E39176CB27200798745</string>
-				<string>E4F76E3B176CB27200798745</string>
-				<string>E4F76E3D176CB27200798745</string>
-				<string>E4F76E3F176CB27200798745</string>
-				<string>E4F76E41176CB27200798745</string>
-				<string>E4F76E43176CB27200798745</string>
-				<string>E4F76E45176CB27200798745</string>
-				<string>E4F76E49176CB27200798745</string>
-				<string>E4F76E4B176CB27200798745</string>
-				<string>90080014204EDA1300DC786A</string>
-				<string>E4F76E4D176CB27200798745</string>
-				<string>E4F76E4F176CB27200798745</string>
-				<string>E4F76E51176CB27200798745</string>
-				<string>E4F76E55176CB27200798745</string>
-				<string>E4F76E57176CB27200798745</string>
-				<string>E4F76E59176CB27200798745</string>
-				<string>E4F76E5B176CB27200798745</string>
-				<string>E4F76E5F176CB27200798745</string>
-				<string>E4F76E61176CB27200798745</string>
-				<string>E4F76E63176CB27200798745</string>
-				<string>E4F76E65176CB27200798745</string>
-				<string>67833F8619F8990D00DBE7AA</string>
-				<string>E4F76E67176CB27200798745</string>
-				<string>E4F76E69176CB27200798745</string>
-				<string>E4F76E6B176CB27200798745</string>
-				<string>E4F76E6D176CB27200798745</string>
-				<string>E4F76E70176CB27200798745</string>
-				<string>69433CD01FE45BF2004D5B73</string>
-				<string>E4F76E80176CB27200798745</string>
-				<string>E4F76E82176CB27200798745</string>
-				<string>E4F76E84176CB27200798745</string>
-				<string>E4F76E86176CB27200798745</string>
-				<string>6678E97619FEB2DF00C00581</string>
-				<string>E4F76E88176CB27200798745</string>
-				<string>E4F76E8A176CB27200798745</string>
-				<string>E4F76E8E176CB27200798745</string>
-				<string>E4F76E92176CB27200798745</string>
-				<string>E4F76E94176CB27200798745</string>
-				<string>E4F76E96176CB27200798745</string>
-				<string>E4F76E99176CB27200798745</string>
-				<string>E4F76E9B176CB27200798745</string>
-				<string>E4F76E9D176CB27200798745</string>
-				<string>E4F76E9F176CB27200798745</string>
-				<string>E4F76EB5176CB27200798745</string>
-				<string>E4F76EB7176CB27200798745</string>
-				<string>15594F0C15C55AC900727FF2</string>
-				<string>9252B7F21CDA2A6100A8032B</string>
-				<string>9979E8281A1CDBD4007E55D1</string>
-				<string>15594F0D15C55AC900727FF2</string>
-				<string>15594F0E15C55AC900727FF2</string>
-				<string>15594F8115C5697C00727FF2</string>
-				<string>15594F9115C56A8A00727FF2</string>
-				<string>15594F9215C56A8A00727FF2</string>
-				<string>69433CCA1FE45BCD004D5B73</string>
-				<string>15594F9315C56A8A00727FF2</string>
-				<string>9008001D204EDC0F00DC786A</string>
-				<string>15594FA315C56BB700727FF2</string>
-				<string>15594FA415C56BB700727FF2</string>
-				<string>15594FAC15C56C9500727FF2</string>
-				<string>15594FBE15C56D1E00727FF2</string>
-				<string>15594FBF15C56D1E00727FF2</string>
-				<string>15594FC015C56D1E00727FF2</string>
-				<string>15594FC115C56D1E00727FF2</string>
-				<string>15594FC215C56D1E00727FF2</string>
-				<string>15594FC315C56D1E00727FF2</string>
-				<string>15594FC415C56D1E00727FF2</string>
-				<string>69433CC31FE45BAC004D5B73</string>
-				<string>67833F8A19F8996300DBE7AA</string>
-				<string>1594366415CF5F420087B684</string>
-				<string>1594366515CF5F420087B684</string>
-				<string>678C3D24176F04F800D1CC68</string>
-				<string>678C3D26176F04F800D1CC68</string>
-				<string>678C3D28176F04F800D1CC68</string>
-				<string>678C3D2A176F04F800D1CC68</string>
-				<string>678C3D2C176F04F800D1CC68</string>
-				<string>671C0AF51770246200DF03B3</string>
-				<string>671C0AF71770246200DF03B3</string>
-				<string>67509ABC17979781003A3A29</string>
-				<string>66EA462B17A6D396009BB12A</string>
-				<string>67D48ED41C103BAE00F719BC</string>
-				<string>9008001A204EDB5500DC786A</string>
-				<string>66EA462D17A6D396009BB12A</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BB24DEC910DA7A3F00E9C588</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>99752D331BF21EEE0026316A</string>
-				<string>67D48ED01C10399900F719BC</string>
-				<string>BB24DECA10DA7A3F00E9C588</string>
-				<string>BB24DECB10DA7A3F00E9C588</string>
-				<string>BB24DECC10DA7A3F00E9C588</string>
-				<string>BB24DECD10DA7A3F00E9C588</string>
-				<string>901808B9205362D7004A7774</string>
-				<string>BB24DECE10DA7A3F00E9C588</string>
-				<string>BB24DECF10DA7A3F00E9C588</string>
-				<string>BB24DED010DA7A3F00E9C588</string>
-				<string>BB24DED110DA7A3F00E9C588</string>
-				<string>5E2E99DD10ED147800587639</string>
-				<string>53DA338A12DF8F4500C622CE</string>
-				<string>53DA338E12DF8F5000C622CE</string>
-				<string>53DA339012DF8F5000C622CE</string>
-				<string>53DA339212DF8F5000C622CE</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>BB24DECA10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BBE5EAB70F49AD8400F28951</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DECB10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BB16EBD10F2B2A9500518274</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DECC10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1DF5F4DF0D08C38300B7A737</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DECD10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>53F323EA10A20EDB00E0DAE4</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DECE10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>1D30AB110D05D00D00671497</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DECF10DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>288765FC0DF74451002DB57D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DED010DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>5326AEA710A23A0500278DE6</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DED110DA7A3F00E9C588</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BB16EBD80F2B2AB500518274</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>BB24DED210DA7A3F00E9C588</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>BB24DED310DA7A3F00E9C588</string>
-				<string>BB24DED410DA7A3F00E9C588</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Debug</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>BB24DED310DA7A3F00E9C588</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DEAD_CODE_STRIPPING</key>
-				<string>NO</string>
-				<key>EXECUTABLE_PREFIX</key>
-				<string>lib</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>NO</string>
-				<key>GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS</key>
-				<string>YES</string>
-				<key>GCC_WARN_NON_VIRTUAL_DESTRUCTOR</key>
-				<string>YES</string>
-				<key>LIBRARY_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(SRCROOT)/kiss/lib/linux"</string>
-					<string>"$(SRCROOT)/kiss/lib/linux64"</string>
-					<string>"$(SRCROOT)/../../../tess2/lib/ios"</string>
-					<string>"$(SRCROOT)/../../../poco/lib/ios"</string>
-				</array>
-				<key>PRODUCT_NAME</key>
-				<string>ofxiOS_${PLATFORM_NAME}_Debug</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>BB24DED410DA7A3F00E9C588</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD)</string>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEAD_CODE_STRIPPING</key>
-				<string>NO</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>EXECUTABLE_PREFIX</key>
-				<string>lib</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>NO</string>
-				<key>GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS</key>
-				<string>YES</string>
-				<key>GCC_WARN_NON_VIRTUAL_DESTRUCTOR</key>
-				<string>YES</string>
-				<key>LIBRARY_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>"$(SRCROOT)/kiss/lib/linux"</string>
-					<string>"$(SRCROOT)/kiss/lib/linux64"</string>
-					<string>"$(SRCROOT)/../../../tess2/lib/ios"</string>
-					<string>"$(SRCROOT)/../../../poco/lib/ios"</string>
-				</array>
-				<key>PRODUCT_NAME</key>
-				<string>ofxiOS_${PLATFORM_NAME}_Release</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-				<key>ZERO_LINK</key>
-				<string>NO</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>BB24DED610DA7A3F00E9C588</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libofxiOS_iphoneos_Debug.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>BB24E02310DA7C6100E9C588</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>BB24E02810DA7C6100E9C588</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ofxiOS</string>
-			<key>path</key>
-			<string>../../../../addons/ofxiOS</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>BB24E02810DA7C6100E9C588</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>860B024C17A96D840032B827</string>
-				<string>6711091F19D3EAC6005D095F</string>
-				<string>15BC775215A5C31F00772525</string>
-				<string>15594EFE15C55A5700727FF2</string>
-				<string>15594F8A15C56A4E00727FF2</string>
-				<string>15594F0015C55A5700727FF2</string>
-				<string>15594F0115C55A5700727FF2</string>
-				<string>15594F0315C55A5700727FF2</string>
-				<string>15594EFF15C55A5700727FF2</string>
-				<string>15594F0215C55A5700727FF2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>src</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BBE5E94E0F497BD800F28951</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>29B97323FDCFA39411CA2CEA</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>core</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BBE5EAB70F49AD8400F28951</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AudioToolbox.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AudioToolbox.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>C01FCF4E08A954540054247B</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>C01FCF4F08A954540054247B</string>
-				<string>C01FCF5008A954540054247B</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Debug</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>C01FCF4F08A954540054247B</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E41D3E9113B38BE900A75A5D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD)</string>
-				<key>CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_COMMA</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INFINITE_RECURSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_NON_LITERAL_NULL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_LITERAL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_RANGE_LOOP_ANALYSIS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_STRICT_PROTOTYPES</key>
-				<string>YES</string>
-				<key>CLANG_WARN_SUSPICIOUS_MOVE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>CONFIGURATION_TEMP_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/build/debug/</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_CHECK_SWITCH_STATEMENTS</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/../../lib/ios/build/debug</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SUPPORTED_PLATFORMS</key>
-				<string>iphonesimulator iphoneos</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>VALID_ARCHS</key>
-				<string>$(ARCHS_STANDARD)</string>
-				<key>WARNING_CFLAGS</key>
-				<array>
-					<string>-Wno-non-virtual-dtor</string>
-					<string>-Wno-overloaded-virtual</string>
-				</array>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>C01FCF5008A954540054247B</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E41D3E9213B38BE900A75A5D</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD)</string>
-				<key>CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_COMMA</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INFINITE_RECURSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_NON_LITERAL_NULL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_LITERAL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_RANGE_LOOP_ANALYSIS</key>
-				<string>YES</string>
-				<key>CLANG_WARN_STRICT_PROTOTYPES</key>
-				<string>YES</string>
-				<key>CLANG_WARN_SUSPICIOUS_MOVE</key>
-				<string>YES</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>CONFIGURATION_TEMP_DIR</key>
-				<string>$(SRCROOT)/../../lib/ios/build/release/</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_CHECK_SWITCH_STATEMENTS</key>
-				<string>NO</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/../../lib/ios/build/release</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>NO</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>SUPPORTED_PLATFORMS</key>
-				<string>iphonesimulator iphoneos</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/../../lib/ios/</string>
-				<key>VALID_ARCHS</key>
-				<string>$(ARCHS_STANDARD)</string>
-				<key>WARNING_CFLAGS</key>
-				<array>
-					<string>-Wno-non-virtual-dtor</string>
-					<string>-Wno-overloaded-virtual</string>
-				</array>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>E41D3E9013B38BE900A75A5D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>CoreOF.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>E41D3E9113B38BE900A75A5D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>E41D3E9213B38BE900A75A5D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>E41D3E9313B38BE900A75A5D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Shared.xcconfig</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>E4F76D69176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4F76DCF176CB27200798745</string>
-				<string>E4F76D6E176CB27200798745</string>
-				<string>E4F76D7B176CB27200798745</string>
-				<string>E4F76D89176CB27200798745</string>
-				<string>E4F76D8E176CB27200798745</string>
-				<string>E4F76D92176CB27200798745</string>
-				<string>E4F76DA9176CB27200798745</string>
-				<string>E4F76DC0176CB27200798745</string>
-				<string>E4F76DD0176CB27200798745</string>
-				<string>E4F76DE1176CB27200798745</string>
-				<string>E4F76DEF176CB27200798745</string>
-				<string>E4F76E00176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>openFrameworks</string>
-			<key>path</key>
-			<string>../../../openFrameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D6E176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CCD1FE45BD9004D5B73</string>
-				<string>E4F76D6F176CB27200798745</string>
-				<string>E4F76D70176CB27200798745</string>
-				<string>E4F76D71176CB27200798745</string>
-				<string>E4F76D72176CB27200798745</string>
-				<string>E4F76D73176CB27200798745</string>
-				<string>E4F76D74176CB27200798745</string>
-				<string>E4F76D75176CB27200798745</string>
-				<string>E4F76D76176CB27200798745</string>
-				<string>E4F76D78176CB27200798745</string>
-				<string>E4F76D79176CB27200798745</string>
-				<string>E4F76D7A176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>3d</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D6F176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>of3dPrimitives.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D70176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dPrimitives.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D71176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>of3dUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D72176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D73176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofCamera.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D74176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofCamera.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D75176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofEasyCam.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D76176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEasyCam.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D78176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMesh.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D79176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofNode.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D7A176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D7B176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CC21FE45BAC004D5B73</string>
-				<string>E4F76D7C176CB27200798745</string>
-				<string>E4F76D85176CB27200798745</string>
-				<string>E4F76D86176CB27200798745</string>
-				<string>E4F76D87176CB27200798745</string>
-				<string>9979E8261A1CDBD4007E55D1</string>
-				<string>9979E8271A1CDBD4007E55D1</string>
-				<string>9979E8171A1B9883007E55D1</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>app</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D7C176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofAppBaseWindow.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D85176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofAppRunner.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D86176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofAppRunner.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D87176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBaseApp.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D89176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>communication</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D8E176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D86F1BDDCD440002D53C</string>
-				<string>E4F76D8F176CB27200798745</string>
-				<string>E4F76D90176CB27200798745</string>
-				<string>E4F76D91176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>events</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D8F176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofEvents.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D90176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEvents.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D91176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEventUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D92176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CC41FE45BB7004D5B73</string>
-				<string>67833F8819F8996300DBE7AA</string>
-				<string>67833F8919F8996300DBE7AA</string>
-				<string>E4F76D93176CB27200798745</string>
-				<string>E4F76D94176CB27200798745</string>
-				<string>E4F76D95176CB27200798745</string>
-				<string>E4F76D96176CB27200798745</string>
-				<string>E4F76D97176CB27200798745</string>
-				<string>E4F76D98176CB27200798745</string>
-				<string>E4F76D99176CB27200798745</string>
-				<string>E4F76D9A176CB27200798745</string>
-				<string>E4F76D9B176CB27200798745</string>
-				<string>E4F76D9C176CB27200798745</string>
-				<string>E4F76D9D176CB27200798745</string>
-				<string>E4F76D9E176CB27200798745</string>
-				<string>E4F76D9F176CB27200798745</string>
-				<string>E4F76DA0176CB27200798745</string>
-				<string>E4F76DA3176CB27200798745</string>
-				<string>E4F76DA4176CB27200798745</string>
-				<string>E4F76DA5176CB27200798745</string>
-				<string>E4F76DA6176CB27200798745</string>
-				<string>E4F76DA7176CB27200798745</string>
-				<string>E4F76DA8176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>gl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D93176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofFbo.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D94176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFbo.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D95176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLProgrammableRenderer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D96176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLProgrammableRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D97176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLRenderer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D98176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D99176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9A176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9B176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofLight.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9C176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofLight.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9D176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMaterial.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9E176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMaterial.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76D9F176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofShader.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA0176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofShader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA3176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTexture.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA4176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTexture.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA5176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVbo.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA6176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVbo.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA7176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVboMesh.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA8176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVboMesh.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DA9176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CC61FE45BCD004D5B73</string>
-				<string>69433CC71FE45BCD004D5B73</string>
-				<string>69433CC81FE45BCD004D5B73</string>
-				<string>69433CC91FE45BCD004D5B73</string>
-				<string>E4F76DAA176CB27200798745</string>
-				<string>E4F76DAB176CB27200798745</string>
-				<string>E4F76DAC176CB27200798745</string>
-				<string>E4F76DAD176CB27200798745</string>
-				<string>E4F76DB0176CB27200798745</string>
-				<string>E4F76DB1176CB27200798745</string>
-				<string>E4F76DB2176CB27200798745</string>
-				<string>E4F76DB3176CB27200798745</string>
-				<string>E4F76DB4176CB27200798745</string>
-				<string>E4F76DB5176CB27200798745</string>
-				<string>E4F76DB6176CB27200798745</string>
-				<string>E4F76DB7176CB27200798745</string>
-				<string>E4F76DB9176CB27200798745</string>
-				<string>E4F76DBA176CB27200798745</string>
-				<string>E4F76DBB176CB27200798745</string>
-				<string>E4F76DBC176CB27200798745</string>
-				<string>E4F76DBD176CB27200798745</string>
-				<string>E4F76DBE176CB27200798745</string>
-				<string>E4F76DBF176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>graphics</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DAA176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>of3dGraphics.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DAB176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dGraphics.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DAC176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBitmapFont.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DAD176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBitmapFont.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB0176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGraphics.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB1176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphics.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB2176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofImage.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB3176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofImage.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB4176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofPath.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB5176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB6176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofPixels.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB7176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPixels.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DB9176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPolyline.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBA176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofRendererCollection.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBB176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofRendererCollection.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBC176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTessellator.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBD176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTessellator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBE176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTrueTypeFont.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DBF176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTrueTypeFont.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC0176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CD21FE45E41004D5B73</string>
-				<string>E4F76DC1176CB27200798745</string>
-				<string>E4F76DC2176CB27200798745</string>
-				<string>E4F76DC3176CB27200798745</string>
-				<string>E4F76DC4176CB27200798745</string>
-				<string>E4F76DC5176CB27200798745</string>
-				<string>E4F76DC6176CB27200798745</string>
-				<string>E4F76DC7176CB27200798745</string>
-				<string>E4F76DC8176CB27200798745</string>
-				<string>E4F76DC9176CB27200798745</string>
-				<string>E4F76DCA176CB27200798745</string>
-				<string>E4F76DCB176CB27200798745</string>
-				<string>E4F76DCC176CB27200798745</string>
-				<string>E4F76DCD176CB27200798745</string>
-				<string>E4F76DCE176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>math</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC1176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMath.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC2176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC3176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMatrix3x3.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC4176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrix3x3.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC5176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMatrix4x4.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC6176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrix4x4.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC7176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofQuaternion.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC8176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofQuaternion.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DC9176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVec2f.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCA176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec2f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCB176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec3f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCC176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVec4f.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCD176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec4f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCE176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVectorMath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DCF176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMain.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DD0176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>69433CCE1FE45BF2004D5B73</string>
-				<string>69433CCF1FE45BF2004D5B73</string>
-				<string>6678E97219FEB2DF00C00581</string>
-				<string>6678E97319FEB2DF00C00581</string>
-				<string>E4F76DDD176CB27200798745</string>
-				<string>E4F76DDE176CB27200798745</string>
-				<string>E4F76DDF176CB27200798745</string>
-				<string>E4F76DE0176CB27200798745</string>
-				<string>6678E97419FEB2DF00C00581</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>sound</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DDD176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DDE176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DDF176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundStream.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE0176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE1176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4F76DE2176CB27200798745</string>
-				<string>E4F76DE4176CB27200798745</string>
-				<string>E4F76DE5176CB27200798745</string>
-				<string>E4F76DE6176CB27200798745</string>
-				<string>E4F76DE7176CB27200798745</string>
-				<string>E4F76DE8176CB27200798745</string>
-				<string>E4F76DE9176CB27200798745</string>
-				<string>E4F76DEB176CB27200798745</string>
-				<string>E4F76DEC176CB27200798745</string>
-				<string>E4F76DED176CB27200798745</string>
-				<string>E4F76DEE176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>types</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE2176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE4176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofColor.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE5176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofColor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE6176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofParameter.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE7176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofParameter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE8176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofParameterGroup.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DE9176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofParameterGroup.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DEB176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPoint.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DEC176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofRectangle.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DED176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofRectangle.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DEE176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DEF176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4F76DF0176CB27200798745</string>
-				<string>E4F76DF1176CB27200798745</string>
-				<string>E4F76DF2176CB27200798745</string>
-				<string>67833F7E19F8990D00DBE7AA</string>
-				<string>67833F7F19F8990D00DBE7AA</string>
-				<string>E4F76DF3176CB27200798745</string>
-				<string>E4F76DF4176CB27200798745</string>
-				<string>E4F76DF5176CB27200798745</string>
-				<string>E4F76DF6176CB27200798745</string>
-				<string>E4F76DF7176CB27200798745</string>
-				<string>E4F76DF8176CB27200798745</string>
-				<string>E4F76DF9176CB27200798745</string>
-				<string>E4F76DFA176CB27200798745</string>
-				<string>E4F76DFB176CB27200798745</string>
-				<string>67833F8019F8990D00DBE7AA</string>
-				<string>67833F8119F8990D00DBE7AA</string>
-				<string>67833F8219F8990D00DBE7AA</string>
-				<string>E4F76DFC176CB27200798745</string>
-				<string>E4F76DFD176CB27200798745</string>
-				<string>E4F76DFE176CB27200798745</string>
-				<string>E4F76DFF176CB27200798745</string>
-				<string>67509ABA17979781003A3A29</string>
-				<string>67509ABB17979781003A3A29</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>utils</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF0176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF1176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofFileUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF2176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFileUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF3176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofLog.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF4176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofLog.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF5176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofMatrixStack.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF6176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrixStack.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF7176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofNoise.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF8176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofSystemUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DF9176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSystemUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFA176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofThread.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFB176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofThread.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFC176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofURLFileLoader.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFD176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofURLFileLoader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFE176CB27200798745</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76DFF176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E00176CB27200798745</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>E4F76E15176CB27200798745</string>
-				<string>E4F76E16176CB27200798745</string>
-				<string>E4F76E17176CB27200798745</string>
-				<string>E4F76E18176CB27200798745</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>video</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E15176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVideoGrabber.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E16176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E17176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVideoPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E18176CB27200798745</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>E4F76E19176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D6F176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D70176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D71176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D72176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D73176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D74176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E1F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D75176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E20176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D76176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E22176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D78176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E23176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D79176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E24176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D7A176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E25176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D7C176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E2E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D85176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E2F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D86176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E30176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D87176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E36176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D8F176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E37176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D90176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E38176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D91176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E39176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D93176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D94176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D95176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D96176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D97176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D98176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E3F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D99176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E40176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9A176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E41176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9B176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E42176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9C176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E43176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9D176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E44176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9E176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E45176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76D9F176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E46176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA0176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E49176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA3176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA4176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA5176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA6176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA7176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DA8176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E4F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DAA176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E50176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DAB176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E51176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DAC176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E52176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DAD176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E55176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB0176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E56176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB1176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E57176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB2176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E58176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB3176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E59176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB4176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E5A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB5176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E5B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB6176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E5C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB7176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E5E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DB9176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E5F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBA176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E60176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBB176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E61176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBC176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E62176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBD176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E63176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBE176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E64176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DBF176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E65176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC1176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E66176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC2176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E67176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC3176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E68176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC4176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E69176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC5176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC6176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC7176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC8176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DC9176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCA176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E6F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCB176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E70176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCC176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E71176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCD176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E72176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCE176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E73176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DCF176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E80176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DDD176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E81176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DDE176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E82176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DDF176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E83176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE0176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E84176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE2176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E86176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE4176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E87176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE5176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E88176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE6176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E89176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE7176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E8A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE8176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E8B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DE9176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E8D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DEB176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E8E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DEC176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E8F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DED176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E90176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DEE176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E91176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF0176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E92176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF1176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E93176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF2176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E94176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF3176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E95176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF4176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E96176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF5176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E97176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF6176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E98176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF7176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E99176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF8176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9A176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DF9176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9B176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFA176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9C176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFB176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9D176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFC176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9E176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFD176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76E9F176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFE176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76EA0176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76DFF176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76EB5176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76E15176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76EB6176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76E16176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76EB7176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76E17176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>E4F76EB8176CB27200798745</key>
-		<dict>
-			<key>fileRef</key>
-			<string>E4F76E18176CB27200798745</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>29B97313FDCFA39411CA2CEA</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		15594F0C15C55AC900727FF2 /* EAGLView.m in Sources */ = {isa = PBXBuildFile; fileRef = 15594F0515C55AC900727FF2 /* EAGLView.m */; };
+		15594F0D15C55AC900727FF2 /* ES1Renderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 15594F0615C55AC900727FF2 /* ES1Renderer.m */; };
+		15594F0E15C55AC900727FF2 /* ES2Renderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 15594F0715C55AC900727FF2 /* ES2Renderer.m */; };
+		15594F0F15C55AC900727FF2 /* EAGLView.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F0815C55AC900727FF2 /* EAGLView.h */; };
+		15594F1015C55AC900727FF2 /* ES1Renderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F0915C55AC900727FF2 /* ES1Renderer.h */; };
+		15594F1115C55AC900727FF2 /* ES2Renderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F0A15C55AC900727FF2 /* ES2Renderer.h */; };
+		15594F1215C55AC900727FF2 /* ESRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F0B15C55AC900727FF2 /* ESRenderer.h */; };
+		15594F8115C5697C00727FF2 /* ofAppiOSWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594F7815C5697C00727FF2 /* ofAppiOSWindow.mm */; };
+		15594F8515C5697C00727FF2 /* ofAppiOSWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F7C15C5697C00727FF2 /* ofAppiOSWindow.h */; };
+		15594F8715C5697C00727FF2 /* ofxiOSApp.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F7E15C5697C00727FF2 /* ofxiOSApp.h */; };
+		15594F9115C56A8A00727FF2 /* ofxiOSEAGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594F8B15C56A8A00727FF2 /* ofxiOSEAGLView.mm */; };
+		15594F9215C56A8A00727FF2 /* ofxiOSAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594F8C15C56A8A00727FF2 /* ofxiOSAppDelegate.mm */; };
+		15594F9315C56A8A00727FF2 /* ofxiOSViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594F8D15C56A8A00727FF2 /* ofxiOSViewController.mm */; };
+		15594F9415C56A8A00727FF2 /* ofxiOSEAGLView.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F8E15C56A8A00727FF2 /* ofxiOSEAGLView.h */; };
+		15594F9515C56A8A00727FF2 /* ofxiOSAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F8F15C56A8A00727FF2 /* ofxiOSAppDelegate.h */; };
+		15594F9615C56A8A00727FF2 /* ofxiOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594F9015C56A8A00727FF2 /* ofxiOSViewController.h */; };
+		15594FA315C56BB700727FF2 /* AVFoundationVideoGrabber.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594F9F15C56BB700727FF2 /* AVFoundationVideoGrabber.mm */; };
+		15594FA415C56BB700727FF2 /* AVFoundationVideoPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 15594FA015C56BB700727FF2 /* AVFoundationVideoPlayer.m */; };
+		15594FA515C56BB700727FF2 /* AVFoundationVideoGrabber.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FA115C56BB700727FF2 /* AVFoundationVideoGrabber.h */; };
+		15594FA615C56BB700727FF2 /* AVFoundationVideoPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FA215C56BB700727FF2 /* AVFoundationVideoPlayer.h */; };
+		15594FAC15C56C9500727FF2 /* ofxiOSAlerts.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FA815C56C9500727FF2 /* ofxiOSAlerts.mm */; };
+		15594FAD15C56C9500727FF2 /* ofxiOSAlerts.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FA915C56C9500727FF2 /* ofxiOSAlerts.h */; };
+		15594FAE15C56C9500727FF2 /* ofxiOSAlertsListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FAA15C56C9500727FF2 /* ofxiOSAlertsListener.h */; };
+		15594FBE15C56D1E00727FF2 /* ofxiOSCoreLocation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FAF15C56D1E00727FF2 /* ofxiOSCoreLocation.mm */; };
+		15594FBF15C56D1E00727FF2 /* ofxiOSExternalDisplay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB015C56D1E00727FF2 /* ofxiOSExternalDisplay.mm */; };
+		15594FC015C56D1E00727FF2 /* ofxiOSExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB115C56D1E00727FF2 /* ofxiOSExtras.mm */; };
+		15594FC115C56D1E00727FF2 /* ofxiOSImagePicker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB215C56D1E00727FF2 /* ofxiOSImagePicker.mm */; };
+		15594FC215C56D1E00727FF2 /* ofxiOSKeyboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB315C56D1E00727FF2 /* ofxiOSKeyboard.mm */; };
+		15594FC315C56D1E00727FF2 /* ofxiOSMapKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB415C56D1E00727FF2 /* ofxiOSMapKit.mm */; };
+		15594FC415C56D1E00727FF2 /* ofxiOSMapKitDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 15594FB515C56D1E00727FF2 /* ofxiOSMapKitDelegate.mm */; };
+		15594FC515C56D1E00727FF2 /* ofxiOSCoreLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FB615C56D1E00727FF2 /* ofxiOSCoreLocation.h */; };
+		15594FC615C56D1E00727FF2 /* ofxiOSExternalDisplay.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FB715C56D1E00727FF2 /* ofxiOSExternalDisplay.h */; };
+		15594FC715C56D1E00727FF2 /* ofxiOSExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FB815C56D1E00727FF2 /* ofxiOSExtras.h */; };
+		15594FC815C56D1E00727FF2 /* ofxiOSImagePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FB915C56D1E00727FF2 /* ofxiOSImagePicker.h */; };
+		15594FC915C56D1E00727FF2 /* ofxiOSKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FBA15C56D1E00727FF2 /* ofxiOSKeyboard.h */; };
+		15594FCA15C56D1E00727FF2 /* ofxiOSMapKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FBB15C56D1E00727FF2 /* ofxiOSMapKit.h */; };
+		15594FCB15C56D1E00727FF2 /* ofxiOSMapKitDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FBC15C56D1E00727FF2 /* ofxiOSMapKitDelegate.h */; };
+		15594FCC15C56D1E00727FF2 /* ofxiOSMapKitListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 15594FBD15C56D1E00727FF2 /* ofxiOSMapKitListener.h */; };
+		1594366415CF5F420087B684 /* ofxiOSVideoGrabber.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1594366015CF5F420087B684 /* ofxiOSVideoGrabber.mm */; };
+		1594366515CF5F420087B684 /* ofxiOSVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1594366115CF5F420087B684 /* ofxiOSVideoPlayer.mm */; };
+		1594366615CF5F420087B684 /* ofxiOSVideoGrabber.h in Headers */ = {isa = PBXBuildFile; fileRef = 1594366215CF5F420087B684 /* ofxiOSVideoGrabber.h */; };
+		1594366715CF5F420087B684 /* ofxiOSVideoPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1594366315CF5F420087B684 /* ofxiOSVideoPlayer.h */; };
+		53DA338A12DF8F4500C622CE /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA338912DF8F4500C622CE /* AVFoundation.framework */; };
+		53DA338E12DF8F5000C622CE /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA338D12DF8F5000C622CE /* CoreAudio.framework */; };
+		53DA339012DF8F5000C622CE /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA338F12DF8F5000C622CE /* CoreMedia.framework */; };
+		53DA339212DF8F5000C622CE /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53DA339112DF8F5000C622CE /* CoreVideo.framework */; };
+		5E2E99DD10ED147800587639 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E2E99DC10ED147800587639 /* MapKit.framework */; };
+		6678E97619FEB2DF00C00581 /* ofSoundBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6678E97219FEB2DF00C00581 /* ofSoundBuffer.cpp */; };
+		6678E97719FEB2DF00C00581 /* ofSoundBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6678E97319FEB2DF00C00581 /* ofSoundBuffer.h */; };
+		6678E97819FEB2DF00C00581 /* ofSoundUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6678E97419FEB2DF00C00581 /* ofSoundUtils.h */; };
+		66EA462B17A6D396009BB12A /* ofxOpenALSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */; };
+		66EA462C17A6D396009BB12A /* ofxOpenALSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */; };
+		66EA462D17A6D396009BB12A /* SoundEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66EA462917A6D396009BB12A /* SoundEngine.cpp */; };
+		66EA462E17A6D396009BB12A /* SoundEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 66EA462A17A6D396009BB12A /* SoundEngine.h */; };
+		671C0AF41770246200DF03B3 /* AVSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 671C0AF01770246200DF03B3 /* AVSoundPlayer.h */; };
+		671C0AF51770246200DF03B3 /* AVSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 671C0AF11770246200DF03B3 /* AVSoundPlayer.m */; };
+		671C0AF61770246200DF03B3 /* ofxiOSSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 671C0AF21770246200DF03B3 /* ofxiOSSoundPlayer.h */; };
+		671C0AF71770246200DF03B3 /* ofxiOSSoundPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 671C0AF31770246200DF03B3 /* ofxiOSSoundPlayer.mm */; };
+		67509ABC17979781003A3A29 /* ofXml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67509ABA17979781003A3A29 /* ofXml.cpp */; };
+		67509ABD17979781003A3A29 /* ofXml.h in Headers */ = {isa = PBXBuildFile; fileRef = 67509ABB17979781003A3A29 /* ofXml.h */; };
+		67833F8319F8990D00DBE7AA /* ofFpsCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67833F7E19F8990D00DBE7AA /* ofFpsCounter.cpp */; };
+		67833F8419F8990D00DBE7AA /* ofFpsCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = 67833F7F19F8990D00DBE7AA /* ofFpsCounter.h */; };
+		67833F8519F8990D00DBE7AA /* ofThreadChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 67833F8019F8990D00DBE7AA /* ofThreadChannel.h */; };
+		67833F8619F8990D00DBE7AA /* ofTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67833F8119F8990D00DBE7AA /* ofTimer.cpp */; };
+		67833F8719F8990D00DBE7AA /* ofTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 67833F8219F8990D00DBE7AA /* ofTimer.h */; };
+		67833F8A19F8996300DBE7AA /* ofBufferObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 67833F8819F8996300DBE7AA /* ofBufferObject.cpp */; };
+		67833F8B19F8996300DBE7AA /* ofBufferObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 67833F8919F8996300DBE7AA /* ofBufferObject.h */; };
+		678C3D23176F04F800D1CC68 /* ofxiOSSoundStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 678C3D19176F04F800D1CC68 /* ofxiOSSoundStream.h */; };
+		678C3D24176F04F800D1CC68 /* ofxiOSSoundStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 678C3D1A176F04F800D1CC68 /* ofxiOSSoundStream.mm */; };
+		678C3D25176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 678C3D1B176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h */; };
+		678C3D26176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 678C3D1C176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.mm */; };
+		678C3D27176F04F800D1CC68 /* SoundInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 678C3D1D176F04F800D1CC68 /* SoundInputStream.h */; };
+		678C3D28176F04F800D1CC68 /* SoundInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 678C3D1E176F04F800D1CC68 /* SoundInputStream.m */; };
+		678C3D29176F04F800D1CC68 /* SoundOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 678C3D1F176F04F800D1CC68 /* SoundOutputStream.h */; };
+		678C3D2A176F04F800D1CC68 /* SoundOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 678C3D20176F04F800D1CC68 /* SoundOutputStream.m */; };
+		678C3D2B176F04F800D1CC68 /* SoundStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 678C3D21176F04F800D1CC68 /* SoundStream.h */; };
+		678C3D2C176F04F800D1CC68 /* SoundStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 678C3D22176F04F800D1CC68 /* SoundStream.m */; };
+		67D48ED01C10399900F719BC /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67D48ECF1C10399900F719BC /* CoreMotion.framework */; };
+		67D48ED31C103BAE00F719BC /* ofxiOSCoreMotion.h in Headers */ = {isa = PBXBuildFile; fileRef = 67D48ED11C103BAE00F719BC /* ofxiOSCoreMotion.h */; };
+		67D48ED41C103BAE00F719BC /* ofxiOSCoreMotion.mm in Sources */ = {isa = PBXBuildFile; fileRef = 67D48ED21C103BAE00F719BC /* ofxiOSCoreMotion.mm */; };
+		69433CC31FE45BAC004D5B73 /* ofBaseApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 69433CC21FE45BAC004D5B73 /* ofBaseApp.cpp */; };
+		69433CC51FE45BB7004D5B73 /* ofGLBaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 69433CC41FE45BB7004D5B73 /* ofGLBaseTypes.h */; };
+		69433CCA1FE45BCD004D5B73 /* ofGraphicsBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 69433CC61FE45BCD004D5B73 /* ofGraphicsBaseTypes.cpp */; };
+		69433CCB1FE45BCD004D5B73 /* ofGraphicsBaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 69433CC71FE45BCD004D5B73 /* ofGraphicsBaseTypes.h */; };
+		69433CCC1FE45BCD004D5B73 /* ofGraphicsConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 69433CC81FE45BCD004D5B73 /* ofGraphicsConstants.h */; };
+		69433CD01FE45BF2004D5B73 /* ofSoundBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 69433CCE1FE45BF2004D5B73 /* ofSoundBaseTypes.cpp */; };
+		69433CD11FE45BF2004D5B73 /* ofSoundBaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 69433CCF1FE45BF2004D5B73 /* ofSoundBaseTypes.h */; };
+		69433CD31FE45E41004D5B73 /* ofMathConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 69433CD21FE45E41004D5B73 /* ofMathConstants.h */; };
+		860B024D17A96D840032B827 /* ofxiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 860B024C17A96D840032B827 /* ofxiOS.h */; };
+		90080014204EDA1300DC786A /* ofxiOSGLKViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 90080013204EDA1300DC786A /* ofxiOSGLKViewController.mm */; };
+		90080016204EDA4B00DC786A /* ofxiOSGLKViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 90080015204EDA4600DC786A /* ofxiOSGLKViewController.h */; };
+		90080019204EDB5500DC786A /* ofxiOSGLKView.h in Headers */ = {isa = PBXBuildFile; fileRef = 90080017204EDB5500DC786A /* ofxiOSGLKView.h */; };
+		9008001A204EDB5500DC786A /* ofxiOSGLKView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 90080018204EDB5500DC786A /* ofxiOSGLKView.mm */; };
+		9008001D204EDC0F00DC786A /* EAGLKView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9008001B204EDC0E00DC786A /* EAGLKView.m */; };
+		9008001E204EDC0F00DC786A /* EAGLKView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9008001C204EDC0F00DC786A /* EAGLKView.h */; };
+		901808B9205362D7004A7774 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 901808B8205362D7004A7774 /* GLKit.framework */; };
+		9252B7F11CDA2A6100A8032B /* ofxiOSEventAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 9252B7EF1CDA2A6100A8032B /* ofxiOSEventAdapter.h */; };
+		9252B7F21CDA2A6100A8032B /* ofxiOSEventAdapter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9252B7F01CDA2A6100A8032B /* ofxiOSEventAdapter.mm */; };
+		9957D8701BDDCD440002D53C /* ofEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 9957D86F1BDDCD440002D53C /* ofEvent.h */; };
+		99752D331BF21EEE0026316A /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99752D321BF21EEE0026316A /* GameController.framework */; };
+		9979E8181A1B9883007E55D1 /* ofWindowSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979E8171A1B9883007E55D1 /* ofWindowSettings.h */; };
+		9979E8281A1CDBD4007E55D1 /* ofMainLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9979E8261A1CDBD4007E55D1 /* ofMainLoop.cpp */; };
+		9979E8291A1CDBD4007E55D1 /* ofMainLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979E8271A1CDBD4007E55D1 /* ofMainLoop.h */; };
+		BB24DECA10DA7A3F00E9C588 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBE5EAB70F49AD8400F28951 /* AudioToolbox.framework */; };
+		BB24DECB10DA7A3F00E9C588 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB16EBD10F2B2A9500518274 /* OpenGLES.framework */; };
+		BB24DECC10DA7A3F00E9C588 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
+		BB24DECD10DA7A3F00E9C588 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53F323EA10A20EDB00E0DAE4 /* OpenAL.framework */; };
+		BB24DECE10DA7A3F00E9C588 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
+		BB24DECF10DA7A3F00E9C588 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
+		BB24DED010DA7A3F00E9C588 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5326AEA710A23A0500278DE6 /* CoreLocation.framework */; };
+		BB24DED110DA7A3F00E9C588 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB16EBD80F2B2AB500518274 /* QuartzCore.framework */; };
+		E4F76E19176CB27200798745 /* of3dPrimitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D6F176CB27200798745 /* of3dPrimitives.cpp */; };
+		E4F76E1A176CB27200798745 /* of3dPrimitives.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D70176CB27200798745 /* of3dPrimitives.h */; };
+		E4F76E1B176CB27200798745 /* of3dUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D71176CB27200798745 /* of3dUtils.cpp */; };
+		E4F76E1C176CB27200798745 /* of3dUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D72176CB27200798745 /* of3dUtils.h */; };
+		E4F76E1D176CB27200798745 /* ofCamera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D73176CB27200798745 /* ofCamera.cpp */; };
+		E4F76E1E176CB27200798745 /* ofCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D74176CB27200798745 /* ofCamera.h */; };
+		E4F76E1F176CB27200798745 /* ofEasyCam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D75176CB27200798745 /* ofEasyCam.cpp */; };
+		E4F76E20176CB27200798745 /* ofEasyCam.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D76176CB27200798745 /* ofEasyCam.h */; };
+		E4F76E22176CB27200798745 /* ofMesh.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D78176CB27200798745 /* ofMesh.h */; };
+		E4F76E23176CB27200798745 /* ofNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D79176CB27200798745 /* ofNode.cpp */; };
+		E4F76E24176CB27200798745 /* ofNode.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D7A176CB27200798745 /* ofNode.h */; };
+		E4F76E25176CB27200798745 /* ofAppBaseWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D7C176CB27200798745 /* ofAppBaseWindow.h */; };
+		E4F76E2E176CB27200798745 /* ofAppRunner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D85176CB27200798745 /* ofAppRunner.cpp */; };
+		E4F76E2F176CB27200798745 /* ofAppRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D86176CB27200798745 /* ofAppRunner.h */; };
+		E4F76E30176CB27200798745 /* ofBaseApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D87176CB27200798745 /* ofBaseApp.h */; };
+		E4F76E36176CB27200798745 /* ofEvents.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D8F176CB27200798745 /* ofEvents.cpp */; };
+		E4F76E37176CB27200798745 /* ofEvents.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D90176CB27200798745 /* ofEvents.h */; };
+		E4F76E38176CB27200798745 /* ofEventUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D91176CB27200798745 /* ofEventUtils.h */; };
+		E4F76E39176CB27200798745 /* ofFbo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D93176CB27200798745 /* ofFbo.cpp */; };
+		E4F76E3A176CB27200798745 /* ofFbo.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D94176CB27200798745 /* ofFbo.h */; };
+		E4F76E3B176CB27200798745 /* ofGLProgrammableRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D95176CB27200798745 /* ofGLProgrammableRenderer.cpp */; };
+		E4F76E3C176CB27200798745 /* ofGLProgrammableRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D96176CB27200798745 /* ofGLProgrammableRenderer.h */; };
+		E4F76E3D176CB27200798745 /* ofGLRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D97176CB27200798745 /* ofGLRenderer.cpp */; };
+		E4F76E3E176CB27200798745 /* ofGLRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D98176CB27200798745 /* ofGLRenderer.h */; };
+		E4F76E3F176CB27200798745 /* ofGLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D99176CB27200798745 /* ofGLUtils.cpp */; };
+		E4F76E40176CB27200798745 /* ofGLUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D9A176CB27200798745 /* ofGLUtils.h */; };
+		E4F76E41176CB27200798745 /* ofLight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D9B176CB27200798745 /* ofLight.cpp */; };
+		E4F76E42176CB27200798745 /* ofLight.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D9C176CB27200798745 /* ofLight.h */; };
+		E4F76E43176CB27200798745 /* ofMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D9D176CB27200798745 /* ofMaterial.cpp */; };
+		E4F76E44176CB27200798745 /* ofMaterial.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76D9E176CB27200798745 /* ofMaterial.h */; };
+		E4F76E45176CB27200798745 /* ofShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76D9F176CB27200798745 /* ofShader.cpp */; };
+		E4F76E46176CB27200798745 /* ofShader.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DA0176CB27200798745 /* ofShader.h */; };
+		E4F76E49176CB27200798745 /* ofTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DA3176CB27200798745 /* ofTexture.cpp */; };
+		E4F76E4A176CB27200798745 /* ofTexture.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DA4176CB27200798745 /* ofTexture.h */; };
+		E4F76E4B176CB27200798745 /* ofVbo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DA5176CB27200798745 /* ofVbo.cpp */; };
+		E4F76E4C176CB27200798745 /* ofVbo.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DA6176CB27200798745 /* ofVbo.h */; };
+		E4F76E4D176CB27200798745 /* ofVboMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DA7176CB27200798745 /* ofVboMesh.cpp */; };
+		E4F76E4E176CB27200798745 /* ofVboMesh.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DA8176CB27200798745 /* ofVboMesh.h */; };
+		E4F76E4F176CB27200798745 /* of3dGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DAA176CB27200798745 /* of3dGraphics.cpp */; };
+		E4F76E50176CB27200798745 /* of3dGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DAB176CB27200798745 /* of3dGraphics.h */; };
+		E4F76E51176CB27200798745 /* ofBitmapFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DAC176CB27200798745 /* ofBitmapFont.cpp */; };
+		E4F76E52176CB27200798745 /* ofBitmapFont.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DAD176CB27200798745 /* ofBitmapFont.h */; };
+		E4F76E55176CB27200798745 /* ofGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DB0176CB27200798745 /* ofGraphics.cpp */; };
+		E4F76E56176CB27200798745 /* ofGraphics.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DB1176CB27200798745 /* ofGraphics.h */; };
+		E4F76E57176CB27200798745 /* ofImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DB2176CB27200798745 /* ofImage.cpp */; };
+		E4F76E58176CB27200798745 /* ofImage.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DB3176CB27200798745 /* ofImage.h */; };
+		E4F76E59176CB27200798745 /* ofPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DB4176CB27200798745 /* ofPath.cpp */; };
+		E4F76E5A176CB27200798745 /* ofPath.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DB5176CB27200798745 /* ofPath.h */; };
+		E4F76E5B176CB27200798745 /* ofPixels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DB6176CB27200798745 /* ofPixels.cpp */; };
+		E4F76E5C176CB27200798745 /* ofPixels.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DB7176CB27200798745 /* ofPixels.h */; };
+		E4F76E5E176CB27200798745 /* ofPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DB9176CB27200798745 /* ofPolyline.h */; };
+		E4F76E5F176CB27200798745 /* ofRendererCollection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DBA176CB27200798745 /* ofRendererCollection.cpp */; };
+		E4F76E60176CB27200798745 /* ofRendererCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DBB176CB27200798745 /* ofRendererCollection.h */; };
+		E4F76E61176CB27200798745 /* ofTessellator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DBC176CB27200798745 /* ofTessellator.cpp */; };
+		E4F76E62176CB27200798745 /* ofTessellator.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DBD176CB27200798745 /* ofTessellator.h */; };
+		E4F76E63176CB27200798745 /* ofTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DBE176CB27200798745 /* ofTrueTypeFont.cpp */; };
+		E4F76E64176CB27200798745 /* ofTrueTypeFont.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DBF176CB27200798745 /* ofTrueTypeFont.h */; };
+		E4F76E65176CB27200798745 /* ofMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DC1176CB27200798745 /* ofMath.cpp */; };
+		E4F76E66176CB27200798745 /* ofMath.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DC2176CB27200798745 /* ofMath.h */; };
+		E4F76E67176CB27200798745 /* ofMatrix3x3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DC3176CB27200798745 /* ofMatrix3x3.cpp */; };
+		E4F76E68176CB27200798745 /* ofMatrix3x3.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DC4176CB27200798745 /* ofMatrix3x3.h */; };
+		E4F76E69176CB27200798745 /* ofMatrix4x4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DC5176CB27200798745 /* ofMatrix4x4.cpp */; };
+		E4F76E6A176CB27200798745 /* ofMatrix4x4.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DC6176CB27200798745 /* ofMatrix4x4.h */; };
+		E4F76E6B176CB27200798745 /* ofQuaternion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DC7176CB27200798745 /* ofQuaternion.cpp */; };
+		E4F76E6C176CB27200798745 /* ofQuaternion.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DC8176CB27200798745 /* ofQuaternion.h */; };
+		E4F76E6D176CB27200798745 /* ofVec2f.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DC9176CB27200798745 /* ofVec2f.cpp */; };
+		E4F76E6E176CB27200798745 /* ofVec2f.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DCA176CB27200798745 /* ofVec2f.h */; };
+		E4F76E6F176CB27200798745 /* ofVec3f.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DCB176CB27200798745 /* ofVec3f.h */; };
+		E4F76E70176CB27200798745 /* ofVec4f.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DCC176CB27200798745 /* ofVec4f.cpp */; };
+		E4F76E71176CB27200798745 /* ofVec4f.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DCD176CB27200798745 /* ofVec4f.h */; };
+		E4F76E72176CB27200798745 /* ofVectorMath.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DCE176CB27200798745 /* ofVectorMath.h */; };
+		E4F76E73176CB27200798745 /* ofMain.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DCF176CB27200798745 /* ofMain.h */; };
+		E4F76E80176CB27200798745 /* ofSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DDD176CB27200798745 /* ofSoundPlayer.cpp */; };
+		E4F76E81176CB27200798745 /* ofSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DDE176CB27200798745 /* ofSoundPlayer.h */; };
+		E4F76E82176CB27200798745 /* ofSoundStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DDF176CB27200798745 /* ofSoundStream.cpp */; };
+		E4F76E83176CB27200798745 /* ofSoundStream.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DE0176CB27200798745 /* ofSoundStream.h */; };
+		E4F76E84176CB27200798745 /* ofBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DE2176CB27200798745 /* ofBaseTypes.cpp */; };
+		E4F76E86176CB27200798745 /* ofColor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DE4176CB27200798745 /* ofColor.cpp */; };
+		E4F76E87176CB27200798745 /* ofColor.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DE5176CB27200798745 /* ofColor.h */; };
+		E4F76E88176CB27200798745 /* ofParameter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DE6176CB27200798745 /* ofParameter.cpp */; };
+		E4F76E89176CB27200798745 /* ofParameter.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DE7176CB27200798745 /* ofParameter.h */; };
+		E4F76E8A176CB27200798745 /* ofParameterGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DE8176CB27200798745 /* ofParameterGroup.cpp */; };
+		E4F76E8B176CB27200798745 /* ofParameterGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DE9176CB27200798745 /* ofParameterGroup.h */; };
+		E4F76E8D176CB27200798745 /* ofPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DEB176CB27200798745 /* ofPoint.h */; };
+		E4F76E8E176CB27200798745 /* ofRectangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DEC176CB27200798745 /* ofRectangle.cpp */; };
+		E4F76E8F176CB27200798745 /* ofRectangle.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DED176CB27200798745 /* ofRectangle.h */; };
+		E4F76E90176CB27200798745 /* ofTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DEE176CB27200798745 /* ofTypes.h */; };
+		E4F76E91176CB27200798745 /* ofConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF0176CB27200798745 /* ofConstants.h */; };
+		E4F76E92176CB27200798745 /* ofFileUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DF1176CB27200798745 /* ofFileUtils.cpp */; };
+		E4F76E93176CB27200798745 /* ofFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF2176CB27200798745 /* ofFileUtils.h */; };
+		E4F76E94176CB27200798745 /* ofLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DF3176CB27200798745 /* ofLog.cpp */; };
+		E4F76E95176CB27200798745 /* ofLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF4176CB27200798745 /* ofLog.h */; };
+		E4F76E96176CB27200798745 /* ofMatrixStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DF5176CB27200798745 /* ofMatrixStack.cpp */; };
+		E4F76E97176CB27200798745 /* ofMatrixStack.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF6176CB27200798745 /* ofMatrixStack.h */; };
+		E4F76E98176CB27200798745 /* ofNoise.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF7176CB27200798745 /* ofNoise.h */; };
+		E4F76E99176CB27200798745 /* ofSystemUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DF8176CB27200798745 /* ofSystemUtils.cpp */; };
+		E4F76E9A176CB27200798745 /* ofSystemUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DF9176CB27200798745 /* ofSystemUtils.h */; };
+		E4F76E9B176CB27200798745 /* ofThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DFA176CB27200798745 /* ofThread.cpp */; };
+		E4F76E9C176CB27200798745 /* ofThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DFB176CB27200798745 /* ofThread.h */; };
+		E4F76E9D176CB27200798745 /* ofURLFileLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DFC176CB27200798745 /* ofURLFileLoader.cpp */; };
+		E4F76E9E176CB27200798745 /* ofURLFileLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DFD176CB27200798745 /* ofURLFileLoader.h */; };
+		E4F76E9F176CB27200798745 /* ofUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76DFE176CB27200798745 /* ofUtils.cpp */; };
+		E4F76EA0176CB27200798745 /* ofUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76DFF176CB27200798745 /* ofUtils.h */; };
+		E4F76EB5176CB27200798745 /* ofVideoGrabber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76E15176CB27200798745 /* ofVideoGrabber.cpp */; };
+		E4F76EB6176CB27200798745 /* ofVideoGrabber.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76E16176CB27200798745 /* ofVideoGrabber.h */; };
+		E4F76EB7176CB27200798745 /* ofVideoPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E4F76E17176CB27200798745 /* ofVideoPlayer.cpp */; };
+		E4F76EB8176CB27200798745 /* ofVideoPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = E4F76E18176CB27200798745 /* ofVideoPlayer.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		15594F0515C55AC900727FF2 /* EAGLView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EAGLView.m; sourceTree = "<group>"; };
+		15594F0615C55AC900727FF2 /* ES1Renderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ES1Renderer.m; sourceTree = "<group>"; };
+		15594F0715C55AC900727FF2 /* ES2Renderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ES2Renderer.m; sourceTree = "<group>"; };
+		15594F0815C55AC900727FF2 /* EAGLView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EAGLView.h; sourceTree = "<group>"; };
+		15594F0915C55AC900727FF2 /* ES1Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ES1Renderer.h; sourceTree = "<group>"; };
+		15594F0A15C55AC900727FF2 /* ES2Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ES2Renderer.h; sourceTree = "<group>"; };
+		15594F0B15C55AC900727FF2 /* ESRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ESRenderer.h; sourceTree = "<group>"; };
+		15594F7815C5697C00727FF2 /* ofAppiOSWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofAppiOSWindow.mm; sourceTree = "<group>"; };
+		15594F7C15C5697C00727FF2 /* ofAppiOSWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppiOSWindow.h; sourceTree = "<group>"; };
+		15594F7E15C5697C00727FF2 /* ofxiOSApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSApp.h; sourceTree = "<group>"; };
+		15594F8B15C56A8A00727FF2 /* ofxiOSEAGLView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSEAGLView.mm; sourceTree = "<group>"; };
+		15594F8C15C56A8A00727FF2 /* ofxiOSAppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSAppDelegate.mm; sourceTree = "<group>"; };
+		15594F8D15C56A8A00727FF2 /* ofxiOSViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSViewController.mm; sourceTree = "<group>"; };
+		15594F8E15C56A8A00727FF2 /* ofxiOSEAGLView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSEAGLView.h; sourceTree = "<group>"; };
+		15594F8F15C56A8A00727FF2 /* ofxiOSAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAppDelegate.h; sourceTree = "<group>"; };
+		15594F9015C56A8A00727FF2 /* ofxiOSViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSViewController.h; sourceTree = "<group>"; };
+		15594F9F15C56BB700727FF2 /* AVFoundationVideoGrabber.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationVideoGrabber.mm; sourceTree = "<group>"; };
+		15594FA015C56BB700727FF2 /* AVFoundationVideoPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVFoundationVideoPlayer.m; sourceTree = "<group>"; };
+		15594FA115C56BB700727FF2 /* AVFoundationVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationVideoGrabber.h; sourceTree = "<group>"; };
+		15594FA215C56BB700727FF2 /* AVFoundationVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationVideoPlayer.h; sourceTree = "<group>"; };
+		15594FA815C56C9500727FF2 /* ofxiOSAlerts.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSAlerts.mm; sourceTree = "<group>"; };
+		15594FA915C56C9500727FF2 /* ofxiOSAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAlerts.h; sourceTree = "<group>"; };
+		15594FAA15C56C9500727FF2 /* ofxiOSAlertsListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAlertsListener.h; sourceTree = "<group>"; };
+		15594FAF15C56D1E00727FF2 /* ofxiOSCoreLocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSCoreLocation.mm; sourceTree = "<group>"; };
+		15594FB015C56D1E00727FF2 /* ofxiOSExternalDisplay.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSExternalDisplay.mm; sourceTree = "<group>"; };
+		15594FB115C56D1E00727FF2 /* ofxiOSExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSExtras.mm; sourceTree = "<group>"; };
+		15594FB215C56D1E00727FF2 /* ofxiOSImagePicker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSImagePicker.mm; sourceTree = "<group>"; };
+		15594FB315C56D1E00727FF2 /* ofxiOSKeyboard.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSKeyboard.mm; sourceTree = "<group>"; };
+		15594FB415C56D1E00727FF2 /* ofxiOSMapKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSMapKit.mm; sourceTree = "<group>"; };
+		15594FB515C56D1E00727FF2 /* ofxiOSMapKitDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSMapKitDelegate.mm; sourceTree = "<group>"; usesTabs = 1; };
+		15594FB615C56D1E00727FF2 /* ofxiOSCoreLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSCoreLocation.h; sourceTree = "<group>"; };
+		15594FB715C56D1E00727FF2 /* ofxiOSExternalDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSExternalDisplay.h; sourceTree = "<group>"; };
+		15594FB815C56D1E00727FF2 /* ofxiOSExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSExtras.h; sourceTree = "<group>"; };
+		15594FB915C56D1E00727FF2 /* ofxiOSImagePicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSImagePicker.h; sourceTree = "<group>"; };
+		15594FBA15C56D1E00727FF2 /* ofxiOSKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSKeyboard.h; sourceTree = "<group>"; };
+		15594FBB15C56D1E00727FF2 /* ofxiOSMapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKit.h; sourceTree = "<group>"; };
+		15594FBC15C56D1E00727FF2 /* ofxiOSMapKitDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKitDelegate.h; sourceTree = "<group>"; };
+		15594FBD15C56D1E00727FF2 /* ofxiOSMapKitListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKitListener.h; sourceTree = "<group>"; };
+		1594366015CF5F420087B684 /* ofxiOSVideoGrabber.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSVideoGrabber.mm; sourceTree = "<group>"; };
+		1594366115CF5F420087B684 /* ofxiOSVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSVideoPlayer.mm; sourceTree = "<group>"; };
+		1594366215CF5F420087B684 /* ofxiOSVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSVideoGrabber.h; sourceTree = "<group>"; };
+		1594366315CF5F420087B684 /* ofxiOSVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSVideoPlayer.h; sourceTree = "<group>"; };
+		15BC775215A5C31F00772525 /* ofxiOSExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxiOSExtensions.h; sourceTree = "<group>"; };
+		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		5326AEA710A23A0500278DE6 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		53DA338912DF8F4500C622CE /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		53DA338D12DF8F5000C622CE /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		53DA338F12DF8F5000C622CE /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		53DA339112DF8F5000C622CE /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		53F323EA10A20EDB00E0DAE4 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
+		5E2E99DC10ED147800587639 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		6678E97219FEB2DF00C00581 /* ofSoundBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundBuffer.cpp; sourceTree = "<group>"; };
+		6678E97319FEB2DF00C00581 /* ofSoundBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundBuffer.h; sourceTree = "<group>"; };
+		6678E97419FEB2DF00C00581 /* ofSoundUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundUtils.h; sourceTree = "<group>"; };
+		66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxOpenALSoundPlayer.cpp; sourceTree = "<group>"; };
+		66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxOpenALSoundPlayer.h; sourceTree = "<group>"; };
+		66EA462917A6D396009BB12A /* SoundEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SoundEngine.cpp; sourceTree = "<group>"; };
+		66EA462A17A6D396009BB12A /* SoundEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundEngine.h; sourceTree = "<group>"; };
+		6711091F19D3EAC6005D095F /* ofxiOSConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxiOSConstants.h; sourceTree = "<group>"; };
+		671C0AF01770246200DF03B3 /* AVSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSoundPlayer.h; sourceTree = "<group>"; };
+		671C0AF11770246200DF03B3 /* AVSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSoundPlayer.m; sourceTree = "<group>"; };
+		671C0AF21770246200DF03B3 /* ofxiOSSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundPlayer.h; sourceTree = "<group>"; };
+		671C0AF31770246200DF03B3 /* ofxiOSSoundPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundPlayer.mm; sourceTree = "<group>"; };
+		67509ABA17979781003A3A29 /* ofXml.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofXml.cpp; sourceTree = "<group>"; };
+		67509ABB17979781003A3A29 /* ofXml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofXml.h; sourceTree = "<group>"; };
+		67833F7E19F8990D00DBE7AA /* ofFpsCounter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofFpsCounter.cpp; sourceTree = "<group>"; };
+		67833F7F19F8990D00DBE7AA /* ofFpsCounter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFpsCounter.h; sourceTree = "<group>"; };
+		67833F8019F8990D00DBE7AA /* ofThreadChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofThreadChannel.h; sourceTree = "<group>"; };
+		67833F8119F8990D00DBE7AA /* ofTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTimer.cpp; sourceTree = "<group>"; };
+		67833F8219F8990D00DBE7AA /* ofTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTimer.h; sourceTree = "<group>"; };
+		67833F8819F8996300DBE7AA /* ofBufferObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBufferObject.cpp; sourceTree = "<group>"; };
+		67833F8919F8996300DBE7AA /* ofBufferObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBufferObject.h; sourceTree = "<group>"; };
+		678C3D19176F04F800D1CC68 /* ofxiOSSoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundStream.h; sourceTree = "<group>"; };
+		678C3D1A176F04F800D1CC68 /* ofxiOSSoundStream.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundStream.mm; sourceTree = "<group>"; };
+		678C3D1B176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundStreamDelegate.h; sourceTree = "<group>"; };
+		678C3D1C176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundStreamDelegate.mm; sourceTree = "<group>"; };
+		678C3D1D176F04F800D1CC68 /* SoundInputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundInputStream.h; sourceTree = "<group>"; };
+		678C3D1E176F04F800D1CC68 /* SoundInputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundInputStream.m; sourceTree = "<group>"; };
+		678C3D1F176F04F800D1CC68 /* SoundOutputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundOutputStream.h; sourceTree = "<group>"; };
+		678C3D20176F04F800D1CC68 /* SoundOutputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundOutputStream.m; sourceTree = "<group>"; };
+		678C3D21176F04F800D1CC68 /* SoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundStream.h; sourceTree = "<group>"; };
+		678C3D22176F04F800D1CC68 /* SoundStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundStream.m; sourceTree = "<group>"; };
+		67D48ECF1C10399900F719BC /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
+		67D48ED11C103BAE00F719BC /* ofxiOSCoreMotion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSCoreMotion.h; sourceTree = "<group>"; };
+		67D48ED21C103BAE00F719BC /* ofxiOSCoreMotion.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSCoreMotion.mm; sourceTree = "<group>"; };
+		69433CC21FE45BAC004D5B73 /* ofBaseApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseApp.cpp; sourceTree = "<group>"; };
+		69433CC41FE45BB7004D5B73 /* ofGLBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLBaseTypes.h; sourceTree = "<group>"; };
+		69433CC61FE45BCD004D5B73 /* ofGraphicsBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGraphicsBaseTypes.cpp; sourceTree = "<group>"; };
+		69433CC71FE45BCD004D5B73 /* ofGraphicsBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphicsBaseTypes.h; sourceTree = "<group>"; };
+		69433CC81FE45BCD004D5B73 /* ofGraphicsConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphicsConstants.h; sourceTree = "<group>"; };
+		69433CC91FE45BCD004D5B73 /* ofPolyline.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ofPolyline.inl; sourceTree = "<group>"; };
+		69433CCD1FE45BD9004D5B73 /* ofMesh.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ofMesh.inl; sourceTree = "<group>"; };
+		69433CCE1FE45BF2004D5B73 /* ofSoundBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundBaseTypes.cpp; sourceTree = "<group>"; };
+		69433CCF1FE45BF2004D5B73 /* ofSoundBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundBaseTypes.h; sourceTree = "<group>"; };
+		69433CD21FE45E41004D5B73 /* ofMathConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMathConstants.h; sourceTree = "<group>"; };
+		860B024C17A96D840032B827 /* ofxiOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOS.h; sourceTree = "<group>"; };
+		90080013204EDA1300DC786A /* ofxiOSGLKViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSGLKViewController.mm; sourceTree = "<group>"; };
+		90080015204EDA4600DC786A /* ofxiOSGLKViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ofxiOSGLKViewController.h; sourceTree = "<group>"; };
+		90080017204EDB5500DC786A /* ofxiOSGLKView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSGLKView.h; sourceTree = "<group>"; };
+		90080018204EDB5500DC786A /* ofxiOSGLKView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSGLKView.mm; sourceTree = "<group>"; };
+		9008001B204EDC0E00DC786A /* EAGLKView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EAGLKView.m; sourceTree = "<group>"; };
+		9008001C204EDC0F00DC786A /* EAGLKView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EAGLKView.h; sourceTree = "<group>"; };
+		901808B8205362D7004A7774 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		9252B7EF1CDA2A6100A8032B /* ofxiOSEventAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSEventAdapter.h; sourceTree = "<group>"; };
+		9252B7F01CDA2A6100A8032B /* ofxiOSEventAdapter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSEventAdapter.mm; sourceTree = "<group>"; };
+		9957D86F1BDDCD440002D53C /* ofEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEvent.h; sourceTree = "<group>"; };
+		99752D321BF21EEE0026316A /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
+		9979E8171A1B9883007E55D1 /* ofWindowSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofWindowSettings.h; sourceTree = "<group>"; };
+		9979E8261A1CDBD4007E55D1 /* ofMainLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMainLoop.cpp; sourceTree = "<group>"; };
+		9979E8271A1CDBD4007E55D1 /* ofMainLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMainLoop.h; sourceTree = "<group>"; };
+		BB16EBD10F2B2A9500518274 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		BB16EBD80F2B2AB500518274 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		BB24DED610DA7A3F00E9C588 /* libofxiOS_iphoneos_Debug.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libofxiOS_iphoneos_Debug.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		BBE5EAB70F49AD8400F28951 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		E41D3E9013B38BE900A75A5D /* CoreOF.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = CoreOF.xcconfig; sourceTree = SOURCE_ROOT; };
+		E41D3E9113B38BE900A75A5D /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		E41D3E9213B38BE900A75A5D /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = SOURCE_ROOT; };
+		E41D3E9313B38BE900A75A5D /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = SOURCE_ROOT; };
+		E4F76D6F176CB27200798745 /* of3dPrimitives.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = of3dPrimitives.cpp; sourceTree = "<group>"; };
+		E4F76D70176CB27200798745 /* of3dPrimitives.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dPrimitives.h; sourceTree = "<group>"; };
+		E4F76D71176CB27200798745 /* of3dUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = of3dUtils.cpp; sourceTree = "<group>"; };
+		E4F76D72176CB27200798745 /* of3dUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dUtils.h; sourceTree = "<group>"; };
+		E4F76D73176CB27200798745 /* ofCamera.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofCamera.cpp; sourceTree = "<group>"; };
+		E4F76D74176CB27200798745 /* ofCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofCamera.h; sourceTree = "<group>"; };
+		E4F76D75176CB27200798745 /* ofEasyCam.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofEasyCam.cpp; sourceTree = "<group>"; };
+		E4F76D76176CB27200798745 /* ofEasyCam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEasyCam.h; sourceTree = "<group>"; };
+		E4F76D78176CB27200798745 /* ofMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMesh.h; sourceTree = "<group>"; };
+		E4F76D79176CB27200798745 /* ofNode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofNode.cpp; sourceTree = "<group>"; };
+		E4F76D7A176CB27200798745 /* ofNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofNode.h; sourceTree = "<group>"; };
+		E4F76D7C176CB27200798745 /* ofAppBaseWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppBaseWindow.h; sourceTree = "<group>"; };
+		E4F76D85176CB27200798745 /* ofAppRunner.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofAppRunner.cpp; sourceTree = "<group>"; };
+		E4F76D86176CB27200798745 /* ofAppRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppRunner.h; sourceTree = "<group>"; };
+		E4F76D87176CB27200798745 /* ofBaseApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBaseApp.h; sourceTree = "<group>"; };
+		E4F76D8F176CB27200798745 /* ofEvents.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofEvents.cpp; sourceTree = "<group>"; };
+		E4F76D90176CB27200798745 /* ofEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEvents.h; sourceTree = "<group>"; };
+		E4F76D91176CB27200798745 /* ofEventUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEventUtils.h; sourceTree = "<group>"; };
+		E4F76D93176CB27200798745 /* ofFbo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofFbo.cpp; sourceTree = "<group>"; };
+		E4F76D94176CB27200798745 /* ofFbo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFbo.h; sourceTree = "<group>"; };
+		E4F76D95176CB27200798745 /* ofGLProgrammableRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLProgrammableRenderer.cpp; sourceTree = "<group>"; };
+		E4F76D96176CB27200798745 /* ofGLProgrammableRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLProgrammableRenderer.h; sourceTree = "<group>"; };
+		E4F76D97176CB27200798745 /* ofGLRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLRenderer.cpp; sourceTree = "<group>"; };
+		E4F76D98176CB27200798745 /* ofGLRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLRenderer.h; sourceTree = "<group>"; };
+		E4F76D99176CB27200798745 /* ofGLUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLUtils.cpp; sourceTree = "<group>"; };
+		E4F76D9A176CB27200798745 /* ofGLUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLUtils.h; sourceTree = "<group>"; };
+		E4F76D9B176CB27200798745 /* ofLight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofLight.cpp; sourceTree = "<group>"; };
+		E4F76D9C176CB27200798745 /* ofLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofLight.h; sourceTree = "<group>"; };
+		E4F76D9D176CB27200798745 /* ofMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMaterial.cpp; sourceTree = "<group>"; };
+		E4F76D9E176CB27200798745 /* ofMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMaterial.h; sourceTree = "<group>"; };
+		E4F76D9F176CB27200798745 /* ofShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofShader.cpp; sourceTree = "<group>"; };
+		E4F76DA0176CB27200798745 /* ofShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofShader.h; sourceTree = "<group>"; };
+		E4F76DA3176CB27200798745 /* ofTexture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTexture.cpp; sourceTree = "<group>"; };
+		E4F76DA4176CB27200798745 /* ofTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTexture.h; sourceTree = "<group>"; };
+		E4F76DA5176CB27200798745 /* ofVbo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVbo.cpp; sourceTree = "<group>"; };
+		E4F76DA6176CB27200798745 /* ofVbo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVbo.h; sourceTree = "<group>"; };
+		E4F76DA7176CB27200798745 /* ofVboMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVboMesh.cpp; sourceTree = "<group>"; };
+		E4F76DA8176CB27200798745 /* ofVboMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVboMesh.h; sourceTree = "<group>"; };
+		E4F76DAA176CB27200798745 /* of3dGraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = of3dGraphics.cpp; sourceTree = "<group>"; };
+		E4F76DAB176CB27200798745 /* of3dGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dGraphics.h; sourceTree = "<group>"; };
+		E4F76DAC176CB27200798745 /* ofBitmapFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBitmapFont.cpp; sourceTree = "<group>"; };
+		E4F76DAD176CB27200798745 /* ofBitmapFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBitmapFont.h; sourceTree = "<group>"; };
+		E4F76DB0176CB27200798745 /* ofGraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGraphics.cpp; sourceTree = "<group>"; };
+		E4F76DB1176CB27200798745 /* ofGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphics.h; sourceTree = "<group>"; };
+		E4F76DB2176CB27200798745 /* ofImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofImage.cpp; sourceTree = "<group>"; };
+		E4F76DB3176CB27200798745 /* ofImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofImage.h; sourceTree = "<group>"; };
+		E4F76DB4176CB27200798745 /* ofPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofPath.cpp; sourceTree = "<group>"; };
+		E4F76DB5176CB27200798745 /* ofPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPath.h; sourceTree = "<group>"; };
+		E4F76DB6176CB27200798745 /* ofPixels.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofPixels.cpp; sourceTree = "<group>"; };
+		E4F76DB7176CB27200798745 /* ofPixels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPixels.h; sourceTree = "<group>"; };
+		E4F76DB9176CB27200798745 /* ofPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPolyline.h; sourceTree = "<group>"; };
+		E4F76DBA176CB27200798745 /* ofRendererCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofRendererCollection.cpp; sourceTree = "<group>"; };
+		E4F76DBB176CB27200798745 /* ofRendererCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofRendererCollection.h; sourceTree = "<group>"; };
+		E4F76DBC176CB27200798745 /* ofTessellator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTessellator.cpp; sourceTree = "<group>"; };
+		E4F76DBD176CB27200798745 /* ofTessellator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTessellator.h; sourceTree = "<group>"; };
+		E4F76DBE176CB27200798745 /* ofTrueTypeFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTrueTypeFont.cpp; sourceTree = "<group>"; };
+		E4F76DBF176CB27200798745 /* ofTrueTypeFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTrueTypeFont.h; sourceTree = "<group>"; };
+		E4F76DC1176CB27200798745 /* ofMath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMath.cpp; sourceTree = "<group>"; };
+		E4F76DC2176CB27200798745 /* ofMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMath.h; sourceTree = "<group>"; };
+		E4F76DC3176CB27200798745 /* ofMatrix3x3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMatrix3x3.cpp; sourceTree = "<group>"; };
+		E4F76DC4176CB27200798745 /* ofMatrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrix3x3.h; sourceTree = "<group>"; };
+		E4F76DC5176CB27200798745 /* ofMatrix4x4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMatrix4x4.cpp; sourceTree = "<group>"; };
+		E4F76DC6176CB27200798745 /* ofMatrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrix4x4.h; sourceTree = "<group>"; };
+		E4F76DC7176CB27200798745 /* ofQuaternion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofQuaternion.cpp; sourceTree = "<group>"; };
+		E4F76DC8176CB27200798745 /* ofQuaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofQuaternion.h; sourceTree = "<group>"; };
+		E4F76DC9176CB27200798745 /* ofVec2f.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVec2f.cpp; sourceTree = "<group>"; };
+		E4F76DCA176CB27200798745 /* ofVec2f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec2f.h; sourceTree = "<group>"; };
+		E4F76DCB176CB27200798745 /* ofVec3f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec3f.h; sourceTree = "<group>"; };
+		E4F76DCC176CB27200798745 /* ofVec4f.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVec4f.cpp; sourceTree = "<group>"; };
+		E4F76DCD176CB27200798745 /* ofVec4f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec4f.h; sourceTree = "<group>"; };
+		E4F76DCE176CB27200798745 /* ofVectorMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVectorMath.h; sourceTree = "<group>"; };
+		E4F76DCF176CB27200798745 /* ofMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMain.h; sourceTree = "<group>"; };
+		E4F76DDD176CB27200798745 /* ofSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundPlayer.cpp; sourceTree = "<group>"; };
+		E4F76DDE176CB27200798745 /* ofSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundPlayer.h; sourceTree = "<group>"; };
+		E4F76DDF176CB27200798745 /* ofSoundStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundStream.cpp; sourceTree = "<group>"; };
+		E4F76DE0176CB27200798745 /* ofSoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundStream.h; sourceTree = "<group>"; };
+		E4F76DE2176CB27200798745 /* ofBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseTypes.cpp; sourceTree = "<group>"; };
+		E4F76DE4176CB27200798745 /* ofColor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofColor.cpp; sourceTree = "<group>"; };
+		E4F76DE5176CB27200798745 /* ofColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofColor.h; sourceTree = "<group>"; };
+		E4F76DE6176CB27200798745 /* ofParameter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameter.cpp; sourceTree = "<group>"; };
+		E4F76DE7176CB27200798745 /* ofParameter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameter.h; sourceTree = "<group>"; };
+		E4F76DE8176CB27200798745 /* ofParameterGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameterGroup.cpp; sourceTree = "<group>"; };
+		E4F76DE9176CB27200798745 /* ofParameterGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameterGroup.h; sourceTree = "<group>"; };
+		E4F76DEB176CB27200798745 /* ofPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPoint.h; sourceTree = "<group>"; };
+		E4F76DEC176CB27200798745 /* ofRectangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofRectangle.cpp; sourceTree = "<group>"; };
+		E4F76DED176CB27200798745 /* ofRectangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofRectangle.h; sourceTree = "<group>"; };
+		E4F76DEE176CB27200798745 /* ofTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTypes.h; sourceTree = "<group>"; };
+		E4F76DF0176CB27200798745 /* ofConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofConstants.h; sourceTree = "<group>"; };
+		E4F76DF1176CB27200798745 /* ofFileUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofFileUtils.cpp; sourceTree = "<group>"; };
+		E4F76DF2176CB27200798745 /* ofFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFileUtils.h; sourceTree = "<group>"; };
+		E4F76DF3176CB27200798745 /* ofLog.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofLog.cpp; sourceTree = "<group>"; };
+		E4F76DF4176CB27200798745 /* ofLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofLog.h; sourceTree = "<group>"; };
+		E4F76DF5176CB27200798745 /* ofMatrixStack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofMatrixStack.cpp; sourceTree = "<group>"; };
+		E4F76DF6176CB27200798745 /* ofMatrixStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrixStack.h; sourceTree = "<group>"; };
+		E4F76DF7176CB27200798745 /* ofNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofNoise.h; sourceTree = "<group>"; };
+		E4F76DF8176CB27200798745 /* ofSystemUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofSystemUtils.cpp; sourceTree = "<group>"; };
+		E4F76DF9176CB27200798745 /* ofSystemUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSystemUtils.h; sourceTree = "<group>"; };
+		E4F76DFA176CB27200798745 /* ofThread.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofThread.cpp; sourceTree = "<group>"; };
+		E4F76DFB176CB27200798745 /* ofThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofThread.h; sourceTree = "<group>"; };
+		E4F76DFC176CB27200798745 /* ofURLFileLoader.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofURLFileLoader.cpp; sourceTree = "<group>"; };
+		E4F76DFD176CB27200798745 /* ofURLFileLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofURLFileLoader.h; sourceTree = "<group>"; };
+		E4F76DFE176CB27200798745 /* ofUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofUtils.cpp; sourceTree = "<group>"; };
+		E4F76DFF176CB27200798745 /* ofUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofUtils.h; sourceTree = "<group>"; };
+		E4F76E15176CB27200798745 /* ofVideoGrabber.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVideoGrabber.cpp; sourceTree = "<group>"; };
+		E4F76E16176CB27200798745 /* ofVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVideoGrabber.h; sourceTree = "<group>"; };
+		E4F76E17176CB27200798745 /* ofVideoPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVideoPlayer.cpp; sourceTree = "<group>"; };
+		E4F76E18176CB27200798745 /* ofVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVideoPlayer.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BB24DEC910DA7A3F00E9C588 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				99752D331BF21EEE0026316A /* GameController.framework in Frameworks */,
+				67D48ED01C10399900F719BC /* CoreMotion.framework in Frameworks */,
+				BB24DECA10DA7A3F00E9C588 /* AudioToolbox.framework in Frameworks */,
+				BB24DECB10DA7A3F00E9C588 /* OpenGLES.framework in Frameworks */,
+				BB24DECC10DA7A3F00E9C588 /* UIKit.framework in Frameworks */,
+				BB24DECD10DA7A3F00E9C588 /* OpenAL.framework in Frameworks */,
+				901808B9205362D7004A7774 /* GLKit.framework in Frameworks */,
+				BB24DECE10DA7A3F00E9C588 /* Foundation.framework in Frameworks */,
+				BB24DECF10DA7A3F00E9C588 /* CoreGraphics.framework in Frameworks */,
+				BB24DED010DA7A3F00E9C588 /* CoreLocation.framework in Frameworks */,
+				BB24DED110DA7A3F00E9C588 /* QuartzCore.framework in Frameworks */,
+				5E2E99DD10ED147800587639 /* MapKit.framework in Frameworks */,
+				53DA338A12DF8F4500C622CE /* AVFoundation.framework in Frameworks */,
+				53DA338E12DF8F5000C622CE /* CoreAudio.framework in Frameworks */,
+				53DA339012DF8F5000C622CE /* CoreMedia.framework in Frameworks */,
+				53DA339212DF8F5000C622CE /* CoreVideo.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		15594EFE15C55A5700727FF2 /* app */ = {
+			isa = PBXGroup;
+			children = (
+				15594F7C15C5697C00727FF2 /* ofAppiOSWindow.h */,
+				15594F7815C5697C00727FF2 /* ofAppiOSWindow.mm */,
+				15594F7E15C5697C00727FF2 /* ofxiOSApp.h */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
+		15594EFF15C55A5700727FF2 /* events */ = {
+			isa = PBXGroup;
+			children = (
+				15594FA915C56C9500727FF2 /* ofxiOSAlerts.h */,
+				15594FA815C56C9500727FF2 /* ofxiOSAlerts.mm */,
+				15594FAA15C56C9500727FF2 /* ofxiOSAlertsListener.h */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
+		15594F0015C55A5700727FF2 /* gl */ = {
+			isa = PBXGroup;
+			children = (
+				9008001C204EDC0F00DC786A /* EAGLKView.h */,
+				9008001B204EDC0E00DC786A /* EAGLKView.m */,
+				15594F0815C55AC900727FF2 /* EAGLView.h */,
+				15594F0515C55AC900727FF2 /* EAGLView.m */,
+				15594F0915C55AC900727FF2 /* ES1Renderer.h */,
+				15594F0615C55AC900727FF2 /* ES1Renderer.m */,
+				15594F0A15C55AC900727FF2 /* ES2Renderer.h */,
+				15594F0715C55AC900727FF2 /* ES2Renderer.m */,
+				15594F0B15C55AC900727FF2 /* ESRenderer.h */,
+			);
+			path = gl;
+			sourceTree = "<group>";
+		};
+		15594F0115C55A5700727FF2 /* sound */ = {
+			isa = PBXGroup;
+			children = (
+				671C0AF01770246200DF03B3 /* AVSoundPlayer.h */,
+				671C0AF11770246200DF03B3 /* AVSoundPlayer.m */,
+				671C0AF21770246200DF03B3 /* ofxiOSSoundPlayer.h */,
+				671C0AF31770246200DF03B3 /* ofxiOSSoundPlayer.mm */,
+				678C3D19176F04F800D1CC68 /* ofxiOSSoundStream.h */,
+				678C3D1A176F04F800D1CC68 /* ofxiOSSoundStream.mm */,
+				678C3D1B176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h */,
+				678C3D1C176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.mm */,
+				66EA462717A6D396009BB12A /* ofxOpenALSoundPlayer.cpp */,
+				66EA462817A6D396009BB12A /* ofxOpenALSoundPlayer.h */,
+				66EA462917A6D396009BB12A /* SoundEngine.cpp */,
+				66EA462A17A6D396009BB12A /* SoundEngine.h */,
+				678C3D1D176F04F800D1CC68 /* SoundInputStream.h */,
+				678C3D1E176F04F800D1CC68 /* SoundInputStream.m */,
+				678C3D1F176F04F800D1CC68 /* SoundOutputStream.h */,
+				678C3D20176F04F800D1CC68 /* SoundOutputStream.m */,
+				678C3D21176F04F800D1CC68 /* SoundStream.h */,
+				678C3D22176F04F800D1CC68 /* SoundStream.m */,
+			);
+			path = sound;
+			sourceTree = "<group>";
+		};
+		15594F0215C55A5700727FF2 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				15594FB615C56D1E00727FF2 /* ofxiOSCoreLocation.h */,
+				15594FAF15C56D1E00727FF2 /* ofxiOSCoreLocation.mm */,
+				67D48ED11C103BAE00F719BC /* ofxiOSCoreMotion.h */,
+				67D48ED21C103BAE00F719BC /* ofxiOSCoreMotion.mm */,
+				9252B7EF1CDA2A6100A8032B /* ofxiOSEventAdapter.h */,
+				9252B7F01CDA2A6100A8032B /* ofxiOSEventAdapter.mm */,
+				15594FB715C56D1E00727FF2 /* ofxiOSExternalDisplay.h */,
+				15594FB015C56D1E00727FF2 /* ofxiOSExternalDisplay.mm */,
+				15594FB815C56D1E00727FF2 /* ofxiOSExtras.h */,
+				15594FB115C56D1E00727FF2 /* ofxiOSExtras.mm */,
+				15594FB915C56D1E00727FF2 /* ofxiOSImagePicker.h */,
+				15594FB215C56D1E00727FF2 /* ofxiOSImagePicker.mm */,
+				15594FBA15C56D1E00727FF2 /* ofxiOSKeyboard.h */,
+				15594FB315C56D1E00727FF2 /* ofxiOSKeyboard.mm */,
+				15594FBB15C56D1E00727FF2 /* ofxiOSMapKit.h */,
+				15594FB415C56D1E00727FF2 /* ofxiOSMapKit.mm */,
+				15594FBC15C56D1E00727FF2 /* ofxiOSMapKitDelegate.h */,
+				15594FB515C56D1E00727FF2 /* ofxiOSMapKitDelegate.mm */,
+				15594FBD15C56D1E00727FF2 /* ofxiOSMapKitListener.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		15594F0315C55A5700727FF2 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				15594FA215C56BB700727FF2 /* AVFoundationVideoPlayer.h */,
+				15594FA015C56BB700727FF2 /* AVFoundationVideoPlayer.m */,
+				15594FA115C56BB700727FF2 /* AVFoundationVideoGrabber.h */,
+				15594F9F15C56BB700727FF2 /* AVFoundationVideoGrabber.mm */,
+				1594366315CF5F420087B684 /* ofxiOSVideoPlayer.h */,
+				1594366115CF5F420087B684 /* ofxiOSVideoPlayer.mm */,
+				1594366215CF5F420087B684 /* ofxiOSVideoGrabber.h */,
+				1594366015CF5F420087B684 /* ofxiOSVideoGrabber.mm */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+		15594F8A15C56A4E00727FF2 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				15594F8F15C56A8A00727FF2 /* ofxiOSAppDelegate.h */,
+				15594F8C15C56A8A00727FF2 /* ofxiOSAppDelegate.mm */,
+				15594F8E15C56A8A00727FF2 /* ofxiOSEAGLView.h */,
+				15594F8B15C56A8A00727FF2 /* ofxiOSEAGLView.mm */,
+				90080017204EDB5500DC786A /* ofxiOSGLKView.h */,
+				90080018204EDB5500DC786A /* ofxiOSGLKView.mm */,
+				90080015204EDA4600DC786A /* ofxiOSGLKViewController.h */,
+				90080013204EDA1300DC786A /* ofxiOSGLKViewController.mm */,
+				15594F9015C56A8A00727FF2 /* ofxiOSViewController.h */,
+				15594F8D15C56A8A00727FF2 /* ofxiOSViewController.mm */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BB24DED610DA7A3F00E9C588 /* libofxiOS_iphoneos_Debug.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+			isa = PBXGroup;
+			children = (
+				E41D3E9013B38BE900A75A5D /* CoreOF.xcconfig */,
+				E41D3E9113B38BE900A75A5D /* Debug.xcconfig */,
+				E41D3E9213B38BE900A75A5D /* Release.xcconfig */,
+				E41D3E9313B38BE900A75A5D /* Shared.xcconfig */,
+				BB16F26B0F2B646B00518274 /* addons */,
+				E4F76D69176CB27200798745 /* openFrameworks */,
+				BB16E9930F2B1E5900518274 /* libs */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			indentWidth = 4;
+			name = CustomTemplate;
+			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
+		};
+		29B97323FDCFA39411CA2CEA /* core frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				99752D321BF21EEE0026316A /* GameController.framework */,
+				5E2E99DC10ED147800587639 /* MapKit.framework */,
+				901808B8205362D7004A7774 /* GLKit.framework */,
+				BBE5EAB70F49AD8400F28951 /* AudioToolbox.framework */,
+				BB16EBD80F2B2AB500518274 /* QuartzCore.framework */,
+				BB16EBD10F2B2A9500518274 /* OpenGLES.framework */,
+				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
+				1D30AB110D05D00D00671497 /* Foundation.framework */,
+				288765FC0DF74451002DB57D /* CoreGraphics.framework */,
+				53F323EA10A20EDB00E0DAE4 /* OpenAL.framework */,
+				5326AEA710A23A0500278DE6 /* CoreLocation.framework */,
+				53DA338912DF8F4500C622CE /* AVFoundation.framework */,
+				53DA338D12DF8F5000C622CE /* CoreAudio.framework */,
+				53DA338F12DF8F5000C622CE /* CoreMedia.framework */,
+				53DA339112DF8F5000C622CE /* CoreVideo.framework */,
+				67D48ECF1C10399900F719BC /* CoreMotion.framework */,
+			);
+			name = "core frameworks";
+			sourceTree = "<group>";
+		};
+		BB16E9930F2B1E5900518274 /* libs */ = {
+			isa = PBXGroup;
+			children = (
+				BBE5E94E0F497BD800F28951 /* core */,
+			);
+			name = libs;
+			sourceTree = "<group>";
+		};
+		BB16F26B0F2B646B00518274 /* addons */ = {
+			isa = PBXGroup;
+			children = (
+				BB24E02310DA7C6100E9C588 /* ofxiOS */,
+			);
+			name = addons;
+			sourceTree = "<group>";
+		};
+		BB24E02310DA7C6100E9C588 /* ofxiOS */ = {
+			isa = PBXGroup;
+			children = (
+				BB24E02810DA7C6100E9C588 /* src */,
+			);
+			name = ofxiOS;
+			path = ../../../../addons/ofxiOS;
+			sourceTree = SOURCE_ROOT;
+		};
+		BB24E02810DA7C6100E9C588 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				860B024C17A96D840032B827 /* ofxiOS.h */,
+				6711091F19D3EAC6005D095F /* ofxiOSConstants.h */,
+				15BC775215A5C31F00772525 /* ofxiOSExtensions.h */,
+				15594EFE15C55A5700727FF2 /* app */,
+				15594F8A15C56A4E00727FF2 /* core */,
+				15594F0015C55A5700727FF2 /* gl */,
+				15594F0115C55A5700727FF2 /* sound */,
+				15594F0315C55A5700727FF2 /* video */,
+				15594EFF15C55A5700727FF2 /* events */,
+				15594F0215C55A5700727FF2 /* utils */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		BBE5E94E0F497BD800F28951 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				29B97323FDCFA39411CA2CEA /* core frameworks */,
+			);
+			name = core;
+			sourceTree = "<group>";
+		};
+		E4F76D69176CB27200798745 /* openFrameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E4F76DCF176CB27200798745 /* ofMain.h */,
+				E4F76D6E176CB27200798745 /* 3d */,
+				E4F76D7B176CB27200798745 /* app */,
+				E4F76D89176CB27200798745 /* communication */,
+				E4F76D8E176CB27200798745 /* events */,
+				E4F76D92176CB27200798745 /* gl */,
+				E4F76DA9176CB27200798745 /* graphics */,
+				E4F76DC0176CB27200798745 /* math */,
+				E4F76DD0176CB27200798745 /* sound */,
+				E4F76DE1176CB27200798745 /* types */,
+				E4F76DEF176CB27200798745 /* utils */,
+				E4F76E00176CB27200798745 /* video */,
+			);
+			name = openFrameworks;
+			path = ../../../openFrameworks;
+			sourceTree = "<group>";
+		};
+		E4F76D6E176CB27200798745 /* 3d */ = {
+			isa = PBXGroup;
+			children = (
+				69433CCD1FE45BD9004D5B73 /* ofMesh.inl */,
+				E4F76D6F176CB27200798745 /* of3dPrimitives.cpp */,
+				E4F76D70176CB27200798745 /* of3dPrimitives.h */,
+				E4F76D71176CB27200798745 /* of3dUtils.cpp */,
+				E4F76D72176CB27200798745 /* of3dUtils.h */,
+				E4F76D73176CB27200798745 /* ofCamera.cpp */,
+				E4F76D74176CB27200798745 /* ofCamera.h */,
+				E4F76D75176CB27200798745 /* ofEasyCam.cpp */,
+				E4F76D76176CB27200798745 /* ofEasyCam.h */,
+				E4F76D78176CB27200798745 /* ofMesh.h */,
+				E4F76D79176CB27200798745 /* ofNode.cpp */,
+				E4F76D7A176CB27200798745 /* ofNode.h */,
+			);
+			path = 3d;
+			sourceTree = "<group>";
+		};
+		E4F76D7B176CB27200798745 /* app */ = {
+			isa = PBXGroup;
+			children = (
+				69433CC21FE45BAC004D5B73 /* ofBaseApp.cpp */,
+				E4F76D7C176CB27200798745 /* ofAppBaseWindow.h */,
+				E4F76D85176CB27200798745 /* ofAppRunner.cpp */,
+				E4F76D86176CB27200798745 /* ofAppRunner.h */,
+				E4F76D87176CB27200798745 /* ofBaseApp.h */,
+				9979E8261A1CDBD4007E55D1 /* ofMainLoop.cpp */,
+				9979E8271A1CDBD4007E55D1 /* ofMainLoop.h */,
+				9979E8171A1B9883007E55D1 /* ofWindowSettings.h */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
+		E4F76D89176CB27200798745 /* communication */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = communication;
+			sourceTree = "<group>";
+		};
+		E4F76D8E176CB27200798745 /* events */ = {
+			isa = PBXGroup;
+			children = (
+				9957D86F1BDDCD440002D53C /* ofEvent.h */,
+				E4F76D8F176CB27200798745 /* ofEvents.cpp */,
+				E4F76D90176CB27200798745 /* ofEvents.h */,
+				E4F76D91176CB27200798745 /* ofEventUtils.h */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
+		E4F76D92176CB27200798745 /* gl */ = {
+			isa = PBXGroup;
+			children = (
+				69433CC41FE45BB7004D5B73 /* ofGLBaseTypes.h */,
+				67833F8819F8996300DBE7AA /* ofBufferObject.cpp */,
+				67833F8919F8996300DBE7AA /* ofBufferObject.h */,
+				E4F76D93176CB27200798745 /* ofFbo.cpp */,
+				E4F76D94176CB27200798745 /* ofFbo.h */,
+				E4F76D95176CB27200798745 /* ofGLProgrammableRenderer.cpp */,
+				E4F76D96176CB27200798745 /* ofGLProgrammableRenderer.h */,
+				E4F76D97176CB27200798745 /* ofGLRenderer.cpp */,
+				E4F76D98176CB27200798745 /* ofGLRenderer.h */,
+				E4F76D99176CB27200798745 /* ofGLUtils.cpp */,
+				E4F76D9A176CB27200798745 /* ofGLUtils.h */,
+				E4F76D9B176CB27200798745 /* ofLight.cpp */,
+				E4F76D9C176CB27200798745 /* ofLight.h */,
+				E4F76D9D176CB27200798745 /* ofMaterial.cpp */,
+				E4F76D9E176CB27200798745 /* ofMaterial.h */,
+				E4F76D9F176CB27200798745 /* ofShader.cpp */,
+				E4F76DA0176CB27200798745 /* ofShader.h */,
+				E4F76DA3176CB27200798745 /* ofTexture.cpp */,
+				E4F76DA4176CB27200798745 /* ofTexture.h */,
+				E4F76DA5176CB27200798745 /* ofVbo.cpp */,
+				E4F76DA6176CB27200798745 /* ofVbo.h */,
+				E4F76DA7176CB27200798745 /* ofVboMesh.cpp */,
+				E4F76DA8176CB27200798745 /* ofVboMesh.h */,
+			);
+			path = gl;
+			sourceTree = "<group>";
+		};
+		E4F76DA9176CB27200798745 /* graphics */ = {
+			isa = PBXGroup;
+			children = (
+				69433CC61FE45BCD004D5B73 /* ofGraphicsBaseTypes.cpp */,
+				69433CC71FE45BCD004D5B73 /* ofGraphicsBaseTypes.h */,
+				69433CC81FE45BCD004D5B73 /* ofGraphicsConstants.h */,
+				69433CC91FE45BCD004D5B73 /* ofPolyline.inl */,
+				E4F76DAA176CB27200798745 /* of3dGraphics.cpp */,
+				E4F76DAB176CB27200798745 /* of3dGraphics.h */,
+				E4F76DAC176CB27200798745 /* ofBitmapFont.cpp */,
+				E4F76DAD176CB27200798745 /* ofBitmapFont.h */,
+				E4F76DB0176CB27200798745 /* ofGraphics.cpp */,
+				E4F76DB1176CB27200798745 /* ofGraphics.h */,
+				E4F76DB2176CB27200798745 /* ofImage.cpp */,
+				E4F76DB3176CB27200798745 /* ofImage.h */,
+				E4F76DB4176CB27200798745 /* ofPath.cpp */,
+				E4F76DB5176CB27200798745 /* ofPath.h */,
+				E4F76DB6176CB27200798745 /* ofPixels.cpp */,
+				E4F76DB7176CB27200798745 /* ofPixels.h */,
+				E4F76DB9176CB27200798745 /* ofPolyline.h */,
+				E4F76DBA176CB27200798745 /* ofRendererCollection.cpp */,
+				E4F76DBB176CB27200798745 /* ofRendererCollection.h */,
+				E4F76DBC176CB27200798745 /* ofTessellator.cpp */,
+				E4F76DBD176CB27200798745 /* ofTessellator.h */,
+				E4F76DBE176CB27200798745 /* ofTrueTypeFont.cpp */,
+				E4F76DBF176CB27200798745 /* ofTrueTypeFont.h */,
+			);
+			path = graphics;
+			sourceTree = "<group>";
+		};
+		E4F76DC0176CB27200798745 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				69433CD21FE45E41004D5B73 /* ofMathConstants.h */,
+				E4F76DC1176CB27200798745 /* ofMath.cpp */,
+				E4F76DC2176CB27200798745 /* ofMath.h */,
+				E4F76DC3176CB27200798745 /* ofMatrix3x3.cpp */,
+				E4F76DC4176CB27200798745 /* ofMatrix3x3.h */,
+				E4F76DC5176CB27200798745 /* ofMatrix4x4.cpp */,
+				E4F76DC6176CB27200798745 /* ofMatrix4x4.h */,
+				E4F76DC7176CB27200798745 /* ofQuaternion.cpp */,
+				E4F76DC8176CB27200798745 /* ofQuaternion.h */,
+				E4F76DC9176CB27200798745 /* ofVec2f.cpp */,
+				E4F76DCA176CB27200798745 /* ofVec2f.h */,
+				E4F76DCB176CB27200798745 /* ofVec3f.h */,
+				E4F76DCC176CB27200798745 /* ofVec4f.cpp */,
+				E4F76DCD176CB27200798745 /* ofVec4f.h */,
+				E4F76DCE176CB27200798745 /* ofVectorMath.h */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		E4F76DD0176CB27200798745 /* sound */ = {
+			isa = PBXGroup;
+			children = (
+				69433CCE1FE45BF2004D5B73 /* ofSoundBaseTypes.cpp */,
+				69433CCF1FE45BF2004D5B73 /* ofSoundBaseTypes.h */,
+				6678E97219FEB2DF00C00581 /* ofSoundBuffer.cpp */,
+				6678E97319FEB2DF00C00581 /* ofSoundBuffer.h */,
+				E4F76DDD176CB27200798745 /* ofSoundPlayer.cpp */,
+				E4F76DDE176CB27200798745 /* ofSoundPlayer.h */,
+				E4F76DDF176CB27200798745 /* ofSoundStream.cpp */,
+				E4F76DE0176CB27200798745 /* ofSoundStream.h */,
+				6678E97419FEB2DF00C00581 /* ofSoundUtils.h */,
+			);
+			path = sound;
+			sourceTree = "<group>";
+		};
+		E4F76DE1176CB27200798745 /* types */ = {
+			isa = PBXGroup;
+			children = (
+				E4F76DE2176CB27200798745 /* ofBaseTypes.cpp */,
+				E4F76DE4176CB27200798745 /* ofColor.cpp */,
+				E4F76DE5176CB27200798745 /* ofColor.h */,
+				E4F76DE6176CB27200798745 /* ofParameter.cpp */,
+				E4F76DE7176CB27200798745 /* ofParameter.h */,
+				E4F76DE8176CB27200798745 /* ofParameterGroup.cpp */,
+				E4F76DE9176CB27200798745 /* ofParameterGroup.h */,
+				E4F76DEB176CB27200798745 /* ofPoint.h */,
+				E4F76DEC176CB27200798745 /* ofRectangle.cpp */,
+				E4F76DED176CB27200798745 /* ofRectangle.h */,
+				E4F76DEE176CB27200798745 /* ofTypes.h */,
+			);
+			path = types;
+			sourceTree = "<group>";
+		};
+		E4F76DEF176CB27200798745 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				E4F76DF0176CB27200798745 /* ofConstants.h */,
+				E4F76DF1176CB27200798745 /* ofFileUtils.cpp */,
+				E4F76DF2176CB27200798745 /* ofFileUtils.h */,
+				67833F7E19F8990D00DBE7AA /* ofFpsCounter.cpp */,
+				67833F7F19F8990D00DBE7AA /* ofFpsCounter.h */,
+				E4F76DF3176CB27200798745 /* ofLog.cpp */,
+				E4F76DF4176CB27200798745 /* ofLog.h */,
+				E4F76DF5176CB27200798745 /* ofMatrixStack.cpp */,
+				E4F76DF6176CB27200798745 /* ofMatrixStack.h */,
+				E4F76DF7176CB27200798745 /* ofNoise.h */,
+				E4F76DF8176CB27200798745 /* ofSystemUtils.cpp */,
+				E4F76DF9176CB27200798745 /* ofSystemUtils.h */,
+				E4F76DFA176CB27200798745 /* ofThread.cpp */,
+				E4F76DFB176CB27200798745 /* ofThread.h */,
+				67833F8019F8990D00DBE7AA /* ofThreadChannel.h */,
+				67833F8119F8990D00DBE7AA /* ofTimer.cpp */,
+				67833F8219F8990D00DBE7AA /* ofTimer.h */,
+				E4F76DFC176CB27200798745 /* ofURLFileLoader.cpp */,
+				E4F76DFD176CB27200798745 /* ofURLFileLoader.h */,
+				E4F76DFE176CB27200798745 /* ofUtils.cpp */,
+				E4F76DFF176CB27200798745 /* ofUtils.h */,
+				67509ABA17979781003A3A29 /* ofXml.cpp */,
+				67509ABB17979781003A3A29 /* ofXml.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		E4F76E00176CB27200798745 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				E4F76E15176CB27200798745 /* ofVideoGrabber.cpp */,
+				E4F76E16176CB27200798745 /* ofVideoGrabber.h */,
+				E4F76E17176CB27200798745 /* ofVideoPlayer.cpp */,
+				E4F76E18176CB27200798745 /* ofVideoPlayer.h */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		BB24DE5D10DA7A3F00E9C588 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4F76E1A176CB27200798745 /* of3dPrimitives.h in Headers */,
+				E4F76E1C176CB27200798745 /* of3dUtils.h in Headers */,
+				E4F76E1E176CB27200798745 /* ofCamera.h in Headers */,
+				E4F76E20176CB27200798745 /* ofEasyCam.h in Headers */,
+				E4F76E22176CB27200798745 /* ofMesh.h in Headers */,
+				E4F76E24176CB27200798745 /* ofNode.h in Headers */,
+				67833F8419F8990D00DBE7AA /* ofFpsCounter.h in Headers */,
+				E4F76E25176CB27200798745 /* ofAppBaseWindow.h in Headers */,
+				90080019204EDB5500DC786A /* ofxiOSGLKView.h in Headers */,
+				E4F76E2F176CB27200798745 /* ofAppRunner.h in Headers */,
+				E4F76E30176CB27200798745 /* ofBaseApp.h in Headers */,
+				E4F76E37176CB27200798745 /* ofEvents.h in Headers */,
+				E4F76E38176CB27200798745 /* ofEventUtils.h in Headers */,
+				67D48ED31C103BAE00F719BC /* ofxiOSCoreMotion.h in Headers */,
+				E4F76E3A176CB27200798745 /* ofFbo.h in Headers */,
+				E4F76E3C176CB27200798745 /* ofGLProgrammableRenderer.h in Headers */,
+				E4F76E3E176CB27200798745 /* ofGLRenderer.h in Headers */,
+				69433CD31FE45E41004D5B73 /* ofMathConstants.h in Headers */,
+				E4F76E40176CB27200798745 /* ofGLUtils.h in Headers */,
+				E4F76E42176CB27200798745 /* ofLight.h in Headers */,
+				E4F76E44176CB27200798745 /* ofMaterial.h in Headers */,
+				9252B7F11CDA2A6100A8032B /* ofxiOSEventAdapter.h in Headers */,
+				E4F76E46176CB27200798745 /* ofShader.h in Headers */,
+				E4F76E4A176CB27200798745 /* ofTexture.h in Headers */,
+				E4F76E4C176CB27200798745 /* ofVbo.h in Headers */,
+				E4F76E4E176CB27200798745 /* ofVboMesh.h in Headers */,
+				E4F76E50176CB27200798745 /* of3dGraphics.h in Headers */,
+				E4F76E52176CB27200798745 /* ofBitmapFont.h in Headers */,
+				E4F76E56176CB27200798745 /* ofGraphics.h in Headers */,
+				E4F76E58176CB27200798745 /* ofImage.h in Headers */,
+				E4F76E5A176CB27200798745 /* ofPath.h in Headers */,
+				E4F76E5C176CB27200798745 /* ofPixels.h in Headers */,
+				69433CCB1FE45BCD004D5B73 /* ofGraphicsBaseTypes.h in Headers */,
+				E4F76E5E176CB27200798745 /* ofPolyline.h in Headers */,
+				E4F76E60176CB27200798745 /* ofRendererCollection.h in Headers */,
+				E4F76E62176CB27200798745 /* ofTessellator.h in Headers */,
+				E4F76E64176CB27200798745 /* ofTrueTypeFont.h in Headers */,
+				E4F76E66176CB27200798745 /* ofMath.h in Headers */,
+				E4F76E68176CB27200798745 /* ofMatrix3x3.h in Headers */,
+				E4F76E6A176CB27200798745 /* ofMatrix4x4.h in Headers */,
+				69433CC51FE45BB7004D5B73 /* ofGLBaseTypes.h in Headers */,
+				E4F76E6C176CB27200798745 /* ofQuaternion.h in Headers */,
+				69433CCC1FE45BCD004D5B73 /* ofGraphicsConstants.h in Headers */,
+				E4F76E6E176CB27200798745 /* ofVec2f.h in Headers */,
+				9979E8291A1CDBD4007E55D1 /* ofMainLoop.h in Headers */,
+				E4F76E6F176CB27200798745 /* ofVec3f.h in Headers */,
+				E4F76E71176CB27200798745 /* ofVec4f.h in Headers */,
+				E4F76E72176CB27200798745 /* ofVectorMath.h in Headers */,
+				9008001E204EDC0F00DC786A /* EAGLKView.h in Headers */,
+				67833F8519F8990D00DBE7AA /* ofThreadChannel.h in Headers */,
+				E4F76E73176CB27200798745 /* ofMain.h in Headers */,
+				E4F76E81176CB27200798745 /* ofSoundPlayer.h in Headers */,
+				E4F76E83176CB27200798745 /* ofSoundStream.h in Headers */,
+				9957D8701BDDCD440002D53C /* ofEvent.h in Headers */,
+				E4F76E87176CB27200798745 /* ofColor.h in Headers */,
+				E4F76E89176CB27200798745 /* ofParameter.h in Headers */,
+				E4F76E8B176CB27200798745 /* ofParameterGroup.h in Headers */,
+				E4F76E8D176CB27200798745 /* ofPoint.h in Headers */,
+				6678E97819FEB2DF00C00581 /* ofSoundUtils.h in Headers */,
+				E4F76E8F176CB27200798745 /* ofRectangle.h in Headers */,
+				E4F76E90176CB27200798745 /* ofTypes.h in Headers */,
+				E4F76E91176CB27200798745 /* ofConstants.h in Headers */,
+				9979E8181A1B9883007E55D1 /* ofWindowSettings.h in Headers */,
+				E4F76E93176CB27200798745 /* ofFileUtils.h in Headers */,
+				E4F76E95176CB27200798745 /* ofLog.h in Headers */,
+				E4F76E97176CB27200798745 /* ofMatrixStack.h in Headers */,
+				E4F76E98176CB27200798745 /* ofNoise.h in Headers */,
+				E4F76E9A176CB27200798745 /* ofSystemUtils.h in Headers */,
+				E4F76E9C176CB27200798745 /* ofThread.h in Headers */,
+				E4F76E9E176CB27200798745 /* ofURLFileLoader.h in Headers */,
+				E4F76EA0176CB27200798745 /* ofUtils.h in Headers */,
+				E4F76EB6176CB27200798745 /* ofVideoGrabber.h in Headers */,
+				67833F8B19F8996300DBE7AA /* ofBufferObject.h in Headers */,
+				E4F76EB8176CB27200798745 /* ofVideoPlayer.h in Headers */,
+				15594F0F15C55AC900727FF2 /* EAGLView.h in Headers */,
+				15594F1015C55AC900727FF2 /* ES1Renderer.h in Headers */,
+				15594F1115C55AC900727FF2 /* ES2Renderer.h in Headers */,
+				15594F1215C55AC900727FF2 /* ESRenderer.h in Headers */,
+				15594F8515C5697C00727FF2 /* ofAppiOSWindow.h in Headers */,
+				15594F8715C5697C00727FF2 /* ofxiOSApp.h in Headers */,
+				15594F9415C56A8A00727FF2 /* ofxiOSEAGLView.h in Headers */,
+				15594F9515C56A8A00727FF2 /* ofxiOSAppDelegate.h in Headers */,
+				15594F9615C56A8A00727FF2 /* ofxiOSViewController.h in Headers */,
+				6678E97719FEB2DF00C00581 /* ofSoundBuffer.h in Headers */,
+				15594FA515C56BB700727FF2 /* AVFoundationVideoGrabber.h in Headers */,
+				15594FA615C56BB700727FF2 /* AVFoundationVideoPlayer.h in Headers */,
+				15594FAD15C56C9500727FF2 /* ofxiOSAlerts.h in Headers */,
+				15594FAE15C56C9500727FF2 /* ofxiOSAlertsListener.h in Headers */,
+				15594FC515C56D1E00727FF2 /* ofxiOSCoreLocation.h in Headers */,
+				15594FC615C56D1E00727FF2 /* ofxiOSExternalDisplay.h in Headers */,
+				15594FC715C56D1E00727FF2 /* ofxiOSExtras.h in Headers */,
+				15594FC815C56D1E00727FF2 /* ofxiOSImagePicker.h in Headers */,
+				15594FC915C56D1E00727FF2 /* ofxiOSKeyboard.h in Headers */,
+				15594FCA15C56D1E00727FF2 /* ofxiOSMapKit.h in Headers */,
+				69433CD11FE45BF2004D5B73 /* ofSoundBaseTypes.h in Headers */,
+				15594FCB15C56D1E00727FF2 /* ofxiOSMapKitDelegate.h in Headers */,
+				90080016204EDA4B00DC786A /* ofxiOSGLKViewController.h in Headers */,
+				15594FCC15C56D1E00727FF2 /* ofxiOSMapKitListener.h in Headers */,
+				1594366615CF5F420087B684 /* ofxiOSVideoGrabber.h in Headers */,
+				1594366715CF5F420087B684 /* ofxiOSVideoPlayer.h in Headers */,
+				678C3D23176F04F800D1CC68 /* ofxiOSSoundStream.h in Headers */,
+				678C3D25176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.h in Headers */,
+				678C3D27176F04F800D1CC68 /* SoundInputStream.h in Headers */,
+				678C3D29176F04F800D1CC68 /* SoundOutputStream.h in Headers */,
+				678C3D2B176F04F800D1CC68 /* SoundStream.h in Headers */,
+				671C0AF41770246200DF03B3 /* AVSoundPlayer.h in Headers */,
+				671C0AF61770246200DF03B3 /* ofxiOSSoundPlayer.h in Headers */,
+				67833F8719F8990D00DBE7AA /* ofTimer.h in Headers */,
+				67509ABD17979781003A3A29 /* ofXml.h in Headers */,
+				66EA462C17A6D396009BB12A /* ofxOpenALSoundPlayer.h in Headers */,
+				66EA462E17A6D396009BB12A /* SoundEngine.h in Headers */,
+				860B024D17A96D840032B827 /* ofxiOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		BB24DE5C10DA7A3F00E9C588 /* iPhone+OF Static Library */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "iPhone+OF Static Library" */;
+			buildPhases = (
+				BB24DE5D10DA7A3F00E9C588 /* Headers */,
+				BB24DEB110DA7A3F00E9C588 /* Sources */,
+				BB24DEC910DA7A3F00E9C588 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iPhone+OF Static Library";
+			productName = "Static Library";
+			productReference = BB24DED610DA7A3F00E9C588 /* libofxiOS_iphoneos_Debug.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0920;
+			};
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "iOS+OFLib" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				BB24DE5C10DA7A3F00E9C588 /* iPhone+OF Static Library */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BB24DEB110DA7A3F00E9C588 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4F76E19176CB27200798745 /* of3dPrimitives.cpp in Sources */,
+				E4F76E1B176CB27200798745 /* of3dUtils.cpp in Sources */,
+				E4F76E1D176CB27200798745 /* ofCamera.cpp in Sources */,
+				E4F76E1F176CB27200798745 /* ofEasyCam.cpp in Sources */,
+				E4F76E23176CB27200798745 /* ofNode.cpp in Sources */,
+				E4F76E2E176CB27200798745 /* ofAppRunner.cpp in Sources */,
+				67833F8319F8990D00DBE7AA /* ofFpsCounter.cpp in Sources */,
+				E4F76E36176CB27200798745 /* ofEvents.cpp in Sources */,
+				E4F76E39176CB27200798745 /* ofFbo.cpp in Sources */,
+				E4F76E3B176CB27200798745 /* ofGLProgrammableRenderer.cpp in Sources */,
+				E4F76E3D176CB27200798745 /* ofGLRenderer.cpp in Sources */,
+				E4F76E3F176CB27200798745 /* ofGLUtils.cpp in Sources */,
+				E4F76E41176CB27200798745 /* ofLight.cpp in Sources */,
+				E4F76E43176CB27200798745 /* ofMaterial.cpp in Sources */,
+				E4F76E45176CB27200798745 /* ofShader.cpp in Sources */,
+				E4F76E49176CB27200798745 /* ofTexture.cpp in Sources */,
+				E4F76E4B176CB27200798745 /* ofVbo.cpp in Sources */,
+				90080014204EDA1300DC786A /* ofxiOSGLKViewController.mm in Sources */,
+				E4F76E4D176CB27200798745 /* ofVboMesh.cpp in Sources */,
+				E4F76E4F176CB27200798745 /* of3dGraphics.cpp in Sources */,
+				E4F76E51176CB27200798745 /* ofBitmapFont.cpp in Sources */,
+				E4F76E55176CB27200798745 /* ofGraphics.cpp in Sources */,
+				E4F76E57176CB27200798745 /* ofImage.cpp in Sources */,
+				E4F76E59176CB27200798745 /* ofPath.cpp in Sources */,
+				E4F76E5B176CB27200798745 /* ofPixels.cpp in Sources */,
+				E4F76E5F176CB27200798745 /* ofRendererCollection.cpp in Sources */,
+				E4F76E61176CB27200798745 /* ofTessellator.cpp in Sources */,
+				E4F76E63176CB27200798745 /* ofTrueTypeFont.cpp in Sources */,
+				E4F76E65176CB27200798745 /* ofMath.cpp in Sources */,
+				67833F8619F8990D00DBE7AA /* ofTimer.cpp in Sources */,
+				E4F76E67176CB27200798745 /* ofMatrix3x3.cpp in Sources */,
+				E4F76E69176CB27200798745 /* ofMatrix4x4.cpp in Sources */,
+				E4F76E6B176CB27200798745 /* ofQuaternion.cpp in Sources */,
+				E4F76E6D176CB27200798745 /* ofVec2f.cpp in Sources */,
+				E4F76E70176CB27200798745 /* ofVec4f.cpp in Sources */,
+				69433CD01FE45BF2004D5B73 /* ofSoundBaseTypes.cpp in Sources */,
+				E4F76E80176CB27200798745 /* ofSoundPlayer.cpp in Sources */,
+				E4F76E82176CB27200798745 /* ofSoundStream.cpp in Sources */,
+				E4F76E84176CB27200798745 /* ofBaseTypes.cpp in Sources */,
+				E4F76E86176CB27200798745 /* ofColor.cpp in Sources */,
+				6678E97619FEB2DF00C00581 /* ofSoundBuffer.cpp in Sources */,
+				E4F76E88176CB27200798745 /* ofParameter.cpp in Sources */,
+				E4F76E8A176CB27200798745 /* ofParameterGroup.cpp in Sources */,
+				E4F76E8E176CB27200798745 /* ofRectangle.cpp in Sources */,
+				E4F76E92176CB27200798745 /* ofFileUtils.cpp in Sources */,
+				E4F76E94176CB27200798745 /* ofLog.cpp in Sources */,
+				E4F76E96176CB27200798745 /* ofMatrixStack.cpp in Sources */,
+				E4F76E99176CB27200798745 /* ofSystemUtils.cpp in Sources */,
+				E4F76E9B176CB27200798745 /* ofThread.cpp in Sources */,
+				E4F76E9D176CB27200798745 /* ofURLFileLoader.cpp in Sources */,
+				E4F76E9F176CB27200798745 /* ofUtils.cpp in Sources */,
+				E4F76EB5176CB27200798745 /* ofVideoGrabber.cpp in Sources */,
+				E4F76EB7176CB27200798745 /* ofVideoPlayer.cpp in Sources */,
+				15594F0C15C55AC900727FF2 /* EAGLView.m in Sources */,
+				9252B7F21CDA2A6100A8032B /* ofxiOSEventAdapter.mm in Sources */,
+				9979E8281A1CDBD4007E55D1 /* ofMainLoop.cpp in Sources */,
+				15594F0D15C55AC900727FF2 /* ES1Renderer.m in Sources */,
+				15594F0E15C55AC900727FF2 /* ES2Renderer.m in Sources */,
+				15594F8115C5697C00727FF2 /* ofAppiOSWindow.mm in Sources */,
+				15594F9115C56A8A00727FF2 /* ofxiOSEAGLView.mm in Sources */,
+				15594F9215C56A8A00727FF2 /* ofxiOSAppDelegate.mm in Sources */,
+				69433CCA1FE45BCD004D5B73 /* ofGraphicsBaseTypes.cpp in Sources */,
+				15594F9315C56A8A00727FF2 /* ofxiOSViewController.mm in Sources */,
+				9008001D204EDC0F00DC786A /* EAGLKView.m in Sources */,
+				15594FA315C56BB700727FF2 /* AVFoundationVideoGrabber.mm in Sources */,
+				15594FA415C56BB700727FF2 /* AVFoundationVideoPlayer.m in Sources */,
+				15594FAC15C56C9500727FF2 /* ofxiOSAlerts.mm in Sources */,
+				15594FBE15C56D1E00727FF2 /* ofxiOSCoreLocation.mm in Sources */,
+				15594FBF15C56D1E00727FF2 /* ofxiOSExternalDisplay.mm in Sources */,
+				15594FC015C56D1E00727FF2 /* ofxiOSExtras.mm in Sources */,
+				15594FC115C56D1E00727FF2 /* ofxiOSImagePicker.mm in Sources */,
+				15594FC215C56D1E00727FF2 /* ofxiOSKeyboard.mm in Sources */,
+				15594FC315C56D1E00727FF2 /* ofxiOSMapKit.mm in Sources */,
+				15594FC415C56D1E00727FF2 /* ofxiOSMapKitDelegate.mm in Sources */,
+				69433CC31FE45BAC004D5B73 /* ofBaseApp.cpp in Sources */,
+				67833F8A19F8996300DBE7AA /* ofBufferObject.cpp in Sources */,
+				1594366415CF5F420087B684 /* ofxiOSVideoGrabber.mm in Sources */,
+				1594366515CF5F420087B684 /* ofxiOSVideoPlayer.mm in Sources */,
+				678C3D24176F04F800D1CC68 /* ofxiOSSoundStream.mm in Sources */,
+				678C3D26176F04F800D1CC68 /* ofxiOSSoundStreamDelegate.mm in Sources */,
+				678C3D28176F04F800D1CC68 /* SoundInputStream.m in Sources */,
+				678C3D2A176F04F800D1CC68 /* SoundOutputStream.m in Sources */,
+				678C3D2C176F04F800D1CC68 /* SoundStream.m in Sources */,
+				671C0AF51770246200DF03B3 /* AVSoundPlayer.m in Sources */,
+				671C0AF71770246200DF03B3 /* ofxiOSSoundPlayer.mm in Sources */,
+				67509ABC17979781003A3A29 /* ofXml.cpp in Sources */,
+				66EA462B17A6D396009BB12A /* ofxOpenALSoundPlayer.cpp in Sources */,
+				67D48ED41C103BAE00F719BC /* ofxiOSCoreMotion.mm in Sources */,
+				9008001A204EDB5500DC786A /* ofxiOSGLKView.mm in Sources */,
+				66EA462D17A6D396009BB12A /* SoundEngine.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BB24DED310DA7A3F00E9C588 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
+				EXECUTABLE_PREFIX = lib;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/kiss/lib/linux\"",
+					"\"$(SRCROOT)/kiss/lib/linux64\"",
+					"\"$(SRCROOT)/../../../tess2/lib/ios\"",
+					"\"$(SRCROOT)/../../../poco/lib/ios\"",
+				);
+				PRODUCT_NAME = "ofxiOS_${PLATFORM_NAME}_Debug";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		BB24DED410DA7A3F00E9C588 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
+				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EXECUTABLE_PREFIX = lib;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = NO;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/kiss/lib/linux\"",
+					"\"$(SRCROOT)/kiss/lib/linux64\"",
+					"\"$(SRCROOT)/../../../tess2/lib/ios\"",
+					"\"$(SRCROOT)/../../../poco/lib/ios\"",
+				);
+				PRODUCT_NAME = "ofxiOS_${PLATFORM_NAME}_Release";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E41D3E9113B38BE900A75A5D /* Debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/ios/build/debug/";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				OBJROOT = "$(SRCROOT)/../../lib/ios/build/debug";
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SYMROOT = "$(SRCROOT)/../../lib/ios/";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				WARNING_CFLAGS = (
+					"-Wno-non-virtual-dtor",
+					"-Wno-overloaded-virtual",
+				);
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E41D3E9213B38BE900A75A5D /* Release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/ios/";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/ios/build/release/";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				OBJROOT = "$(SRCROOT)/../../lib/ios/build/release";
+				ONLY_ACTIVE_ARCH = NO;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SYMROOT = "$(SRCROOT)/../../lib/ios/";
+				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				WARNING_CFLAGS = (
+					"-Wno-non-virtual-dtor",
+					"-Wno-overloaded-virtual",
+				);
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "iPhone+OF Static Library" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BB24DED310DA7A3F00E9C588 /* Debug */,
+				BB24DED410DA7A3F00E9C588 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "iOS+OFLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
-			usesTabs = 0;
+			usesTabs = 1;
 		};
 		E4F3BA5212F4C4BF002D19BB /* 3d */ = {
 			isa = PBXGroup;

--- a/libs/openFrameworksCompiled/project/tvOS/tvOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/tvOS/tvOS+OFLib.xcodeproj/project.pbxproj
@@ -1,4846 +1,1157 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>691108A91FE53C7000BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>ofMesh.inl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108AA1FE53C7B00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBaseApp.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108AB1FE53C7B00BDBA78</key>
-		<dict>
-			<key>fileRef</key>
-			<string>691108AA1FE53C7B00BDBA78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>691108AC1FE53C8A00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108AD1FE53C9E00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>ofPolyline.inl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108AE1FE53CA800BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGraphicsBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108AF1FE53CA800BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphicsBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108B01FE53CA800BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphicsConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108B11FE53CA800BDBA78</key>
-		<dict>
-			<key>fileRef</key>
-			<string>691108AE1FE53CA800BDBA78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>691108B21FE53CB400BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMathConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108B31FE53CCF00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108B41FE53CCF00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>691108B51FE53CCF00BDBA78</key>
-		<dict>
-			<key>fileRef</key>
-			<string>691108B31FE53CCF00BDBA78</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>691108B61FE53CEB00BDBA78</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVideoBaseTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639531BC343E000F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D8FD1BDDDC9B0002D53C</string>
-				<string>844639C01BC3443E00F24926</string>
-				<string>844639681BC3442400F24926</string>
-				<string>844639691BC3442400F24926</string>
-				<string>8446396A1BC3442400F24926</string>
-				<string>8446396B1BC3442400F24926</string>
-				<string>84463AB91BC3452B00F24926</string>
-				<string>8446395D1BC343E000F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639541BC343E000F24926</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0710</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>cc.openframeworks.tvOS</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>8446395B1BC343E000F24926</key>
-					<dict>
-						<key>CreatedOnToolsVersion</key>
-						<string>7.1</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>844639571BC343E000F24926</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>844639531BC343E000F24926</string>
-			<key>productRefGroup</key>
-			<string>8446395D1BC343E000F24926</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>8446395B1BC343E000F24926</string>
-			</array>
-		</dict>
-		<key>844639571BC343E000F24926</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>844639631BC343E000F24926</string>
-				<string>844639641BC343E000F24926</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>844639581BC343E000F24926</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>9957D9081BDDDC9B0002D53C</string>
-				<string>9957D9171BDDDC9B0002D53C</string>
-				<string>844639C81BC3443E00F24926</string>
-				<string>9957D92A1BDDDC9B0002D53C</string>
-				<string>9957D9251BDDDC9B0002D53C</string>
-				<string>9957D9041BDDDC9B0002D53C</string>
-				<string>691108AB1FE53C7B00BDBA78</string>
-				<string>9957D8FF1BDDDC9B0002D53C</string>
-				<string>9957D9261BDDDC9B0002D53C</string>
-				<string>9957D9211BDDDC9B0002D53C</string>
-				<string>9957D90E1BDDDC9B0002D53C</string>
-				<string>9957D9031BDDDC9B0002D53C</string>
-				<string>9957D92B1BDDDC9B0002D53C</string>
-				<string>9957D9091BDDDC9B0002D53C</string>
-				<string>844639DE1BC3443E00F24926</string>
-				<string>844639CA1BC3443E00F24926</string>
-				<string>844639C61BC3443E00F24926</string>
-				<string>9957D9201BDDDC9B0002D53C</string>
-				<string>844639C71BC3443E00F24926</string>
-				<string>9957D9011BDDDC9B0002D53C</string>
-				<string>844639CD1BC3443E00F24926</string>
-				<string>844639DA1BC3443E00F24926</string>
-				<string>9957D9111BDDDC9B0002D53C</string>
-				<string>9957D9231BDDDC9B0002D53C</string>
-				<string>90180899205355B5004A7774</string>
-				<string>9957D9341BDDDC9B0002D53C</string>
-				<string>844639D21BC3443E00F24926</string>
-				<string>9957D9101BDDDC9B0002D53C</string>
-				<string>844639D81BC3443E00F24926</string>
-				<string>9957D9271BDDDC9B0002D53C</string>
-				<string>844639D31BC3443E00F24926</string>
-				<string>9957D9321BDDDC9B0002D53C</string>
-				<string>9957D9311BDDDC9B0002D53C</string>
-				<string>9957D90B1BDDDC9B0002D53C</string>
-				<string>9957D91A1BDDDC9B0002D53C</string>
-				<string>844639D61BC3443E00F24926</string>
-				<string>9957D9351BDDDC9B0002D53C</string>
-				<string>9957D91F1BDDDC9B0002D53C</string>
-				<string>9957D90D1BDDDC9B0002D53C</string>
-				<string>9957D5371BDDB9BA0002D53C</string>
-				<string>844639C51BC3443E00F24926</string>
-				<string>844639D41BC3443E00F24926</string>
-				<string>9957D90C1BDDDC9B0002D53C</string>
-				<string>9957D9051BDDDC9B0002D53C</string>
-				<string>9957D9331BDDDC9B0002D53C</string>
-				<string>844639DD1BC3443E00F24926</string>
-				<string>844639D01BC3443E00F24926</string>
-				<string>9957D9301BDDDC9B0002D53C</string>
-				<string>844639C91BC3443E00F24926</string>
-				<string>9957D9001BDDDC9B0002D53C</string>
-				<string>9957D9191BDDDC9B0002D53C</string>
-				<string>691108B51FE53CCF00BDBA78</string>
-				<string>844639DB1BC3443E00F24926</string>
-				<string>9957D9291BDDDC9B0002D53C</string>
-				<string>9957D90A1BDDDC9B0002D53C</string>
-				<string>9018089F20535AA8004A7774</string>
-				<string>9957D9141BDDDC9B0002D53C</string>
-				<string>9957D9361BDDDC9B0002D53C</string>
-				<string>9957D92D1BDDDC9B0002D53C</string>
-				<string>844639CE1BC3443E00F24926</string>
-				<string>844639C41BC3443E00F24926</string>
-				<string>9957D91D1BDDDC9B0002D53C</string>
-				<string>9957D91E1BDDDC9B0002D53C</string>
-				<string>9957D9131BDDDC9B0002D53C</string>
-				<string>9018089E20535AA8004A7774</string>
-				<string>9957D9241BDDDC9B0002D53C</string>
-				<string>9957D90F1BDDDC9B0002D53C</string>
-				<string>9957D92F1BDDDC9B0002D53C</string>
-				<string>9957D9071BDDDC9B0002D53C</string>
-				<string>844639CC1BC3443E00F24926</string>
-				<string>844639D91BC3443E00F24926</string>
-				<string>691108B11FE53CA800BDBA78</string>
-				<string>901808962053554C004A7774</string>
-				<string>9957D53A1BDDBB1E0002D53C</string>
-				<string>9957D91B1BDDDC9B0002D53C</string>
-				<string>9957D9061BDDDC9B0002D53C</string>
-				<string>9957D92E1BDDDC9B0002D53C</string>
-				<string>844639C31BC3443E00F24926</string>
-				<string>844639DF1BC3443E00F24926</string>
-				<string>844639D71BC3443E00F24926</string>
-				<string>844639CB1BC3443E00F24926</string>
-				<string>9957D9121BDDDC9B0002D53C</string>
-				<string>9957D8FE1BDDDC9B0002D53C</string>
-				<string>9957D9161BDDDC9B0002D53C</string>
-				<string>844639C21BC3443E00F24926</string>
-				<string>844639D11BC3443E00F24926</string>
-				<string>9957D92C1BDDDC9B0002D53C</string>
-				<string>9957D9151BDDDC9B0002D53C</string>
-				<string>844639D51BC3443E00F24926</string>
-				<string>9957D91C1BDDDC9B0002D53C</string>
-				<string>844639DC1BC3443E00F24926</string>
-				<string>9957D9281BDDDC9B0002D53C</string>
-				<string>844639CF1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>844639591BC343E000F24926</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>901808A720535D54004A7774</string>
-				<string>99752D301BF20A4C0026316A</string>
-				<string>84463AAF1BC3452400F24926</string>
-				<string>84463AB01BC3452400F24926</string>
-				<string>84463AB11BC3452400F24926</string>
-				<string>84463AB21BC3452400F24926</string>
-				<string>84463AB31BC3452400F24926</string>
-				<string>84463AB41BC3452400F24926</string>
-				<string>84463AB51BC3452400F24926</string>
-				<string>84463AB61BC3452400F24926</string>
-				<string>84463AB71BC3452400F24926</string>
-				<string>84463AB81BC3452400F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>8446395A1BC343E000F24926</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>dstPath</key>
-			<string>include/$(PRODUCT_NAME)</string>
-			<key>dstSubfolderSpec</key>
-			<string>16</string>
-			<key>files</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXCopyFilesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>8446395B1BC343E000F24926</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>844639651BC343E000F24926</string>
-			<key>buildPhases</key>
-			<array>
-				<string>844639581BC343E000F24926</string>
-				<string>844639591BC343E000F24926</string>
-				<string>8446395A1BC343E000F24926</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>tvOS+OFLib</string>
-			<key>productName</key>
-			<string>tvOS+OFLib</string>
-			<key>productReference</key>
-			<string>8446395C1BC343E000F24926</string>
-			<key>productType</key>
-			<string>com.apple.product-type.library.static</string>
-		</dict>
-		<key>8446395C1BC343E000F24926</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libtvOS+OFLib_Debug.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>8446395D1BC343E000F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8446395C1BC343E000F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639631BC343E000F24926</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>844639691BC3442400F24926</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>YES</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>NO</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/tvOS</string>
-				<key>CONFIGURATION_TEMP_DIR</key>
-				<string>$(SRCROOT)/../../lib/tvOS/build/debug/</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>ENABLE_TESTABILITY</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>compiler-default</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>YES</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/../../lib/tvOS/build/debug</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>appletvos</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/../../lib/tvOS/</string>
-				<key>TVOS_DEPLOYMENT_TARGET</key>
-				<string>13.0</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>844639641BC343E000F24926</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>8446396A1BC3442400F24926</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>YES</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>NO</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_UNREACHABLE_CODE</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CONFIGURATION_BUILD_DIR</key>
-				<string>$(SRCROOT)/../../lib/tvOS</string>
-				<key>CONFIGURATION_TEMP_DIR</key>
-				<string>$(SRCROOT)/../../lib/tvOS/build/release/</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>DEBUG_INFORMATION_FORMAT</key>
-				<string>dwarf-with-dsym</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>compiler-default</string>
-				<key>GCC_NO_COMMON_BLOCKS</key>
-				<string>YES</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES_AGGRESSIVE</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>MTL_ENABLE_DEBUG_INFO</key>
-				<string>NO</string>
-				<key>OBJROOT</key>
-				<string>$(SRCROOT)/../../lib/tvOS/build/release</string>
-				<key>SDKROOT</key>
-				<string>appletvos</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>NO</string>
-				<key>SYMROOT</key>
-				<string>$(SRCROOT)/../../lib/tvOS/</string>
-				<key>TVOS_DEPLOYMENT_TARGET</key>
-				<string>13.0</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>844639651BC343E000F24926</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>844639661BC343E000F24926</string>
-				<string>844639671BC343E000F24926</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>844639661BC343E000F24926</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(PROJECT_DIR)</string>
-				</array>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>NO</string>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)_Debug</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>844639671BC343E000F24926</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(PROJECT_DIR)</string>
-				</array>
-				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)_Release</string>
-				<key>SKIP_INSTALL</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>844639681BC3442400F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>CoreOF.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639691BC3442400F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446396A1BC3442400F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446396B1BC3442400F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>path</key>
-			<string>Shared.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639711BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>changelog.txt</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639721BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text</string>
-			<key>path</key>
-			<string>LICENSE.txt</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639731BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofxAccelerometer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639741BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxAccelerometer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639751BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639731BC3443E00F24926</string>
-				<string>844639741BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>src</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639761BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639711BC3443E00F24926</string>
-				<string>844639721BC3443E00F24926</string>
-				<string>844639751BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ofxAccelerometer</string>
-			<key>path</key>
-			<string>../../../../addons/ofxAccelerometer</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639771BC3443E00F24926</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofxiOS.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639781BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639791BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSExtensions.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397A1BC3443E00F24926</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofAppiOSWindow.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397B1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofAppiOSWindow.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397C1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSApp.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397D1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8446397A1BC3443E00F24926</string>
-				<string>8446397B1BC3443E00F24926</string>
-				<string>8446397C1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>app</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397E1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446397F1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSAppDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639801BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639811BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639821BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSEAGLView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639831BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSEAGLView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639841BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9018089A20535AA7004A7774</string>
-				<string>9018089D20535AA8004A7774</string>
-				<string>9018089B20535AA8004A7774</string>
-				<string>9018089C20535AA8004A7774</string>
-				<string>8446397E1BC3443E00F24926</string>
-				<string>8446397F1BC3443E00F24926</string>
-				<string>844639801BC3443E00F24926</string>
-				<string>844639811BC3443E00F24926</string>
-				<string>844639821BC3443E00F24926</string>
-				<string>844639831BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>core</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639851BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>EAGLView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639861BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>EAGLView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639871BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ESRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639881BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ES1Renderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639891BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ES1Renderer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398A1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ES2Renderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398B1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ES2Renderer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398C1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>90180898205355B5004A7774</string>
-				<string>90180897205355B5004A7774</string>
-				<string>844639851BC3443E00F24926</string>
-				<string>844639861BC3443E00F24926</string>
-				<string>844639871BC3443E00F24926</string>
-				<string>844639881BC3443E00F24926</string>
-				<string>844639891BC3443E00F24926</string>
-				<string>8446398A1BC3443E00F24926</string>
-				<string>8446398B1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>gl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398D1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398E1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AVSoundPlayer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446398F1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639901BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundPlayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639911BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639921BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundStream.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639931BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSSoundStreamDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639941BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSSoundStreamDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639951BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofxOpenALSoundPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639961BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxOpenALSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639971BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>SoundEngine.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639981BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundEngine.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639991BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundInputStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399A1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundInputStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399B1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundOutputStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399C1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundOutputStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399D1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>SoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399E1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>SoundStream.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>8446399F1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>8446398D1BC3443E00F24926</string>
-				<string>8446398E1BC3443E00F24926</string>
-				<string>8446398F1BC3443E00F24926</string>
-				<string>844639901BC3443E00F24926</string>
-				<string>844639911BC3443E00F24926</string>
-				<string>844639921BC3443E00F24926</string>
-				<string>844639931BC3443E00F24926</string>
-				<string>844639941BC3443E00F24926</string>
-				<string>844639951BC3443E00F24926</string>
-				<string>844639961BC3443E00F24926</string>
-				<string>844639971BC3443E00F24926</string>
-				<string>844639981BC3443E00F24926</string>
-				<string>844639991BC3443E00F24926</string>
-				<string>8446399A1BC3443E00F24926</string>
-				<string>8446399B1BC3443E00F24926</string>
-				<string>8446399C1BC3443E00F24926</string>
-				<string>8446399D1BC3443E00F24926</string>
-				<string>8446399E1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>sound</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A01BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVFoundationVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A11BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AVFoundationVideoPlayer.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A21BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AVFoundationVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A31BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>AVFoundationVideoGrabber.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A41BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A51BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSVideoPlayer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A61BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A71BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSVideoGrabber.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A81BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639A01BC3443E00F24926</string>
-				<string>844639A11BC3443E00F24926</string>
-				<string>844639A21BC3443E00F24926</string>
-				<string>844639A31BC3443E00F24926</string>
-				<string>844639A41BC3443E00F24926</string>
-				<string>844639A51BC3443E00F24926</string>
-				<string>844639A61BC3443E00F24926</string>
-				<string>844639A71BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>video</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639A91BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAlerts.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AA1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSAlerts.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AB1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSAlertsListener.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AC1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSAccelerometer.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AD1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639A91BC3443E00F24926</string>
-				<string>844639AA1BC3443E00F24926</string>
-				<string>844639AB1BC3443E00F24926</string>
-				<string>844639AC1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>events</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AE1BC3443E00F24926</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofxiOSExtras.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639AF1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSExtras.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B01BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSExternalDisplay.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B11BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSExternalDisplay.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B21BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSCoreLocation.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B31BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSCoreLocation.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B41BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSImagePicker.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B51BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSImagePicker.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B61BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSKeyboard.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B71BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSKeyboard.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B81BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKit.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639B91BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSMapKit.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BA1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKitDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BB1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSMapKitDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BC1BC3443E00F24926</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSMapKitListener.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BD1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639AE1BC3443E00F24926</string>
-				<string>844639AF1BC3443E00F24926</string>
-				<string>844639B01BC3443E00F24926</string>
-				<string>844639B11BC3443E00F24926</string>
-				<string>844639B21BC3443E00F24926</string>
-				<string>844639B31BC3443E00F24926</string>
-				<string>844639B41BC3443E00F24926</string>
-				<string>844639B51BC3443E00F24926</string>
-				<string>844639B61BC3443E00F24926</string>
-				<string>844639B71BC3443E00F24926</string>
-				<string>844639B81BC3443E00F24926</string>
-				<string>844639B91BC3443E00F24926</string>
-				<string>844639BA1BC3443E00F24926</string>
-				<string>844639BB1BC3443E00F24926</string>
-				<string>844639BC1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>utils</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BE1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D5331BDDB8370002D53C</string>
-				<string>9957D5341BDDB98E0002D53C</string>
-				<string>844639771BC3443E00F24926</string>
-				<string>844639781BC3443E00F24926</string>
-				<string>844639791BC3443E00F24926</string>
-				<string>8446397D1BC3443E00F24926</string>
-				<string>844639841BC3443E00F24926</string>
-				<string>8446398C1BC3443E00F24926</string>
-				<string>8446399F1BC3443E00F24926</string>
-				<string>844639A81BC3443E00F24926</string>
-				<string>844639AD1BC3443E00F24926</string>
-				<string>844639BD1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>src</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639BF1BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639BE1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>ofxiOS</string>
-			<key>path</key>
-			<string>../../../../addons/ofxiOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639C01BC3443E00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>844639761BC3443E00F24926</string>
-				<string>844639BF1BC3443E00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>addons</string>
-			<key>path</key>
-			<string>../ios</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>844639C21BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639731BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C31BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446397B1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C41BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446397F1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C51BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639811BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C61BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639831BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C71BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639861BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C81BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639891BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639C91BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446398B1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CA1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446398E1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CB1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639901BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CC1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639921BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CD1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639941BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CE1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639951BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639CF1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639971BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D01BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446399A1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D11BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446399C1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D21BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>8446399E1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D31BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639A11BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D41BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639A31BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D51BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639A51BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D61BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639A71BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D71BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639AA1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D81BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639AC1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639D91BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639AF1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DA1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639B11BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DB1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639B31BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DC1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639B51BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DD1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639B71BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DE1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639B91BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>844639DF1BC3443E00F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>844639BB1BC3443E00F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AA51BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AudioToolbox.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AudioToolbox.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AA61BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AVFoundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AVFoundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AA71BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreAudio.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreAudio.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AA81BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AA91BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreMedia.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreMedia.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAA1BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAB1BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>OpenAL.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/OpenAL.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAC1BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>OpenGLES.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/OpenGLES.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAD1BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>QuartzCore.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/QuartzCore.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAE1BC3452400F24926</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>84463AAF1BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AA51BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB01BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AA61BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB11BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AA71BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB21BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AA81BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB31BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AA91BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB41BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AAA1BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB51BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AAB1BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB61BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AAC1BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB71BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AAD1BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB81BC3452400F24926</key>
-		<dict>
-			<key>fileRef</key>
-			<string>84463AAE1BC3452400F24926</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>84463AB91BC3452B00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>84463ABA1BC3453500F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>libs</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>84463ABA1BC3453500F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>84463ABB1BC3453B00F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>core</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>84463ABB1BC3453B00F24926</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>901808A520535D35004A7774</string>
-				<string>99752D2F1BF20A4C0026316A</string>
-				<string>84463AA51BC3452400F24926</string>
-				<string>84463AA61BC3452400F24926</string>
-				<string>84463AA71BC3452400F24926</string>
-				<string>84463AA81BC3452400F24926</string>
-				<string>84463AA91BC3452400F24926</string>
-				<string>84463AAA1BC3452400F24926</string>
-				<string>84463AAB1BC3452400F24926</string>
-				<string>84463AAC1BC3452400F24926</string>
-				<string>84463AAD1BC3452400F24926</string>
-				<string>84463AAE1BC3452400F24926</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>core frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>901808942053554C004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxtvOSGLKViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>901808952053554C004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxtvOSGLKViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>901808962053554C004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>901808942053554C004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>90180897205355B5004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>EAGLKView.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90180898205355B5004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>EAGLKView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>90180899205355B5004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>90180897205355B5004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9018089A20535AA7004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSGLKView.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9018089B20535AA8004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxiOSGLKViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9018089C20535AA8004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSGLKViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9018089D20535AA8004A7774</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxiOSGLKView.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9018089E20535AA8004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9018089C20535AA8004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9018089F20535AA8004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9018089D20535AA8004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>901808A520535D35004A7774</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>GLKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/GLKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>901808A720535D54004A7774</key>
-		<dict>
-			<key>fileRef</key>
-			<string>901808A520535D35004A7774</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D5331BDDB8370002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofxtvOS.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D5341BDDB98E0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D5361BDDB9BA0002D53C</string>
-				<string>9957D5351BDDB9BA0002D53C</string>
-				<string>901808952053554C004A7774</string>
-				<string>901808942053554C004A7774</string>
-				<string>9957D5381BDDBB1E0002D53C</string>
-				<string>9957D5391BDDBB1E0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>tvOS</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D5351BDDB9BA0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxtvOSAppDelegate.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D5361BDDB9BA0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxtvOSAppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D5371BDDB9BA0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D5351BDDB9BA0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D5381BDDBB1E0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.objcpp</string>
-			<key>path</key>
-			<string>ofxtvOSViewController.mm</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D5391BDDBB1E0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofxtvOSViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D53A1BDDBB1E0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D5381BDDBB1E0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D8711BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMain.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8721BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>of3dPrimitives.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8731BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dPrimitives.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8741BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>of3dUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8751BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8761BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofCamera.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8771BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofCamera.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8781BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofEasyCam.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8791BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEasyCam.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D87B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMesh.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D87C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofNode.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D87D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofNode.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D87E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108A91FE53C7000BDBA78</string>
-				<string>9957D8721BDDDC9B0002D53C</string>
-				<string>9957D8731BDDDC9B0002D53C</string>
-				<string>9957D8741BDDDC9B0002D53C</string>
-				<string>9957D8751BDDDC9B0002D53C</string>
-				<string>9957D8761BDDDC9B0002D53C</string>
-				<string>9957D8771BDDDC9B0002D53C</string>
-				<string>9957D8781BDDDC9B0002D53C</string>
-				<string>9957D8791BDDDC9B0002D53C</string>
-				<string>9957D87B1BDDDC9B0002D53C</string>
-				<string>9957D87C1BDDDC9B0002D53C</string>
-				<string>9957D87D1BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>3d</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D87F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofAppBaseWindow.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8801BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofAppRunner.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8811BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofAppRunner.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8821BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBaseApp.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8831BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMainLoop.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8841BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMainLoop.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8851BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofWindowSettings.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8861BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108AA1FE53C7B00BDBA78</string>
-				<string>9957D87F1BDDDC9B0002D53C</string>
-				<string>9957D8801BDDDC9B0002D53C</string>
-				<string>9957D8811BDDDC9B0002D53C</string>
-				<string>9957D8821BDDDC9B0002D53C</string>
-				<string>9957D8831BDDDC9B0002D53C</string>
-				<string>9957D8841BDDDC9B0002D53C</string>
-				<string>9957D8851BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>app</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8871BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>communication</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8881BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEvent.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8891BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofEvents.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88A1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEvents.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofEventUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D8881BDDDC9B0002D53C</string>
-				<string>9957D8891BDDDC9B0002D53C</string>
-				<string>9957D88A1BDDDC9B0002D53C</string>
-				<string>9957D88B1BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>events</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBufferObject.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBufferObject.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D88F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofFbo.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8901BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFbo.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8911BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLProgrammableRenderer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8921BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLProgrammableRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8931BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLRenderer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8941BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLRenderer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8951BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGLUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8961BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGLUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8971BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofLight.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8981BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofLight.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8991BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMaterial.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89A1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMaterial.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofShader.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofShader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTexture.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTexture.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D89F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVbo.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A01BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVbo.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A11BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVboMesh.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A21BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVboMesh.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A31BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108AC1FE53C8A00BDBA78</string>
-				<string>9957D88D1BDDDC9B0002D53C</string>
-				<string>9957D88E1BDDDC9B0002D53C</string>
-				<string>9957D88F1BDDDC9B0002D53C</string>
-				<string>9957D8901BDDDC9B0002D53C</string>
-				<string>9957D8911BDDDC9B0002D53C</string>
-				<string>9957D8921BDDDC9B0002D53C</string>
-				<string>9957D8931BDDDC9B0002D53C</string>
-				<string>9957D8941BDDDC9B0002D53C</string>
-				<string>9957D8951BDDDC9B0002D53C</string>
-				<string>9957D8961BDDDC9B0002D53C</string>
-				<string>9957D8971BDDDC9B0002D53C</string>
-				<string>9957D8981BDDDC9B0002D53C</string>
-				<string>9957D8991BDDDC9B0002D53C</string>
-				<string>9957D89A1BDDDC9B0002D53C</string>
-				<string>9957D89B1BDDDC9B0002D53C</string>
-				<string>9957D89C1BDDDC9B0002D53C</string>
-				<string>9957D89D1BDDDC9B0002D53C</string>
-				<string>9957D89E1BDDDC9B0002D53C</string>
-				<string>9957D89F1BDDDC9B0002D53C</string>
-				<string>9957D8A01BDDDC9B0002D53C</string>
-				<string>9957D8A11BDDDC9B0002D53C</string>
-				<string>9957D8A21BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>gl</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A41BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>of3dGraphics.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A51BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>of3dGraphics.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBitmapFont.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A71BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofBitmapFont.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A81BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofGraphics.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8A91BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofGraphics.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AA1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofImage.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofImage.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofPath.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AD1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofPixels.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8AF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPixels.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B11BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPolyline.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B21BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofRendererCollection.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B31BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofRendererCollection.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B41BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTessellator.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B51BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTessellator.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTrueTypeFont.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B71BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTrueTypeFont.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B81BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108AE1FE53CA800BDBA78</string>
-				<string>691108AF1FE53CA800BDBA78</string>
-				<string>691108B01FE53CA800BDBA78</string>
-				<string>691108AD1FE53C9E00BDBA78</string>
-				<string>9957D8A41BDDDC9B0002D53C</string>
-				<string>9957D8A51BDDDC9B0002D53C</string>
-				<string>9957D8A61BDDDC9B0002D53C</string>
-				<string>9957D8A71BDDDC9B0002D53C</string>
-				<string>9957D8A81BDDDC9B0002D53C</string>
-				<string>9957D8A91BDDDC9B0002D53C</string>
-				<string>9957D8AA1BDDDC9B0002D53C</string>
-				<string>9957D8AB1BDDDC9B0002D53C</string>
-				<string>9957D8AC1BDDDC9B0002D53C</string>
-				<string>9957D8AD1BDDDC9B0002D53C</string>
-				<string>9957D8AE1BDDDC9B0002D53C</string>
-				<string>9957D8AF1BDDDC9B0002D53C</string>
-				<string>9957D8B11BDDDC9B0002D53C</string>
-				<string>9957D8B21BDDDC9B0002D53C</string>
-				<string>9957D8B31BDDDC9B0002D53C</string>
-				<string>9957D8B41BDDDC9B0002D53C</string>
-				<string>9957D8B51BDDDC9B0002D53C</string>
-				<string>9957D8B61BDDDC9B0002D53C</string>
-				<string>9957D8B71BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>graphics</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8B91BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMath.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BA1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMatrix3x3.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrix3x3.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BD1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofMatrix4x4.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrix4x4.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8BF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofQuaternion.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C01BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofQuaternion.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C11BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVec2f.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C21BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec2f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C31BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec3f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C41BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVec4f.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C51BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVec4f.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVectorMath.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8C71BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108B21FE53CB400BDBA78</string>
-				<string>9957D8B91BDDDC9B0002D53C</string>
-				<string>9957D8BA1BDDDC9B0002D53C</string>
-				<string>9957D8BB1BDDDC9B0002D53C</string>
-				<string>9957D8BC1BDDDC9B0002D53C</string>
-				<string>9957D8BD1BDDDC9B0002D53C</string>
-				<string>9957D8BE1BDDDC9B0002D53C</string>
-				<string>9957D8BF1BDDDC9B0002D53C</string>
-				<string>9957D8C01BDDDC9B0002D53C</string>
-				<string>9957D8C11BDDDC9B0002D53C</string>
-				<string>9957D8C21BDDDC9B0002D53C</string>
-				<string>9957D8C31BDDDC9B0002D53C</string>
-				<string>9957D8C41BDDDC9B0002D53C</string>
-				<string>9957D8C51BDDDC9B0002D53C</string>
-				<string>9957D8C61BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>math</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8CB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundBuffer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8CC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundBuffer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8CD1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8CE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8CF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofSoundStream.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D01BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundStream.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D11BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSoundUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D21BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108B31FE53CCF00BDBA78</string>
-				<string>691108B41FE53CCF00BDBA78</string>
-				<string>9957D8CB1BDDDC9B0002D53C</string>
-				<string>9957D8CC1BDDDC9B0002D53C</string>
-				<string>9957D8CD1BDDDC9B0002D53C</string>
-				<string>9957D8CE1BDDDC9B0002D53C</string>
-				<string>9957D8CF1BDDDC9B0002D53C</string>
-				<string>9957D8D01BDDDC9B0002D53C</string>
-				<string>9957D8D11BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>sound</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D31BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofBaseTypes.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D51BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofColor.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofColor.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D71BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofParameter.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D81BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofParameter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8D91BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofParameterGroup.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DA1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofParameterGroup.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofPoint.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofRectangle.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DD1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofRectangle.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTypes.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8DF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D8D31BDDDC9B0002D53C</string>
-				<string>9957D8D51BDDDC9B0002D53C</string>
-				<string>9957D8D61BDDDC9B0002D53C</string>
-				<string>9957D8D71BDDDC9B0002D53C</string>
-				<string>9957D8D81BDDDC9B0002D53C</string>
-				<string>9957D8D91BDDDC9B0002D53C</string>
-				<string>9957D8DA1BDDDC9B0002D53C</string>
-				<string>9957D8DB1BDDDC9B0002D53C</string>
-				<string>9957D8DC1BDDDC9B0002D53C</string>
-				<string>9957D8DD1BDDDC9B0002D53C</string>
-				<string>9957D8DE1BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>types</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E01BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofConstants.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E11BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofFileUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E21BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFileUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E31BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofFpsCounter.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E41BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofFpsCounter.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E51BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofLog.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofLog.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E71BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofMatrixStack.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E81BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofMatrixStack.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8E91BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofNoise.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8EA1BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofSystemUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8EB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofSystemUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8EC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofThread.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8ED1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofThread.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8EE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofThreadChannel.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8EF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofTimer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F01BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofTimer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F11BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofURLFileLoader.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F21BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofURLFileLoader.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F31BDDDC9B0002D53C</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>sourcecode.cpp.objcpp.preprocessed</string>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>ofUtils.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F41BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofUtils.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F51BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofXml.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F61BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofXml.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F71BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D8E01BDDDC9B0002D53C</string>
-				<string>9957D8E11BDDDC9B0002D53C</string>
-				<string>9957D8E21BDDDC9B0002D53C</string>
-				<string>9957D8E31BDDDC9B0002D53C</string>
-				<string>9957D8E41BDDDC9B0002D53C</string>
-				<string>9957D8E51BDDDC9B0002D53C</string>
-				<string>9957D8E61BDDDC9B0002D53C</string>
-				<string>9957D8E71BDDDC9B0002D53C</string>
-				<string>9957D8E81BDDDC9B0002D53C</string>
-				<string>9957D8E91BDDDC9B0002D53C</string>
-				<string>9957D8EA1BDDDC9B0002D53C</string>
-				<string>9957D8EB1BDDDC9B0002D53C</string>
-				<string>9957D8EC1BDDDC9B0002D53C</string>
-				<string>9957D8ED1BDDDC9B0002D53C</string>
-				<string>9957D8EE1BDDDC9B0002D53C</string>
-				<string>9957D8EF1BDDDC9B0002D53C</string>
-				<string>9957D8F01BDDDC9B0002D53C</string>
-				<string>9957D8F11BDDDC9B0002D53C</string>
-				<string>9957D8F21BDDDC9B0002D53C</string>
-				<string>9957D8F31BDDDC9B0002D53C</string>
-				<string>9957D8F41BDDDC9B0002D53C</string>
-				<string>9957D8F51BDDDC9B0002D53C</string>
-				<string>9957D8F61BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>utils</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F81BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVideoGrabber.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8F91BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVideoGrabber.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8FA1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.cpp.cpp</string>
-			<key>path</key>
-			<string>ofVideoPlayer.cpp</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8FB1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ofVideoPlayer.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8FC1BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>691108B61FE53CEB00BDBA78</string>
-				<string>9957D8F81BDDDC9B0002D53C</string>
-				<string>9957D8F91BDDDC9B0002D53C</string>
-				<string>9957D8FA1BDDDC9B0002D53C</string>
-				<string>9957D8FB1BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>video</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>9957D8FD1BDDDC9B0002D53C</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>9957D8711BDDDC9B0002D53C</string>
-				<string>9957D87E1BDDDC9B0002D53C</string>
-				<string>9957D8861BDDDC9B0002D53C</string>
-				<string>9957D8871BDDDC9B0002D53C</string>
-				<string>9957D88C1BDDDC9B0002D53C</string>
-				<string>9957D8A31BDDDC9B0002D53C</string>
-				<string>9957D8B81BDDDC9B0002D53C</string>
-				<string>9957D8C71BDDDC9B0002D53C</string>
-				<string>9957D8D21BDDDC9B0002D53C</string>
-				<string>9957D8DF1BDDDC9B0002D53C</string>
-				<string>9957D8F71BDDDC9B0002D53C</string>
-				<string>9957D8FC1BDDDC9B0002D53C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>openFrameworks</string>
-			<key>path</key>
-			<string>../../../openFrameworks</string>
-			<key>sourceTree</key>
-			<string>SOURCE_ROOT</string>
-		</dict>
-		<key>9957D8FE1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8721BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D8FF1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8741BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9001BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8761BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9011BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8781BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9031BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D87C1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9041BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8801BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9051BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8831BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9061BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8891BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9071BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D88D1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9081BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D88F1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9091BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8911BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90A1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8931BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8951BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8971BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8991BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D89B1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D90F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D89D1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9101BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D89F1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9111BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8A11BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9121BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8A41BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9131BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8A61BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9141BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8A81BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9151BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8AA1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9161BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8AC1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9171BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8AE1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9191BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8B21BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91A1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8B41BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8B61BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8B91BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8BB1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8BD1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D91F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8BF1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9201BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8C11BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9211BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8C41BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9231BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8CB1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9241BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8CD1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9251BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8CF1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9261BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8D31BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9271BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8D51BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9281BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8D71BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9291BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8D91BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92A1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8DC1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92B1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8E11BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92C1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8E31BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92D1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8E51BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92E1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8E71BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D92F1BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8EA1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9301BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8EC1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9311BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8EF1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9321BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8F11BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9331BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8F31BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9341BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8F51BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9351BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8F81BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>9957D9361BDDDC9B0002D53C</key>
-		<dict>
-			<key>fileRef</key>
-			<string>9957D8FA1BDDDC9B0002D53C</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>99752D2F1BF20A4C0026316A</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>GameController.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/GameController.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>99752D301BF20A4C0026316A</key>
-		<dict>
-			<key>fileRef</key>
-			<string>99752D2F1BF20A4C0026316A</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>844639541BC343E000F24926</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		691108AB1FE53C7B00BDBA78 /* ofBaseApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 691108AA1FE53C7B00BDBA78 /* ofBaseApp.cpp */; };
+		691108B11FE53CA800BDBA78 /* ofGraphicsBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 691108AE1FE53CA800BDBA78 /* ofGraphicsBaseTypes.cpp */; };
+		691108B51FE53CCF00BDBA78 /* ofSoundBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 691108B31FE53CCF00BDBA78 /* ofSoundBaseTypes.cpp */; };
+		844639C21BC3443E00F24926 /* ofxAccelerometer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 844639731BC3443E00F24926 /* ofxAccelerometer.cpp */; };
+		844639C31BC3443E00F24926 /* ofAppiOSWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8446397B1BC3443E00F24926 /* ofAppiOSWindow.mm */; };
+		844639C41BC3443E00F24926 /* ofxiOSAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8446397F1BC3443E00F24926 /* ofxiOSAppDelegate.mm */; };
+		844639C51BC3443E00F24926 /* ofxiOSViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639811BC3443E00F24926 /* ofxiOSViewController.mm */; };
+		844639C61BC3443E00F24926 /* ofxiOSEAGLView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639831BC3443E00F24926 /* ofxiOSEAGLView.mm */; };
+		844639C71BC3443E00F24926 /* EAGLView.m in Sources */ = {isa = PBXBuildFile; fileRef = 844639861BC3443E00F24926 /* EAGLView.m */; };
+		844639C81BC3443E00F24926 /* ES1Renderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 844639891BC3443E00F24926 /* ES1Renderer.m */; };
+		844639C91BC3443E00F24926 /* ES2Renderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8446398B1BC3443E00F24926 /* ES2Renderer.m */; };
+		844639CA1BC3443E00F24926 /* AVSoundPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8446398E1BC3443E00F24926 /* AVSoundPlayer.m */; };
+		844639CB1BC3443E00F24926 /* ofxiOSSoundPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639901BC3443E00F24926 /* ofxiOSSoundPlayer.mm */; };
+		844639CC1BC3443E00F24926 /* ofxiOSSoundStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639921BC3443E00F24926 /* ofxiOSSoundStream.mm */; };
+		844639CD1BC3443E00F24926 /* ofxiOSSoundStreamDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639941BC3443E00F24926 /* ofxiOSSoundStreamDelegate.mm */; };
+		844639CE1BC3443E00F24926 /* ofxOpenALSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 844639951BC3443E00F24926 /* ofxOpenALSoundPlayer.cpp */; };
+		844639CF1BC3443E00F24926 /* SoundEngine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 844639971BC3443E00F24926 /* SoundEngine.cpp */; };
+		844639D01BC3443E00F24926 /* SoundInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 8446399A1BC3443E00F24926 /* SoundInputStream.m */; };
+		844639D11BC3443E00F24926 /* SoundOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 8446399C1BC3443E00F24926 /* SoundOutputStream.m */; };
+		844639D21BC3443E00F24926 /* SoundStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 8446399E1BC3443E00F24926 /* SoundStream.m */; };
+		844639D31BC3443E00F24926 /* AVFoundationVideoPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 844639A11BC3443E00F24926 /* AVFoundationVideoPlayer.m */; };
+		844639D41BC3443E00F24926 /* AVFoundationVideoGrabber.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639A31BC3443E00F24926 /* AVFoundationVideoGrabber.mm */; };
+		844639D51BC3443E00F24926 /* ofxiOSVideoPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639A51BC3443E00F24926 /* ofxiOSVideoPlayer.mm */; };
+		844639D61BC3443E00F24926 /* ofxiOSVideoGrabber.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639A71BC3443E00F24926 /* ofxiOSVideoGrabber.mm */; };
+		844639D71BC3443E00F24926 /* ofxiOSAlerts.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639AA1BC3443E00F24926 /* ofxiOSAlerts.mm */; };
+		844639D81BC3443E00F24926 /* ofxiOSAccelerometer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639AC1BC3443E00F24926 /* ofxiOSAccelerometer.mm */; };
+		844639D91BC3443E00F24926 /* ofxiOSExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639AF1BC3443E00F24926 /* ofxiOSExtras.mm */; };
+		844639DA1BC3443E00F24926 /* ofxiOSExternalDisplay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639B11BC3443E00F24926 /* ofxiOSExternalDisplay.mm */; };
+		844639DB1BC3443E00F24926 /* ofxiOSCoreLocation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639B31BC3443E00F24926 /* ofxiOSCoreLocation.mm */; };
+		844639DC1BC3443E00F24926 /* ofxiOSImagePicker.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639B51BC3443E00F24926 /* ofxiOSImagePicker.mm */; };
+		844639DD1BC3443E00F24926 /* ofxiOSKeyboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639B71BC3443E00F24926 /* ofxiOSKeyboard.mm */; };
+		844639DE1BC3443E00F24926 /* ofxiOSMapKit.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639B91BC3443E00F24926 /* ofxiOSMapKit.mm */; };
+		844639DF1BC3443E00F24926 /* ofxiOSMapKitDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 844639BB1BC3443E00F24926 /* ofxiOSMapKitDelegate.mm */; };
+		84463AAF1BC3452400F24926 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AA51BC3452400F24926 /* AudioToolbox.framework */; };
+		84463AB01BC3452400F24926 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AA61BC3452400F24926 /* AVFoundation.framework */; };
+		84463AB11BC3452400F24926 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AA71BC3452400F24926 /* CoreAudio.framework */; };
+		84463AB21BC3452400F24926 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AA81BC3452400F24926 /* CoreGraphics.framework */; };
+		84463AB31BC3452400F24926 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AA91BC3452400F24926 /* CoreMedia.framework */; };
+		84463AB41BC3452400F24926 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AAA1BC3452400F24926 /* Foundation.framework */; };
+		84463AB51BC3452400F24926 /* OpenAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AAB1BC3452400F24926 /* OpenAL.framework */; };
+		84463AB61BC3452400F24926 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AAC1BC3452400F24926 /* OpenGLES.framework */; };
+		84463AB71BC3452400F24926 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AAD1BC3452400F24926 /* QuartzCore.framework */; };
+		84463AB81BC3452400F24926 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84463AAE1BC3452400F24926 /* UIKit.framework */; };
+		901808962053554C004A7774 /* ofxtvOSGLKViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 901808942053554C004A7774 /* ofxtvOSGLKViewController.mm */; };
+		90180899205355B5004A7774 /* EAGLKView.m in Sources */ = {isa = PBXBuildFile; fileRef = 90180897205355B5004A7774 /* EAGLKView.m */; };
+		9018089E20535AA8004A7774 /* ofxiOSGLKViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9018089C20535AA8004A7774 /* ofxiOSGLKViewController.mm */; };
+		9018089F20535AA8004A7774 /* ofxiOSGLKView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9018089D20535AA8004A7774 /* ofxiOSGLKView.mm */; };
+		901808A720535D54004A7774 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 901808A520535D35004A7774 /* GLKit.framework */; };
+		9957D5371BDDB9BA0002D53C /* ofxtvOSAppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9957D5351BDDB9BA0002D53C /* ofxtvOSAppDelegate.mm */; };
+		9957D53A1BDDBB1E0002D53C /* ofxtvOSViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9957D5381BDDBB1E0002D53C /* ofxtvOSViewController.mm */; };
+		9957D8FE1BDDDC9B0002D53C /* of3dPrimitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8721BDDDC9B0002D53C /* of3dPrimitives.cpp */; };
+		9957D8FF1BDDDC9B0002D53C /* of3dUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8741BDDDC9B0002D53C /* of3dUtils.cpp */; };
+		9957D9001BDDDC9B0002D53C /* ofCamera.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8761BDDDC9B0002D53C /* ofCamera.cpp */; };
+		9957D9011BDDDC9B0002D53C /* ofEasyCam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8781BDDDC9B0002D53C /* ofEasyCam.cpp */; };
+		9957D9031BDDDC9B0002D53C /* ofNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D87C1BDDDC9B0002D53C /* ofNode.cpp */; };
+		9957D9041BDDDC9B0002D53C /* ofAppRunner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8801BDDDC9B0002D53C /* ofAppRunner.cpp */; };
+		9957D9051BDDDC9B0002D53C /* ofMainLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8831BDDDC9B0002D53C /* ofMainLoop.cpp */; };
+		9957D9061BDDDC9B0002D53C /* ofEvents.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8891BDDDC9B0002D53C /* ofEvents.cpp */; };
+		9957D9071BDDDC9B0002D53C /* ofBufferObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D88D1BDDDC9B0002D53C /* ofBufferObject.cpp */; };
+		9957D9081BDDDC9B0002D53C /* ofFbo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D88F1BDDDC9B0002D53C /* ofFbo.cpp */; };
+		9957D9091BDDDC9B0002D53C /* ofGLProgrammableRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8911BDDDC9B0002D53C /* ofGLProgrammableRenderer.cpp */; };
+		9957D90A1BDDDC9B0002D53C /* ofGLRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8931BDDDC9B0002D53C /* ofGLRenderer.cpp */; };
+		9957D90B1BDDDC9B0002D53C /* ofGLUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8951BDDDC9B0002D53C /* ofGLUtils.cpp */; };
+		9957D90C1BDDDC9B0002D53C /* ofLight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8971BDDDC9B0002D53C /* ofLight.cpp */; };
+		9957D90D1BDDDC9B0002D53C /* ofMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8991BDDDC9B0002D53C /* ofMaterial.cpp */; };
+		9957D90E1BDDDC9B0002D53C /* ofShader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D89B1BDDDC9B0002D53C /* ofShader.cpp */; };
+		9957D90F1BDDDC9B0002D53C /* ofTexture.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D89D1BDDDC9B0002D53C /* ofTexture.cpp */; };
+		9957D9101BDDDC9B0002D53C /* ofVbo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D89F1BDDDC9B0002D53C /* ofVbo.cpp */; };
+		9957D9111BDDDC9B0002D53C /* ofVboMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8A11BDDDC9B0002D53C /* ofVboMesh.cpp */; };
+		9957D9121BDDDC9B0002D53C /* of3dGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8A41BDDDC9B0002D53C /* of3dGraphics.cpp */; };
+		9957D9131BDDDC9B0002D53C /* ofBitmapFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8A61BDDDC9B0002D53C /* ofBitmapFont.cpp */; };
+		9957D9141BDDDC9B0002D53C /* ofGraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8A81BDDDC9B0002D53C /* ofGraphics.cpp */; };
+		9957D9151BDDDC9B0002D53C /* ofImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8AA1BDDDC9B0002D53C /* ofImage.cpp */; };
+		9957D9161BDDDC9B0002D53C /* ofPath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8AC1BDDDC9B0002D53C /* ofPath.cpp */; };
+		9957D9171BDDDC9B0002D53C /* ofPixels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8AE1BDDDC9B0002D53C /* ofPixels.cpp */; };
+		9957D9191BDDDC9B0002D53C /* ofRendererCollection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8B21BDDDC9B0002D53C /* ofRendererCollection.cpp */; };
+		9957D91A1BDDDC9B0002D53C /* ofTessellator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8B41BDDDC9B0002D53C /* ofTessellator.cpp */; };
+		9957D91B1BDDDC9B0002D53C /* ofTrueTypeFont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8B61BDDDC9B0002D53C /* ofTrueTypeFont.cpp */; };
+		9957D91C1BDDDC9B0002D53C /* ofMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8B91BDDDC9B0002D53C /* ofMath.cpp */; };
+		9957D91D1BDDDC9B0002D53C /* ofMatrix3x3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8BB1BDDDC9B0002D53C /* ofMatrix3x3.cpp */; };
+		9957D91E1BDDDC9B0002D53C /* ofMatrix4x4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8BD1BDDDC9B0002D53C /* ofMatrix4x4.cpp */; };
+		9957D91F1BDDDC9B0002D53C /* ofQuaternion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8BF1BDDDC9B0002D53C /* ofQuaternion.cpp */; };
+		9957D9201BDDDC9B0002D53C /* ofVec2f.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8C11BDDDC9B0002D53C /* ofVec2f.cpp */; };
+		9957D9211BDDDC9B0002D53C /* ofVec4f.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8C41BDDDC9B0002D53C /* ofVec4f.cpp */; };
+		9957D9231BDDDC9B0002D53C /* ofSoundBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8CB1BDDDC9B0002D53C /* ofSoundBuffer.cpp */; };
+		9957D9241BDDDC9B0002D53C /* ofSoundPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8CD1BDDDC9B0002D53C /* ofSoundPlayer.cpp */; };
+		9957D9251BDDDC9B0002D53C /* ofSoundStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8CF1BDDDC9B0002D53C /* ofSoundStream.cpp */; };
+		9957D9261BDDDC9B0002D53C /* ofBaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8D31BDDDC9B0002D53C /* ofBaseTypes.cpp */; };
+		9957D9271BDDDC9B0002D53C /* ofColor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8D51BDDDC9B0002D53C /* ofColor.cpp */; };
+		9957D9281BDDDC9B0002D53C /* ofParameter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8D71BDDDC9B0002D53C /* ofParameter.cpp */; };
+		9957D9291BDDDC9B0002D53C /* ofParameterGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8D91BDDDC9B0002D53C /* ofParameterGroup.cpp */; };
+		9957D92A1BDDDC9B0002D53C /* ofRectangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8DC1BDDDC9B0002D53C /* ofRectangle.cpp */; };
+		9957D92B1BDDDC9B0002D53C /* ofFileUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8E11BDDDC9B0002D53C /* ofFileUtils.cpp */; };
+		9957D92C1BDDDC9B0002D53C /* ofFpsCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8E31BDDDC9B0002D53C /* ofFpsCounter.cpp */; };
+		9957D92D1BDDDC9B0002D53C /* ofLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8E51BDDDC9B0002D53C /* ofLog.cpp */; };
+		9957D92E1BDDDC9B0002D53C /* ofMatrixStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8E71BDDDC9B0002D53C /* ofMatrixStack.cpp */; };
+		9957D92F1BDDDC9B0002D53C /* ofSystemUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8EA1BDDDC9B0002D53C /* ofSystemUtils.cpp */; };
+		9957D9301BDDDC9B0002D53C /* ofThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8EC1BDDDC9B0002D53C /* ofThread.cpp */; };
+		9957D9311BDDDC9B0002D53C /* ofTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8EF1BDDDC9B0002D53C /* ofTimer.cpp */; };
+		9957D9321BDDDC9B0002D53C /* ofURLFileLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8F11BDDDC9B0002D53C /* ofURLFileLoader.cpp */; };
+		9957D9331BDDDC9B0002D53C /* ofUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8F31BDDDC9B0002D53C /* ofUtils.cpp */; };
+		9957D9341BDDDC9B0002D53C /* ofXml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8F51BDDDC9B0002D53C /* ofXml.cpp */; };
+		9957D9351BDDDC9B0002D53C /* ofVideoGrabber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8F81BDDDC9B0002D53C /* ofVideoGrabber.cpp */; };
+		9957D9361BDDDC9B0002D53C /* ofVideoPlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9957D8FA1BDDDC9B0002D53C /* ofVideoPlayer.cpp */; };
+		99752D301BF20A4C0026316A /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99752D2F1BF20A4C0026316A /* GameController.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		8446395A1BC343E000F24926 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		691108A91FE53C7000BDBA78 /* ofMesh.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ofMesh.inl; sourceTree = "<group>"; };
+		691108AA1FE53C7B00BDBA78 /* ofBaseApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseApp.cpp; sourceTree = "<group>"; };
+		691108AC1FE53C8A00BDBA78 /* ofGLBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLBaseTypes.h; sourceTree = "<group>"; };
+		691108AD1FE53C9E00BDBA78 /* ofPolyline.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ofPolyline.inl; sourceTree = "<group>"; };
+		691108AE1FE53CA800BDBA78 /* ofGraphicsBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGraphicsBaseTypes.cpp; sourceTree = "<group>"; };
+		691108AF1FE53CA800BDBA78 /* ofGraphicsBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphicsBaseTypes.h; sourceTree = "<group>"; };
+		691108B01FE53CA800BDBA78 /* ofGraphicsConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphicsConstants.h; sourceTree = "<group>"; };
+		691108B21FE53CB400BDBA78 /* ofMathConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMathConstants.h; sourceTree = "<group>"; };
+		691108B31FE53CCF00BDBA78 /* ofSoundBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundBaseTypes.cpp; sourceTree = "<group>"; };
+		691108B41FE53CCF00BDBA78 /* ofSoundBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundBaseTypes.h; sourceTree = "<group>"; };
+		691108B61FE53CEB00BDBA78 /* ofVideoBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVideoBaseTypes.h; sourceTree = "<group>"; };
+		8446395C1BC343E000F24926 /* libtvOS+OFLib_Debug.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libtvOS+OFLib_Debug.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		844639681BC3442400F24926 /* CoreOF.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = CoreOF.xcconfig; sourceTree = "<group>"; };
+		844639691BC3442400F24926 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		8446396A1BC3442400F24926 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8446396B1BC3442400F24926 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
+		844639711BC3443E00F24926 /* changelog.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = changelog.txt; sourceTree = "<group>"; };
+		844639721BC3443E00F24926 /* LICENSE.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
+		844639731BC3443E00F24926 /* ofxAccelerometer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxAccelerometer.cpp; sourceTree = "<group>"; };
+		844639741BC3443E00F24926 /* ofxAccelerometer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxAccelerometer.h; sourceTree = "<group>"; };
+		844639771BC3443E00F24926 /* ofxiOS.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = ofxiOS.h; sourceTree = "<group>"; };
+		844639781BC3443E00F24926 /* ofxiOSConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSConstants.h; sourceTree = "<group>"; };
+		844639791BC3443E00F24926 /* ofxiOSExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSExtensions.h; sourceTree = "<group>"; };
+		8446397A1BC3443E00F24926 /* ofAppiOSWindow.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = ofAppiOSWindow.h; sourceTree = "<group>"; };
+		8446397B1BC3443E00F24926 /* ofAppiOSWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofAppiOSWindow.mm; sourceTree = "<group>"; };
+		8446397C1BC3443E00F24926 /* ofxiOSApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSApp.h; sourceTree = "<group>"; };
+		8446397E1BC3443E00F24926 /* ofxiOSAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAppDelegate.h; sourceTree = "<group>"; };
+		8446397F1BC3443E00F24926 /* ofxiOSAppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSAppDelegate.mm; sourceTree = "<group>"; };
+		844639801BC3443E00F24926 /* ofxiOSViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSViewController.h; sourceTree = "<group>"; };
+		844639811BC3443E00F24926 /* ofxiOSViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSViewController.mm; sourceTree = "<group>"; };
+		844639821BC3443E00F24926 /* ofxiOSEAGLView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSEAGLView.h; sourceTree = "<group>"; };
+		844639831BC3443E00F24926 /* ofxiOSEAGLView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSEAGLView.mm; sourceTree = "<group>"; };
+		844639851BC3443E00F24926 /* EAGLView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EAGLView.h; sourceTree = "<group>"; };
+		844639861BC3443E00F24926 /* EAGLView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EAGLView.m; sourceTree = "<group>"; };
+		844639871BC3443E00F24926 /* ESRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ESRenderer.h; sourceTree = "<group>"; };
+		844639881BC3443E00F24926 /* ES1Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ES1Renderer.h; sourceTree = "<group>"; };
+		844639891BC3443E00F24926 /* ES1Renderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ES1Renderer.m; sourceTree = "<group>"; };
+		8446398A1BC3443E00F24926 /* ES2Renderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ES2Renderer.h; sourceTree = "<group>"; };
+		8446398B1BC3443E00F24926 /* ES2Renderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ES2Renderer.m; sourceTree = "<group>"; };
+		8446398D1BC3443E00F24926 /* AVSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSoundPlayer.h; sourceTree = "<group>"; };
+		8446398E1BC3443E00F24926 /* AVSoundPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSoundPlayer.m; sourceTree = "<group>"; };
+		8446398F1BC3443E00F24926 /* ofxiOSSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundPlayer.h; sourceTree = "<group>"; };
+		844639901BC3443E00F24926 /* ofxiOSSoundPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundPlayer.mm; sourceTree = "<group>"; };
+		844639911BC3443E00F24926 /* ofxiOSSoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundStream.h; sourceTree = "<group>"; };
+		844639921BC3443E00F24926 /* ofxiOSSoundStream.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundStream.mm; sourceTree = "<group>"; };
+		844639931BC3443E00F24926 /* ofxiOSSoundStreamDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSSoundStreamDelegate.h; sourceTree = "<group>"; };
+		844639941BC3443E00F24926 /* ofxiOSSoundStreamDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSSoundStreamDelegate.mm; sourceTree = "<group>"; };
+		844639951BC3443E00F24926 /* ofxOpenALSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofxOpenALSoundPlayer.cpp; sourceTree = "<group>"; };
+		844639961BC3443E00F24926 /* ofxOpenALSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxOpenALSoundPlayer.h; sourceTree = "<group>"; };
+		844639971BC3443E00F24926 /* SoundEngine.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SoundEngine.cpp; sourceTree = "<group>"; };
+		844639981BC3443E00F24926 /* SoundEngine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundEngine.h; sourceTree = "<group>"; };
+		844639991BC3443E00F24926 /* SoundInputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundInputStream.h; sourceTree = "<group>"; };
+		8446399A1BC3443E00F24926 /* SoundInputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundInputStream.m; sourceTree = "<group>"; };
+		8446399B1BC3443E00F24926 /* SoundOutputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundOutputStream.h; sourceTree = "<group>"; };
+		8446399C1BC3443E00F24926 /* SoundOutputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundOutputStream.m; sourceTree = "<group>"; };
+		8446399D1BC3443E00F24926 /* SoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SoundStream.h; sourceTree = "<group>"; };
+		8446399E1BC3443E00F24926 /* SoundStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SoundStream.m; sourceTree = "<group>"; };
+		844639A01BC3443E00F24926 /* AVFoundationVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationVideoPlayer.h; sourceTree = "<group>"; };
+		844639A11BC3443E00F24926 /* AVFoundationVideoPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVFoundationVideoPlayer.m; sourceTree = "<group>"; };
+		844639A21BC3443E00F24926 /* AVFoundationVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVFoundationVideoGrabber.h; sourceTree = "<group>"; };
+		844639A31BC3443E00F24926 /* AVFoundationVideoGrabber.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationVideoGrabber.mm; sourceTree = "<group>"; };
+		844639A41BC3443E00F24926 /* ofxiOSVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSVideoPlayer.h; sourceTree = "<group>"; };
+		844639A51BC3443E00F24926 /* ofxiOSVideoPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSVideoPlayer.mm; sourceTree = "<group>"; };
+		844639A61BC3443E00F24926 /* ofxiOSVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSVideoGrabber.h; sourceTree = "<group>"; };
+		844639A71BC3443E00F24926 /* ofxiOSVideoGrabber.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSVideoGrabber.mm; sourceTree = "<group>"; };
+		844639A91BC3443E00F24926 /* ofxiOSAlerts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAlerts.h; sourceTree = "<group>"; };
+		844639AA1BC3443E00F24926 /* ofxiOSAlerts.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSAlerts.mm; sourceTree = "<group>"; };
+		844639AB1BC3443E00F24926 /* ofxiOSAlertsListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSAlertsListener.h; sourceTree = "<group>"; };
+		844639AC1BC3443E00F24926 /* ofxiOSAccelerometer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSAccelerometer.mm; sourceTree = "<group>"; };
+		844639AE1BC3443E00F24926 /* ofxiOSExtras.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = ofxiOSExtras.h; sourceTree = "<group>"; };
+		844639AF1BC3443E00F24926 /* ofxiOSExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSExtras.mm; sourceTree = "<group>"; };
+		844639B01BC3443E00F24926 /* ofxiOSExternalDisplay.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSExternalDisplay.h; sourceTree = "<group>"; };
+		844639B11BC3443E00F24926 /* ofxiOSExternalDisplay.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSExternalDisplay.mm; sourceTree = "<group>"; };
+		844639B21BC3443E00F24926 /* ofxiOSCoreLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSCoreLocation.h; sourceTree = "<group>"; };
+		844639B31BC3443E00F24926 /* ofxiOSCoreLocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSCoreLocation.mm; sourceTree = "<group>"; };
+		844639B41BC3443E00F24926 /* ofxiOSImagePicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSImagePicker.h; sourceTree = "<group>"; };
+		844639B51BC3443E00F24926 /* ofxiOSImagePicker.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSImagePicker.mm; sourceTree = "<group>"; };
+		844639B61BC3443E00F24926 /* ofxiOSKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSKeyboard.h; sourceTree = "<group>"; };
+		844639B71BC3443E00F24926 /* ofxiOSKeyboard.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSKeyboard.mm; sourceTree = "<group>"; };
+		844639B81BC3443E00F24926 /* ofxiOSMapKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKit.h; sourceTree = "<group>"; };
+		844639B91BC3443E00F24926 /* ofxiOSMapKit.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSMapKit.mm; sourceTree = "<group>"; };
+		844639BA1BC3443E00F24926 /* ofxiOSMapKitDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKitDelegate.h; sourceTree = "<group>"; };
+		844639BB1BC3443E00F24926 /* ofxiOSMapKitDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSMapKitDelegate.mm; sourceTree = "<group>"; };
+		844639BC1BC3443E00F24926 /* ofxiOSMapKitListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSMapKitListener.h; sourceTree = "<group>"; };
+		84463AA51BC3452400F24926 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		84463AA61BC3452400F24926 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		84463AA71BC3452400F24926 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		84463AA81BC3452400F24926 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		84463AA91BC3452400F24926 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		84463AAA1BC3452400F24926 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		84463AAB1BC3452400F24926 /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
+		84463AAC1BC3452400F24926 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		84463AAD1BC3452400F24926 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		84463AAE1BC3452400F24926 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		901808942053554C004A7774 /* ofxtvOSGLKViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxtvOSGLKViewController.mm; sourceTree = "<group>"; };
+		901808952053554C004A7774 /* ofxtvOSGLKViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxtvOSGLKViewController.h; sourceTree = "<group>"; };
+		90180897205355B5004A7774 /* EAGLKView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EAGLKView.m; sourceTree = "<group>"; };
+		90180898205355B5004A7774 /* EAGLKView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EAGLKView.h; sourceTree = "<group>"; };
+		9018089A20535AA7004A7774 /* ofxiOSGLKView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSGLKView.h; sourceTree = "<group>"; };
+		9018089B20535AA8004A7774 /* ofxiOSGLKViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxiOSGLKViewController.h; sourceTree = "<group>"; };
+		9018089C20535AA8004A7774 /* ofxiOSGLKViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSGLKViewController.mm; sourceTree = "<group>"; };
+		9018089D20535AA8004A7774 /* ofxiOSGLKView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxiOSGLKView.mm; sourceTree = "<group>"; };
+		901808A520535D35004A7774 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
+		9957D5331BDDB8370002D53C /* ofxtvOS.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = ofxtvOS.h; sourceTree = "<group>"; };
+		9957D5351BDDB9BA0002D53C /* ofxtvOSAppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxtvOSAppDelegate.mm; sourceTree = "<group>"; };
+		9957D5361BDDB9BA0002D53C /* ofxtvOSAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxtvOSAppDelegate.h; sourceTree = "<group>"; };
+		9957D5381BDDBB1E0002D53C /* ofxtvOSViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofxtvOSViewController.mm; sourceTree = "<group>"; };
+		9957D5391BDDBB1E0002D53C /* ofxtvOSViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofxtvOSViewController.h; sourceTree = "<group>"; };
+		9957D8711BDDDC9B0002D53C /* ofMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMain.h; sourceTree = "<group>"; };
+		9957D8721BDDDC9B0002D53C /* of3dPrimitives.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = of3dPrimitives.cpp; sourceTree = "<group>"; };
+		9957D8731BDDDC9B0002D53C /* of3dPrimitives.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dPrimitives.h; sourceTree = "<group>"; };
+		9957D8741BDDDC9B0002D53C /* of3dUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = of3dUtils.cpp; sourceTree = "<group>"; };
+		9957D8751BDDDC9B0002D53C /* of3dUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dUtils.h; sourceTree = "<group>"; };
+		9957D8761BDDDC9B0002D53C /* ofCamera.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofCamera.cpp; sourceTree = "<group>"; };
+		9957D8771BDDDC9B0002D53C /* ofCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofCamera.h; sourceTree = "<group>"; };
+		9957D8781BDDDC9B0002D53C /* ofEasyCam.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofEasyCam.cpp; sourceTree = "<group>"; };
+		9957D8791BDDDC9B0002D53C /* ofEasyCam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEasyCam.h; sourceTree = "<group>"; };
+		9957D87B1BDDDC9B0002D53C /* ofMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMesh.h; sourceTree = "<group>"; };
+		9957D87C1BDDDC9B0002D53C /* ofNode.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofNode.cpp; sourceTree = "<group>"; };
+		9957D87D1BDDDC9B0002D53C /* ofNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofNode.h; sourceTree = "<group>"; };
+		9957D87F1BDDDC9B0002D53C /* ofAppBaseWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppBaseWindow.h; sourceTree = "<group>"; };
+		9957D8801BDDDC9B0002D53C /* ofAppRunner.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofAppRunner.cpp; sourceTree = "<group>"; };
+		9957D8811BDDDC9B0002D53C /* ofAppRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppRunner.h; sourceTree = "<group>"; };
+		9957D8821BDDDC9B0002D53C /* ofBaseApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBaseApp.h; sourceTree = "<group>"; };
+		9957D8831BDDDC9B0002D53C /* ofMainLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMainLoop.cpp; sourceTree = "<group>"; };
+		9957D8841BDDDC9B0002D53C /* ofMainLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMainLoop.h; sourceTree = "<group>"; };
+		9957D8851BDDDC9B0002D53C /* ofWindowSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofWindowSettings.h; sourceTree = "<group>"; };
+		9957D8881BDDDC9B0002D53C /* ofEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEvent.h; sourceTree = "<group>"; };
+		9957D8891BDDDC9B0002D53C /* ofEvents.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofEvents.cpp; sourceTree = "<group>"; };
+		9957D88A1BDDDC9B0002D53C /* ofEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEvents.h; sourceTree = "<group>"; };
+		9957D88B1BDDDC9B0002D53C /* ofEventUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofEventUtils.h; sourceTree = "<group>"; };
+		9957D88D1BDDDC9B0002D53C /* ofBufferObject.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBufferObject.cpp; sourceTree = "<group>"; };
+		9957D88E1BDDDC9B0002D53C /* ofBufferObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBufferObject.h; sourceTree = "<group>"; };
+		9957D88F1BDDDC9B0002D53C /* ofFbo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofFbo.cpp; sourceTree = "<group>"; };
+		9957D8901BDDDC9B0002D53C /* ofFbo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFbo.h; sourceTree = "<group>"; };
+		9957D8911BDDDC9B0002D53C /* ofGLProgrammableRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLProgrammableRenderer.cpp; sourceTree = "<group>"; };
+		9957D8921BDDDC9B0002D53C /* ofGLProgrammableRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLProgrammableRenderer.h; sourceTree = "<group>"; };
+		9957D8931BDDDC9B0002D53C /* ofGLRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLRenderer.cpp; sourceTree = "<group>"; };
+		9957D8941BDDDC9B0002D53C /* ofGLRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLRenderer.h; sourceTree = "<group>"; };
+		9957D8951BDDDC9B0002D53C /* ofGLUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGLUtils.cpp; sourceTree = "<group>"; };
+		9957D8961BDDDC9B0002D53C /* ofGLUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGLUtils.h; sourceTree = "<group>"; };
+		9957D8971BDDDC9B0002D53C /* ofLight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofLight.cpp; sourceTree = "<group>"; };
+		9957D8981BDDDC9B0002D53C /* ofLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofLight.h; sourceTree = "<group>"; };
+		9957D8991BDDDC9B0002D53C /* ofMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMaterial.cpp; sourceTree = "<group>"; };
+		9957D89A1BDDDC9B0002D53C /* ofMaterial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMaterial.h; sourceTree = "<group>"; };
+		9957D89B1BDDDC9B0002D53C /* ofShader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofShader.cpp; sourceTree = "<group>"; };
+		9957D89C1BDDDC9B0002D53C /* ofShader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofShader.h; sourceTree = "<group>"; };
+		9957D89D1BDDDC9B0002D53C /* ofTexture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTexture.cpp; sourceTree = "<group>"; };
+		9957D89E1BDDDC9B0002D53C /* ofTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTexture.h; sourceTree = "<group>"; };
+		9957D89F1BDDDC9B0002D53C /* ofVbo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVbo.cpp; sourceTree = "<group>"; };
+		9957D8A01BDDDC9B0002D53C /* ofVbo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVbo.h; sourceTree = "<group>"; };
+		9957D8A11BDDDC9B0002D53C /* ofVboMesh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVboMesh.cpp; sourceTree = "<group>"; };
+		9957D8A21BDDDC9B0002D53C /* ofVboMesh.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVboMesh.h; sourceTree = "<group>"; };
+		9957D8A41BDDDC9B0002D53C /* of3dGraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = of3dGraphics.cpp; sourceTree = "<group>"; };
+		9957D8A51BDDDC9B0002D53C /* of3dGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dGraphics.h; sourceTree = "<group>"; };
+		9957D8A61BDDDC9B0002D53C /* ofBitmapFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBitmapFont.cpp; sourceTree = "<group>"; };
+		9957D8A71BDDDC9B0002D53C /* ofBitmapFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBitmapFont.h; sourceTree = "<group>"; };
+		9957D8A81BDDDC9B0002D53C /* ofGraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGraphics.cpp; sourceTree = "<group>"; };
+		9957D8A91BDDDC9B0002D53C /* ofGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphics.h; sourceTree = "<group>"; };
+		9957D8AA1BDDDC9B0002D53C /* ofImage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofImage.cpp; sourceTree = "<group>"; };
+		9957D8AB1BDDDC9B0002D53C /* ofImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofImage.h; sourceTree = "<group>"; };
+		9957D8AC1BDDDC9B0002D53C /* ofPath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofPath.cpp; sourceTree = "<group>"; };
+		9957D8AD1BDDDC9B0002D53C /* ofPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPath.h; sourceTree = "<group>"; };
+		9957D8AE1BDDDC9B0002D53C /* ofPixels.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofPixels.cpp; sourceTree = "<group>"; };
+		9957D8AF1BDDDC9B0002D53C /* ofPixels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPixels.h; sourceTree = "<group>"; };
+		9957D8B11BDDDC9B0002D53C /* ofPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPolyline.h; sourceTree = "<group>"; };
+		9957D8B21BDDDC9B0002D53C /* ofRendererCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofRendererCollection.cpp; sourceTree = "<group>"; };
+		9957D8B31BDDDC9B0002D53C /* ofRendererCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofRendererCollection.h; sourceTree = "<group>"; };
+		9957D8B41BDDDC9B0002D53C /* ofTessellator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTessellator.cpp; sourceTree = "<group>"; };
+		9957D8B51BDDDC9B0002D53C /* ofTessellator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTessellator.h; sourceTree = "<group>"; };
+		9957D8B61BDDDC9B0002D53C /* ofTrueTypeFont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTrueTypeFont.cpp; sourceTree = "<group>"; };
+		9957D8B71BDDDC9B0002D53C /* ofTrueTypeFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTrueTypeFont.h; sourceTree = "<group>"; };
+		9957D8B91BDDDC9B0002D53C /* ofMath.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMath.cpp; sourceTree = "<group>"; };
+		9957D8BA1BDDDC9B0002D53C /* ofMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMath.h; sourceTree = "<group>"; };
+		9957D8BB1BDDDC9B0002D53C /* ofMatrix3x3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMatrix3x3.cpp; sourceTree = "<group>"; };
+		9957D8BC1BDDDC9B0002D53C /* ofMatrix3x3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrix3x3.h; sourceTree = "<group>"; };
+		9957D8BD1BDDDC9B0002D53C /* ofMatrix4x4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMatrix4x4.cpp; sourceTree = "<group>"; };
+		9957D8BE1BDDDC9B0002D53C /* ofMatrix4x4.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrix4x4.h; sourceTree = "<group>"; };
+		9957D8BF1BDDDC9B0002D53C /* ofQuaternion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofQuaternion.cpp; sourceTree = "<group>"; };
+		9957D8C01BDDDC9B0002D53C /* ofQuaternion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofQuaternion.h; sourceTree = "<group>"; };
+		9957D8C11BDDDC9B0002D53C /* ofVec2f.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVec2f.cpp; sourceTree = "<group>"; };
+		9957D8C21BDDDC9B0002D53C /* ofVec2f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec2f.h; sourceTree = "<group>"; };
+		9957D8C31BDDDC9B0002D53C /* ofVec3f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec3f.h; sourceTree = "<group>"; };
+		9957D8C41BDDDC9B0002D53C /* ofVec4f.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVec4f.cpp; sourceTree = "<group>"; };
+		9957D8C51BDDDC9B0002D53C /* ofVec4f.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVec4f.h; sourceTree = "<group>"; };
+		9957D8C61BDDDC9B0002D53C /* ofVectorMath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVectorMath.h; sourceTree = "<group>"; };
+		9957D8CB1BDDDC9B0002D53C /* ofSoundBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundBuffer.cpp; sourceTree = "<group>"; };
+		9957D8CC1BDDDC9B0002D53C /* ofSoundBuffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundBuffer.h; sourceTree = "<group>"; };
+		9957D8CD1BDDDC9B0002D53C /* ofSoundPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundPlayer.cpp; sourceTree = "<group>"; };
+		9957D8CE1BDDDC9B0002D53C /* ofSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundPlayer.h; sourceTree = "<group>"; };
+		9957D8CF1BDDDC9B0002D53C /* ofSoundStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofSoundStream.cpp; sourceTree = "<group>"; };
+		9957D8D01BDDDC9B0002D53C /* ofSoundStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundStream.h; sourceTree = "<group>"; };
+		9957D8D11BDDDC9B0002D53C /* ofSoundUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSoundUtils.h; sourceTree = "<group>"; };
+		9957D8D31BDDDC9B0002D53C /* ofBaseTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseTypes.cpp; sourceTree = "<group>"; };
+		9957D8D51BDDDC9B0002D53C /* ofColor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofColor.cpp; sourceTree = "<group>"; };
+		9957D8D61BDDDC9B0002D53C /* ofColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofColor.h; sourceTree = "<group>"; };
+		9957D8D71BDDDC9B0002D53C /* ofParameter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameter.cpp; sourceTree = "<group>"; };
+		9957D8D81BDDDC9B0002D53C /* ofParameter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameter.h; sourceTree = "<group>"; };
+		9957D8D91BDDDC9B0002D53C /* ofParameterGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameterGroup.cpp; sourceTree = "<group>"; };
+		9957D8DA1BDDDC9B0002D53C /* ofParameterGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameterGroup.h; sourceTree = "<group>"; };
+		9957D8DB1BDDDC9B0002D53C /* ofPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPoint.h; sourceTree = "<group>"; };
+		9957D8DC1BDDDC9B0002D53C /* ofRectangle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofRectangle.cpp; sourceTree = "<group>"; };
+		9957D8DD1BDDDC9B0002D53C /* ofRectangle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofRectangle.h; sourceTree = "<group>"; };
+		9957D8DE1BDDDC9B0002D53C /* ofTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTypes.h; sourceTree = "<group>"; };
+		9957D8E01BDDDC9B0002D53C /* ofConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofConstants.h; sourceTree = "<group>"; };
+		9957D8E11BDDDC9B0002D53C /* ofFileUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofFileUtils.cpp; sourceTree = "<group>"; };
+		9957D8E21BDDDC9B0002D53C /* ofFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFileUtils.h; sourceTree = "<group>"; };
+		9957D8E31BDDDC9B0002D53C /* ofFpsCounter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofFpsCounter.cpp; sourceTree = "<group>"; };
+		9957D8E41BDDDC9B0002D53C /* ofFpsCounter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofFpsCounter.h; sourceTree = "<group>"; };
+		9957D8E51BDDDC9B0002D53C /* ofLog.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofLog.cpp; sourceTree = "<group>"; };
+		9957D8E61BDDDC9B0002D53C /* ofLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofLog.h; sourceTree = "<group>"; };
+		9957D8E71BDDDC9B0002D53C /* ofMatrixStack.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofMatrixStack.cpp; sourceTree = "<group>"; };
+		9957D8E81BDDDC9B0002D53C /* ofMatrixStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrixStack.h; sourceTree = "<group>"; };
+		9957D8E91BDDDC9B0002D53C /* ofNoise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofNoise.h; sourceTree = "<group>"; };
+		9957D8EA1BDDDC9B0002D53C /* ofSystemUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofSystemUtils.cpp; sourceTree = "<group>"; };
+		9957D8EB1BDDDC9B0002D53C /* ofSystemUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofSystemUtils.h; sourceTree = "<group>"; };
+		9957D8EC1BDDDC9B0002D53C /* ofThread.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofThread.cpp; sourceTree = "<group>"; };
+		9957D8ED1BDDDC9B0002D53C /* ofThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofThread.h; sourceTree = "<group>"; };
+		9957D8EE1BDDDC9B0002D53C /* ofThreadChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofThreadChannel.h; sourceTree = "<group>"; };
+		9957D8EF1BDDDC9B0002D53C /* ofTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTimer.cpp; sourceTree = "<group>"; };
+		9957D8F01BDDDC9B0002D53C /* ofTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTimer.h; sourceTree = "<group>"; };
+		9957D8F11BDDDC9B0002D53C /* ofURLFileLoader.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofURLFileLoader.cpp; sourceTree = "<group>"; };
+		9957D8F21BDDDC9B0002D53C /* ofURLFileLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofURLFileLoader.h; sourceTree = "<group>"; };
+		9957D8F31BDDDC9B0002D53C /* ofUtils.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; fileEncoding = 4; path = ofUtils.cpp; sourceTree = "<group>"; };
+		9957D8F41BDDDC9B0002D53C /* ofUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofUtils.h; sourceTree = "<group>"; };
+		9957D8F51BDDDC9B0002D53C /* ofXml.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofXml.cpp; sourceTree = "<group>"; };
+		9957D8F61BDDDC9B0002D53C /* ofXml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofXml.h; sourceTree = "<group>"; };
+		9957D8F81BDDDC9B0002D53C /* ofVideoGrabber.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVideoGrabber.cpp; sourceTree = "<group>"; };
+		9957D8F91BDDDC9B0002D53C /* ofVideoGrabber.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVideoGrabber.h; sourceTree = "<group>"; };
+		9957D8FA1BDDDC9B0002D53C /* ofVideoPlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofVideoPlayer.cpp; sourceTree = "<group>"; };
+		9957D8FB1BDDDC9B0002D53C /* ofVideoPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofVideoPlayer.h; sourceTree = "<group>"; };
+		99752D2F1BF20A4C0026316A /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		844639591BC343E000F24926 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				901808A720535D54004A7774 /* GLKit.framework in Frameworks */,
+				99752D301BF20A4C0026316A /* GameController.framework in Frameworks */,
+				84463AAF1BC3452400F24926 /* AudioToolbox.framework in Frameworks */,
+				84463AB01BC3452400F24926 /* AVFoundation.framework in Frameworks */,
+				84463AB11BC3452400F24926 /* CoreAudio.framework in Frameworks */,
+				84463AB21BC3452400F24926 /* CoreGraphics.framework in Frameworks */,
+				84463AB31BC3452400F24926 /* CoreMedia.framework in Frameworks */,
+				84463AB41BC3452400F24926 /* Foundation.framework in Frameworks */,
+				84463AB51BC3452400F24926 /* OpenAL.framework in Frameworks */,
+				84463AB61BC3452400F24926 /* OpenGLES.framework in Frameworks */,
+				84463AB71BC3452400F24926 /* QuartzCore.framework in Frameworks */,
+				84463AB81BC3452400F24926 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		844639531BC343E000F24926 = {
+			isa = PBXGroup;
+			children = (
+				9957D8FD1BDDDC9B0002D53C /* openFrameworks */,
+				844639C01BC3443E00F24926 /* addons */,
+				844639681BC3442400F24926 /* CoreOF.xcconfig */,
+				844639691BC3442400F24926 /* Debug.xcconfig */,
+				8446396A1BC3442400F24926 /* Release.xcconfig */,
+				8446396B1BC3442400F24926 /* Shared.xcconfig */,
+				84463AB91BC3452B00F24926 /* libs */,
+				8446395D1BC343E000F24926 /* Products */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		8446395D1BC343E000F24926 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8446395C1BC343E000F24926 /* libtvOS+OFLib_Debug.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		844639751BC3443E00F24926 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				844639731BC3443E00F24926 /* ofxAccelerometer.cpp */,
+				844639741BC3443E00F24926 /* ofxAccelerometer.h */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		844639761BC3443E00F24926 /* ofxAccelerometer */ = {
+			isa = PBXGroup;
+			children = (
+				844639711BC3443E00F24926 /* changelog.txt */,
+				844639721BC3443E00F24926 /* LICENSE.txt */,
+				844639751BC3443E00F24926 /* src */,
+			);
+			name = ofxAccelerometer;
+			path = ../../../../addons/ofxAccelerometer;
+			sourceTree = "<group>";
+		};
+		8446397D1BC3443E00F24926 /* app */ = {
+			isa = PBXGroup;
+			children = (
+				8446397A1BC3443E00F24926 /* ofAppiOSWindow.h */,
+				8446397B1BC3443E00F24926 /* ofAppiOSWindow.mm */,
+				8446397C1BC3443E00F24926 /* ofxiOSApp.h */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
+		844639841BC3443E00F24926 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				9018089A20535AA7004A7774 /* ofxiOSGLKView.h */,
+				9018089D20535AA8004A7774 /* ofxiOSGLKView.mm */,
+				9018089B20535AA8004A7774 /* ofxiOSGLKViewController.h */,
+				9018089C20535AA8004A7774 /* ofxiOSGLKViewController.mm */,
+				8446397E1BC3443E00F24926 /* ofxiOSAppDelegate.h */,
+				8446397F1BC3443E00F24926 /* ofxiOSAppDelegate.mm */,
+				844639801BC3443E00F24926 /* ofxiOSViewController.h */,
+				844639811BC3443E00F24926 /* ofxiOSViewController.mm */,
+				844639821BC3443E00F24926 /* ofxiOSEAGLView.h */,
+				844639831BC3443E00F24926 /* ofxiOSEAGLView.mm */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		8446398C1BC3443E00F24926 /* gl */ = {
+			isa = PBXGroup;
+			children = (
+				90180898205355B5004A7774 /* EAGLKView.h */,
+				90180897205355B5004A7774 /* EAGLKView.m */,
+				844639851BC3443E00F24926 /* EAGLView.h */,
+				844639861BC3443E00F24926 /* EAGLView.m */,
+				844639871BC3443E00F24926 /* ESRenderer.h */,
+				844639881BC3443E00F24926 /* ES1Renderer.h */,
+				844639891BC3443E00F24926 /* ES1Renderer.m */,
+				8446398A1BC3443E00F24926 /* ES2Renderer.h */,
+				8446398B1BC3443E00F24926 /* ES2Renderer.m */,
+			);
+			path = gl;
+			sourceTree = "<group>";
+		};
+		8446399F1BC3443E00F24926 /* sound */ = {
+			isa = PBXGroup;
+			children = (
+				8446398D1BC3443E00F24926 /* AVSoundPlayer.h */,
+				8446398E1BC3443E00F24926 /* AVSoundPlayer.m */,
+				8446398F1BC3443E00F24926 /* ofxiOSSoundPlayer.h */,
+				844639901BC3443E00F24926 /* ofxiOSSoundPlayer.mm */,
+				844639911BC3443E00F24926 /* ofxiOSSoundStream.h */,
+				844639921BC3443E00F24926 /* ofxiOSSoundStream.mm */,
+				844639931BC3443E00F24926 /* ofxiOSSoundStreamDelegate.h */,
+				844639941BC3443E00F24926 /* ofxiOSSoundStreamDelegate.mm */,
+				844639951BC3443E00F24926 /* ofxOpenALSoundPlayer.cpp */,
+				844639961BC3443E00F24926 /* ofxOpenALSoundPlayer.h */,
+				844639971BC3443E00F24926 /* SoundEngine.cpp */,
+				844639981BC3443E00F24926 /* SoundEngine.h */,
+				844639991BC3443E00F24926 /* SoundInputStream.h */,
+				8446399A1BC3443E00F24926 /* SoundInputStream.m */,
+				8446399B1BC3443E00F24926 /* SoundOutputStream.h */,
+				8446399C1BC3443E00F24926 /* SoundOutputStream.m */,
+				8446399D1BC3443E00F24926 /* SoundStream.h */,
+				8446399E1BC3443E00F24926 /* SoundStream.m */,
+			);
+			path = sound;
+			sourceTree = "<group>";
+		};
+		844639A81BC3443E00F24926 /* video */ = {
+			isa = PBXGroup;
+			children = (
+				844639A01BC3443E00F24926 /* AVFoundationVideoPlayer.h */,
+				844639A11BC3443E00F24926 /* AVFoundationVideoPlayer.m */,
+				844639A21BC3443E00F24926 /* AVFoundationVideoGrabber.h */,
+				844639A31BC3443E00F24926 /* AVFoundationVideoGrabber.mm */,
+				844639A41BC3443E00F24926 /* ofxiOSVideoPlayer.h */,
+				844639A51BC3443E00F24926 /* ofxiOSVideoPlayer.mm */,
+				844639A61BC3443E00F24926 /* ofxiOSVideoGrabber.h */,
+				844639A71BC3443E00F24926 /* ofxiOSVideoGrabber.mm */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+		844639AD1BC3443E00F24926 /* events */ = {
+			isa = PBXGroup;
+			children = (
+				844639A91BC3443E00F24926 /* ofxiOSAlerts.h */,
+				844639AA1BC3443E00F24926 /* ofxiOSAlerts.mm */,
+				844639AB1BC3443E00F24926 /* ofxiOSAlertsListener.h */,
+				844639AC1BC3443E00F24926 /* ofxiOSAccelerometer.mm */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
+		844639BD1BC3443E00F24926 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				844639AE1BC3443E00F24926 /* ofxiOSExtras.h */,
+				844639AF1BC3443E00F24926 /* ofxiOSExtras.mm */,
+				844639B01BC3443E00F24926 /* ofxiOSExternalDisplay.h */,
+				844639B11BC3443E00F24926 /* ofxiOSExternalDisplay.mm */,
+				844639B21BC3443E00F24926 /* ofxiOSCoreLocation.h */,
+				844639B31BC3443E00F24926 /* ofxiOSCoreLocation.mm */,
+				844639B41BC3443E00F24926 /* ofxiOSImagePicker.h */,
+				844639B51BC3443E00F24926 /* ofxiOSImagePicker.mm */,
+				844639B61BC3443E00F24926 /* ofxiOSKeyboard.h */,
+				844639B71BC3443E00F24926 /* ofxiOSKeyboard.mm */,
+				844639B81BC3443E00F24926 /* ofxiOSMapKit.h */,
+				844639B91BC3443E00F24926 /* ofxiOSMapKit.mm */,
+				844639BA1BC3443E00F24926 /* ofxiOSMapKitDelegate.h */,
+				844639BB1BC3443E00F24926 /* ofxiOSMapKitDelegate.mm */,
+				844639BC1BC3443E00F24926 /* ofxiOSMapKitListener.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		844639BE1BC3443E00F24926 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				9957D5331BDDB8370002D53C /* ofxtvOS.h */,
+				9957D5341BDDB98E0002D53C /* tvOS */,
+				844639771BC3443E00F24926 /* ofxiOS.h */,
+				844639781BC3443E00F24926 /* ofxiOSConstants.h */,
+				844639791BC3443E00F24926 /* ofxiOSExtensions.h */,
+				8446397D1BC3443E00F24926 /* app */,
+				844639841BC3443E00F24926 /* core */,
+				8446398C1BC3443E00F24926 /* gl */,
+				8446399F1BC3443E00F24926 /* sound */,
+				844639A81BC3443E00F24926 /* video */,
+				844639AD1BC3443E00F24926 /* events */,
+				844639BD1BC3443E00F24926 /* utils */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		844639BF1BC3443E00F24926 /* ofxiOS */ = {
+			isa = PBXGroup;
+			children = (
+				844639BE1BC3443E00F24926 /* src */,
+			);
+			name = ofxiOS;
+			path = ../../../../addons/ofxiOS;
+			sourceTree = "<group>";
+		};
+		844639C01BC3443E00F24926 /* addons */ = {
+			isa = PBXGroup;
+			children = (
+				844639761BC3443E00F24926 /* ofxAccelerometer */,
+				844639BF1BC3443E00F24926 /* ofxiOS */,
+			);
+			name = addons;
+			path = ../ios;
+			sourceTree = "<group>";
+		};
+		84463AB91BC3452B00F24926 /* libs */ = {
+			isa = PBXGroup;
+			children = (
+				84463ABA1BC3453500F24926 /* core */,
+			);
+			name = libs;
+			sourceTree = "<group>";
+		};
+		84463ABA1BC3453500F24926 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				84463ABB1BC3453B00F24926 /* core frameworks */,
+			);
+			name = core;
+			sourceTree = "<group>";
+		};
+		84463ABB1BC3453B00F24926 /* core frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				901808A520535D35004A7774 /* GLKit.framework */,
+				99752D2F1BF20A4C0026316A /* GameController.framework */,
+				84463AA51BC3452400F24926 /* AudioToolbox.framework */,
+				84463AA61BC3452400F24926 /* AVFoundation.framework */,
+				84463AA71BC3452400F24926 /* CoreAudio.framework */,
+				84463AA81BC3452400F24926 /* CoreGraphics.framework */,
+				84463AA91BC3452400F24926 /* CoreMedia.framework */,
+				84463AAA1BC3452400F24926 /* Foundation.framework */,
+				84463AAB1BC3452400F24926 /* OpenAL.framework */,
+				84463AAC1BC3452400F24926 /* OpenGLES.framework */,
+				84463AAD1BC3452400F24926 /* QuartzCore.framework */,
+				84463AAE1BC3452400F24926 /* UIKit.framework */,
+			);
+			name = "core frameworks";
+			sourceTree = "<group>";
+		};
+		9957D5341BDDB98E0002D53C /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				9957D5361BDDB9BA0002D53C /* ofxtvOSAppDelegate.h */,
+				9957D5351BDDB9BA0002D53C /* ofxtvOSAppDelegate.mm */,
+				901808952053554C004A7774 /* ofxtvOSGLKViewController.h */,
+				901808942053554C004A7774 /* ofxtvOSGLKViewController.mm */,
+				9957D5381BDDBB1E0002D53C /* ofxtvOSViewController.mm */,
+				9957D5391BDDBB1E0002D53C /* ofxtvOSViewController.h */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
+		9957D87E1BDDDC9B0002D53C /* 3d */ = {
+			isa = PBXGroup;
+			children = (
+				691108A91FE53C7000BDBA78 /* ofMesh.inl */,
+				9957D8721BDDDC9B0002D53C /* of3dPrimitives.cpp */,
+				9957D8731BDDDC9B0002D53C /* of3dPrimitives.h */,
+				9957D8741BDDDC9B0002D53C /* of3dUtils.cpp */,
+				9957D8751BDDDC9B0002D53C /* of3dUtils.h */,
+				9957D8761BDDDC9B0002D53C /* ofCamera.cpp */,
+				9957D8771BDDDC9B0002D53C /* ofCamera.h */,
+				9957D8781BDDDC9B0002D53C /* ofEasyCam.cpp */,
+				9957D8791BDDDC9B0002D53C /* ofEasyCam.h */,
+				9957D87B1BDDDC9B0002D53C /* ofMesh.h */,
+				9957D87C1BDDDC9B0002D53C /* ofNode.cpp */,
+				9957D87D1BDDDC9B0002D53C /* ofNode.h */,
+			);
+			path = 3d;
+			sourceTree = "<group>";
+		};
+		9957D8861BDDDC9B0002D53C /* app */ = {
+			isa = PBXGroup;
+			children = (
+				691108AA1FE53C7B00BDBA78 /* ofBaseApp.cpp */,
+				9957D87F1BDDDC9B0002D53C /* ofAppBaseWindow.h */,
+				9957D8801BDDDC9B0002D53C /* ofAppRunner.cpp */,
+				9957D8811BDDDC9B0002D53C /* ofAppRunner.h */,
+				9957D8821BDDDC9B0002D53C /* ofBaseApp.h */,
+				9957D8831BDDDC9B0002D53C /* ofMainLoop.cpp */,
+				9957D8841BDDDC9B0002D53C /* ofMainLoop.h */,
+				9957D8851BDDDC9B0002D53C /* ofWindowSettings.h */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
+		9957D8871BDDDC9B0002D53C /* communication */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = communication;
+			sourceTree = "<group>";
+		};
+		9957D88C1BDDDC9B0002D53C /* events */ = {
+			isa = PBXGroup;
+			children = (
+				9957D8881BDDDC9B0002D53C /* ofEvent.h */,
+				9957D8891BDDDC9B0002D53C /* ofEvents.cpp */,
+				9957D88A1BDDDC9B0002D53C /* ofEvents.h */,
+				9957D88B1BDDDC9B0002D53C /* ofEventUtils.h */,
+			);
+			path = events;
+			sourceTree = "<group>";
+		};
+		9957D8A31BDDDC9B0002D53C /* gl */ = {
+			isa = PBXGroup;
+			children = (
+				691108AC1FE53C8A00BDBA78 /* ofGLBaseTypes.h */,
+				9957D88D1BDDDC9B0002D53C /* ofBufferObject.cpp */,
+				9957D88E1BDDDC9B0002D53C /* ofBufferObject.h */,
+				9957D88F1BDDDC9B0002D53C /* ofFbo.cpp */,
+				9957D8901BDDDC9B0002D53C /* ofFbo.h */,
+				9957D8911BDDDC9B0002D53C /* ofGLProgrammableRenderer.cpp */,
+				9957D8921BDDDC9B0002D53C /* ofGLProgrammableRenderer.h */,
+				9957D8931BDDDC9B0002D53C /* ofGLRenderer.cpp */,
+				9957D8941BDDDC9B0002D53C /* ofGLRenderer.h */,
+				9957D8951BDDDC9B0002D53C /* ofGLUtils.cpp */,
+				9957D8961BDDDC9B0002D53C /* ofGLUtils.h */,
+				9957D8971BDDDC9B0002D53C /* ofLight.cpp */,
+				9957D8981BDDDC9B0002D53C /* ofLight.h */,
+				9957D8991BDDDC9B0002D53C /* ofMaterial.cpp */,
+				9957D89A1BDDDC9B0002D53C /* ofMaterial.h */,
+				9957D89B1BDDDC9B0002D53C /* ofShader.cpp */,
+				9957D89C1BDDDC9B0002D53C /* ofShader.h */,
+				9957D89D1BDDDC9B0002D53C /* ofTexture.cpp */,
+				9957D89E1BDDDC9B0002D53C /* ofTexture.h */,
+				9957D89F1BDDDC9B0002D53C /* ofVbo.cpp */,
+				9957D8A01BDDDC9B0002D53C /* ofVbo.h */,
+				9957D8A11BDDDC9B0002D53C /* ofVboMesh.cpp */,
+				9957D8A21BDDDC9B0002D53C /* ofVboMesh.h */,
+			);
+			path = gl;
+			sourceTree = "<group>";
+		};
+		9957D8B81BDDDC9B0002D53C /* graphics */ = {
+			isa = PBXGroup;
+			children = (
+				691108AE1FE53CA800BDBA78 /* ofGraphicsBaseTypes.cpp */,
+				691108AF1FE53CA800BDBA78 /* ofGraphicsBaseTypes.h */,
+				691108B01FE53CA800BDBA78 /* ofGraphicsConstants.h */,
+				691108AD1FE53C9E00BDBA78 /* ofPolyline.inl */,
+				9957D8A41BDDDC9B0002D53C /* of3dGraphics.cpp */,
+				9957D8A51BDDDC9B0002D53C /* of3dGraphics.h */,
+				9957D8A61BDDDC9B0002D53C /* ofBitmapFont.cpp */,
+				9957D8A71BDDDC9B0002D53C /* ofBitmapFont.h */,
+				9957D8A81BDDDC9B0002D53C /* ofGraphics.cpp */,
+				9957D8A91BDDDC9B0002D53C /* ofGraphics.h */,
+				9957D8AA1BDDDC9B0002D53C /* ofImage.cpp */,
+				9957D8AB1BDDDC9B0002D53C /* ofImage.h */,
+				9957D8AC1BDDDC9B0002D53C /* ofPath.cpp */,
+				9957D8AD1BDDDC9B0002D53C /* ofPath.h */,
+				9957D8AE1BDDDC9B0002D53C /* ofPixels.cpp */,
+				9957D8AF1BDDDC9B0002D53C /* ofPixels.h */,
+				9957D8B11BDDDC9B0002D53C /* ofPolyline.h */,
+				9957D8B21BDDDC9B0002D53C /* ofRendererCollection.cpp */,
+				9957D8B31BDDDC9B0002D53C /* ofRendererCollection.h */,
+				9957D8B41BDDDC9B0002D53C /* ofTessellator.cpp */,
+				9957D8B51BDDDC9B0002D53C /* ofTessellator.h */,
+				9957D8B61BDDDC9B0002D53C /* ofTrueTypeFont.cpp */,
+				9957D8B71BDDDC9B0002D53C /* ofTrueTypeFont.h */,
+			);
+			path = graphics;
+			sourceTree = "<group>";
+		};
+		9957D8C71BDDDC9B0002D53C /* math */ = {
+			isa = PBXGroup;
+			children = (
+				691108B21FE53CB400BDBA78 /* ofMathConstants.h */,
+				9957D8B91BDDDC9B0002D53C /* ofMath.cpp */,
+				9957D8BA1BDDDC9B0002D53C /* ofMath.h */,
+				9957D8BB1BDDDC9B0002D53C /* ofMatrix3x3.cpp */,
+				9957D8BC1BDDDC9B0002D53C /* ofMatrix3x3.h */,
+				9957D8BD1BDDDC9B0002D53C /* ofMatrix4x4.cpp */,
+				9957D8BE1BDDDC9B0002D53C /* ofMatrix4x4.h */,
+				9957D8BF1BDDDC9B0002D53C /* ofQuaternion.cpp */,
+				9957D8C01BDDDC9B0002D53C /* ofQuaternion.h */,
+				9957D8C11BDDDC9B0002D53C /* ofVec2f.cpp */,
+				9957D8C21BDDDC9B0002D53C /* ofVec2f.h */,
+				9957D8C31BDDDC9B0002D53C /* ofVec3f.h */,
+				9957D8C41BDDDC9B0002D53C /* ofVec4f.cpp */,
+				9957D8C51BDDDC9B0002D53C /* ofVec4f.h */,
+				9957D8C61BDDDC9B0002D53C /* ofVectorMath.h */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		9957D8D21BDDDC9B0002D53C /* sound */ = {
+			isa = PBXGroup;
+			children = (
+				691108B31FE53CCF00BDBA78 /* ofSoundBaseTypes.cpp */,
+				691108B41FE53CCF00BDBA78 /* ofSoundBaseTypes.h */,
+				9957D8CB1BDDDC9B0002D53C /* ofSoundBuffer.cpp */,
+				9957D8CC1BDDDC9B0002D53C /* ofSoundBuffer.h */,
+				9957D8CD1BDDDC9B0002D53C /* ofSoundPlayer.cpp */,
+				9957D8CE1BDDDC9B0002D53C /* ofSoundPlayer.h */,
+				9957D8CF1BDDDC9B0002D53C /* ofSoundStream.cpp */,
+				9957D8D01BDDDC9B0002D53C /* ofSoundStream.h */,
+				9957D8D11BDDDC9B0002D53C /* ofSoundUtils.h */,
+			);
+			path = sound;
+			sourceTree = "<group>";
+		};
+		9957D8DF1BDDDC9B0002D53C /* types */ = {
+			isa = PBXGroup;
+			children = (
+				9957D8D31BDDDC9B0002D53C /* ofBaseTypes.cpp */,
+				9957D8D51BDDDC9B0002D53C /* ofColor.cpp */,
+				9957D8D61BDDDC9B0002D53C /* ofColor.h */,
+				9957D8D71BDDDC9B0002D53C /* ofParameter.cpp */,
+				9957D8D81BDDDC9B0002D53C /* ofParameter.h */,
+				9957D8D91BDDDC9B0002D53C /* ofParameterGroup.cpp */,
+				9957D8DA1BDDDC9B0002D53C /* ofParameterGroup.h */,
+				9957D8DB1BDDDC9B0002D53C /* ofPoint.h */,
+				9957D8DC1BDDDC9B0002D53C /* ofRectangle.cpp */,
+				9957D8DD1BDDDC9B0002D53C /* ofRectangle.h */,
+				9957D8DE1BDDDC9B0002D53C /* ofTypes.h */,
+			);
+			path = types;
+			sourceTree = "<group>";
+		};
+		9957D8F71BDDDC9B0002D53C /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				9957D8E01BDDDC9B0002D53C /* ofConstants.h */,
+				9957D8E11BDDDC9B0002D53C /* ofFileUtils.cpp */,
+				9957D8E21BDDDC9B0002D53C /* ofFileUtils.h */,
+				9957D8E31BDDDC9B0002D53C /* ofFpsCounter.cpp */,
+				9957D8E41BDDDC9B0002D53C /* ofFpsCounter.h */,
+				9957D8E51BDDDC9B0002D53C /* ofLog.cpp */,
+				9957D8E61BDDDC9B0002D53C /* ofLog.h */,
+				9957D8E71BDDDC9B0002D53C /* ofMatrixStack.cpp */,
+				9957D8E81BDDDC9B0002D53C /* ofMatrixStack.h */,
+				9957D8E91BDDDC9B0002D53C /* ofNoise.h */,
+				9957D8EA1BDDDC9B0002D53C /* ofSystemUtils.cpp */,
+				9957D8EB1BDDDC9B0002D53C /* ofSystemUtils.h */,
+				9957D8EC1BDDDC9B0002D53C /* ofThread.cpp */,
+				9957D8ED1BDDDC9B0002D53C /* ofThread.h */,
+				9957D8EE1BDDDC9B0002D53C /* ofThreadChannel.h */,
+				9957D8EF1BDDDC9B0002D53C /* ofTimer.cpp */,
+				9957D8F01BDDDC9B0002D53C /* ofTimer.h */,
+				9957D8F11BDDDC9B0002D53C /* ofURLFileLoader.cpp */,
+				9957D8F21BDDDC9B0002D53C /* ofURLFileLoader.h */,
+				9957D8F31BDDDC9B0002D53C /* ofUtils.cpp */,
+				9957D8F41BDDDC9B0002D53C /* ofUtils.h */,
+				9957D8F51BDDDC9B0002D53C /* ofXml.cpp */,
+				9957D8F61BDDDC9B0002D53C /* ofXml.h */,
+			);
+			path = utils;
+			sourceTree = "<group>";
+		};
+		9957D8FC1BDDDC9B0002D53C /* video */ = {
+			isa = PBXGroup;
+			children = (
+				691108B61FE53CEB00BDBA78 /* ofVideoBaseTypes.h */,
+				9957D8F81BDDDC9B0002D53C /* ofVideoGrabber.cpp */,
+				9957D8F91BDDDC9B0002D53C /* ofVideoGrabber.h */,
+				9957D8FA1BDDDC9B0002D53C /* ofVideoPlayer.cpp */,
+				9957D8FB1BDDDC9B0002D53C /* ofVideoPlayer.h */,
+			);
+			path = video;
+			sourceTree = "<group>";
+		};
+		9957D8FD1BDDDC9B0002D53C /* openFrameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9957D8711BDDDC9B0002D53C /* ofMain.h */,
+				9957D87E1BDDDC9B0002D53C /* 3d */,
+				9957D8861BDDDC9B0002D53C /* app */,
+				9957D8871BDDDC9B0002D53C /* communication */,
+				9957D88C1BDDDC9B0002D53C /* events */,
+				9957D8A31BDDDC9B0002D53C /* gl */,
+				9957D8B81BDDDC9B0002D53C /* graphics */,
+				9957D8C71BDDDC9B0002D53C /* math */,
+				9957D8D21BDDDC9B0002D53C /* sound */,
+				9957D8DF1BDDDC9B0002D53C /* types */,
+				9957D8F71BDDDC9B0002D53C /* utils */,
+				9957D8FC1BDDDC9B0002D53C /* video */,
+			);
+			name = openFrameworks;
+			path = ../../../openFrameworks;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8446395B1BC343E000F24926 /* tvOS+OFLib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 844639651BC343E000F24926 /* Build configuration list for PBXNativeTarget "tvOS+OFLib" */;
+			buildPhases = (
+				844639581BC343E000F24926 /* Sources */,
+				844639591BC343E000F24926 /* Frameworks */,
+				8446395A1BC343E000F24926 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "tvOS+OFLib";
+			productName = "tvOS+OFLib";
+			productReference = 8446395C1BC343E000F24926 /* libtvOS+OFLib_Debug.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		844639541BC343E000F24926 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = cc.openframeworks.tvOS;
+				TargetAttributes = {
+					8446395B1BC343E000F24926 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+				};
+			};
+			buildConfigurationList = 844639571BC343E000F24926 /* Build configuration list for PBXProject "tvOS+OFLib" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				English,
+				en,
+			);
+			mainGroup = 844639531BC343E000F24926;
+			productRefGroup = 8446395D1BC343E000F24926 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8446395B1BC343E000F24926 /* tvOS+OFLib */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		844639581BC343E000F24926 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9957D9081BDDDC9B0002D53C /* ofFbo.cpp in Sources */,
+				9957D9171BDDDC9B0002D53C /* ofPixels.cpp in Sources */,
+				844639C81BC3443E00F24926 /* ES1Renderer.m in Sources */,
+				9957D92A1BDDDC9B0002D53C /* ofRectangle.cpp in Sources */,
+				9957D9251BDDDC9B0002D53C /* ofSoundStream.cpp in Sources */,
+				9957D9041BDDDC9B0002D53C /* ofAppRunner.cpp in Sources */,
+				691108AB1FE53C7B00BDBA78 /* ofBaseApp.cpp in Sources */,
+				9957D8FF1BDDDC9B0002D53C /* of3dUtils.cpp in Sources */,
+				9957D9261BDDDC9B0002D53C /* ofBaseTypes.cpp in Sources */,
+				9957D9211BDDDC9B0002D53C /* ofVec4f.cpp in Sources */,
+				9957D90E1BDDDC9B0002D53C /* ofShader.cpp in Sources */,
+				9957D9031BDDDC9B0002D53C /* ofNode.cpp in Sources */,
+				9957D92B1BDDDC9B0002D53C /* ofFileUtils.cpp in Sources */,
+				9957D9091BDDDC9B0002D53C /* ofGLProgrammableRenderer.cpp in Sources */,
+				844639DE1BC3443E00F24926 /* ofxiOSMapKit.mm in Sources */,
+				844639CA1BC3443E00F24926 /* AVSoundPlayer.m in Sources */,
+				844639C61BC3443E00F24926 /* ofxiOSEAGLView.mm in Sources */,
+				9957D9201BDDDC9B0002D53C /* ofVec2f.cpp in Sources */,
+				844639C71BC3443E00F24926 /* EAGLView.m in Sources */,
+				9957D9011BDDDC9B0002D53C /* ofEasyCam.cpp in Sources */,
+				844639CD1BC3443E00F24926 /* ofxiOSSoundStreamDelegate.mm in Sources */,
+				844639DA1BC3443E00F24926 /* ofxiOSExternalDisplay.mm in Sources */,
+				9957D9111BDDDC9B0002D53C /* ofVboMesh.cpp in Sources */,
+				9957D9231BDDDC9B0002D53C /* ofSoundBuffer.cpp in Sources */,
+				90180899205355B5004A7774 /* EAGLKView.m in Sources */,
+				9957D9341BDDDC9B0002D53C /* ofXml.cpp in Sources */,
+				844639D21BC3443E00F24926 /* SoundStream.m in Sources */,
+				9957D9101BDDDC9B0002D53C /* ofVbo.cpp in Sources */,
+				844639D81BC3443E00F24926 /* ofxiOSAccelerometer.mm in Sources */,
+				9957D9271BDDDC9B0002D53C /* ofColor.cpp in Sources */,
+				844639D31BC3443E00F24926 /* AVFoundationVideoPlayer.m in Sources */,
+				9957D9321BDDDC9B0002D53C /* ofURLFileLoader.cpp in Sources */,
+				9957D9311BDDDC9B0002D53C /* ofTimer.cpp in Sources */,
+				9957D90B1BDDDC9B0002D53C /* ofGLUtils.cpp in Sources */,
+				9957D91A1BDDDC9B0002D53C /* ofTessellator.cpp in Sources */,
+				844639D61BC3443E00F24926 /* ofxiOSVideoGrabber.mm in Sources */,
+				9957D9351BDDDC9B0002D53C /* ofVideoGrabber.cpp in Sources */,
+				9957D91F1BDDDC9B0002D53C /* ofQuaternion.cpp in Sources */,
+				9957D90D1BDDDC9B0002D53C /* ofMaterial.cpp in Sources */,
+				9957D5371BDDB9BA0002D53C /* ofxtvOSAppDelegate.mm in Sources */,
+				844639C51BC3443E00F24926 /* ofxiOSViewController.mm in Sources */,
+				844639D41BC3443E00F24926 /* AVFoundationVideoGrabber.mm in Sources */,
+				9957D90C1BDDDC9B0002D53C /* ofLight.cpp in Sources */,
+				9957D9051BDDDC9B0002D53C /* ofMainLoop.cpp in Sources */,
+				9957D9331BDDDC9B0002D53C /* ofUtils.cpp in Sources */,
+				844639DD1BC3443E00F24926 /* ofxiOSKeyboard.mm in Sources */,
+				844639D01BC3443E00F24926 /* SoundInputStream.m in Sources */,
+				9957D9301BDDDC9B0002D53C /* ofThread.cpp in Sources */,
+				844639C91BC3443E00F24926 /* ES2Renderer.m in Sources */,
+				9957D9001BDDDC9B0002D53C /* ofCamera.cpp in Sources */,
+				9957D9191BDDDC9B0002D53C /* ofRendererCollection.cpp in Sources */,
+				691108B51FE53CCF00BDBA78 /* ofSoundBaseTypes.cpp in Sources */,
+				844639DB1BC3443E00F24926 /* ofxiOSCoreLocation.mm in Sources */,
+				9957D9291BDDDC9B0002D53C /* ofParameterGroup.cpp in Sources */,
+				9957D90A1BDDDC9B0002D53C /* ofGLRenderer.cpp in Sources */,
+				9018089F20535AA8004A7774 /* ofxiOSGLKView.mm in Sources */,
+				9957D9141BDDDC9B0002D53C /* ofGraphics.cpp in Sources */,
+				9957D9361BDDDC9B0002D53C /* ofVideoPlayer.cpp in Sources */,
+				9957D92D1BDDDC9B0002D53C /* ofLog.cpp in Sources */,
+				844639CE1BC3443E00F24926 /* ofxOpenALSoundPlayer.cpp in Sources */,
+				844639C41BC3443E00F24926 /* ofxiOSAppDelegate.mm in Sources */,
+				9957D91D1BDDDC9B0002D53C /* ofMatrix3x3.cpp in Sources */,
+				9957D91E1BDDDC9B0002D53C /* ofMatrix4x4.cpp in Sources */,
+				9957D9131BDDDC9B0002D53C /* ofBitmapFont.cpp in Sources */,
+				9018089E20535AA8004A7774 /* ofxiOSGLKViewController.mm in Sources */,
+				9957D9241BDDDC9B0002D53C /* ofSoundPlayer.cpp in Sources */,
+				9957D90F1BDDDC9B0002D53C /* ofTexture.cpp in Sources */,
+				9957D92F1BDDDC9B0002D53C /* ofSystemUtils.cpp in Sources */,
+				9957D9071BDDDC9B0002D53C /* ofBufferObject.cpp in Sources */,
+				844639CC1BC3443E00F24926 /* ofxiOSSoundStream.mm in Sources */,
+				844639D91BC3443E00F24926 /* ofxiOSExtras.mm in Sources */,
+				691108B11FE53CA800BDBA78 /* ofGraphicsBaseTypes.cpp in Sources */,
+				901808962053554C004A7774 /* ofxtvOSGLKViewController.mm in Sources */,
+				9957D53A1BDDBB1E0002D53C /* ofxtvOSViewController.mm in Sources */,
+				9957D91B1BDDDC9B0002D53C /* ofTrueTypeFont.cpp in Sources */,
+				9957D9061BDDDC9B0002D53C /* ofEvents.cpp in Sources */,
+				9957D92E1BDDDC9B0002D53C /* ofMatrixStack.cpp in Sources */,
+				844639C31BC3443E00F24926 /* ofAppiOSWindow.mm in Sources */,
+				844639DF1BC3443E00F24926 /* ofxiOSMapKitDelegate.mm in Sources */,
+				844639D71BC3443E00F24926 /* ofxiOSAlerts.mm in Sources */,
+				844639CB1BC3443E00F24926 /* ofxiOSSoundPlayer.mm in Sources */,
+				9957D9121BDDDC9B0002D53C /* of3dGraphics.cpp in Sources */,
+				9957D8FE1BDDDC9B0002D53C /* of3dPrimitives.cpp in Sources */,
+				9957D9161BDDDC9B0002D53C /* ofPath.cpp in Sources */,
+				844639C21BC3443E00F24926 /* ofxAccelerometer.cpp in Sources */,
+				844639D11BC3443E00F24926 /* SoundOutputStream.m in Sources */,
+				9957D92C1BDDDC9B0002D53C /* ofFpsCounter.cpp in Sources */,
+				9957D9151BDDDC9B0002D53C /* ofImage.cpp in Sources */,
+				844639D51BC3443E00F24926 /* ofxiOSVideoPlayer.mm in Sources */,
+				9957D91C1BDDDC9B0002D53C /* ofMath.cpp in Sources */,
+				844639DC1BC3443E00F24926 /* ofxiOSImagePicker.mm in Sources */,
+				9957D9281BDDDC9B0002D53C /* ofParameter.cpp in Sources */,
+				844639CF1BC3443E00F24926 /* SoundEngine.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		844639631BC343E000F24926 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 844639691BC3442400F24926 /* Debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/tvOS";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/tvOS/build/debug/";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = "compiler-default";
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OBJROOT = "$(SRCROOT)/../../lib/tvOS/build/debug";
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = appletvos;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "$(SRCROOT)/../../lib/tvOS/";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+			};
+			name = Debug;
+		};
+		844639641BC343E000F24926 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8446396A1BC3442400F24926 /* Release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/tvOS";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/tvOS/build/release/";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = "compiler-default";
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OBJROOT = "$(SRCROOT)/../../lib/tvOS/build/release";
+				SDKROOT = appletvos;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "$(SRCROOT)/../../lib/tvOS/";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		844639661BC343E000F24926 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)_Debug";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		844639671BC343E000F24926 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)_Release";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		844639571BC343E000F24926 /* Build configuration list for PBXProject "tvOS+OFLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				844639631BC343E000F24926 /* Debug */,
+				844639641BC343E000F24926 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		844639651BC343E000F24926 /* Build configuration list for PBXNativeTarget "tvOS+OFLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				844639661BC343E000F24926 /* Debug */,
+				844639671BC343E000F24926 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 844639541BC343E000F24926 /* Project object */;
+}


### PR DESCRIPTION
So, I didn't know oF code style, and it says use hard tab (4).
https://github.com/openframeworks/openFrameworks/wiki/oF-code-style

Because Xcode settings about indentation is space (4).

This PR change it (only oF library project, not include pg-template) to hard tab (4).