### PR TITLE
Make - missing a return a hard error now

### DIFF
--- a/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
+++ b/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
@@ -90,6 +90,8 @@ PLATFORM_CFLAGS += -Wall
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
 PLATFORM_CFLAGS += -fexceptions
 
+PLATFORM_CFLAGS += -Werror=return-type
+
 ifeq ($(shell xcode-select -print-path 2> /dev/null; echo $$?),0)
 	MAC_OS_XCODE_ROOT=$(shell xcode-select -print-path)
 


### PR DESCRIPTION
 Change template to make missing a return a hard error instead of allowing functions not return anything.