### PR TITLE
Bugfix OpenAL libsndfile error on linux and msys2 

### DIFF
--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -7,7 +7,6 @@
 #include "glm/common.hpp"
 #include "ofLog.h"
 #include "ofEvents.h"
-#include <sndfile.h>
 
 #if defined (TARGET_OF_IOS) || defined (TARGET_OSX)
 #include <OpenAL/al.h>

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -14,8 +14,8 @@ typedef unsigned int ALuint;
 #include "kiss_fftr.h"
 
 
-
-typedef	struct SNDFILE_tag	SNDFILE ;
+//defined by libsndfile in .cpp
+struct SNDFILE;
 
 
 #ifdef OF_USING_MPG123

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -12,10 +12,7 @@ typedef unsigned int ALuint;
 
 #include "kiss_fft.h"
 #include "kiss_fftr.h"
-
-
-//defined by libsndfile in .cpp
-struct SNDFILE;
+#include <sndfile.h>
 
 
 #ifdef OF_USING_MPG123


### PR DESCRIPTION
Seems to be due an update in libsndfile. 
Fix for CI and core.

Still an OpenCV error for msys2 will address in another PR. 