### PR TITLE
Icon simplification

### DIFF
--- a/scripts/templates/osx/Project.xcconfig
+++ b/scripts/templates/osx/Project.xcconfig
@@ -10,9 +10,9 @@ CLANG_CXX_LANGUAGE_STANDARD = c++17
 MACOSX_DEPLOYMENT_TARGET = 10.15
 
 //ICONS - NEW IN 0072 
-ICON_NAME_DEBUG = icon-debug.icns
-ICON_NAME_RELEASE = icon.icns
-ICON_FILE_PATH = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/
+ICON_NAME = icon.icns
+ICON_NAME[config=Debug] = icon-debug.icns
+ICON_FILE = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/$(ICON_NAME)
 
 //IF YOU WANT AN APP TO HAVE A CUSTOM ICON - PUT THEM IN YOUR DATA FOLDER AND CHANGE ICON_FILE_PATH to:
 //ICON_FILE_PATH = bin/data/

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -221,10 +221,6 @@ fi
 					<string>$(OF_CORE_HEADERS)</string>
 					<string>src</string>
 				</array>
-				<key>ICON</key>
-				<string>$(ICON_NAME_RELEASE)</string>
-				<key>ICON_FILE</key>
-				<string>$(ICON_FILE_PATH)$(ICON)</string>
 				<key>INFOPLIST_FILE</key>
 				<string>openFrameworks-Info.plist</string>
 				<key>INSTALL_PATH</key>
@@ -3200,10 +3196,6 @@ fi
 					<string>$(OF_CORE_HEADERS)</string>
 					<string>src</string>
 				</array>
-				<key>ICON</key>
-				<string>$(ICON_NAME_DEBUG)</string>
-				<key>ICON_FILE</key>
-				<string>$(ICON_FILE_PATH)$(ICON)</string>
 				<key>INFOPLIST_FILE</key>
 				<string>openFrameworks-Info.plist</string>
 				<key>INSTALL_PATH</key>
@@ -3251,10 +3243,6 @@ fi
 					<string>$(OF_CORE_HEADERS)</string>
 					<string>src</string>
 				</array>
-				<key>ICON</key>
-				<string>$(ICON_NAME_RELEASE)</string>
-				<key>ICON_FILE</key>
-				<string>$(ICON_FILE_PATH)$(ICON)</string>
 				<key>INFOPLIST_FILE</key>
 				<string>openFrameworks-Info.plist</string>
 				<key>INSTALL_PATH</key>

--- a/scripts/templates/osx/openFrameworks-Info.plist
+++ b/scripts/templates/osx/openFrameworks-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>CFBundleIconFile</key>
-	<string>${ICON}</string>
+	<string>$(ICON_NAME)</string>
 	<key>NSCameraUsageDescription</key>
 	<string>This app needs to access the camera</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
this PR simplificates the app icon. all the logic is removed from pbxproj except the rsync script
and everything is now concentrated inside the readable .xcconfig
the debug icon uses the xcconfig conditional [config=Debug]