### PR TITLE
fix ofTrueTypeFont::stringWidth

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -231,7 +231,7 @@ static ofPath makeContoursForCharacter(FT_Face face){
 
 #ifdef TARGET_OSX
 //------------------------------------------------------------------
-static std::string osxFontPathByName(const std::string& fontname){
+static string osxFontPathByName(const string& fontname){
 	CFStringRef targetName = CFStringCreateWithCString(nullptr, fontname.c_str(), kCFStringEncodingUTF8);
 	CTFontDescriptorRef targetDescriptor = CTFontDescriptorCreateWithNameAndSize(targetName, 0.0);
 	CFURLRef targetURL = (CFURLRef) CTFontDescriptorCopyAttribute(targetDescriptor, kCTFontURLAttribute);
@@ -240,7 +240,7 @@ static std::string osxFontPathByName(const std::string& fontname){
 	if(targetURL) {
 		UInt8 buffer[PATH_MAX];
 		CFURLGetFileSystemRepresentation(targetURL, true, buffer, PATH_MAX);
-		fontPath = std::string((char *)buffer);
+		fontPath = string((char *)buffer);
 		CFRelease(targetURL);
 	}
 
@@ -254,7 +254,7 @@ static std::string osxFontPathByName(const std::string& fontname){
 #ifdef TARGET_WIN32
 #include <map>
 // font font face -> file name name mapping
-static std::map<std::string, std::string> fonts_table;
+static std::map<string, string> fonts_table;
 // read font linking information from registry, and store in std::map
 //------------------------------------------------------------------
 void initWindows(){
@@ -299,7 +299,7 @@ void initWindows(){
 	char fontsPath[2048];
 	SHGetKnownFolderIDList(FOLDERID_Fonts, 0, nullptr, &ppidl);
 	SHGetPathFromIDList(ppidl,&fontsPath);*/
-	std::string fontsDir = getenv ("windir");
+	string fontsDir = getenv ("windir");
 	fontsDir += "\\Fonts\\";
 	for (DWORD i = 0; i < value_count; ++i)
 	{
@@ -314,8 +314,8 @@ void initWindows(){
 
 			wcstombs(value_name_char,value_name,2048);
 			wcstombs(value_data_char,reinterpret_cast<wchar_t *>(value_data),2048);
-			std::string curr_face = value_name_char;
-			std::string font_file = value_data_char;
+			string curr_face = value_name_char;
+			string font_file = value_data_char;
 			curr_face = curr_face.substr(0, curr_face.find('(') - 1);
 			fonts_table[curr_face] = fontsDir + font_file;
 	}
@@ -327,11 +327,11 @@ void initWindows(){
 }
 
 
-static std::string winFontPathByName(const std::string& fontname ){
+static string winFontPathByName(const string& fontname ){
 	if(fonts_table.find(fontname)!=fonts_table.end()){
 		return fonts_table[fontname];
 	}
-	for(std::map<std::string,std::string>::iterator it = fonts_table.begin(); it!=fonts_table.end(); it++){
+	for(std::map<string,string>::iterator it = fonts_table.begin(); it!=fonts_table.end(); it++){
 		if(ofIsStringInString(ofToLower(it->first),ofToLower(fontname))) return it->second;
 	}
 	return "";
@@ -340,8 +340,8 @@ static std::string winFontPathByName(const std::string& fontname ){
 
 #ifdef TARGET_LINUX
 //------------------------------------------------------------------
-static std::string linuxFontPathByName(const std::string& fontname){
-	std::string filename;
+static string linuxFontPathByName(const string& fontname){
+	string filename;
 	FcPattern * pattern = FcNameParse((const FcChar8*)fontname.c_str());
 	FcBool ret = FcConfigSubstitute(0,pattern,FcMatchPattern);
 	if(!ret){
@@ -382,7 +382,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 	int fontID = index;
 	if(!fontFile.exists()){
 #ifdef TARGET_LINUX
-        filename = linuxFontPathByName(fontname.string());
+		filename = linuxFontPathByName(fontname.string());
 #elif defined(TARGET_OSX)
 		if(fontname==OF_TTF_SANS){
 			fontname = "Helvetica Neue";
@@ -396,7 +396,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 		}else if(fontname==OF_TTF_MONO){
 			fontname = "Menlo Regular";
 		}
-        filename = osxFontPathByName(fontname.string());
+		filename = osxFontPathByName(fontname.string());
 #elif defined(TARGET_WIN32)
 		if(fontname==OF_TTF_SANS){
 			fontname = "Arial";
@@ -405,7 +405,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 		}else if(fontname==OF_TTF_MONO){
 			fontname = "Courier New";
 		}
-        filename = winFontPathByName(fontname.string());
+		filename = winFontPathByName(fontname.string());
 #endif
 		if(filename == "" ){
 			ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't find font \"" << fontname << "\"";
@@ -414,7 +414,7 @@ static bool loadFontFace(const std::filesystem::path& _fontname, FT_Face & face,
 		ofLogVerbose("ofTrueTypeFont") << "loadFontFace(): \"" << fontname << "\" not a file in data loading system font from \"" << filename << "\"";
 	}
 	FT_Error err;
-    err = FT_New_Face( library, filename.string().c_str(), fontID, &face );
+	err = FT_New_Face( library, filename.string().c_str(), fontID, &face );
 	if (err) {
 		// simple error table in lieu of full table (see fterrors.h)
 		string errorString = "unknown freetype";
@@ -729,7 +729,7 @@ bool ofTrueTypeFont::load(const ofTrueTypeFontSettings & _settings){
 
 	//--------------- load the library and typeface
 	FT_Face loadFace;
-    if(!loadFontFace(settings.fontName, loadFace, settings.fontName, settings.index)){
+	if(!loadFontFace(settings.fontName, loadFace, settings.fontName, settings.index)){
 		return false;
 	}
 	face = std::shared_ptr<struct FT_FaceRec_>(loadFace,FT_Done_Face);
@@ -781,7 +781,7 @@ bool ofTrueTypeFont::load(const ofTrueTypeFontSettings & _settings){
 
 			if(settings.contours){
 				if(printVectorInfo){
-					std::string str;
+					string str;
 					ofUTF8Append(str,g);
 					ofLogNotice("ofTrueTypeFont") <<  "character " << str;
 				}
@@ -1056,7 +1056,7 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 	float directionX = settings.direction == OF_TTF_LEFT_TO_RIGHT?1:-1;
 
 	uint32_t prevC = 0;
-    for(auto c: ofUTF8Iterator(str)){
+	for(auto c: ofUTF8Iterator(str)){
 		try{
 			if (c == '\n') {
 				pos.y += lineHeight*newLineDirection;
@@ -1071,11 +1071,11 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 					f(c, pos);
 				}
 				prevC = c;
-            }else if(c == ' '){
-                pos.x += getGlyphProperties(' ').advance * spaceSize * directionX;
-                f(c, pos);
-                prevC = c;
-            }else if(isValidGlyph(c)) {
+			}else if(c == ' '){
+				pos.x += getGlyphProperties(' ').advance * spaceSize * directionX;
+				f(c, pos);
+				prevC = c;
+			}else if(isValidGlyph(c)) {
 				const auto & props = getGlyphProperties(c);
 				if(prevC>0){
 					if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
@@ -1091,14 +1091,14 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 				}else{
 					pos.x += props.advance  * directionX;
 					pos.x += getGlyphProperties(' ').advance * (letterSpacing - 1.f) * directionX;
-				    f(c,pos);
+					f(c,pos);
 				}
 				prevC = c;
-            }
-        }catch(...){
+			}
+		}catch(...){
 			break;
 		}
-    }
+	}
 }
 
 //-----------------------------------------------------------
@@ -1160,7 +1160,7 @@ void ofTrueTypeFont::drawCharAsShape(uint32_t c, float x, float y, bool vFlipped
 }
 
 //-----------------------------------------------------------
-float ofTrueTypeFont::stringWidth(const std::string& c) const{
+float ofTrueTypeFont::stringWidth(const string& c) const{
 //	return getStringBoundingBox(c, 0,0).width;
 	int w = 0;
 	iterateString( c, 0, 0, false, [&]( uint32_t c, glm::vec2 pos ){
@@ -1174,7 +1174,7 @@ float ofTrueTypeFont::stringWidth(const std::string& c) const{
 }
 
 //-----------------------------------------------------------
-ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, float y, bool vflip) const{
+ofRectangle ofTrueTypeFont::getStringBoundingBox(const string& c, float x, float y, bool vflip) const{
 
 	if ( c.empty() ){
 		return ofRectangle( x, y, 0.f, 0.f);
@@ -1216,20 +1216,20 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 }
 
 //-----------------------------------------------------------
-float ofTrueTypeFont::stringHeight(const std::string& c) const{
+float ofTrueTypeFont::stringHeight(const string& c) const{
 	ofRectangle rect = getStringBoundingBox(c, 0,0);
 	return rect.height;
 }
 
 //-----------------------------------------------------------
-void ofTrueTypeFont::createStringMesh(const std::string& str, float x, float y, bool vflip) const{
+void ofTrueTypeFont::createStringMesh(const string& str, float x, float y, bool vflip) const{
 	iterateString(str,x,y,vflip,[&](uint32_t c, glm::vec2 pos){
 		drawChar(c, pos.x, pos.y, vflip);
 	});
 }
 
 //-----------------------------------------------------------
-const ofMesh & ofTrueTypeFont::getStringMesh(const std::string& c, float x, float y, bool vFlipped) const{
+const ofMesh & ofTrueTypeFont::getStringMesh(const string& c, float x, float y, bool vFlipped) const{
 	stringQuads.clear();
 	createStringMesh(c,x,y,vFlipped);
 	return stringQuads;
@@ -1241,7 +1241,7 @@ const ofTexture & ofTrueTypeFont::getFontTexture() const{
 }
 
 //-----------------------------------------------------------
-glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bool vflip) const{
+glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const string & str, bool vflip) const{
 	if(!str.empty()){
 		try{
 			auto c = *ofUTF8Iterator(str).begin();
@@ -1257,9 +1257,9 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 					try{
 						if (c != '\n') {
 							auto g = loadGlyph(c);
-                            if(c == '\t')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-                            else if(c == ' ')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize;
-                            else if(isValidGlyph(c))lineWidth += g.props.advance + getGlyphProperties(' ').advance * (letterSpacing - 1.f);
+							if(c == '\t')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+							else if(c == ' ')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize;
+							else if(isValidGlyph(c))lineWidth += g.props.advance + getGlyphProperties(' ').advance * (letterSpacing - 1.f);
 							width = max(width, lineWidth);
 						}else{
 							lineWidth = 0;
@@ -1281,7 +1281,7 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 }
 
 //-----------------------------------------------------------
-ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) const{
+ofTexture ofTrueTypeFont::getStringTexture(const string& str, bool vflip) const{
 	vector<glyph> glyphs;
 	vector<glm::vec2> glyphPositions;
 	float height = 0;
@@ -1289,28 +1289,28 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
 	float lineWidth = 0;
 	iterateString(str, 0, 0, vflip, [&](uint32_t c, ofVec2f pos){
 		try{
-            if (c != '\n') {
+			if (c != '\n') {
 				auto g = loadGlyph(c);
-                
-                if (c == '\t'){
-                    auto temp = loadGlyph(' ');
-                    glyphs.push_back(temp);
-                }else{
-                    glyphs.push_back(g);
-                }
-                 
+				
+				if (c == '\t'){
+					auto temp = loadGlyph(' ');
+					glyphs.push_back(temp);
+				}else{
+					glyphs.push_back(g);
+				}
+				 
 				int x = pos.x + g.props.xmin;
-                int y = pos.y;
+				int y = pos.y;
 				glyphPositions.emplace_back(x, y);
-                
-                if(c == '\t')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-                else if(c == ' ')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize;
-                else if(isValidGlyph(c))lineWidth += g.props.advance + getGlyphProperties(' ').advance * (letterSpacing - 1.f);
-                
-                width = max(width, lineWidth);
-                y += g.props.ymax;
+				
+				if(c == '\t')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+				else if(c == ' ')lineWidth += g.props.advance + getGlyphProperties(' ').advance * spaceSize;
+				else if(isValidGlyph(c))lineWidth += g.props.advance + getGlyphProperties(' ').advance * (letterSpacing - 1.f);
+				
+				width = max(width, lineWidth);
+				y += g.props.ymax;
 				height = max(height, y + getLineHeight());
-            }else{
+			}else{
 				lineWidth = 0;
 			}
 		}catch(...){
@@ -1340,7 +1340,7 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
 }
 
 //-----------------------------------------------------------
-void ofTrueTypeFont::drawString(const std::string &  c, float x, float y) const{
+void ofTrueTypeFont::drawString(const string &  c, float x, float y) const{
 
 	if (!bLoadedOk){
 		ofLogError("ofTrueTypeFont") << "drawString(): font not allocated";
@@ -1352,7 +1352,7 @@ void ofTrueTypeFont::drawString(const std::string &  c, float x, float y) const{
 }
 
 //-----------------------------------------------------------
-void ofTrueTypeFont::drawStringAsShapes(const std::string& str, float x, float y) const{
+void ofTrueTypeFont::drawStringAsShapes(const string& str, float x, float y) const{
 	if (!bLoadedOk){
 		ofLogError("ofTrueTypeFont") << "drawStringAsShapes(): font not allocated: line " << __LINE__ << " in " << __FILE__;
 		return;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -707,9 +707,7 @@ bool ofTrueTypeFont::load(const std::filesystem::path& filename, int fontSize, b
 	}else{
 		settings.ranges = {ofUnicode::Latin};
 	}
-	using std::cout;
-	using std::endl;
-	cout << "ofTrueTypeFont::load - simplify : " << settings.simplifyAmt << endl;
+//	std::cout << "ofTrueTypeFont::load - simplify : " << settings.simplifyAmt << std::endl;
 	return load(settings);
 }
 
@@ -1166,8 +1164,8 @@ void ofTrueTypeFont::drawCharAsShape(uint32_t c, float x, float y, bool vFlipped
 
 //-----------------------------------------------------------
 float ofTrueTypeFont::stringWidth(const std::string& c) const{
+//	return getStringBoundingBox(c, 0,0).width;
 	int w = 0;
-	// vflip is always false here
 	iterateString( c, 0, 0, false, [&]( uint32_t c, glm::vec2 pos ){
 		if ( c == '\t' ){
 			w += getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
@@ -1204,7 +1202,8 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 		if ( c == '\t' ){
             props.advance = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
 		}
-		maxX = max( maxX, pos.x + props.xmin + props.width  );
+//		maxX = max( maxX, pos.x + props.xmin + props.width  );
+		maxX = max( maxX, pos.x + props.advance );
 		minX = min( minX, pos.x );
 		if ( vflip ){
 			minY = min( minY, pos.y - ( props.ymax - props.ymin ) );

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -710,7 +710,6 @@ bool ofTrueTypeFont::load(const std::filesystem::path& filename, int fontSize, b
 	}else{
 		settings.ranges = {ofUnicode::Latin};
 	}
-//	std::cout << "ofTrueTypeFont::load - simplify : " << settings.simplifyAmt << std::endl;
 	return load(settings);
 }
 
@@ -1012,7 +1011,6 @@ void ofTrueTypeFont::drawChar(uint32_t c, float x, float y, bool vFlipped) const
 
 	ofIndexType firstIndex = stringQuads.getVertices().size();
 
-//	std::cout << glm::vec3(xmin,ymin,0.f) << std::endl;
 	stringQuads.addVertex(glm::vec3(xmin,ymin,0.f));
 	stringQuads.addVertex(glm::vec3(xmax,ymin,0.f));
 	stringQuads.addVertex(glm::vec3(xmax,ymax,0.f));
@@ -1101,7 +1099,6 @@ void ofTrueTypeFont::iterateString(const string & str, float x, float y, bool vF
 			break;
 		}
     }
-//	std::cout << pos << std::endl;
 }
 
 //-----------------------------------------------------------
@@ -1147,8 +1144,6 @@ const ofTrueTypeFont::glyphProps & ofTrueTypeFont::getGlyphProperties(uint32_t g
 
 //-----------------------------------------------------------
 void ofTrueTypeFont::drawCharAsShape(uint32_t c, float x, float y, bool vFlipped, bool filled) const{
-		std::cout << "drawCharAsShape " << x << " : " << y << std::endl;
-
 	if(vFlipped){
 		if(filled){
 			charOutlines[indexForGlyph(c)].draw(x,y);
@@ -1185,9 +1180,9 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 		return ofRectangle( x, y, 0.f, 0.f);
 	}
 
+	float minX = x;
 	float minY = y;
 	float maxY = y;
-	float minX = x;
 	// Calculate bounding box by iterating over glyph properties
 	// Meaning of props can be deduced from illustration at top of:
 	// https://www.freetype.org/freetype2/docs/tutorial/step2.html

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -639,15 +639,15 @@ ofTrueTypeFont::glyph ofTrueTypeFont::loadGlyph(uint32_t utf8) const{
 	// -------------------------
 	// info about the character:
 	aGlyph.props.glyph		= utf8;
-	aGlyph.props.height 	= face->glyph->metrics.height>>6;
-	aGlyph.props.width 		= face->glyph->metrics.width>>6;
-	aGlyph.props.bearingX	= face->glyph->metrics.horiBearingX>>6;
-	aGlyph.props.bearingY	= face->glyph->metrics.horiBearingY>>6;
+	aGlyph.props.height 	= int26p6_to_dbl(face->glyph->metrics.height);
+	aGlyph.props.width 		= int26p6_to_dbl(face->glyph->metrics.width);
+	aGlyph.props.bearingX	= int26p6_to_dbl(face->glyph->metrics.horiBearingX);
+	aGlyph.props.bearingY	= int26p6_to_dbl(face->glyph->metrics.horiBearingY);
 	aGlyph.props.xmin		= face->glyph->bitmap_left;
 	aGlyph.props.xmax		= aGlyph.props.xmin + aGlyph.props.width;
 	aGlyph.props.ymin		= -face->glyph->bitmap_top;
 	aGlyph.props.ymax		= aGlyph.props.ymin + aGlyph.props.height;
-	aGlyph.props.advance	= face->glyph->metrics.horiAdvance>>6;
+	aGlyph.props.advance	= int26p6_to_dbl(face->glyph->metrics.horiAdvance);
 	aGlyph.props.tW			= aGlyph.props.width;
 	aGlyph.props.tH			= aGlyph.props.height;
 
@@ -738,7 +738,7 @@ bool ofTrueTypeFont::load(const ofTrueTypeFontSettings & _settings){
 	int border = 1;
 
 
-	FT_Set_Char_Size( face.get(), settings.fontSize << 6, settings.fontSize << 6, settings.dpi, settings.dpi);
+	FT_Set_Char_Size( face.get(), dbl_to_int26p6(settings.fontSize), dbl_to_int26p6(settings.fontSize), settings.dpi, settings.dpi);
 	fontUnitScale = (float(settings.fontSize * settings.dpi)) / (72 * face->units_per_EM);
 	lineHeight = face->height * fontUnitScale;
 	ascenderHeight = face->ascender * fontUnitScale;
@@ -993,7 +993,7 @@ void ofTrueTypeFont::drawChar(uint32_t c, float x, float y, bool vFlipped) const
 	}
 
 
-	long xmin, ymin, xmax, ymax;
+	float xmin, ymin, xmax, ymax;
 	float t1, v1, t2, v2;
 	auto props = getGlyphProperties(c);
 	t1		= props.t1;
@@ -1001,9 +1001,9 @@ void ofTrueTypeFont::drawChar(uint32_t c, float x, float y, bool vFlipped) const
 	v2		= props.v2;
 	v1		= props.v1;
 
-	xmin		= long(props.xmin+x);
+	xmin		= props.xmin+x;
 	ymin		= props.ymin;
-	xmax		= long(props.xmax+x);
+	xmax		= props.xmax+x;
 	ymax		= props.ymax;
 
 	if(!vFlipped){
@@ -1035,13 +1035,13 @@ void ofTrueTypeFont::drawChar(uint32_t c, float x, float y, bool vFlipped) const
 }
 
 //-----------------------------------------------------------
-int ofTrueTypeFont::getKerning(uint32_t leftC, uint32_t rightC) const{
+double ofTrueTypeFont::getKerning(uint32_t leftC, uint32_t rightC) const{
 	if(FT_HAS_KERNING( face )){
 		FT_Vector kerning;
 		FT_Get_Kerning(face.get(), FT_Get_Char_Index(face.get(), leftC), FT_Get_Char_Index(face.get(), rightC), FT_KERNING_UNFITTED, &kerning);
-		return kerning.x >> 6;
+		return int26p6_to_dbl(kerning.x);
 	}else{
-		return 0;
+		return 0.0;
 	}
 }
 
@@ -1183,11 +1183,9 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 		return ofRectangle( x, y, 0.f, 0.f);
 	}
 
-	float minX = x;
 	float minY = y;
-	float maxX = x;
 	float maxY = y;
-
+	float minX = x;
 	// Calculate bounding box by iterating over glyph properties
 	// Meaning of props can be deduced from illustration at top of:
 	// https://www.freetype.org/freetype2/docs/tutorial/step2.html
@@ -1196,14 +1194,15 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 	// vertices, as this would not correctly return spacing for
 	// blank characters.
 	
+	float w = 0;
 	iterateString( c, x, y, vflip, [&]( uint32_t c, glm::vec2 pos ){
-		auto  props = getGlyphProperties( c );
-
+		auto props = getGlyphProperties( c );
 		if ( c == '\t' ){
-            props.advance = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+			w += props.advance * spaceSize * TAB_WIDTH;
+		} else {
+			w += props.advance;
 		}
-//		maxX = max( maxX, pos.x + props.xmin + props.width  );
-		maxX = max( maxX, pos.x + props.advance );
+
 		minX = min( minX, pos.x );
 		if ( vflip ){
 			minY = min( minY, pos.y - ( props.ymax - props.ymin ) );
@@ -1212,12 +1211,11 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const std::string& c, float x, 
 			minY = min( minY, pos.y - ( props.ymax) );
 			maxY = max( maxY, pos.y - ( props.ymin ) );
 		}
-	} );
+	});
 
-	float width = maxX - minX;
 	float height = maxY - minY;
 
-	return ofRectangle(minX, minY, width, height);
+	return ofRectangle(minX, minY, w, height);
 }
 
 //-----------------------------------------------------------
@@ -1289,9 +1287,9 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const std::string & str, bo
 ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) const{
 	vector<glyph> glyphs;
 	vector<glm::vec2> glyphPositions;
-	long height = 0;
-	int width = 0;
-	int lineWidth = 0;
+	float height = 0;
+	float width = 0;
+	float lineWidth = 0;
 	iterateString(str, 0, 0, vflip, [&](uint32_t c, ofVec2f pos){
 		try{
             if (c != '\n') {
@@ -1314,7 +1312,7 @@ ofTexture ofTrueTypeFont::getStringTexture(const std::string& str, bool vflip) c
                 
                 width = max(width, lineWidth);
                 y += g.props.ymax;
-				height = max(height, y + long(getLineHeight()));
+				height = max(height, y + getLineHeight());
             }else{
 				lineWidth = 0;
 			}

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -377,10 +377,10 @@ public:
     /// \returns current font direction
 	void setDirection(ofTrueTypeFontDirection direction);
 
-	float charWidth(uint32_t c) const{
+	float getCharWidth(uint32_t c) const {
 		return getGlyphProperties(c).width;
 	}
-	float charAdvance(uint32_t c) const{
+	float getCharAdvance(uint32_t c) const {
 		return getGlyphProperties(c).advance;
 	}
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -377,6 +377,13 @@ public:
     /// \returns current font direction
 	void setDirection(ofTrueTypeFontDirection direction);
 
+	float charWidth(uint32_t c) const{
+		return getGlyphProperties(c).width;
+	}
+	float charAdvance(uint32_t c) const{
+		return getGlyphProperties(c).advance;
+	}
+
 protected:
 	/// \cond INTERNAL
 	

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -387,6 +387,14 @@ public:
 protected:
 	/// \cond INTERNAL
 	
+	static inline double int26p6_to_dbl(int p) {
+		return double(p) / 64.0;
+	}
+	
+	static inline int dbl_to_int26p6(double p) {
+		return int(p * 64.0 + 0.5);
+	}
+	
 	bool bLoadedOk;
 	
 	std::vector <ofPath> charOutlines;
@@ -405,11 +413,11 @@ protected:
 	struct glyphProps{
 		std::size_t characterIndex;
 		uint32_t glyph;
-		long height;
-		long width;
-		long bearingX, bearingY;
-		long xmin, xmax, ymin, ymax;
-		long advance;
+		float height;
+		float width;
+		float bearingX, bearingY;
+		float xmin, xmax, ymin, ymax;
+		float advance;
 		float tW,tH;
 		float t1,t2,v1,v2;
 	};
@@ -424,7 +432,7 @@ protected:
 	ofTrueTypeFontSettings settings;
 	std::unordered_map<uint32_t,size_t> glyphIndexMap;
 
-	int getKerning(uint32_t leftC, uint32_t rightC) const;
+	double getKerning(uint32_t leftC, uint32_t rightC) const;
 	void drawChar(uint32_t c, float x, float y, bool vFlipped) const;
 	void drawCharAsShape(uint32_t c, float x, float y, bool vFlipped, bool filled) const;
 	void createStringMesh(const std::string & s, float x, float y, bool vFlipped) const;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -142,7 +142,7 @@ struct ofTrueTypeFontSettings{
     int                       fontSize = 0;
     bool                      antialiased = true;
     bool                      contours = false;
-    float                     simplifyAmt = 0.3f;
+    float                     simplifyAmt = 0.0f;
     int                       dpi = 0;
     int                       index = 0;
     ofTrueTypeFontDirection direction = OF_TTF_LEFT_TO_RIGHT;
@@ -201,7 +201,7 @@ public:
                   bool _bAntiAliased=true,
                   bool _bFullCharacterSet=true,
                   bool makeContours=false,
-                  float simplifyAmt=0.3f,
+                  float simplifyAmt=0.0f,
 				  int dpi=0);
 
 	OF_DEPRECATED_MSG("Use load instead",bool loadFont(std::string filename,
@@ -209,7 +209,7 @@ public:
                   bool _bAntiAliased=true,
                   bool _bFullCharacterSet=false,
                   bool makeContours=false,
-                  float simplifyAmt=0.3f,
+                  float simplifyAmt=0.0f,
 				  int dpi=0));
 	
 	bool load(const ofTrueTypeFontSettings & settings);
@@ -383,17 +383,19 @@ public:
 	float getCharAdvance(uint32_t c) const {
 		return getGlyphProperties(c).advance;
 	}
-
-protected:
-	/// \cond INTERNAL
 	
-	static inline double int26p6_to_dbl(int p) {
+	static double int26p6_to_dbl(long p) {
 		return double(p) / 64.0;
 	}
 	
 	static inline int dbl_to_int26p6(double p) {
 		return int(p * 64.0 + 0.5);
 	}
+
+protected:
+	/// \cond INTERNAL
+	
+
 	
 	bool bLoadedOk;
 	


### PR DESCRIPTION
I'm submitting this PR to start a discussion.
stringWidth actually get width of getStringBoundingBox, which uses a mixture of glyphProperties advance and xmin+width, that are not the same thing.

this PR fixes getStringBoundingBox, makes stringWidth independent of the function, so it is less overhead.

address the issue discussed here
https://forum.openframeworks.cc/t/are-monospace-fonts-really-monospace/40358/3