### PR TITLE
removing unneeded .h

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1,13 +1,7 @@
 #include "ofAppGLFWWindow.h"
-#include "ofEvents.h"
 
-#include "ofBaseApp.h"
 #include "ofGLRenderer.h"
 #include "ofGLProgrammableRenderer.h"
-#include "ofAppRunner.h"
-#include "ofFileUtils.h"
-#include "ofEvents.h"
-#include "ofPixels.h"
 
 #define GLFW_INCLUDE_NONE
 #include "GLFW/glfw3.h"

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -1,6 +1,5 @@
 #include "ofAppGlutWindow.h"
 #include "ofBaseApp.h"
-//#include "ofConstants.h"
 #include "ofPixels.h"
 #include "ofGLRenderer.h"
 

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -1,6 +1,6 @@
 #include "ofAppGlutWindow.h"
 #include "ofBaseApp.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofPixels.h"
 #include "ofGLRenderer.h"
 

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -7,7 +7,7 @@
 
 #include <ofMainLoop.h>
 #include "ofWindowSettings.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofAppBaseWindow.h"
 #include "ofBaseApp.h"
 

--- a/libs/openFrameworks/app/ofMainLoop.cpp
+++ b/libs/openFrameworks/app/ofMainLoop.cpp
@@ -7,7 +7,6 @@
 
 #include <ofMainLoop.h>
 #include "ofWindowSettings.h"
-//#include "ofConstants.h"
 #include "ofAppBaseWindow.h"
 #include "ofBaseApp.h"
 

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -1,5 +1,4 @@
 #include "ofBufferObject.h"
-//#include "ofConstants.h"
 #include "ofAppRunner.h"
 #include "ofPixels.h"
 #include "ofGLUtils.h"

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -1,5 +1,5 @@
 #include "ofBufferObject.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofAppRunner.h"
 #include "ofPixels.h"
 #include "ofGLUtils.h"

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -1,5 +1,5 @@
 #include "ofMaterial.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofLight.h"
 #include "ofGLProgrammableRenderer.h"
 

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -1,5 +1,4 @@
 #include "ofMaterial.h"
-//#include "ofConstants.h"
 #include "ofLight.h"
 #include "ofGLProgrammableRenderer.h"
 

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -1,5 +1,5 @@
 #include "ofCairoRenderer.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofMesh.h"
 #include "ofImage.h"
 #include "ofTrueTypeFont.h"

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -1,5 +1,4 @@
 #include "ofCairoRenderer.h"
-//#include "ofConstants.h"
 #include "ofMesh.h"
 #include "ofImage.h"
 #include "ofTrueTypeFont.h"

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -1,5 +1,4 @@
 #include "ofImage.h"
-//#include "ofConstants.h"
 #include "ofAppRunner.h"
 #include "FreeImage.h"
 

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -1,5 +1,5 @@
 #include "ofImage.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofAppRunner.h"
 #include "FreeImage.h"
 

--- a/libs/openFrameworks/math/ofMatrix4x4.cpp
+++ b/libs/openFrameworks/math/ofMatrix4x4.cpp
@@ -3,7 +3,7 @@
 
 
 #include "ofMatrix4x4.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 #include <limits>
 #include <stdlib.h>

--- a/libs/openFrameworks/math/ofMatrix4x4.cpp
+++ b/libs/openFrameworks/math/ofMatrix4x4.cpp
@@ -3,7 +3,6 @@
 
 
 #include "ofMatrix4x4.h"
-//#include "ofConstants.h"
 
 #include <limits>
 #include <stdlib.h>

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -2,7 +2,6 @@
 
 #ifdef OF_SOUND_PLAYER_OPENAL
 
-//#include "ofConstants.h"
 #include "glm/gtc/constants.hpp"
 #include "glm/common.hpp"
 #include "ofLog.h"

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -2,7 +2,7 @@
 
 #ifdef OF_SOUND_PLAYER_OPENAL
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "glm/gtc/constants.hpp"
 #include "glm/common.hpp"
 #include "ofLog.h"

--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -1,5 +1,5 @@
 #include "ofColor.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::gray(limit() / 2, limit() / 2, limit() / 2);
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::white(limit(), limit(), limit());

--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -1,5 +1,4 @@
 #include "ofColor.h"
-//#include "ofConstants.h"
 
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::gray(limit() / 2, limit() / 2, limit() / 2);
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::white(limit(), limit(), limit());

--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -1,5 +1,5 @@
 #include "ofLog.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include <ofUtils.h>
 #include <map>
 #include <cstdarg>

--- a/libs/openFrameworks/utils/ofLog.cpp
+++ b/libs/openFrameworks/utils/ofLog.cpp
@@ -1,5 +1,4 @@
 #include "ofLog.h"
-//#include "ofConstants.h"
 #include <ofUtils.h>
 #include <map>
 #include <cstdarg>

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -5,7 +5,7 @@
  *      Author: arturo
  */
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofMatrixStack.h"
 #include "ofAppBaseWindow.h"
 #include "glm/mat4x4.hpp"

--- a/libs/openFrameworks/utils/ofMatrixStack.cpp
+++ b/libs/openFrameworks/utils/ofMatrixStack.cpp
@@ -5,7 +5,6 @@
  *      Author: arturo
  */
 
-//#include "ofConstants.h"
 #include "ofMatrixStack.h"
 #include "ofAppBaseWindow.h"
 #include "glm/mat4x4.hpp"

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -1,5 +1,5 @@
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofSystemUtils.h"
 #include "ofFileUtils.h"
 #include "ofLog.h"

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -1,5 +1,4 @@
 
-//#include "ofConstants.h"
 #include "ofSystemUtils.h"
 #include "ofFileUtils.h"
 #include "ofLog.h"

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -2,8 +2,6 @@
 #include "ofAppRunner.h"
 #include "ofUtils.h"
 
-//#include "ofConstants.h"
-
 using std::move;
 using std::set;
 using std::string;

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -2,7 +2,7 @@
 #include "ofAppRunner.h"
 #include "ofUtils.h"
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 using std::move;
 using std::set;

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -1,7 +1,6 @@
 #include "ofVideoGrabber.h"
 #include "ofUtils.h"
 #include "ofVideoBaseTypes.h"
-//#include "ofConstants.h"
 #include "ofGLUtils.h"
 #include "ofAppRunner.h"
 

--- a/libs/openFrameworks/video/ofVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofVideoGrabber.cpp
@@ -1,7 +1,7 @@
 #include "ofVideoGrabber.h"
 #include "ofUtils.h"
 #include "ofVideoBaseTypes.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofGLUtils.h"
 #include "ofAppRunner.h"
 


### PR DESCRIPTION
in this PR I've removed some more unneeded.h files and removed #include "ofConstants.h" from cpp files where it was already included in .h files.

the only exceptions left are ofFbo.cpp and ofLight.cpp (file isn't included in .h) 
it passes all tests.
what is your opinion @ofTheo ?