### PR TITLE
ofUtils - pragma to  ignore warning

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#pragma clang diagnostic ignored "-Wformat-security"
+
 #include "ofConstants.h"
 #if !defined(TARGET_MINGW) 
 	#include "utf8.h"
@@ -592,11 +594,16 @@ size_t ofUTF8Length(const std::string & utf8);
 /// \param format A printf-style format string.
 /// \param args A variable argument list.
 /// \returns A string representation of the argument list.
+///
 template <typename ... Args>
+//__attribute__((__format__ (__printf__, 2, 0)))
 std::string ofVAArgsToString(const char * format, Args&& ... args){
 	char buf[256];
 	size_t n = std::snprintf(buf, sizeof(buf), format, std::forward<Args>(args)...);
 	
+//	std::string str = format;
+//	size_t n = std::snprintf(buf, sizeof(buf), str, std::forward<Args>(args)...);
+
 	// Static buffer large enough?
 	if (n < sizeof(buf)) {
 		return{ buf, n };


### PR DESCRIPTION
compiler warns at this line the string format should be literal
```c++
	size_t n = std::snprintf(buf, sizeof(buf), format, std::forward<Args>(args)...);
```
but it is not fixable because we are taking format variable from some parameter anyway.
https://stackoverflow.com/a/32362969/9216273

So my suggestion is just adding a pragma to silence this specific warning on this file

