### PR TITLE
fix(c++17) : deprecated std::iterator inheritance

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.h
+++ b/libs/openFrameworks/graphics/ofPixels.h
@@ -458,7 +458,13 @@ public:
 
     /// \cond INTERNAL
 
-    struct ConstPixel: public std::iterator<std::forward_iterator_tag,ConstPixel>{
+    struct ConstPixel{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = ConstPixel;
+		using difference_type = std::ptrdiff_t;
+		using pointer = ConstPixel*;
+		using reference = ConstPixel&;
+
         ConstPixel(const PixelType * pixel, size_t bytesPerPixel, ofPixelFormat pixelFormat);
         const ConstPixel& operator*() const;
         const ConstPixel* operator->() const;
@@ -480,7 +486,13 @@ public:
         ofPixelFormat pixelFormat;
     };
 
-	struct Pixel: public std::iterator<std::forward_iterator_tag,Pixel>{
+	struct Pixel{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Pixel;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Pixel*;
+		using reference = Pixel&;
+
 		Pixel(PixelType * pixel, size_t bytesPerPixel, ofPixelFormat pixelFormat);
         const Pixel& operator*() const;
         const Pixel* operator->() const;
@@ -519,7 +531,13 @@ public:
 		ofPixelFormat pixelFormat;
 	};
 
-	struct Line: public std::iterator<std::forward_iterator_tag,Line>{
+	struct Line{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Line;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Line*;
+		using reference = Line&;
+
 		Line(PixelType * _begin, size_t stride, size_t componentsPerPixel, size_t lineNum, ofPixelFormat pixelFormat);
         const Line& operator*() const;
         const Line* operator->() const;
@@ -583,7 +601,13 @@ public:
 		ofPixelFormat pixelFormat;
 	};
 
-	struct ConstLine: public std::iterator<std::forward_iterator_tag,Line>{
+	struct ConstLine{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Line;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Line*;
+		using reference = Line&;
+
 		ConstLine(const PixelType * _begin, size_t stride, size_t componentsPerPixel, size_t lineNum, ofPixelFormat pixelFormat);
 		const ConstLine& operator*() const;
 		const ConstLine* operator->() const;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -144,7 +144,12 @@ public:
 
 	/// A line of text in the buffer.
 	///
-	struct Line: public std::iterator<std::forward_iterator_tag,Line>{
+	struct Line{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Line;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Line*;
+		using reference = Line&;
 		Line(std::vector<char>::iterator _begin, std::vector<char>::iterator _end);
 		const std::string & operator*() const;
 		const std::string * operator->() const;
@@ -169,7 +174,13 @@ public:
 
 	/// A line of text in the buffer.
 	///
-	struct RLine: public std::iterator<std::forward_iterator_tag,Line>{
+	struct RLine{
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = Line;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Line*;
+		using reference = Line&;
+
 		RLine(std::vector<char>::reverse_iterator _begin, std::vector<char>::reverse_iterator _end);
 		const std::string & operator*() const;
 		const std::string * operator->() const;


### PR DESCRIPTION
fix #6977

as suggested in https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

It also compiles in c++11 (tested only with mingw64)