### PR TITLE
WIP: Fixes for gstreamer 1.20 broken video playback. closes #6871

### DIFF
--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -263,28 +263,6 @@ bool ofGstUtils::startPipeline(){
 
 	gst_object_unref(bus);
 
-	if(isAppSink){
-		ofLogVerbose("ofGstUtils") << "startPipeline(): attaching callbacks";
-		// set the appsink to not emit signals, we are using callbacks instead
-		// and frameByFrame to get buffers by polling instead of callback
-		g_object_set (G_OBJECT (gstSink), "emit-signals", FALSE, "sync", !bFrameByFrame, (void*)NULL);
-		// gst_app_sink_set_drop(GST_APP_SINK(gstSink),1);
-		// gst_app_sink_set_max_buffers(GST_APP_SINK(gstSink),2);
-
-		if(!bFrameByFrame){
-			GstAppSinkCallbacks gstCallbacks;
-			gstCallbacks.eos = &on_eos_from_source;
-			gstCallbacks.new_preroll = &on_new_preroll_from_source;
-#if GST_VERSION_MAJOR==0
-			gstCallbacks.new_buffer = &on_new_buffer_from_source;
-#else
-			gstCallbacks.new_sample = &on_new_buffer_from_source;
-#endif
-
-			gst_app_sink_set_callbacks(GST_APP_SINK(gstSink), &gstCallbacks, this, NULL);
-		}
-	}
-
 	// pause the pipeline
 	//GstState targetState;
 	GstState state;
@@ -316,6 +294,27 @@ bool ofGstUtils::startPipeline(){
 			ofLogVerbose() << "Pipeline is PREROLLED";
 			break;
     }
+    
+    if(isAppSink){
+		ofLogVerbose("ofGstUtils") << "startPipeline(): attaching callbacks";
+		// set the appsink to not emit signals, we are using callbacks instead
+		// and frameByFrame to get buffers by polling instead of callback
+		g_object_set (G_OBJECT (gstSink), "emit-signals", FALSE, "sync", !bFrameByFrame, (void*)NULL);
+		// gst_app_sink_set_drop(GST_APP_SINK(gstSink),1);
+		// gst_app_sink_set_max_buffers(GST_APP_SINK(gstSink),2);
+
+		if(!bFrameByFrame){
+			GstAppSinkCallbacks gstCallbacks;
+			gstCallbacks.eos = &on_eos_from_source;
+			gstCallbacks.new_preroll = &on_new_preroll_from_source;
+#if GST_VERSION_MAJOR==0
+			gstCallbacks.new_buffer = &on_new_buffer_from_source;
+#else
+			gstCallbacks.new_sample = &on_new_buffer_from_source;
+#endif
+			gst_app_sink_set_callbacks(GST_APP_SINK(gstSink), &gstCallbacks, this, NULL);
+		}
+	}
 
 	// wait for paused state to query the duration
 	if(!isStream){

--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -331,8 +331,6 @@ bool ofGstUtils::startPipeline(){
         gst_app_sink_set_drop (GST_APP_SINK(gstSink),true);
 	}
  
-    //gst_debug_bin_to_dot_file(GST_BIN(gstPipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeine-120");
-
 	// wait for paused state to query the duration
 	if(!isStream){
 		bPlaying = true;

--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -275,10 +275,6 @@ bool ofGstUtils::startPipeline(){
 		case GST_STATE_CHANGE_NO_PREROLL:
 			ofLogVerbose() << "Pipeline is live and does not need PREROLL waiting PLAY";
 			gst_element_set_state(GST_ELEMENT(gstPipeline), GST_STATE_PLAYING);
-			if(isAppSink){
-				gst_app_sink_set_max_buffers(GST_APP_SINK(gstSink),1);
-				gst_app_sink_set_drop (GST_APP_SINK(gstSink),true);
-			}
 			break;
 		case GST_STATE_CHANGE_ASYNC:
 			ofLogVerbose() << "Pipeline is PREROLLING";
@@ -297,24 +293,45 @@ bool ofGstUtils::startPipeline(){
     
     if(isAppSink){
 		ofLogVerbose("ofGstUtils") << "startPipeline(): attaching callbacks";
-		// set the appsink to not emit signals, we are using callbacks instead
-		// and frameByFrame to get buffers by polling instead of callback
-		g_object_set (G_OBJECT (gstSink), "emit-signals", FALSE, "sync", !bFrameByFrame, (void*)NULL);
-		// gst_app_sink_set_drop(GST_APP_SINK(gstSink),1);
-		// gst_app_sink_set_max_buffers(GST_APP_SINK(gstSink),2);
 
-		if(!bFrameByFrame){
-			GstAppSinkCallbacks gstCallbacks;
-			gstCallbacks.eos = &on_eos_from_source;
-			gstCallbacks.new_preroll = &on_new_preroll_from_source;
+        bool bSignals = false;
+        
 #if GST_VERSION_MAJOR==0
-			gstCallbacks.new_buffer = &on_new_buffer_from_source;
+
+        GstAppSinkCallbacks gstCallbacks;
+        gstCallbacks.eos = &on_eos_from_source;
+        gstCallbacks.new_preroll = &on_new_preroll_from_source;
+        gstCallbacks.new_buffer = &on_new_buffer_from_source;
+        gst_app_sink_set_callbacks(GST_APP_SINK(gstSink), &gstCallbacks, this, NULL);
+        
+#elseif GST_VERSION_MINOR <= 18
+
+        GstAppSinkCallbacks gstCallbacks;
+        gstCallbacks.eos = &on_eos_from_source;
+        gstCallbacks.new_preroll = &on_new_preroll_from_source;
+        gstCallbacks.new_sample = &on_new_buffer_from_source;
+        gst_app_sink_set_callbacks(GST_APP_SINK(gstSink), &gstCallbacks, this, NULL);
+        
 #else
-			gstCallbacks.new_sample = &on_new_buffer_from_source;
+
+        //GStreamer 1.20 onwards crashes with the callback approach above.
+        //Using signals makes it work! This might be a GStreamer bug - but we'll do this for now
+        g_signal_connect(GST_APP_SINK(gstSink), "eos", G_CALLBACK(on_eos_from_source), this);
+        g_signal_connect(GST_APP_SINK(gstSink), "new-sample", G_CALLBACK(on_new_buffer_from_source), this);
+        g_signal_connect(GST_APP_SINK(gstSink), "new-preroll", G_CALLBACK(on_new_preroll_from_source), this);
+        
+        bSignals = true;
 #endif
-			gst_app_sink_set_callbacks(GST_APP_SINK(gstSink), &gstCallbacks, this, NULL);
-		}
+
+        // set the appsink to not emit signals, we are using callbacks instead
+        // and frameByFrame to get buffers by polling instead of callback
+        g_object_set (G_OBJECT (gstSink), "emit-signals", bSignals, "sync", !bFrameByFrame, (void*)NULL);
+
+        gst_app_sink_set_max_buffers(GST_APP_SINK(gstSink),3);
+        gst_app_sink_set_drop (GST_APP_SINK(gstSink),true);
 	}
+ 
+    //gst_debug_bin_to_dot_file(GST_BIN(gstPipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeine-120");
 
 	// wait for paused state to query the duration
 	if(!isStream){

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -115,14 +115,8 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 	#if GST_VERSION_MAJOR==0
 		GstElement * gstPipeline = gst_element_factory_make("playbin2","player");
 	#else
-		//A bug (we think) with GStreamer 1.20.0 - 1.20.2 means we need a different playbin
-		#if GST_VERSION_MAJOR==1 && GST_VERSION_MINOR==2 && GST_VERSION_MICRO <= 2
-			GstElement * gstPipeline = gst_element_factory_make("playbin3","player");
-            ofLogVerbose("ofGstVideoPlayer::createPipeline") << " using experimental playbin3 - upgrade to GSteamer 1.20.3 or newer. 
-		#else
-			GstElement * gstPipeline = gst_element_factory_make("playbin","player");
-		#endif
-	#endif
+        GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+    #endif
 	g_object_ref_sink(gstPipeline);
 	g_object_set(G_OBJECT(gstPipeline), "uri", name.c_str(), (void*)NULL);
 

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -115,7 +115,13 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 	#if GST_VERSION_MAJOR==0
 		GstElement * gstPipeline = gst_element_factory_make("playbin2","player");
 	#else
-		GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+        #if GST_VERSION_MAJOR==1 && GST_VERSION_MINOR>18
+            //Gsteamer 1.20 and newer has some issues with signals / queues on close with playbin - fixed in playbin3
+            //At some point playbin3 will become playbin and we can go back to using that one
+            GstElement * gstPipeline = gst_element_factory_make("playbin3","player");
+        #else
+            GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+        #endif
 	#endif
 	g_object_ref_sink(gstPipeline);
 	g_object_set(G_OBJECT(gstPipeline), "uri", name.c_str(), (void*)NULL);

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -110,12 +110,19 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 											"format", G_TYPE_STRING, format.c_str(),
 											NULL);
 	}
+    
 #endif
 
 	#if GST_VERSION_MAJOR==0
 		GstElement * gstPipeline = gst_element_factory_make("playbin2","player");
 	#else
-        GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+        #if GST_VERSION_MAJOR==1 && GST_VERSION_MINOR > 18
+            //TODO: Fedora 35 onwards has issues with playbin - so using playbin3
+            //TODO: Check future GStreamer versions and potentially return to "playbin", or use a different approach to create the pipeline.
+            GstElement * gstPipeline = gst_element_factory_make("playbin3","player");
+        #else
+            GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+        #endif
     #endif
 	g_object_ref_sink(gstPipeline);
 	g_object_set(G_OBJECT(gstPipeline), "uri", name.c_str(), (void*)NULL);

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -115,7 +115,13 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 	#if GST_VERSION_MAJOR==0
 		GstElement * gstPipeline = gst_element_factory_make("playbin2","player");
 	#else
-		GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+		//A bug (we think) with GStreamer 1.20.0 - 1.20.2 means we need a different playbin
+		#if GST_VERSION_MAJOR==1 && GST_VERSION_MINOR==2 && GST_VERSION_MICRO <= 2
+			GstElement * gstPipeline = gst_element_factory_make("playbin3","player");
+            ofLogVerbose("ofGstVideoPlayer::createPipeline") << " using experimental playbin3 - upgrade to GSteamer 1.20.3 or newer. 
+		#else
+			GstElement * gstPipeline = gst_element_factory_make("playbin","player");
+		#endif
 	#endif
 	g_object_ref_sink(gstPipeline);
 	g_object_set(G_OBJECT(gstPipeline), "uri", name.c_str(), (void*)NULL);

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -115,13 +115,7 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 	#if GST_VERSION_MAJOR==0
 		GstElement * gstPipeline = gst_element_factory_make("playbin2","player");
 	#else
-        #if GST_VERSION_MAJOR==1 && GST_VERSION_MINOR>18
-            //Gsteamer 1.20 and newer has some issues with signals / queues on close with playbin - fixed in playbin3
-            //At some point playbin3 will become playbin and we can go back to using that one
-            GstElement * gstPipeline = gst_element_factory_make("playbin3","player");
-        #else
-            GstElement * gstPipeline = gst_element_factory_make("playbin","player");
-        #endif
+		GstElement * gstPipeline = gst_element_factory_make("playbin","player");
 	#endif
 	g_object_ref_sink(gstPipeline);
 	g_object_set(G_OBJECT(gstPipeline), "uri", name.c_str(), (void*)NULL);


### PR DESCRIPTION
Fixes broken video playback with GStreamer 1.20 - partially closes #6871 
Huge thanks to Nicholas Lavella ( [from the forums](https://forum.openframeworks.cc/t/ofxgstreamer-on-m1-mac/40257/14?u=theo) ) for helping narrow it down to the callback. 

Needs testing on Linux and older Gstreamer versions ( though the changes should be backwards compatible ). 