### PR TITLE
Feature opencv cvmat

### DIFF
--- a/addons/ofxOpenCv/src/ofxCvColorImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvColorImage.cpp
@@ -106,10 +106,10 @@ void ofxCvColorImage::setFromPixels( const unsigned char* _pixels, int w, int h 
     if( !bAllocated || w != width || h != height ) {
 		if ( !bAllocated ){
 			ofLogNotice("ofxCvColorImage") << "setFromPixels(): allocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}else{
 			ofLogNotice("ofxCvColorImage") << "setFromPixels(): reallocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}
 		allocate(w,h);
 	}

--- a/addons/ofxOpenCv/src/ofxCvFloatImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvFloatImage.cpp
@@ -128,10 +128,10 @@ void ofxCvFloatImage::setFromPixels( const unsigned char* _pixels, int w, int h 
     if( !bAllocated || w != width || h != height ) {
 		if ( !bAllocated ){
 			ofLogNotice("ofxCvFloatImage") << "setFromPixels(): allocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}else{
 			ofLogNotice("ofxCvFloatImage") << "setFromPixels(): reallocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}
 		allocate(w,h);
 	}
@@ -166,10 +166,10 @@ void ofxCvFloatImage::setFromPixels( float* _pixels, int w, int h ) {
     if( !bAllocated || w != width || h != height ) {
 		if ( !bAllocated ){
 			ofLogNotice("ofxCvFloatImage") << "setFromPixels(): allocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}else{
 			ofLogNotice("ofxCvFloatImage") << "setFromPixels(): reallocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}
 		allocate(w,h);
 	}

--- a/addons/ofxOpenCv/src/ofxCvGrayscaleImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvGrayscaleImage.cpp
@@ -66,10 +66,10 @@ void ofxCvGrayscaleImage::setFromPixels( const unsigned char* _pixels, int w, in
     if( !bAllocated || w != width || h != height ) {
 		if ( !bAllocated ){
 			ofLogNotice("ofxCvGrayscaleImage") << "setFromPixels(): allocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}else{
 			ofLogNotice("ofxCvGrayScaleImage") << "setFromPixels(): reallocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}
 		allocate(w,h);
 	}

--- a/addons/ofxOpenCv/src/ofxCvImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvImage.cpp
@@ -230,7 +230,7 @@ void  ofxCvImage::operator = ( const IplImage* mom ) {
 		return;
 	}
 			
-	if( !bAllocated || mom->nChannels == cvImage->nChannels && mom->depth == cvImage->depth ){
+	if( !bAllocated || (mom->nChannels == cvImage->nChannels && mom->depth == cvImage->depth) ){
 		if( !bAllocated ){ 	//lets allocate if needed
 			allocate(mom->width, mom->height);
 		}else if( mom->width != width || mom->height != height ){

--- a/addons/ofxOpenCv/src/ofxCvImage.h
+++ b/addons/ofxOpenCv/src/ofxCvImage.h
@@ -91,7 +91,7 @@ class ofxCvImage : public ofBaseImage {
     // Access the IplImage as the more modern cv::Mat
     // Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
     virtual cv::Mat getCvMat() { return  cv::cvarrToMat(getCvImage()); };
-    virtual cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
+    virtual const cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
 	
     // Draw Image
     //

--- a/addons/ofxOpenCv/src/ofxCvImage.h
+++ b/addons/ofxOpenCv/src/ofxCvImage.h
@@ -88,7 +88,11 @@ class ofxCvImage : public ofBaseImage {
     virtual const ofPixels&		getRoiPixels() const;
     virtual const IplImage*  getCvImage() const { return cvImage; };
 
-
+	// Access the IplImage as the more modern cv::Mat
+	// Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
+    virtual cv::Mat getCvMat() { return  cv::cvarrToMat(getCvImage()); };
+    virtual cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
+	
     // Draw Image
     //
     virtual void updateTexture();

--- a/addons/ofxOpenCv/src/ofxCvImage.h
+++ b/addons/ofxOpenCv/src/ofxCvImage.h
@@ -88,8 +88,8 @@ class ofxCvImage : public ofBaseImage {
     virtual const ofPixels&		getRoiPixels() const;
     virtual const IplImage*  getCvImage() const { return cvImage; };
 
-	// Access the IplImage as the more modern cv::Mat
-	// Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
+    // Access the IplImage as the more modern cv::Mat
+    // Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
     virtual cv::Mat getCvMat() { return  cv::cvarrToMat(getCvImage()); };
     virtual cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
 	

--- a/addons/ofxOpenCv/src/ofxCvShortImage.cpp
+++ b/addons/ofxOpenCv/src/ofxCvShortImage.cpp
@@ -97,10 +97,10 @@ void ofxCvShortImage::setFromPixels( const unsigned char* _pixels, int w, int h 
     if( !bAllocated || w != width || h != height ) {
 		if ( !bAllocated ){
 			ofLogNotice("ofxCvShortImage") << "setFromPixels(): allocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}else{
 			ofLogNotice("ofxCvShortImage") << "setFromPixels(): reallocating to match dimensions: "
-				<< width << " " << height;
+				<< w << " " << h;
 		}
 		allocate(w,h);
 	}


### PR DESCRIPTION
Adds `cv::Mat ofxCvImage::getCvMat();` for easier usage with modern opencv. 

The main addon needs a lot more work, or a newer addon for modern opencv usage, but this function is a nice stop gap for easily using OpenCV's C++ api in the workflow.  

Also fixes incorrect ofLog notices with the wrong allocation size. 