### PR TITLE
macOs template update

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -1,87 +1,81 @@
 {
-	"classes":{
-		
-	},
-	"objectVersion":"46",
-	"archiveVersion":"1",
-	"objects":{
-		"E42963292163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofMaterial.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMaterial.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+	"classes": {},
+	"objectVersion": "54",
+	"archiveVersion": "1",
+	"objects": {
+		"E42963292163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofMaterial.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMaterial.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962ED2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppBaseWindow.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppBaseWindow.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962ED2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppBaseWindow.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppBaseWindow.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429630F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"BB4B014C10F69532006C3DED":{
-			"isa":"PBXGroup",
-			"name":"addons",
-			"children":[
-				
-			],
-			"sourceTree":"<group>"
+		"E42962F82163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppGLFWWindow.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppGLFWWindow.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F82163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppGLFWWindow.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppGLFWWindow.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963272163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofTexture.h",
+			"isa": "PBXFileReference",
+			"name": "ofTexture.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963272163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofTexture.h",
-			"isa":"PBXFileReference",
-			"name":"ofTexture.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"BB4B014C10F69532006C3DED": {
+			"isa": "PBXGroup",
+			"name": "addons",
+			"children": [],
+			"sourceTree": "<group>"
 		},
-		"E42962EB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofWindowSettings.h",
-			"isa":"PBXFileReference",
-			"name":"ofWindowSettings.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962EB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofWindowSettings.h",
+			"isa": "PBXFileReference",
+			"name": "ofWindowSettings.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofPoint.h",
-			"isa":"PBXFileReference",
-			"name":"ofPoint.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962DE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofPoint.h",
+			"isa": "PBXFileReference",
+			"name": "ofPoint.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"6948EE371B920CB800B5AC1A":{
-			"isa":"PBXGroup",
-			"name":"local_addons",
-			"children":[
-				
-			],
-			"sourceTree":"<group>"
+		"6948EE371B920CB800B5AC1A": {
+			"isa": "PBXGroup",
+			"name": "local_addons",
+			"children": [],
+			"sourceTree": "<group>"
 		},
-		"E42962F62163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppGlutWindow.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppGlutWindow.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F62163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppGlutWindow.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppGlutWindow.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963252163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl",
-			"isa":"PBXGroup",
-			"name":"gl",
-			"children":[
+		"E42963252163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl",
+			"isa": "PBXGroup",
+			"name": "gl",
+			"children": [
 				"E429632E2163EDD300A6A9E2",
 				"E42963332163EDD300A6A9E2",
 				"E429632A2163EDD300A6A9E2",
@@ -106,49 +100,54 @@
 				"E429632F2163EDD300A6A9E2",
 				"E42963262163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963182163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMathConstants.h",
-			"isa":"PBXFileReference",
-			"name":"ofMathConstants.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963182163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMathConstants.h",
+			"isa": "PBXFileReference",
+			"name": "ofMathConstants.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DC2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofColor.h",
-			"isa":"PBXFileReference",
-			"name":"ofColor.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962DC2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofColor.h",
+			"isa": "PBXFileReference",
+			"name": "ofColor.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B590A3A1756003C02F2":{
-			"buildActionMask":"2147483647",
-			"isa":"PBXFrameworksBuildPhase",
-			"files":[
-				"E4328149138ABC9F0047C5CB"
-			],
-			"runOnlyForDeploymentPostprocessing":"0"
+		"E4B69B590A3A1756003C02F2": {
+			"isa": "PBXFrameworksBuildPhase",
+			"buildActionMask": "2147483647",
+			"files": [],
+			"runOnlyForDeploymentPostprocessing": "0"
 		},
-		"E42962F42163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppNoWindow.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofAppNoWindow.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F42163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppNoWindow.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofAppNoWindow.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963162163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVec4f.h",
-			"isa":"PBXFileReference",
-			"name":"ofVec4f.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963162163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVec4f.h",
+			"isa": "PBXFileReference",
+			"name": "ofVec4f.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types",
-			"isa":"PBXGroup",
-			"name":"types",
-			"children":[
+		"E429636E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofRtAudioSoundStream.h",
+			"isa": "PBXFileReference",
+			"name": "ofRtAudioSoundStream.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42962DA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types",
+			"isa": "PBXGroup",
+			"name": "types",
+			"children": [
 				"E42962E12163EDD300A6A9E2",
 				"E42962E62163EDD300A6A9E2",
 				"E42962E42163EDD300A6A9E2",
@@ -162,278 +161,328 @@
 				"E42962E02163EDD300A6A9E2",
 				"E42962DF2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofRtAudioSoundStream.h",
-			"isa":"PBXFileReference",
-			"name":"ofRtAudioSoundStream.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F22163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofMainLoop.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMainLoop.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F22163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofMainLoop.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMainLoop.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963142163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVec2f.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVec2f.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963142163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVec2f.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVec2f.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429636C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofOpenALSoundPlayer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofOpenALSoundPlayer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofOpenALSoundPlayer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F02163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofBaseApp.h",
+			"isa": "PBXFileReference",
+			"name": "ofBaseApp.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F02163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofBaseApp.h",
-			"isa":"PBXFileReference",
-			"name":"ofBaseApp.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"191CD6FA2847E21E0085CBB6": {
+			"path": "of.entitlements",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "text.plist.entitlements",
+			"sourceTree": "<group>",
+			"fileEncoding": "4"
 		},
-		"191CD6FA2847E21E0085CBB6":{
-			"path":"of.entitlements",
-			"isa":"PBXFileReference",
-			"lastKnownFileType":"text.plist.entitlements",
-			"sourceTree":"<group>",
-			"fileEncoding":"4"
+		"E42963122163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofTimer.h",
+			"isa": "PBXFileReference",
+			"name": "ofTimer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963122163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofTimer.h",
-			"isa":"PBXFileReference",
-			"name":"ofTimer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E4B69E1F0A3A1BDC003C02F2": {
+			"path": "src/ofApp.h",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "sourcecode.c.h",
+			"name": "ofApp.h",
+			"sourceTree": "SOURCE_ROOT",
+			"fileEncoding": "4"
 		},
-		"E4B69E1F0A3A1BDC003C02F2":{
-			"path":"src\/ofApp.h",
-			"isa":"PBXFileReference",
-			"lastKnownFileType":"sourcecode.c.h",
-			"name":"ofApp.h",
-			"sourceTree":"SOURCE_ROOT",
-			"fileEncoding":"4"
+		"E429636A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofFmodSoundPlayer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofFmodSoundPlayer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofFmodSoundPlayer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofFmodSoundPlayer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963102163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofXml.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofXml.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963102163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofXml.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofXml.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963032163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofSystemUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofSystemUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963032163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofSystemUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofSystemUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E4B69E1D0A3A1BDC003C02F2": {
+			"path": "src/main.cpp",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"name": "main.cpp",
+			"sourceTree": "SOURCE_ROOT",
+			"fileEncoding": "4"
 		},
-		"E4B69E1D0A3A1BDC003C02F2":{
-			"path":"src\/main.cpp",
-			"isa":"PBXFileReference",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"name":"main.cpp",
-			"sourceTree":"SOURCE_ROOT",
-			"fileEncoding":"4"
-		},
-		"E4B69B4F0A3A1720003C02F2":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"CODE_SIGN_ENTITLEMENTS":"of.entitlements",
-				"GCC_UNROLL_LOOPS":"YES",
-				"HEADER_SEARCH_PATHS":[
+		"E4B69B4F0A3A1720003C02F2": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
+				"GCC_UNROLL_LOOPS": "YES",
+				"HEADER_SEARCH_PATHS": [
 					"$(OF_CORE_HEADERS)",
 					"src"
 				],
-				"GCC_OPTIMIZATION_LEVEL":"3",
-				"OTHER_CPLUSPLUSFLAGS":[
-					"-D__MACOSX_CORE__"
-				],
-				"COPY_PHASE_STRIP":"YES"
+				"GCC_OPTIMIZATION_LEVEL": "3",
+				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
+				"COPY_PHASE_STRIP": "YES"
 			},
-			"name":"Release"
+			"name": "Release"
 		},
-		"E42963012163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofFpsCounter.h",
-			"isa":"PBXFileReference",
-			"name":"ofFpsCounter.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963012163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofFpsCounter.h",
+			"isa": "PBXFileReference",
+			"name": "ofFpsCounter.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962D92163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofVideoBaseTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofVideoBaseTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962D92163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofVideoBaseTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofVideoBaseTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"99FA3DBC1C7456C400CFA0EE":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]":"APPSTORE=1",
-				"HEADER_SEARCH_PATHS":[
+		"99FA3DBC1C7456C400CFA0EE": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]": "APPSTORE=1",
+				"HEADER_SEARCH_PATHS": [
 					"$(OF_CORE_HEADERS)",
 					"src"
 				],
-				"FRAMEWORK_SEARCH_PATHS":[
-					"$(inherited)"
-				],
-				"COPY_PHASE_STRIP":"YES",
-				"OTHER_LDFLAGS":[
+				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
+				"COPY_PHASE_STRIP": "YES",
+				"OTHER_LDFLAGS": [
 					"$(OF_CORE_LIBS)",
 					"$(OF_CORE_FRAMEWORKS)",
 					"$(LIB_OF)"
 				],
-				"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-				"LIBRARY_SEARCH_PATHS":[
-					"$(inherited)"
-				]
+				"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+				"LIBRARY_SEARCH_PATHS": "$(inherited)"
 			},
-			"name":"AppStore"
+			"name": "AppStore"
 		},
-		"E42962BF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQuickTimeGrabber.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofQuickTimeGrabber.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQuickTimeGrabber.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofQuickTimeGrabber.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B4D0A3A1720003C02F2":{
-			"defaultConfigurationIsVisible":"0",
-			"defaultConfigurationName":"Release",
-			"isa":"XCConfigurationList",
-			"buildConfigurations":[
+		"E4B69B4D0A3A1720003C02F2": {
+			"isa": "XCConfigurationList",
+			"defaultConfigurationIsVisible": "0",
+			"defaultConfigurationName": "Release",
+			"buildConfigurations": [
 				"E4B69B4E0A3A1720003C02F2",
 				"E4B69B4F0A3A1720003C02F2",
 				"99FA3DBB1C7456C400CFA0EE"
 			]
 		},
-		"E42962D72163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationVideoPlayer.m",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationVideoPlayer.m",
-			"lastKnownFileType":"sourcecode.c.objc",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962D72163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationVideoPlayer.m",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationVideoPlayer.m",
+			"lastKnownFileType": "sourcecode.c.objc",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B5F0A3A1757003C02F2":{
-			"defaultConfigurationIsVisible":"0",
-			"defaultConfigurationName":"Release",
-			"isa":"XCConfigurationList",
-			"buildConfigurations":[
+		"E4B69B5F0A3A1757003C02F2": {
+			"isa": "XCConfigurationList",
+			"defaultConfigurationIsVisible": "0",
+			"defaultConfigurationName": "Release",
+			"buildConfigurations": [
 				"E4B69B600A3A1757003C02F2",
 				"E4B69B610A3A1757003C02F2",
 				"99FA3DBC1C7456C400CFA0EE"
 			]
 		},
-		"E42962BD2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQtUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofQtUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BD2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQtUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofQtUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962D52163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitPlayer.mm",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitPlayer.mm",
-			"lastKnownFileType":"sourcecode.cpp.objcpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962D52163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitPlayer.mm",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitPlayer.mm",
+			"lastKnownFileType": "sourcecode.cpp.objcpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963692163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofRtAudioSoundStream.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofRtAudioSoundStream.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963692163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofRtAudioSoundStream.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofRtAudioSoundStream.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962BB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofVideoPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofVideoPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofVideoPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofVideoPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962AE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofNode.h",
-			"isa":"PBXFileReference",
-			"name":"ofNode.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962AE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofNode.h",
+			"isa": "PBXFileReference",
+			"name": "ofNode.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429634F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofTessellator.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofTessellator.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429634F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofTessellator.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofTessellator.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963672163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofSoundPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963672163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofSoundPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69E200A3A1BDC003C02F2":{
-			"fileRef":"E4B69E1D0A3A1BDC003C02F2",
-			"isa":"PBXBuildFile"
+		"E4B69E200A3A1BDC003C02F2": {
+			"isa": "PBXBuildFile",
+			"fileRef": "E4B69E1D0A3A1BDC003C02F2"
 		},
-		"E429634D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofBitmapFont.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofBitmapFont.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429634D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofBitmapFont.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofBitmapFont.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962AC2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofCamera.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofCamera.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962AC2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofCamera.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofCamera.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963652163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundStream.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSoundStream.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963652163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundStream.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSoundStream.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C42163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofVideoPlayer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVideoPlayer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C42163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofVideoPlayer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVideoPlayer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963582163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/of3dGraphics.cpp",
-			"isa":"PBXFileReference",
-			"name":"of3dGraphics.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963582163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/of3dGraphics.cpp",
+			"isa": "PBXFileReference",
+			"name": "of3dGraphics.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962AA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks",
-			"isa":"PBXGroup",
-			"name":"openFrameworks",
-			"children":[
+		"E429633E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLRenderer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofGLRenderer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963632163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofTessellator.h",
+			"isa": "PBXFileReference",
+			"name": "ofTessellator.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42962C22163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationGrabber.mm",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationGrabber.mm",
+			"lastKnownFileType": "sourcecode.cpp.objcpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963562163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPixels.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofPixels.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E4B6FCAD0C3E899E008CF71C": {
+			"path": "openFrameworks-Info.plist",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "text.plist.xml",
+			"sourceTree": "<group>",
+			"fileEncoding": "4"
+		},
+		"E4EB6923138AFD0F00A09F29": {
+			"path": "Project.xcconfig",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "text.xcconfig",
+			"sourceTree": "<group>",
+			"fileEncoding": "4"
+		},
+		"E429633C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofTexture.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofTexture.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963612163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofImage.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofImage.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963542163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofRendererCollection.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofRendererCollection.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42962AA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks",
+			"isa": "PBXGroup",
+			"name": "openFrameworks",
+			"children": [
 				"E42962AB2163EDD300A6A9E2",
 				"E42962E72163EDD300A6A9E2",
 				"E42963402163EDD300A6A9E2",
@@ -447,290 +496,215 @@
 				"E42962FA2163EDD300A6A9E2",
 				"E42962B82163EDD300A6A9E2"
 			],
-			"sourceTree":"<group>"
+			"sourceTree": "<group>"
 		},
-		"E429633E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLRenderer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofGLRenderer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42962C22163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationGrabber.mm",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationGrabber.mm",
-			"lastKnownFileType":"sourcecode.cpp.objcpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963562163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPixels.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofPixels.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963632163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofTessellator.h",
-			"isa":"PBXFileReference",
-			"name":"ofTessellator.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E4B6FCAD0C3E899E008CF71C":{
-			"path":"openFrameworks-Info.plist",
-			"isa":"PBXFileReference",
-			"lastKnownFileType":"text.plist.xml",
-			"sourceTree":"<group>",
-			"fileEncoding":"4"
-		},
-		"E429633C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofTexture.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofTexture.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963612163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofImage.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofImage.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963542163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofRendererCollection.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofRendererCollection.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E4B69B600A3A1757003C02F2":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"COPY_PHASE_STRIP":"NO",
-				"LIBRARY_SEARCH_PATHS":[
-					"$(inherited)"
-				],
-				"FRAMEWORK_SEARCH_PATHS":[
-					"$(inherited)"
-				],
-				"HEADER_SEARCH_PATHS":[
+		"E4B69B600A3A1757003C02F2": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"COPY_PHASE_STRIP": "NO",
+				"LIBRARY_SEARCH_PATHS": "$(inherited)",
+				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
+				"HEADER_SEARCH_PATHS": [
 					"$(OF_CORE_HEADERS)",
 					"src"
 				],
-				"GCC_DYNAMIC_NO_PIC":"NO",
-				"OTHER_LDFLAGS":[
+				"GCC_DYNAMIC_NO_PIC": "NO",
+				"OTHER_LDFLAGS": [
 					"$(OF_CORE_LIBS)",
 					"$(OF_CORE_FRAMEWORKS)",
 					"$(LIB_OF_DEBUG)"
 				]
 			},
-			"name":"Debug"
+			"name": "Debug"
 		},
-		"E4EB6923138AFD0F00A09F29":{
-			"path":"Project.xcconfig",
-			"isa":"PBXFileReference",
-			"lastKnownFileType":"text.xcconfig",
-			"sourceTree":"<group>",
-			"fileEncoding":"4"
+		"E429633A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofVbo.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVbo.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429633A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofVbo.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVbo.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963522163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofGraphicsBaseTypes.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofGraphicsBaseTypes.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963522163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofGraphicsBaseTypes.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofGraphicsBaseTypes.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429632B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofLight.h",
+			"isa": "PBXFileReference",
+			"name": "ofLight.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofLight.h",
-			"isa":"PBXFileReference",
-			"name":"ofLight.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963502163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofGraphics.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofGraphics.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963502163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofGraphics.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofGraphics.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963412163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/communication/ofArduino.h",
+			"isa": "PBXFileReference",
+			"name": "ofArduino.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963412163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/communication\/ofArduino.h",
-			"isa":"PBXFileReference",
-			"name":"ofArduino.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962FF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofConstants.h",
+			"isa": "PBXFileReference",
+			"name": "ofConstants.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofConstants.h",
-			"isa":"PBXFileReference",
-			"name":"ofConstants.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963392163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLBaseTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofGLBaseTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963392163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLBaseTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofGLBaseTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962FD2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofFpsCounter.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofFpsCounter.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FD2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofFpsCounter.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofFpsCounter.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofQuaternion.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofQuaternion.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofQuaternion.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofQuaternion.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E4B6FFFD0C3F9AB9008CF71C": {
+			"alwaysOutOfDate": "1",
+			"inputPaths": [],
+			"buildActionMask": "2147483647",
+			"shellPath": "/bin/sh",
+			"showEnvVarsInLog": "0",
+			"outputPaths": [],
+			"isa": "PBXShellScriptBuildPhase",
+			"runOnlyForDeploymentPostprocessing": "0",
+			"shellScript": "echo \"\\033[32;1;4m2 - Copying Resources\\033[0m\"\nmkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\nrsync -aved --delete --exclude='.DS_Store' \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved --delete --ignore-existing \"$OF_PATH/libs/fmod/lib/osx/libfmod.dylib\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Frameworks/\";\n# Not needed as we now call install_name_tool -id @loader_path/../Frameworks/libfmod.dylib libfmod.dylib on the dylib directly which prevents the need for calling every post build - keeping here for reference and possible legacy usage \n# install_name_tool -change @rpath/libfmod.dylib @executable_path/../Frameworks/libfmod.dylib \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\";\n",
+			"name": "Run Script — Copy Resources",
+			"files": []
 		},
-		"E4B6FFFD0C3F9AB9008CF71C":{
-			"inputPaths":[
-				
-			],
-			"shellPath":"\/bin\/sh",
-			"buildActionMask":"2147483647",
-			"showEnvVarsInLog":"0",
-			"isa":"PBXShellScriptBuildPhase",
-			"outputPaths":[
-				
-			],
-			"runOnlyForDeploymentPostprocessing":"0",
-			"shellScript":"echo \"\\033[32;1;4m2 - Copying Resources\\033[0m\"\nmkdir -p \"$TARGET_BUILD_DIR\/$PRODUCT_NAME.app\/Contents\/Resources\/\"\n# Copy default icon file into App\/Resources\nrsync -aved --delete --exclude='.DS_Store' \"$ICON_FILE\" \"$TARGET_BUILD_DIR\/$PRODUCT_NAME.app\/Contents\/Resources\/\"\n# Copy libfmod and change install directory for fmod to run\nrsync -aved --delete --ignore-existing \"$OF_PATH\/libs\/fmod\/lib\/osx\/libfmod.dylib\" \"$TARGET_BUILD_DIR\/$PRODUCT_NAME.app\/Contents\/Frameworks\/\";\n# Not needed as we now call install_name_tool -id @loader_path\/..\/Frameworks\/libfmod.dylib libfmod.dylib on the dylib directly which prevents the need for calling every post build - keeping here for reference and possible legacy usage \n# install_name_tool -change @rpath\/libfmod.dylib @executable_path\/..\/Frameworks\/libfmod.dylib \"$TARGET_BUILD_DIR\/$PRODUCT_NAME.app\/Contents\/MacOS\/$PRODUCT_NAME\";\n",
-			"files":[
-				
-			]
+		"E42962FB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofThreadChannel.h",
+			"isa": "PBXFileReference",
+			"name": "ofThreadChannel.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofThreadChannel.h",
-			"isa":"PBXFileReference",
-			"name":"ofThreadChannel.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962EE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofIcon.h",
+			"isa": "PBXFileReference",
+			"name": "ofIcon.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962EE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofIcon.h",
-			"isa":"PBXFileReference",
-			"name":"ofIcon.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963282163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofShader.h",
+			"isa": "PBXFileReference",
+			"name": "ofShader.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963282163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofShader.h",
-			"isa":"PBXFileReference",
-			"name":"ofShader.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962EC2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppEGLWindow.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofAppEGLWindow.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"8466F1851C04CA0E00918B1C":{
-			"inputPaths":[
-				
-			],
-			"shellPath":"\/bin\/sh",
-			"buildActionMask":"12",
-			"showEnvVarsInLog":"0",
-			"isa":"PBXShellScriptBuildPhase",
-			"outputPaths":[
-				
-			],
-			"runOnlyForDeploymentPostprocessing":"0",
-			"shellScript":"echo \"\\033[32;1;4m3 - Code Sign\\033[0m\"\n#echo \"$GCC_PREPROCESSOR_DEFINITIONS\";\nAPPSTORE=`expr \"$GCC_PREPROCESSOR_DEFINITIONS\" : \".*APPSTORE=\\([0-9]*\\)\"`\nif [ -z \"$APPSTORE\" ] ; then\necho \"Note: Not copying bin\/data to App Package or doing App Code signing. Use AppStore target for AppStore distribution\";\nelse\n# Copy bin\/data into App\/Resources\nrsync -avz  --delete --exclude='.DS_Store' \"${SRCROOT}\/bin\/data\/\" \"${TARGET_BUILD_DIR}\/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\/data\/\"\n\n# ---- Code Sign App Package ----\n\n# WARNING: You may have to run Clean in Xcode after changing CODE_SIGN_IDENTITY!\n\n# Verify that $CODE_SIGN_IDENTITY is set\nif [ -z \"${CODE_SIGN_IDENTITY}\" ] ; then\necho \"CODE_SIGN_IDENTITY needs to be set for framework code-signing\"\nexit 0\nfi\n\nif [ -z \"${CODE_SIGN_ENTITLEMENTS}\" ] ; then\necho \"CODE_SIGN_ENTITLEMENTS needs to be set for framework code-signing!\"\n\nif [ \"${CONFIGURATION}\" = \"Release\" ] ; then\nexit 1\nelse\n# Code-signing is optional for non-release builds.\nexit 0\nfi\nfi\n\nITEMS=\"\"\n\nFRAMEWORKS_DIR=\"${TARGET_BUILD_DIR}\/${FRAMEWORKS_FOLDER_PATH}\"\necho \"$FRAMEWORKS_DIR\"\nif [ -d \"$FRAMEWORKS_DIR\" ] ; then\nFRAMEWORKS=$(find \"${FRAMEWORKS_DIR}\" -depth -type d -name \"*.framework\" -or -name \"*.dylib\" -or -name \"*.bundle\" | sed -e \"s\/\\(.*framework\\)\/\\1\\\/Versions\\\/A\\\/\/\")\nRESULT=$?\nif [[ $RESULT != 0 ]] ; then\nexit 1\nfi\n\nITEMS=\"${FRAMEWORKS}\"\nfi\n\nLOGINITEMS_DIR=\"${TARGET_BUILD_DIR}\/${CONTENTS_FOLDER_PATH}\/Library\/LoginItems\/\"\nif [ -d \"$LOGINITEMS_DIR\" ] ; then\nLOGINITEMS=$(find \"${LOGINITEMS_DIR}\" -depth -type d -name \"*.app\")\nRESULT=$?\nif [[ $RESULT != 0 ]] ; then\nexit 1\nfi\n\nITEMS=\"${ITEMS}\"$'\\n'\"${LOGINITEMS}\"\nfi\n\n# Prefer the expanded name, if available.\nCODE_SIGN_IDENTITY_FOR_ITEMS=\"${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\nif [ \"${CODE_SIGN_IDENTITY_FOR_ITEMS}\" = \"\" ] ; then\n# Fall back to old behavior.\nCODE_SIGN_IDENTITY_FOR_ITEMS=\"${CODE_SIGN_IDENTITY}\"\nfi\n\necho \"Identity: ${CODE_SIGN_IDENTITY_FOR_ITEMS}\"\n\necho \"Entitlements: ${CODE_SIGN_ENTITLEMENTS}\"\n\necho \"Found: ${ITEMS}\"\n\n# Change the Internal Field Separator (IFS) so that spaces in paths will not cause problems below.\nSAVED_IFS=$IFS\nIFS=$(echo -en \"\\n\\b\")\n\n# Loop through all items.\nfor ITEM in \"${ITEMS}\";\ndo\n\tif lipo -archs \"${ITEM}\" | grep -q 'i386'; then\n\t\techo \"Stripping invalid archs ${ITEM}\"\n\t\tlipo -remove i386 \"${ITEM}\" -o \"${ITEM}\" \n\telse\n\t\techo \"No need to strip invalid archs {$ITEM}\"\n\tfi\n\n\techo \"Signing '${ITEM}'\"\n\tcodesign --force --verbose --sign \"${CODE_SIGN_IDENTITY_FOR_ITEMS}\" --entitlements \"${CODE_SIGN_ENTITLEMENTS}\" \"${ITEM}\"\n\tRESULT=$?\n\tif [[ $RESULT != 0 ]] ; then\n\t\techo \"Failed to sign '${ITEM}'.\"\n\t\tIFS=$SAVED_IFS\n\t\texit 1\n\tfi\ndone\n\n# Restore $IFS.\nIFS=$SAVED_IFS\n\nfi\n",
-			"files":[
-				
-			]
+		"8466F1851C04CA0E00918B1C": {
+			"alwaysOutOfDate": "1",
+			"inputPaths": [],
+			"buildActionMask": "12",
+			"shellPath": "/bin/sh",
+			"showEnvVarsInLog": "0",
+			"outputPaths": [],
+			"isa": "PBXShellScriptBuildPhase",
+			"runOnlyForDeploymentPostprocessing": "0",
+			"shellScript": "echo \"\\033[32;1;4m3 - Code Sign\\033[0m\"\n#echo \"$GCC_PREPROCESSOR_DEFINITIONS\";\nAPPSTORE=`expr \"$GCC_PREPROCESSOR_DEFINITIONS\" : \".*APPSTORE=\\([0-9]*\\)\"`\nif [ -z \"$APPSTORE\" ] ; then\necho \"Note: Not copying bin/data to App Package or doing App Code signing. Use AppStore target for AppStore distribution\";\nelse\n# Copy bin/data into App/Resources\nrsync -avz  --delete --exclude='.DS_Store' \"${SRCROOT}/bin/data/\" \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/data/\"\n\n# ---- Code Sign App Package ----\n\n# WARNING: You may have to run Clean in Xcode after changing CODE_SIGN_IDENTITY!\n\n# Verify that $CODE_SIGN_IDENTITY is set\nif [ -z \"${CODE_SIGN_IDENTITY}\" ] ; then\necho \"CODE_SIGN_IDENTITY needs to be set for framework code-signing\"\nexit 0\nfi\n\nif [ -z \"${CODE_SIGN_ENTITLEMENTS}\" ] ; then\necho \"CODE_SIGN_ENTITLEMENTS needs to be set for framework code-signing!\"\n\nif [ \"${CONFIGURATION}\" = \"Release\" ] ; then\nexit 1\nelse\n# Code-signing is optional for non-release builds.\nexit 0\nfi\nfi\n\nITEMS=\"\"\n\nFRAMEWORKS_DIR=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\necho \"$FRAMEWORKS_DIR\"\nif [ -d \"$FRAMEWORKS_DIR\" ] ; then\nFRAMEWORKS=$(find \"${FRAMEWORKS_DIR}\" -depth -type d -name \"*.framework\" -or -name \"*.dylib\" -or -name \"*.bundle\" | sed -e \"s/\\(.*framework\\)/\\1\\/Versions\\/A\\//\")\nRESULT=$?\nif [[ $RESULT != 0 ]] ; then\nexit 1\nfi\n\nITEMS=\"${FRAMEWORKS}\"\nfi\n\nLOGINITEMS_DIR=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}/Library/LoginItems/\"\nif [ -d \"$LOGINITEMS_DIR\" ] ; then\nLOGINITEMS=$(find \"${LOGINITEMS_DIR}\" -depth -type d -name \"*.app\")\nRESULT=$?\nif [[ $RESULT != 0 ]] ; then\nexit 1\nfi\n\nITEMS=\"${ITEMS}\"$'\\n'\"${LOGINITEMS}\"\nfi\n\n# Prefer the expanded name, if available.\nCODE_SIGN_IDENTITY_FOR_ITEMS=\"${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\nif [ \"${CODE_SIGN_IDENTITY_FOR_ITEMS}\" = \"\" ] ; then\n# Fall back to old behavior.\nCODE_SIGN_IDENTITY_FOR_ITEMS=\"${CODE_SIGN_IDENTITY}\"\nfi\n\necho \"Identity: ${CODE_SIGN_IDENTITY_FOR_ITEMS}\"\n\necho \"Entitlements: ${CODE_SIGN_ENTITLEMENTS}\"\n\necho \"Found: ${ITEMS}\"\n\n# Change the Internal Field Separator (IFS) so that spaces in paths will not cause problems below.\nSAVED_IFS=$IFS\nIFS=$(echo -en \"\\n\\b\")\n\n# Loop through all items.\nfor ITEM in \"${ITEMS}\";\ndo\n\tif lipo -archs \"${ITEM}\" | grep -q 'i386'; then\n\t\techo \"Stripping invalid archs ${ITEM}\"\n\t\tlipo -remove i386 \"${ITEM}\" -o \"${ITEM}\" \n\telse\n\t\techo \"No need to strip invalid archs {$ITEM}\"\n\tfi\n\n\techo \"Signing '${ITEM}'\"\n\tcodesign --force --verbose --sign \"${CODE_SIGN_IDENTITY_FOR_ITEMS}\" --entitlements \"${CODE_SIGN_ENTITLEMENTS}\" \"${ITEM}\"\n\tRESULT=$?\n\tif [[ $RESULT != 0 ]] ; then\n\t\techo \"Failed to sign '${ITEM}'.\"\n\t\tIFS=$SAVED_IFS\n\t\texit 1\n\tfi\ndone\n\n# Restore $IFS.\nIFS=$SAVED_IFS\n\nfi\n",
+			"name": "Run Script — Code Sign / Copy Data",
+			"files": []
 		},
-		"E42962EC2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppEGLWindow.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofAppEGLWindow.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofMatrixStack.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMatrixStack.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429630E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofMatrixStack.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMatrixStack.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963332163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofBufferObject.h",
+			"isa": "PBXFileReference",
+			"name": "ofBufferObject.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963332163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofBufferObject.h",
-			"isa":"PBXFileReference",
-			"name":"ofBufferObject.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963262163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofVboMesh.h",
+			"isa": "PBXFileReference",
+			"name": "ofVboMesh.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963262163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofVboMesh.h",
-			"isa":"PBXFileReference",
-			"name":"ofVboMesh.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962EA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppGlutWindow.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofAppGlutWindow.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962EA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppGlutWindow.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofAppGlutWindow.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofJson.h",
+			"isa": "PBXFileReference",
+			"name": "ofJson.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429630C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofJson.h",
-			"isa":"PBXFileReference",
-			"name":"ofJson.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E4B69B580A3A1756003C02F2":{
-			"buildActionMask":"2147483647",
-			"isa":"PBXSourcesBuildPhase",
-			"files":[
+		"E4B69B580A3A1756003C02F2": {
+			"isa": "PBXSourcesBuildPhase",
+			"buildActionMask": "2147483647",
+			"files": [
 				"E4B69E200A3A1BDC003C02F2",
 				"E4B69E210A3A1BDC003C02F2"
 			],
-			"runOnlyForDeploymentPostprocessing":"0"
+			"runOnlyForDeploymentPostprocessing": "0"
 		},
-		"E429630A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofThread.h",
-			"isa":"PBXFileReference",
-			"name":"ofThread.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofThread.h",
+			"isa": "PBXFileReference",
+			"name": "ofThread.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963222163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMatrix3x3.h",
-			"isa":"PBXFileReference",
-			"name":"ofMatrix3x3.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963222163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMatrix3x3.h",
+			"isa": "PBXFileReference",
+			"name": "ofMatrix3x3.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963202163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVec2f.h",
-			"isa":"PBXFileReference",
-			"name":"ofVec2f.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963202163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVec2f.h",
+			"isa": "PBXFileReference",
+			"name": "ofVec2f.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963132163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math",
-			"isa":"PBXGroup",
-			"name":"math",
-			"children":[
+		"E42963132163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math",
+			"isa": "PBXGroup",
+			"name": "math",
+			"children": [
 				"E42963172163EDD300A6A9E2",
 				"E429631C2163EDD300A6A9E2",
 				"E42963182163EDD300A6A9E2",
@@ -747,34 +721,34 @@
 				"E42963162163EDD300A6A9E2",
 				"E429631E2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963112163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofMatrixStack.h",
-			"isa":"PBXFileReference",
-			"name":"ofMatrixStack.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963112163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofMatrixStack.h",
+			"isa": "PBXFileReference",
+			"name": "ofMatrixStack.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E92163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofBaseApp.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofBaseApp.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E92163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofBaseApp.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofBaseApp.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962CF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQuickTimePlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofQuickTimePlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962CF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQuickTimePlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofQuickTimePlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E72163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app",
-			"isa":"PBXGroup",
-			"name":"app",
-			"children":[
+		"E42962E72163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app",
+			"isa": "PBXGroup",
+			"name": "app",
+			"children": [
 				"E42962ED2163EDD300A6A9E2",
 				"E42962EC2163EDD300A6A9E2",
 				"E42962F12163EDD300A6A9E2",
@@ -793,140 +767,120 @@
 				"E42962E82163EDD300A6A9E2",
 				"E42962EB2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69E1C0A3A1BDC003C02F2":{
-			"path":"src",
-			"isa":"PBXGroup",
-			"children":[
+		"E4B69E1C0A3A1BDC003C02F2": {
+			"path": "src",
+			"isa": "PBXGroup",
+			"children": [
 				"E4B69E1D0A3A1BDC003C02F2",
 				"E4B69E1E0A3A1BDC003C02F2",
 				"E4B69E1F0A3A1BDC003C02F2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963092163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofFileUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofFileUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963092163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofFileUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofFileUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962CD2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQtUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofQtUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962CD2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQtUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofQtUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E52163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofParameter.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofParameter.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E52163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofParameter.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofParameter.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963072163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofLog.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofLog.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963072163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofLog.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofLog.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"99FA3DBB1C7456C400CFA0EE":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"HEADER_SEARCH_PATHS":[
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"GCC_UNROLL_LOOPS":"YES",
-				"CODE_SIGN_ENTITLEMENTS":"of.entitlements",
-				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]":"DISTRIBUTION=1",
-				"GCC_OPTIMIZATION_LEVEL":"3",
-				"COPY_PHASE_STRIP":"YES",
-				"OTHER_CPLUSPLUSFLAGS":[
-					"-D__MACOSX_CORE__"
-				],
-				"GCC_WARN_UNUSED_VARIABLE":"NO"
-			},
-			"name":"AppStore"
+		"E42962CB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962CB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitGrabber.mm",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitGrabber.mm",
+			"lastKnownFileType": "sourcecode.cpp.objcpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E32163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofParameter.h",
-			"isa":"PBXFileReference",
-			"name":"ofParameter.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E32163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofParameter.h",
+			"isa": "PBXFileReference",
+			"name": "ofParameter.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962D62163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitMovieRenderer.m",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitMovieRenderer.m",
-			"lastKnownFileType":"sourcecode.c.objc",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962D62163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitMovieRenderer.m",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitMovieRenderer.m",
+			"lastKnownFileType": "sourcecode.c.objc",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963052163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963052163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962BE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitGrabber.mm",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitGrabber.mm",
-			"lastKnownFileType":"sourcecode.cpp.objcpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofGraphics.h",
+			"isa": "PBXFileReference",
+			"name": "ofGraphics.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429635D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofTrueTypeFont.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofTrueTypeFont.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofTrueTypeFont.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofTrueTypeFont.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962BC2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BC2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E12163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofBaseTypes.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofBaseTypes.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E12163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofBaseTypes.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofBaseTypes.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429635F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofGraphics.h",
-			"isa":"PBXFileReference",
-			"name":"ofGraphics.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963682163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofOpenALSoundPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofOpenALSoundPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963682163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofOpenALSoundPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofOpenALSoundPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E4B69B4A0A3A1720003C02F2":{
-			"isa":"PBXGroup",
-			"sourceTree":"<group>",
-			"children":[
+		"E4B69B4A0A3A1720003C02F2": {
+			"isa": "PBXGroup",
+			"sourceTree": "<group>",
+			"children": [
 				"191CD6FA2847E21E0085CBB6",
 				"E4B6FCAD0C3E899E008CF71C",
 				"E4EB6923138AFD0F00A09F29",
@@ -937,83 +891,106 @@
 				"E4B69B5B0A3A1756003C02F2"
 			]
 		},
-		"E429635B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofCairoRenderer.h",
-			"isa":"PBXFileReference",
-			"name":"ofCairoRenderer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42962BA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationGrabber.h",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationGrabber.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E429634E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofTrueTypeFont.h",
-			"isa":"PBXFileReference",
-			"name":"ofTrueTypeFont.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963662163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundStream.h",
-			"isa":"PBXFileReference",
-			"name":"ofSoundStream.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963732163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundBaseTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofSoundBaseTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E4B69B4C0A3A1720003C02F2":{
-			"buildConfigurationList":"E4B69B4D0A3A1720003C02F2",
-			"projectDirPath":"",
-			"hasScannedForEncodings":"0",
-			"projectRoot":"",
-			"isa":"PBXProject",
-			"productRefGroup":"E4B69B4A0A3A1720003C02F2",
-			"compatibilityVersion":"Xcode 3.2",
-			"mainGroup":"E4B69B4A0A3A1720003C02F2",
-			"attributes":{
-				"LastUpgradeCheck":"0600"
-			},
-			"targets":[
+		"E4B69B4C0A3A1720003C02F2": {
+			"buildConfigurationList": "E4B69B4D0A3A1720003C02F2",
+			"targets": [
 				"E4B69B5A0A3A1756003C02F2"
-			]
+			],
+			"developmentRegion": "en",
+			"knownRegions": [
+				"en",
+				"Base"
+			],
+			"isa": "PBXProject",
+			"compatibilityVersion": "Xcode 3.2",
+			"productRefGroup": "E4B69B4A0A3A1720003C02F2",
+			"projectDirPath": "",
+			"attributes": {
+				"LastUpgradeCheck": "0600"
+			},
+			"hasScannedForEncodings": "0",
+			"projectRoot": "",
+			"mainGroup": "E4B69B4A0A3A1720003C02F2"
 		},
-		"E429634C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPath.h",
-			"isa":"PBXFileReference",
-			"name":"ofPath.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofCairoRenderer.h",
+			"isa": "PBXFileReference",
+			"name": "ofCairoRenderer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963712163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofFmodSoundPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofFmodSoundPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962BA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationGrabber.h",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationGrabber.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962D02163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofVideoGrabber.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVideoGrabber.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429634E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofTrueTypeFont.h",
+			"isa": "PBXFileReference",
+			"name": "ofTrueTypeFont.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963642163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound",
-			"isa":"PBXGroup",
-			"name":"sound",
-			"children":[
+		"E42963662163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundStream.h",
+			"isa": "PBXFileReference",
+			"name": "ofSoundStream.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963732163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundBaseTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofSoundBaseTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"99FA3DBB1C7456C400CFA0EE": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"HEADER_SEARCH_PATHS": [
+					"$(OF_CORE_HEADERS)",
+					"src"
+				],
+				"GCC_UNROLL_LOOPS": "YES",
+				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]": "DISTRIBUTION=1",
+				"GCC_OPTIMIZATION_LEVEL": "3",
+				"COPY_PHASE_STRIP": "YES",
+				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
+				"GCC_WARN_UNUSED_VARIABLE": "NO"
+			},
+			"name": "AppStore"
+		},
+		"E429634C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPath.h",
+			"isa": "PBXFileReference",
+			"name": "ofPath.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963712163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofFmodSoundPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofFmodSoundPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42962D02163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofVideoGrabber.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVideoGrabber.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42963642163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound",
+			"isa": "PBXGroup",
+			"name": "sound",
+			"children": [
 				"E429636A2163EDD300A6A9E2",
 				"E42963712163EDD300A6A9E2",
 				"E429636C2163EDD300A6A9E2",
@@ -1030,13 +1007,13 @@
 				"E42963662163EDD300A6A9E2",
 				"E429636F2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429634A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics",
-			"isa":"PBXGroup",
-			"name":"graphics",
-			"children":[
+		"E429634A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics",
+			"isa": "PBXGroup",
+			"name": "graphics",
+			"children": [
 				"E42963582163EDD300A6A9E2",
 				"E42963622163EDD300A6A9E2",
 				"E429634D2163EDD300A6A9E2",
@@ -1063,161 +1040,157 @@
 				"E429635D2163EDD300A6A9E2",
 				"E429634E2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963622163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/of3dGraphics.h",
-			"isa":"PBXFileReference",
-			"name":"of3dGraphics.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963622163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/of3dGraphics.h",
+			"isa": "PBXFileReference",
+			"name": "of3dGraphics.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B610A3A1757003C02F2":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-				"LIBRARY_SEARCH_PATHS":[
-					"$(inherited)"
-				],
-				"COPY_PHASE_STRIP":"YES",
-				"HEADER_SEARCH_PATHS":[
+		"E4B69B610A3A1757003C02F2": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+				"LIBRARY_SEARCH_PATHS": "$(inherited)",
+				"COPY_PHASE_STRIP": "YES",
+				"HEADER_SEARCH_PATHS": [
 					"$(OF_CORE_HEADERS)",
 					"src"
 				],
-				"FRAMEWORK_SEARCH_PATHS":[
-					"$(inherited)"
-				],
-				"OTHER_LDFLAGS":[
+				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
+				"OTHER_LDFLAGS": [
 					"$(OF_CORE_LIBS)",
 					"$(OF_CORE_FRAMEWORKS)",
 					"$(LIB_OF)"
 				]
 			},
-			"name":"Release"
+			"name": "Release"
 		},
-		"E429633B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLProgrammableRenderer.h",
-			"isa":"PBXFileReference",
-			"name":"ofGLProgrammableRenderer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429633B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLProgrammableRenderer.h",
+			"isa": "PBXFileReference",
+			"name": "ofGLProgrammableRenderer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963602163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofGraphicsConstants.h",
-			"isa":"PBXFileReference",
-			"name":"ofGraphicsConstants.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963602163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofGraphicsConstants.h",
+			"isa": "PBXFileReference",
+			"name": "ofGraphicsConstants.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B72163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofEasyCam.h",
-			"isa":"PBXFileReference",
-			"name":"ofEasyCam.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B72163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofEasyCam.h",
+			"isa": "PBXFileReference",
+			"name": "ofEasyCam.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963492163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/events\/ofEvents.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofEvents.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963492163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/events/ofEvents.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofEvents.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B52163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/of3dUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"of3dUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B52163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/of3dUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "of3dUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofVboMesh.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVboMesh.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429632F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofVboMesh.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVboMesh.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B32163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofCamera.h",
-			"isa":"PBXFileReference",
-			"name":"ofCamera.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B32163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofCamera.h",
+			"isa": "PBXFileReference",
+			"name": "ofCamera.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963472163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/events\/ofEvent.h",
-			"isa":"PBXFileReference",
-			"name":"ofEvent.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963472163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/events/ofEvent.h",
+			"isa": "PBXFileReference",
+			"name": "ofEvent.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofURLFileLoader.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofURLFileLoader.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962FE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofURLFileLoader.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofURLFileLoader.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofShader.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofShader.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429632D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofShader.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofShader.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B12163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/of3dUtils.h",
-			"isa":"PBXFileReference",
-			"name":"of3dUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B12163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/of3dUtils.h",
+			"isa": "PBXFileReference",
+			"name": "of3dUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963382163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofFbo.h",
-			"isa":"PBXFileReference",
-			"name":"ofFbo.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963382163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofFbo.h",
+			"isa": "PBXFileReference",
+			"name": "ofFbo.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963452163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/events",
-			"isa":"PBXGroup",
-			"name":"events",
-			"children":[
+		"E42963452163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/events",
+			"isa": "PBXGroup",
+			"name": "events",
+			"children": [
 				"E42963472163EDD300A6A9E2",
 				"E42963492163EDD300A6A9E2",
 				"E42963482163EDD300A6A9E2",
 				"E42963462163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FC2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofThread.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofThread.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962FC2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofThread.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofThread.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVectorMath.h",
-			"isa":"PBXFileReference",
-			"name":"ofVectorMath.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVectorMath.h",
+			"isa": "PBXFileReference",
+			"name": "ofVectorMath.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963432163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/communication\/ofSerial.h",
-			"isa":"PBXFileReference",
-			"name":"ofSerial.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963432163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/communication/ofSerial.h",
+			"isa": "PBXFileReference",
+			"name": "ofSerial.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962FA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils",
-			"isa":"PBXGroup",
-			"name":"utils",
-			"children":[
+		"E42962FA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils",
+			"isa": "PBXGroup",
+			"name": "utils",
+			"children": [
 				"E42962FF2163EDD300A6A9E2",
 				"E429630D2163EDD300A6A9E2",
 				"E42963092163EDD300A6A9E2",
@@ -1243,383 +1216,385 @@
 				"E42963102163EDD300A6A9E2",
 				"E42963002163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMath.h",
-			"isa":"PBXFileReference",
-			"name":"ofMath.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMath.h",
+			"isa": "PBXFileReference",
+			"name": "ofMath.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963342163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLProgrammableRenderer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofGLProgrammableRenderer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963342163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofGLProgrammableRenderer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVec3f.h",
-			"isa":"PBXFileReference",
-			"name":"ofVec3f.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVec3f.h",
+			"isa": "PBXFileReference",
+			"name": "ofVec3f.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429630D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofFileUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofFileUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofFileUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofFileUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963322163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofLight.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofLight.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963322163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofLight.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofLight.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B5B0A3A1756003C02F2":{
-			"path":"emptyExample.app",
-			"isa":"PBXFileReference",
-			"includeInIndex":"0",
-			"explicitFileType":"wrapper.application",
-			"sourceTree":"BUILT_PRODUCTS_DIR"
+		"E4B69B5B0A3A1756003C02F2": {
+			"path": "emptyExampleDebug.app",
+			"isa": "PBXFileReference",
+			"includeInIndex": "0",
+			"name": "emptyExample.app",
+			"explicitFileType": "wrapper.application",
+			"sourceTree": "BUILT_PRODUCTS_DIR"
 		},
-		"E429630B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofURLFileLoader.h",
-			"isa":"PBXFileReference",
-			"name":"ofURLFileLoader.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429630B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofURLFileLoader.h",
+			"isa": "PBXFileReference",
+			"name": "ofURLFileLoader.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963302163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofGLUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963302163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofGLUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963212163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMatrix4x4.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMatrix4x4.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963212163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMatrix4x4.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMatrix4x4.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F92163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/ofMain.h",
-			"isa":"PBXFileReference",
-			"name":"ofMain.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F92163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/ofMain.h",
+			"isa": "PBXFileReference",
+			"name": "ofMain.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962DF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F72163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppRunner.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofAppRunner.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F72163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppRunner.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofAppRunner.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963192163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMatrix4x4.h",
-			"isa":"PBXFileReference",
-			"name":"ofMatrix4x4.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963192163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMatrix4x4.h",
+			"isa": "PBXFileReference",
+			"name": "ofMatrix4x4.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DD2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofRectangle.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofRectangle.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962DD2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofRectangle.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofRectangle.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F52163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppGLFWWindow.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofAppGLFWWindow.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F52163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppGLFWWindow.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofAppGLFWWindow.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E82163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofMainLoop.h",
-			"isa":"PBXFileReference",
-			"name":"ofMainLoop.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E82163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofMainLoop.h",
+			"isa": "PBXFileReference",
+			"name": "ofMainLoop.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963172163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMath.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMath.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963172163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMath.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMath.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962DB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofParameterGroup.h",
-			"isa":"PBXFileReference",
-			"name":"ofParameterGroup.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962DB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofParameterGroup.h",
+			"isa": "PBXFileReference",
+			"name": "ofParameterGroup.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962CE2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationPlayer.mm",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationPlayer.mm",
-			"lastKnownFileType":"sourcecode.cpp.objcpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962CE2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationPlayer.mm",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationPlayer.mm",
+			"lastKnownFileType": "sourcecode.cpp.objcpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962A92163ECCD00A6A9E2":{
-			"inputPaths":[
-				
-			],
-			"shellPath":"\/bin\/sh",
-			"buildActionMask":"2147483647",
-			"showEnvVarsInLog":"0",
-			"isa":"PBXShellScriptBuildPhase",
-			"outputPaths":[
-				
-			],
-			"runOnlyForDeploymentPostprocessing":"0",
-			"shellScript":"echo \"\\033[32;1;4m1 - Compiling Openframeworks\\033[0m\"\nxcodebuild -project \"$OF_PATH\/libs\/openFrameworksCompiled\/project\/osx\/openFrameworksLib.xcodeproj\" -target openFrameworks -configuration \"${CONFIGURATION}\"  CLANG_CXX_LANGUAGE_STANDARD=$CLANG_CXX_LANGUAGE_STANDARD MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET",
-			"files":[
-				
-			]
+		"E42962F32163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppRunner.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppRunner.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E62163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofBaseTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofBaseTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E62163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofBaseTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofBaseTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963152163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofVec4f.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofVec4f.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963152163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofVec4f.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofVec4f.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F32163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppRunner.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppRunner.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963082163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofTimer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofTimer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963082163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofTimer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofTimer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429636D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundPlayer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSoundPlayer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundPlayer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSoundPlayer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429636F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofSoundUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962F12163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppEGLWindow.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppEGLWindow.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962F12163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppEGLWindow.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppEGLWindow.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E42163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofColor.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofColor.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E42163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofColor.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofColor.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofSoundUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962A92163ECCD00A6A9E2": {
+			"alwaysOutOfDate": "1",
+			"inputPaths": [],
+			"buildActionMask": "2147483647",
+			"shellPath": "/bin/sh",
+			"showEnvVarsInLog": "0",
+			"outputPaths": [],
+			"isa": "PBXShellScriptBuildPhase",
+			"runOnlyForDeploymentPostprocessing": "0",
+			"shellScript": "echo \"\\033[32;1;4m1 - Compiling Openframeworks\\033[0m\"\nxcodebuild -project \"$OF_PATH/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj\" -target openFrameworks -configuration \"${CONFIGURATION}\"  CLANG_CXX_LANGUAGE_STANDARD=$CLANG_CXX_LANGUAGE_STANDARD MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET\n",
+			"name": "Run Script — Compile OF",
+			"files": []
 		},
-		"E42963062163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofNoise.h",
-			"isa":"PBXFileReference",
-			"name":"ofNoise.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963062163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofNoise.h",
+			"isa": "PBXFileReference",
+			"name": "ofNoise.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429636B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundBaseTypes.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSoundBaseTypes.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429636B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundBaseTypes.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSoundBaseTypes.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962CA2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofVideoGrabber.h",
-			"isa":"PBXFileReference",
-			"name":"ofVideoGrabber.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962CA2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofVideoGrabber.h",
+			"isa": "PBXFileReference",
+			"name": "ofVideoGrabber.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429635E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofRendererCollection.h",
-			"isa":"PBXFileReference",
-			"name":"ofRendererCollection.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofRendererCollection.h",
+			"isa": "PBXFileReference",
+			"name": "ofRendererCollection.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E22163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofParameterGroup.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofParameterGroup.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E22163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofParameterGroup.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofParameterGroup.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963042163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofSystemUtils.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSystemUtils.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963042163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofSystemUtils.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSystemUtils.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69E1E0A3A1BDC003C02F2":{
-			"path":"src\/ofApp.cpp",
-			"isa":"PBXFileReference",
-			"fileEncoding":"4",
-			"name":"ofApp.cpp",
-			"sourceTree":"SOURCE_ROOT",
-			"explicitFileType":"sourcecode.cpp.cpp"
+		"E4B69E1E0A3A1BDC003C02F2": {
+			"path": "src/ofApp.cpp",
+			"isa": "PBXFileReference",
+			"fileEncoding": "4",
+			"name": "ofApp.cpp",
+			"sourceTree": "SOURCE_ROOT",
+			"explicitFileType": "sourcecode.cpp.cpp"
 		},
-		"E429635C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofBitmapFont.h",
-			"isa":"PBXFileReference",
-			"name":"ofBitmapFont.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofBitmapFont.h",
+			"isa": "PBXFileReference",
+			"name": "ofBitmapFont.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962E02163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/types\/ofRectangle.h",
-			"isa":"PBXFileReference",
-			"name":"ofRectangle.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962E02163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/types/ofRectangle.h",
+			"isa": "PBXFileReference",
+			"name": "ofRectangle.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963022163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofLog.h",
-			"isa":"PBXFileReference",
-			"name":"ofLog.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963022163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofLog.h",
+			"isa": "PBXFileReference",
+			"name": "ofLog.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429635A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPixels.h",
-			"isa":"PBXFileReference",
-			"name":"ofPixels.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429635A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPixels.h",
+			"isa": "PBXFileReference",
+			"name": "ofPixels.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963722163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundBuffer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSoundBuffer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963722163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundBuffer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSoundBuffer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B4E0A3A1720003C02F2":{
-			"baseConfigurationReference":"E4EB6923138AFD0F00A09F29",
-			"isa":"XCBuildConfiguration",
-			"buildSettings":{
-				"HEADER_SEARCH_PATHS":[
+		"E4B69B4E0A3A1720003C02F2": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"HEADER_SEARCH_PATHS": [
 					"$(OF_CORE_HEADERS)",
 					"src"
 				],
-				"OTHER_CPLUSPLUSFLAGS":[
-					"-D__MACOSX_CORE__"
-				],
-				"CODE_SIGN_ENTITLEMENTS":"of.entitlements",
-				"COPY_PHASE_STRIP":"NO",
-				"GCC_OPTIMIZATION_LEVEL":"0",
-				"ENABLE_TESTABILITY":"YES",
-				"GCC_WARN_UNUSED_VARIABLE":"NO"
+				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
+				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
+				"COPY_PHASE_STRIP": "NO",
+				"GCC_OPTIMIZATION_LEVEL": "0",
+				"ENABLE_TESTABILITY": "YES",
+				"GCC_WARN_UNUSED_VARIABLE": "NO"
 			},
-			"name":"Debug"
+			"name": "Debug"
 		},
-		"E42963002163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/utils\/ofXml.h",
-			"isa":"PBXFileReference",
-			"name":"ofXml.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963002163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/utils/ofXml.h",
+			"isa": "PBXFileReference",
+			"name": "ofXml.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429634B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofGraphicsBaseTypes.h",
-			"isa":"PBXFileReference",
-			"name":"ofGraphicsBaseTypes.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429634B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofGraphicsBaseTypes.h",
+			"isa": "PBXFileReference",
+			"name": "ofGraphicsBaseTypes.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963702163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/sound\/ofSoundBuffer.h",
-			"isa":"PBXFileReference",
-			"name":"ofSoundBuffer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963702163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/sound/ofSoundBuffer.h",
+			"isa": "PBXFileReference",
+			"name": "ofSoundBuffer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C92163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQuickTimePlayer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofQuickTimePlayer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C92163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQuickTimePlayer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofQuickTimePlayer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962AF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofNode.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofNode.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962AF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofNode.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofNode.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C72163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQuickTimeGrabber.h",
-			"isa":"PBXFileReference",
-			"name":"ofQuickTimeGrabber.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C72163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQuickTimeGrabber.h",
+			"isa": "PBXFileReference",
+			"name": "ofQuickTimeGrabber.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69E210A3A1BDC003C02F2":{
-			"fileRef":"E4B69E1E0A3A1BDC003C02F2",
-			"isa":"PBXBuildFile"
+		"E4B69E210A3A1BDC003C02F2": {
+			"isa": "PBXBuildFile",
+			"fileRef": "E4B69E1E0A3A1BDC003C02F2"
 		},
-		"E42962AD2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofMesh.h",
-			"isa":"PBXFileReference",
-			"name":"ofMesh.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962AD2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofMesh.h",
+			"isa": "PBXFileReference",
+			"name": "ofMesh.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C52163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitGrabber.h",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitGrabber.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C52163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitGrabber.h",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitGrabber.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B82163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video",
-			"isa":"PBXGroup",
-			"name":"video",
-			"children":[
+		"E42963592163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofImage.h",
+			"isa": "PBXFileReference",
+			"name": "ofImage.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E42962B82163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video",
+			"isa": "PBXGroup",
+			"name": "video",
+			"children": [
 				"E42962BA2163EDD300A6A9E2",
 				"E42962C22163EDD300A6A9E2",
 				"E42962BC2163EDD300A6A9E2",
@@ -1644,20 +1619,20 @@
 				"E42962C42163EDD300A6A9E2",
 				"E42962BB2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963592163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofImage.h",
-			"isa":"PBXFileReference",
-			"name":"ofImage.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429633F2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLRenderer.h",
+			"isa": "PBXFileReference",
+			"name": "ofGLRenderer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962AB2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d",
-			"isa":"PBXGroup",
-			"name":"3d",
-			"children":[
+		"E42962AB2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d",
+			"isa": "PBXGroup",
+			"name": "3d",
+			"children": [
 				"E42962B02163EDD300A6A9E2",
 				"E42962B62163EDD300A6A9E2",
 				"E42962B52163EDD300A6A9E2",
@@ -1671,191 +1646,182 @@
 				"E42962AF2163EDD300A6A9E2",
 				"E42962AE2163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429633F2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLRenderer.h",
-			"isa":"PBXFileReference",
-			"name":"ofGLRenderer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C32163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofQTKitMovieRenderer.h",
+			"isa": "PBXFileReference",
+			"name": "ofQTKitMovieRenderer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C32163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofQTKitMovieRenderer.h",
-			"isa":"PBXFileReference",
-			"name":"ofQTKitMovieRenderer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963572163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPolyline.inl",
+			"isa": "PBXFileReference",
+			"name": "ofPolyline.inl",
+			"lastKnownFileType": "text",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B62163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/of3dPrimitives.h",
-			"isa":"PBXFileReference",
-			"name":"of3dPrimitives.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B62163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/of3dPrimitives.h",
+			"isa": "PBXFileReference",
+			"name": "of3dPrimitives.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963572163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPolyline.inl",
-			"isa":"PBXFileReference",
-			"name":"ofPolyline.inl",
-			"lastKnownFileType":"text",
-			"sourceTree":"SOURCE_ROOT"
+		"E429633D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofGLUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofGLUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429633D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofGLUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofGLUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962C12163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/video/ofAVFoundationVideoPlayer.h",
+			"isa": "PBXFileReference",
+			"name": "ofAVFoundationVideoPlayer.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962C12163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/video\/ofAVFoundationVideoPlayer.h",
-			"isa":"PBXFileReference",
-			"name":"ofAVFoundationVideoPlayer.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963482163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/events/ofEvents.h",
+			"isa": "PBXFileReference",
+			"name": "ofEvents.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963482163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/events\/ofEvents.h",
-			"isa":"PBXFileReference",
-			"name":"ofEvents.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963552163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPath.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofPath.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B42163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofMesh.inl",
-			"isa":"PBXFileReference",
-			"name":"ofMesh.inl",
-			"lastKnownFileType":"text",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B42163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofMesh.inl",
+			"isa": "PBXFileReference",
+			"name": "ofMesh.inl",
+			"lastKnownFileType": "text",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963552163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPath.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofPath.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E4C2427710CC5ABF004149E2": {
+			"isa": "PBXCopyFilesBuildPhase",
+			"buildActionMask": "2147483647",
+			"dstPath": "",
+			"dstSubfolderSpec": "10",
+			"files": [],
+			"runOnlyForDeploymentPostprocessing": "0"
 		},
-		"E4C2427710CC5ABF004149E2":{
-			"buildActionMask":"2147483647",
-			"dstPath":"",
-			"files":[
-				
-			],
-			"dstSubfolderSpec":"10",
-			"isa":"PBXCopyFilesBuildPhase",
-			"runOnlyForDeploymentPostprocessing":"0"
+		"E429632E2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofBufferObject.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofBufferObject.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632E2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofBufferObject.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofBufferObject.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963532163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofCairoRenderer.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofCairoRenderer.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963532163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofCairoRenderer.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofCairoRenderer.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B22163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/ofEasyCam.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofEasyCam.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B22163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/ofEasyCam.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofEasyCam.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963462163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/events/ofEventUtils.h",
+			"isa": "PBXFileReference",
+			"name": "ofEventUtils.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963462163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/events\/ofEventUtils.h",
-			"isa":"PBXFileReference",
-			"name":"ofEventUtils.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E429632C2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofMaterial.h",
+			"isa": "PBXFileReference",
+			"name": "ofMaterial.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632C2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofMaterial.h",
-			"isa":"PBXFileReference",
-			"name":"ofMaterial.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963512163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/graphics/ofPolyline.h",
+			"isa": "PBXFileReference",
+			"name": "ofPolyline.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963512163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/graphics\/ofPolyline.h",
-			"isa":"PBXFileReference",
-			"name":"ofPolyline.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962B02163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/3d/of3dPrimitives.cpp",
+			"isa": "PBXFileReference",
+			"name": "of3dPrimitives.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42962B02163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/3d\/of3dPrimitives.cpp",
-			"isa":"PBXFileReference",
-			"name":"of3dPrimitives.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963442163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/communication/ofArduino.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofArduino.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963442163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/communication\/ofArduino.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofArduino.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429632A2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofFbo.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofFbo.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429632A2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofFbo.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofFbo.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631D2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofQuaternion.h",
+			"isa": "PBXFileReference",
+			"name": "ofQuaternion.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631D2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofQuaternion.h",
-			"isa":"PBXFileReference",
-			"name":"ofQuaternion.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963422163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/communication/ofSerial.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofSerial.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963422163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/communication\/ofSerial.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofSerial.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
+		"E429631B2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/math/ofMatrix3x3.cpp",
+			"isa": "PBXFileReference",
+			"name": "ofMatrix3x3.cpp",
+			"lastKnownFileType": "sourcecode.cpp.cpp",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E429631B2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/math\/ofMatrix3x3.cpp",
-			"isa":"PBXFileReference",
-			"name":"ofMatrix3x3.cpp",
-			"lastKnownFileType":"sourcecode.cpp.cpp",
-			"sourceTree":"SOURCE_ROOT"
-		},
-		"E42963402163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/communication",
-			"isa":"PBXGroup",
-			"name":"communication",
-			"children":[
+		"E42963402163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/communication",
+			"isa": "PBXGroup",
+			"name": "communication",
+			"children": [
 				"E42963442163EDD300A6A9E2",
 				"E42963412163EDD300A6A9E2",
 				"E42963422163EDD300A6A9E2",
 				"E42963432163EDD300A6A9E2"
 			],
-			"sourceTree":"SOURCE_ROOT"
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E42963312163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/gl\/ofVbo.h",
-			"isa":"PBXFileReference",
-			"name":"ofVbo.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42963312163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/gl/ofVbo.h",
+			"isa": "PBXFileReference",
+			"name": "ofVbo.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		},
-		"E4B69B5A0A3A1756003C02F2":{
-			"buildConfigurationList":"E4B69B5F0A3A1757003C02F2",
-			"productReference":"E4B69B5B0A3A1756003C02F2",
-			"productType":"com.apple.product-type.application",
-			"productName":"myOFApp",
-			"isa":"PBXNativeTarget",
-			"buildPhases":[
+		"E4B69B5A0A3A1756003C02F2": {
+			"buildConfigurationList": "E4B69B5F0A3A1757003C02F2",
+			"productReference": "E4B69B5B0A3A1756003C02F2",
+			"productType": "com.apple.product-type.application",
+			"productName": "myOFApp",
+			"isa": "PBXNativeTarget",
+			"buildPhases": [
 				"E42962A92163ECCD00A6A9E2",
 				"E4B69B580A3A1756003C02F2",
 				"E4B69B590A3A1756003C02F2",
@@ -1863,21 +1829,17 @@
 				"E4C2427710CC5ABF004149E2",
 				"8466F1851C04CA0E00918B1C"
 			],
-			"dependencies":[
-				
-			],
-			"name":"emptyExample",
-			"buildRules":[
-				
-			]
+			"dependencies": [],
+			"name": "emptyExample",
+			"buildRules": []
 		},
-		"E42962EF2163EDD300A6A9E2":{
-			"path":"..\/..\/..\/libs\/openFrameworks\/app\/ofAppNoWindow.h",
-			"isa":"PBXFileReference",
-			"name":"ofAppNoWindow.h",
-			"lastKnownFileType":"sourcecode.c.h",
-			"sourceTree":"SOURCE_ROOT"
+		"E42962EF2163EDD300A6A9E2": {
+			"path": "../../../libs/openFrameworks/app/ofAppNoWindow.h",
+			"isa": "PBXFileReference",
+			"name": "ofAppNoWindow.h",
+			"lastKnownFileType": "sourcecode.c.h",
+			"sourceTree": "SOURCE_ROOT"
 		}
 	},
-	"rootObject":"E4B69B4C0A3A1720003C02F2"
+	"rootObject": "E4B69B4C0A3A1720003C02F2"
 }


### PR DESCRIPTION
in this template I've renamed the build phases so we know what each Run Script does.
I've also unchecked "Based on dependency analysis"
So we don't have this warning on XCode 14
```
warning build: Run script build phase 'Run Script' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
```
I've edited the project using xcode itself, then converting the results back to json and ident using jq (https://stedolan.github.io/jq)

```bash
cd $ofw/scripts/templates/osx/emptyExample.xcodeproj
plutil -convert json $ofw/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj 
jq --tab . project.pbxproj > ~/Desktop/project.pbxproj
cp ~/Desktop/project.pbxproj .

```

<img width="351" alt="Screen Shot 2022-09-16 at 20 10 31" src="https://user-images.githubusercontent.com/58289/190829145-a540b2a4-c048-4c91-8208-1b7a40ae6c83.png">
