### PR TITLE
This ofBaseApp instance is never used

### DIFF
--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -26,7 +26,8 @@ public:
 		if(!allowMultiWindow){
 		    windowsApps.clear();
 		}
-		windowsApps[window] = std::shared_ptr<ofBaseApp>();
+		windowsApps[window] = NULL;
+
 		currentWindow = window;
 		ofAddListener(window->events().keyPressed,this,&ofMainLoop::keyPressed);
 	}


### PR DESCRIPTION
this PR serves to increase readability in the fact the ofBaseApp here is not used in any way. 
it is only used in the original void ofMainLoop::run
```c++
	windowsApps[window] = app;
```
this PR in fact doesn't do anything other than increase readability.
And I think this map can be changed in the future with something else, like a struct.
