### PR TITLE
No ARC enforcing

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -188,7 +188,7 @@ enum ofTargetPlatform{
 	#endif
 
 	#if defined(__OBJC__) && !__has_feature(objc_arc)
-// 		#error "Please enable ARC (Automatic Reference Counting) at the project level"
+		#warning "Please enable ARC (Automatic Reference Counting) at the project level"
 	#endif
 #endif
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -188,7 +188,7 @@ enum ofTargetPlatform{
 	#endif
 
 	#if defined(__OBJC__) && !__has_feature(objc_arc)
-		#error "Please enable ARC (Automatic Reference Counting) at the project level"
+// 		#error "Please enable ARC (Automatic Reference Counting) at the project level"
 	#endif
 #endif
 


### PR DESCRIPTION
this PR is meant to allow using non ARC projects so OF is compatible with addons like ofxSyphon and others.
Related: https://github.com/openframeworks/openFrameworks/pull/6889#issuecomment-1195667266


