### PR TITLE
ofParameter - remove unused lambda capture this

### DIFF
--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -112,7 +112,7 @@ void ofParameter<void>::trigger(){
         // Erase each invalid parent
         obj->parents.erase(std::remove_if(obj->parents.begin(),
                                           obj->parents.end(),
-                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
+                                          [](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
                            obj->parents.end());
         
         // notify all leftover (valid) parents of this object's changed value.
@@ -136,7 +136,7 @@ void ofParameter<void>::trigger(const void * sender){
         // Erase each invalid parent
         obj->parents.erase(std::remove_if(obj->parents.begin(),
                                           obj->parents.end(),
-                                          [this](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
+                                          [](const std::weak_ptr<ofParameterGroup::Value> & p){ return p.expired(); }),
                            obj->parents.end());
         
         // notify all leftover (valid) parents of this object's changed value.


### PR DESCRIPTION
supress warnings
ofParameter.cpp:115:44: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
ofParameter.cpp:139:44: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]