### PR TITLE
Update config.emscripten.default.mk

### DIFF
--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -81,6 +81,10 @@ else
 	PLATFORM_EMSCRIPTEN_TOTAL_MEMORY=134217728
 endif
 
+# needed to force emcc linker not to make an execuatable
+CUR_CC = $(CC)
+CC := $(CUR_CC) -r
+
 ifdef USE_CCACHE
 	ifeq ($(findstring ccache, $(CC)),)
 		ORIGINAL_CC = $(CC)


### PR DESCRIPTION
Bring in changes from emscripten docker to HEAD. 
PR in question #6665
This forces emcc linker not to create executable - compatibility until emsdk 2.0.6