### PR TITLE
Add transform feedback example to macos (osx) download

### DIFF
--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -328,7 +328,6 @@ function createPackage {
 	    rm -Rf gles
 	    rm -Rf gl/computeShaderParticlesExample
 	    rm -Rf gl/computeShaderTextureExample
-        rm -Rf gl/transformFeedbackExample
 	fi
 
 


### PR DESCRIPTION
As discussed in #7076. 
I think this is all that is needed in order to not be removed from macos download