### PR TITLE
update deprecated cocoaWindow setStyleMask options

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -932,7 +932,7 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 
 		[NSApp setPresentationOptions:NSApplicationPresentationDefault];
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windowP);
-		[cocoaWindow setStyleMask:NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask];
+		[cocoaWindow setStyleMask: NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable];
 
 		setWindowShape(windowRect.width, windowRect.height);
 		setWindowTitle(settings.title);


### PR DESCRIPTION
so it supress another warning
