### PR TITLE
Define - silence OpenGL deprecation in XCode

### DIFF
--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -1,3 +1,4 @@
+#define GL_SILENCE_DEPRECATION 1
 
 #include "ofConstants.h"
 #include "ofSystemUtils.h"

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -4,6 +4,8 @@
 //	Merged with code by Sam Kronick, James George and Elie Zananiri.
 //
 
+#define GL_SILENCE_DEPRECATION 1
+
 //--------------------------------------------------------------
 #import "ofAVFoundationPlayer.h"
 #import "ofAVFoundationVideoPlayer.h"


### PR DESCRIPTION
Avoid this kind of warnings
```
'NSOpenGLContext' is deprecated: first deprecated in macOS 10.14 - Please use Metal or MetalKit. [-Wdeprecated-declarations]
```