### PR TITLE
ofVideoPlayer isPaused fix for macOS

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -285,10 +285,7 @@ void ofAVFoundationPlayer::stop() {
         return;
     }
 
-	// FIXME: videoPlayer stop
 	[videoPlayer stop];
-//    [videoPlayer pause];
-//    [videoPlayer setPosition:0];
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -285,8 +285,10 @@ void ofAVFoundationPlayer::stop() {
         return;
     }
 
-    [videoPlayer pause];
-    [videoPlayer setPosition:0];
+	// FIXME: videoPlayer stop
+	[videoPlayer stop];
+//    [videoPlayer pause];
+//    [videoPlayer setPosition:0];
 }
 
 //--------------------------------------------------------------
@@ -564,7 +566,7 @@ bool ofAVFoundationPlayer::isPaused() const {
         return false;
     }
 
-    return ![videoPlayer isPlaying];
+	return [videoPlayer isPaused];
 }
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.h
@@ -72,7 +72,8 @@ typedef enum _playerLoopType{
 	BOOL bStream;
 	int frameBeforeReady;
 	float positionBeforeReady;
-	
+	BOOL bIsStopped;
+
 	NSLock* asyncLock;
 	NSCondition* deallocCond;
 }
@@ -102,6 +103,7 @@ typedef enum _playerLoopType{
 - (void)play;
 - (void)pause;
 - (void)togglePlayPause;
+- (void)stop;
 
 - (void)stepByCount:(long)frames;
 
@@ -113,6 +115,7 @@ typedef enum _playerLoopType{
 - (BOOL)isReady;
 - (BOOL)isLoaded;
 - (BOOL)isPlaying;
+- (BOOL)isPaused;
 - (BOOL)isNewFrame;
 - (BOOL)isFinished;
 

--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -108,7 +108,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	}
 	
 	[asyncLock lock];
-	
+
 	[asyncLock unlock];
 	
 	// release locks
@@ -159,6 +159,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	bIsUnloaded = NO;
 	bReady = NO;
 	bLoaded = NO;
+	bIsStopped = YES;
 	bPlayStateBeforeLoad = NO;
 	frameBeforeReady = 0;
 	positionBeforeReady = 0.F;
@@ -1114,6 +1115,8 @@ static const void *PlayerRateContext = &ItemStatusContext;
 }
 
 - (void)togglePlayPause {
+	bIsStopped = NO;
+
 	bPlaying = !bPlaying;
 	if([self isPlaying]) {
 		if([self isFinished]) {
@@ -1124,6 +1127,12 @@ static const void *PlayerRateContext = &ItemStatusContext;
 	} else {
 		[_player pause];
 	}
+}
+
+- (void)stop {
+	[self setPosition:0];
+	[self pause];
+	bIsStopped = YES;
 }
 
 - (void)stepByCount:(long)frames
@@ -1223,6 +1232,10 @@ static const void *PlayerRateContext = &ItemStatusContext;
 
 - (BOOL)isPlaying {
 	return bPlaying;
+}
+
+- (BOOL)isPaused {
+	return !bPlaying & !bIsStopped;
 }
 
 - (BOOL)isNewFrame {


### PR DESCRIPTION
now macOS follows windows model as discussed here
https://github.com/openframeworks/openFrameworks/issues/6527

basically the only change is:
after you call video.stop() 
video.isPaused() returns false instead of true
