### PR TITLE
ofxUDPManager : unused variable bytesleft removal

### DIFF
--- a/addons/ofxNetwork/src/ofxUDPManager.cpp
+++ b/addons/ofxNetwork/src/ofxUDPManager.cpp
@@ -309,7 +309,6 @@ int	ofxUDPManager::SendAll(const char*	pBuff, const int iSize)
 	auto timeleftSecs = m_dwTimeoutSend;
 	auto timeleftMicros = 0;
 	int total= 0;
-	int bytesleft = iSize;
 	int ret=-1;
 
 	while (total < iSize) {
@@ -324,7 +323,6 @@ int	ofxUDPManager::SendAll(const char*	pBuff, const int iSize)
 			return SOCKET_ERROR;
 		}
 		total += ret;
-		bytesleft -=ret;
 		if (m_dwTimeoutSend	!= NO_TIMEOUT){
 			auto now = ofGetElapsedTimeMicros();
 			auto diff = now - timestamp;


### PR DESCRIPTION
variable is unused, I can see "int total" variable replaced this logic, this cleanup removes the following warning
```
ofw/addons/ofxNetwork/src/ofxUDPManager.cpp:312:6: warning: variable 'bytesleft' set but not used [-Wunused-but-set-variable]
```