### PR TITLE
unreachable code

### DIFF
--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -44,10 +44,10 @@ void set_conio_terminal_mode()
 int kbhit()
 {
 	return 0;
-    struct timeval tv = { 0L, 0L };
-    fd_set fds;
-    FD_SET(0, &fds);
-    return select(1, &fds, nullptr, nullptr, &tv);
+//    struct timeval tv = { 0L, 0L };
+//    fd_set fds;
+//    FD_SET(0, &fds);
+//    return select(1, &fds, nullptr, nullptr, &tv);
 }
 
 int getch()


### PR DESCRIPTION
XCode complains here because code is unreachable. of course, it begins with return 0;
should we comment out? remove?

https://github.com/openframeworks/openFrameworks/blob/4ccc0b20a6b138dc94bc719bc308e29d518a8e67/libs/openFrameworks/app/ofAppNoWindow.cpp#L44-L51