### PR TITLE
Implement notification loop safeguard in ofParameter<void>

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -1054,14 +1054,17 @@ private:
 	class Value{
 	public:
 		Value()
-		:serializable(false){}
+		:bInNotify(false)
+        ,serializable(false){}
 
 		Value(std::string name)
 		:name(name)
+        ,bInNotify(false)
 		,serializable(false){}
 
 		std::string name;
 		ofEvent<void> changedE;
+        bool bInNotify;
 		bool serializable;
 		std::vector<std::weak_ptr<ofParameterGroup::Value>> parents;
 	};


### PR DESCRIPTION
As discussed in #6602 this PR makes `ofParameter<void>` behave the same way as the rest of parameters does.
As it is a template specialisation, the code proposed in this pull request is just coping the same functionality as is already implemented for the general `ofParameter` template.
https://github.com/openframeworks/openFrameworks/blob/977cbf3797a13a2ec39121405b2a82a35e418de2/libs/openFrameworks/types/ofParameter.h#L726-L766

This pull request does not address the fact that, implementing the same functionality twice, makes the code more prone to errors, and makes you responsible on checking differences in behaviour between the template and the specialisation when some changes are made. For that matter I feel a separate PR could be more clean.