### PR TITLE
ofArduino Cleanup unused code - remove warning

### DIFF
--- a/libs/openFrameworks/communication/ofArduino.cpp
+++ b/libs/openFrameworks/communication/ofArduino.cpp
@@ -986,14 +986,7 @@ void ofArduino::processSysExData(vector <unsigned char> data) {
 			mode = Firmata_Pin_Modes::MODE_ENCODER;
 			break;
 		}
-//		int val;
-		int shift = 0;
-		while (it != data.end()) {
-//			val = *it << shift;
-			it++;
-			shift += 7;
-		} //clear whatever is left
-		//int pinVal[2] = { pin, val }; //I think this was supposed to be the return value
+
 		pair<int, Firmata_Pin_Modes> reply(pin, mode);
 		ofNotifyEvent(EPinStateResponseReceived, reply, this);
 	}


### PR DESCRIPTION
ofArduino.cpp:990:7: warning: variable 'shift' set but not used [-Wunused-but-set-variable]