### PR TITLE
info.plist - change CFBundleIdentifier to the same as XCode proj.

### DIFF
--- a/scripts/templates/osx/openFrameworks-Info.plist
+++ b/scripts/templates/osx/openFrameworks-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>cc.openFrameworks.${EXECUTABLE_NAME}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
this change assures the value here will be the same as the XCode project
so, one less warning here