### PR TITLE
Update ofAppGLFWWindow.cpp for openframeworks/openFrameworks#6719

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -930,12 +930,12 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
 			windowRect.height = getWindowSize().y;
 		}
 
+		setWindowShape(windowRect.width, windowRect.height);
+		setWindowTitle(settings.title);
+
 		[NSApp setPresentationOptions:NSApplicationPresentationDefault];
 		NSWindow * cocoaWindow = glfwGetCocoaWindow(windowP);
 		[cocoaWindow setStyleMask: NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable];
-
-		setWindowShape(windowRect.width, windowRect.height);
-		setWindowTitle(settings.title);
 
 		//----------------------------------------------------
 		// if we have recorded the screen position, put it there


### PR DESCRIPTION
Set the window properties after resizing, to fix openframeworks/openFrameworks#6719

- coming out of fullscreen, we call cocoa's setStyleMask, which triggers the glfw framebuffer_resize callback
- then we call setWindowShape()
    - since the glfw resize was already triggered, the glfw internals do not get called, do not see the glfw callbacks trigger
    - i assume because the window size set by the cocoa call equals the window size we want to set, glfw does not do the 2nd resize
    - theres some y axis offset adjustment that is maybe getting skipped 
        - https://github.com/glfw/glfw/blob/master/src/cocoa_window.m#L1038
        - haven't really looked into the guts of glfw
- workaround is to call setWindowShape() first then setStyleMask
- seems to fix the issue macos 12.3/m1 and 11.6/intel
