### PR TITLE
XCode Boost commented out by default with c++17

### DIFF
--- a/scripts/templates/osx/Project.xcconfig
+++ b/scripts/templates/osx/Project.xcconfig
@@ -9,6 +9,13 @@ OF_PATH = ../../..
 CLANG_CXX_LANGUAGE_STANDARD = c++17
 MACOSX_DEPLOYMENT_TARGET = 10.15
 
+// BOOST - UNCOMMENT BELOW TO ENABLE BOOST
+//HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
+//LIB_BOOST_SYSTEM = "$(OF_PATH)/libs/boost/lib/osx/boost_system.a"
+//LIB_BOOST_FS = "$(OF_PATH)/libs/boost/lib/osx/boost_filesystem.a"
+//OF_CORE_LIBS = $(inherited) $(LIB_BOOST_FS) $(LIB_BOOST_SYSTEM)
+//OF_CORE_HEADERS = $(inherited) $(HEADER_BOOST)
+
 //ICONS - NEW IN 0072 
 ICON_NAME = icon.icns
 ICON_NAME[config=Debug] = icon-debug.icns


### PR DESCRIPTION
I've removed Boost entries from CoreOF and added them commented out in Project.xcconfig