### PR TITLE
Extend of material

### DIFF
--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -165,6 +165,11 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
 
 const ofShader & ofMaterial::getShader(int textureTarget, bool geometryHasColor, ofGLProgrammableRenderer & renderer) const{
     initShaders(renderer);
+	
+	if(bHasCustomShader){
+		return *customShader;
+	}
+	
 	switch(textureTarget){
 	case OF_NO_TEXTURE:
         if(geometryHasColor){
@@ -285,6 +290,13 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 			shader.setUniform3f("lights["+idx+"].right", glm::normalize(toGlm(right)));
 			shader.setUniform3f("lights["+idx+"].up", glm::normalize(up));
 		}
+	}
+}
+
+void ofMaterial::setCustomShader( std::shared_ptr<ofShader> aCustomShader) {
+	customShader = aCustomShader;
+	if( customShader ) {
+		bHasCustomShader = true;
 	}
 }
 

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -166,7 +166,7 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
 const ofShader & ofMaterial::getShader(int textureTarget, bool geometryHasColor, ofGLProgrammableRenderer & renderer) const{
     initShaders(renderer);
 	
-	if(bHasCustomShader){
+	if(bHasCustomShader && customShader){
 		return *customShader;
 	}
 	

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -137,6 +137,8 @@ public:
 	/// \param textureTarget an implementation-specific value to specify the type of shader to use
 	/// \param renderer programmable renderer instance to create the material shader for
 	virtual const ofShader & getShader(int textureTarget, bool geometryHasColor, ofGLProgrammableRenderer & renderer) const=0;
+	
+	virtual void setCustomShader( std::shared_ptr<ofShader> aCustomShader) = 0;
 
 	/// \brief upload the given renderer's normal matrix to the material shader
 	/// \param shader the material shader, created by getShader()
@@ -228,7 +230,7 @@ public:
 	void setCustomUniformTexture(const std::string & name, const ofTexture & value, int textureLocation);
 	void setCustomUniformTexture(const std::string & name, int textureTarget, GLint textureID, int textureLocation);
 
-
+	void setCustomShader( std::shared_ptr<ofShader> aCustomShader);
 
 private:
 	void initShaders(ofGLProgrammableRenderer & renderer) const;
@@ -268,4 +270,7 @@ private:
 	std::map<std::string, glm::mat4> uniforms4m;
 	std::map<std::string, glm::mat3> uniforms3m;
 	std::map<std::string, TextureUnifom> uniformstex;
+	
+	std::shared_ptr<ofShader> customShader;
+	bool bHasCustomShader = false;
 };

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -138,6 +138,8 @@ public:
 	/// \param renderer programmable renderer instance to create the material shader for
 	virtual const ofShader & getShader(int textureTarget, bool geometryHasColor, ofGLProgrammableRenderer & renderer) const=0;
 	
+	/// \brief set a custom shader controlled by the user. 
+	/// \param aCustomShader the material shader, created and maintained by the user
 	virtual void setCustomShader( std::shared_ptr<ofShader> aCustomShader) = 0;
 
 	/// \brief upload the given renderer's normal matrix to the material shader


### PR DESCRIPTION
Added ability to set a custom shader for ofMaterial. If a custom shader is set on the material, then the getShader() function will return the customShader.