### PR TITLE
Refactoring ofBuffer::Lines/RLines

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -14,6 +14,8 @@
 	#include <limits.h>        /* PATH_MAX */
 #endif
 
+#include <iterator>
+
 using namespace std;
 
 namespace{
@@ -266,7 +268,7 @@ vector<char>::const_reverse_iterator ofBuffer::rend() const{
 }
 
 //--------------------------------------------------
-ofBuffer::Line::Line(vector<char>::iterator _begin, vector<char>::iterator _end)
+ofBuffer::Line::Line(vector<char>::const_iterator _begin, vector<char>::const_iterator _end)
 	:_current(_begin)
 	,_begin(_begin)
 	,_end(_end){
@@ -332,7 +334,7 @@ bool ofBuffer::Line::empty() const{
 
 
 //--------------------------------------------------
-ofBuffer::RLine::RLine(vector<char>::reverse_iterator _rbegin, vector<char>::reverse_iterator _rend)
+ofBuffer::RLine::RLine(vector<char>::const_reverse_iterator _rbegin, vector<char>::const_reverse_iterator _rend)
 	:_current(_rbegin)
 	,_rbegin(_rbegin)
 	,_rend(_rend){
@@ -391,43 +393,82 @@ bool ofBuffer::RLine::empty() const{
 }
 
 //--------------------------------------------------
-ofBuffer::Lines::Lines(vector<char>::iterator begin, vector<char>::iterator end)
+ofBuffer::Lines::Lines(vector<char>::const_iterator begin, vector<char>::const_iterator end)
 :_begin(begin)
 ,_end(end){}
 
 //--------------------------------------------------
-ofBuffer::Line ofBuffer::Lines::begin(){
+ofBuffer::Line ofBuffer::Lines::begin() const {
 	return Line(_begin,_end);
 }
 
 //--------------------------------------------------
-ofBuffer::Line ofBuffer::Lines::end(){
+ofBuffer::Line ofBuffer::Lines::cbegin() const {
+	return Line(_begin,_end);
+}
+
+//--------------------------------------------------
+ofBuffer::Line ofBuffer::Lines::end() const {
 	return Line(_end,_end);
 }
 
+//--------------------------------------------------
+ofBuffer::Line ofBuffer::Lines::cend() const {
+	return Line(_end,_end);
+}
 
 //--------------------------------------------------
-ofBuffer::RLines::RLines(vector<char>::reverse_iterator rbegin, vector<char>::reverse_iterator rend)
+ofBuffer::RLine ofBuffer::Lines::rbegin() const {
+	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_end));
+}
+
+//--------------------------------------------------
+ofBuffer::RLine ofBuffer::Lines::crbegin() const {
+	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_end));
+}
+
+//--------------------------------------------------
+ofBuffer::RLine ofBuffer::Lines::rend() const {
+	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_end));
+}
+
+//--------------------------------------------------
+ofBuffer::RLine ofBuffer::Lines::crend() const {
+	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_end));
+}
+
+//--------------------------------------------------
+ofBuffer::RLines::RLines(vector<char>::const_reverse_iterator rbegin, vector<char>::const_reverse_iterator rend)
 :_rbegin(rbegin)
 ,_rend(rend){}
 
 //--------------------------------------------------
-ofBuffer::RLine ofBuffer::RLines::begin(){
+ofBuffer::RLine ofBuffer::RLines::begin() const {
 	return RLine(_rbegin,_rend);
 }
 
 //--------------------------------------------------
-ofBuffer::RLine ofBuffer::RLines::end(){
+ofBuffer::RLine ofBuffer::RLines::cbegin() const {
+	return RLine(_rbegin,_rend);
+}
+
+//--------------------------------------------------
+ofBuffer::RLine ofBuffer::RLines::end() const {
 	return RLine(_rend,_rend);
 }
 
 //--------------------------------------------------
-ofBuffer::Lines ofBuffer::getLines(){
+ofBuffer::RLine ofBuffer::RLines::cend() const {
+	return RLine(_rend,_rend);
+}
+
+//--------------------------------------------------
+ofBuffer::Lines ofBuffer::getLines() const {
 	return ofBuffer::Lines(begin(), end());
 }
 
 //--------------------------------------------------
-ofBuffer::RLines ofBuffer::getReverseLines(){
+ofBuffer::RLines ofBuffer::getReverseLines() const {
 	return ofBuffer::RLines(rbegin(), rend());
 }
 

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -419,22 +419,22 @@ ofBuffer::Line ofBuffer::Lines::cend() const {
 
 //--------------------------------------------------
 ofBuffer::RLine ofBuffer::Lines::rbegin() const {
-	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_end));
+	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_begin));
 }
 
 //--------------------------------------------------
 ofBuffer::RLine ofBuffer::Lines::crbegin() const {
-	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_end));
+	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_begin));
 }
 
 //--------------------------------------------------
 ofBuffer::RLine ofBuffer::Lines::rend() const {
-	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_end));
+	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_begin));
 }
 
 //--------------------------------------------------
 ofBuffer::RLine ofBuffer::Lines::crend() const {
-	return RLine(std::make_reverse_iterator(_end), std::make_reverse_iterator(_end));
+	return RLine(std::make_reverse_iterator(_begin), std::make_reverse_iterator(_begin));
 }
 
 //--------------------------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -268,24 +268,24 @@ vector<char>::const_reverse_iterator ofBuffer::rend() const{
 }
 
 //--------------------------------------------------
-ofBuffer::Line::Line(vector<char>::const_iterator _begin, vector<char>::const_iterator _end)
-	:_current(_begin)
-	,_begin(_begin)
-	,_end(_end){
+ofBuffer::Line::Line(vector<char>::const_iterator _begin, vector<char>::const_iterator _end, bool incremented)
+	:_begin(_begin)
+	,_end(_end)
+{
 
 	if(_begin == _end){
 		line =  "";
 		return;
 	}
 
+	if(incremented) {
+		_begin += 1;
+	}
 	_current = std::find(_begin, _end, '\n');
 	if(_current - 1 >= _begin && *(_current - 1) == '\r'){
 		line = string(_begin, _current - 1);
 	}else{
 		line = string(_begin, _current);
-	}
-	if(_current != _end){
-		_current+=1;
 	}
 }
 
@@ -306,7 +306,7 @@ const std::string & ofBuffer::Line::asString() const{
 
 //--------------------------------------------------
 ofBuffer::Line & ofBuffer::Line::operator++(){
-	*this = Line(_current,_end);
+	*this = Line(_current, _end, true);
 	return *this;
 }
 
@@ -334,20 +334,22 @@ bool ofBuffer::Line::empty() const{
 
 
 //--------------------------------------------------
-ofBuffer::RLine::RLine(vector<char>::const_reverse_iterator _rbegin, vector<char>::const_reverse_iterator _rend)
-	:_current(_rbegin)
-	,_rbegin(_rbegin)
-	,_rend(_rend){
-
+ofBuffer::RLine::RLine(vector<char>::const_reverse_iterator _rbegin, vector<char>::const_reverse_iterator _rend, bool incremented)
+	:_rbegin(_rbegin)
+	,_rend(_rend)
+{
 	if(_rbegin == _rend){
 		line =  "";
 		return;
 	}
+	if(incremented) {
+		_rbegin += 1;
+		if(_rbegin != _rend && *_rbegin == '\r'){
+			_rbegin += 1;
+		}
+	}
 	_current = std::find(_rbegin, _rend, '\n');
 	line = string(_current.base(), _rbegin.base());
-	if(_current < _rend - 1 && *_current == '\n'){
-		_current += 1;
-	}
 }
 
 //--------------------------------------------------
@@ -367,7 +369,7 @@ const std::string & ofBuffer::RLine::asString() const{
 
 //--------------------------------------------------
 ofBuffer::RLine & ofBuffer::RLine::operator++(){
-	*this = RLine(_current,_rend);
+	*this = RLine(_current, _rend, true);
 	return *this;
 }
 

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -343,10 +343,10 @@ ofBuffer::RLine::RLine(vector<char>::const_reverse_iterator _rbegin, vector<char
 		line =  "";
 		return;
 	}
-	_current = std::find(_rbegin+1, _rend, '\n');
-	line = string(_current.base(), _rbegin.base() - 1);
-	if(_current < _rend-1 && *(_current + 1) == '\r'){
-		_current+=1;
+	_current = std::find(_rbegin, _rend, '\n');
+	line = string(_current.base(), _rbegin.base());
+	if(_current < _rend - 1 && *_current == '\n'){
+		_current += 1;
 	}
 }
 

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -151,7 +151,7 @@ public:
 		using pointer = value_type *;
 		using reference = value_type &;
 		
-		Line(std::vector<char>::const_iterator _begin, std::vector<char>::const_iterator _end);
+		Line(std::vector<char>::const_iterator _begin, std::vector<char>::const_iterator _end, bool incremented = false);
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;
@@ -182,7 +182,7 @@ public:
 		using pointer = value_type *;
 		using reference = value_type &;
 		
-		RLine(std::vector<char>::const_reverse_iterator _begin, std::vector<char>::const_reverse_iterator _end);
+		RLine(std::vector<char>::const_reverse_iterator _begin, std::vector<char>::const_reverse_iterator _end, bool incremented = false);
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -144,8 +144,13 @@ public:
 
 	/// A line of text in the buffer.
 	///
-	struct Line: public std::iterator<std::forward_iterator_tag,Line>{
-		Line(std::vector<char>::iterator _begin, std::vector<char>::iterator _end);
+	struct Line {
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = std::string;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type *;
+		using reference = value_type &;
+		
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;
@@ -169,8 +174,13 @@ public:
 
 	/// A line of text in the buffer.
 	///
-	struct RLine: public std::iterator<std::forward_iterator_tag,Line>{
-		RLine(std::vector<char>::reverse_iterator _begin, std::vector<char>::reverse_iterator _end);
+	struct RLine {
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = std::string;
+		using difference_type = std::ptrdiff_t;
+		using pointer = value_type *;
+		using reference = value_type &;
+		
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -151,6 +151,7 @@ public:
 		using pointer = value_type *;
 		using reference = value_type &;
 		
+		Line(std::vector<char>::const_iterator _begin, std::vector<char>::const_iterator _end);
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;
@@ -169,7 +170,7 @@ public:
 
 	private:
 		std::string line;
-		std::vector<char>::iterator _current, _begin, _end;
+		std::vector<char>::const_iterator _current, _begin, _end;
 	};
 
 	/// A line of text in the buffer.
@@ -181,6 +182,7 @@ public:
 		using pointer = value_type *;
 		using reference = value_type &;
 		
+		RLine(std::vector<char>::const_reverse_iterator _begin, std::vector<char>::const_reverse_iterator _end);
 		const std::string & operator*() const;
 		const std::string * operator->() const;
 		const std::string & asString() const;
@@ -199,41 +201,47 @@ public:
 
 	private:
 		std::string line;
-		std::vector<char>::reverse_iterator _current, _rbegin, _rend;
+		std::vector<char>::const_reverse_iterator _current, _rbegin, _rend;
 	};
 
 	/// A series of text lines in the buffer.
 	///
 	struct Lines{
-		Lines(std::vector<char>::iterator begin, std::vector<char>::iterator end);
+		Lines(std::vector<char>::const_iterator begin, std::vector<char>::const_iterator end);
 		
 		/// Get the first line in the buffer.
-		Line begin();
-		
-		/// Get the last line in the buffer.
-		Line end();
+		Line begin() const;
+		Line cbegin() const;
 
-		RLine rbegin();
-		RLine rend();
+		/// Get the last line in the buffer.
+		Line end() const;
+		Line cend() const;
+
+		RLine rbegin() const;
+		RLine crbegin() const;
+		RLine rend() const;
+		RLine crend() const;
 
 	private:
-		std::vector<char>::iterator _begin, _end;
+		std::vector<char>::const_iterator _begin, _end;
 	};
 
 
 	/// A series of text lines in the buffer.
 	///
 	struct RLines{
-		RLines(std::vector<char>::reverse_iterator rbegin, std::vector<char>::reverse_iterator rend);
+		RLines(std::vector<char>::const_reverse_iterator rbegin, std::vector<char>::const_reverse_iterator rend);
 
 		/// Get the first line in the buffer.
-		RLine begin();
+		RLine begin() const;
+		RLine cbegin() const;
 
 		/// Get the last line in the buffer.
-		RLine end();
+		RLine end() const;
+		RLine cend() const;
 
 	private:
-		std::vector<char>::reverse_iterator _rbegin, _rend;
+		std::vector<char>::const_reverse_iterator _rbegin, _rend;
 	};
 
 	/// Access the contents of the buffer as a series of text lines.
@@ -242,7 +250,7 @@ public:
 	/// char '\n', you can access each line individually using Line structs.
 	///
 	/// \returns buffer text lines
-	Lines getLines();
+	Lines getLines() const;
 
 	/// Access the contents of the buffer as a series of text lines in reverse
 	/// order
@@ -251,7 +259,7 @@ public:
 	/// char '\n' or '\r\n', you can access each line individually using Line structs.
 	///
 	/// \returns buffer text lines
-	RLines getReverseLines();
+	RLines getReverseLines() const;
 
 private:
 	std::vector<char> 	buffer;


### PR DESCRIPTION
* remove `std::iterator` with writing type alias directly
* implement `Lines::rbegin` and `Lines::rend` are not implemented (!!)
* add some `const` qualitifiers (and `cbegin`, `cend`, etc...)
* fix logic on RLine:
  * first line (i.e., last line in buffer) was wrong.
* fix edge case on Line/RLine: 
  * empty line was ignored when line break appears at last/first of text (e.g. `"\na\nb\n"`)
    * is this not correct?

related: #6926
