### PR TITLE
ofMaterial set additional textures to support better model loading

### DIFF
--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -142,11 +142,11 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
 
     if(shaders[&renderer] == nullptr){
     
-		//add the custom uniforms to the shader header
-		auto customUniforms = data.customUniforms;
-		for( auto & custom : mCustomUniforms ){
-			customUniforms += custom.second + " " + custom.first + ";\n";
-		}
+        //add the custom uniforms to the shader header
+        auto customUniforms = data.customUniforms;
+        for( auto & custom : mCustomUniforms ){
+        	customUniforms += custom.second + " " + custom.first + ";\n";
+        }
     
         #ifndef TARGET_OPENGLES
             string vertexRectHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_RECTANGLE);

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -422,19 +422,19 @@ namespace{
         if(postFragment.empty()){
             postFragment = "vec4 postFragment(vec4 localColor){ return localColor; }";
         }
-		ofStringReplace(source, "%postFragment%", postFragment);
-		ofStringReplace(source, "%custom_uniforms%", customUniforms);
+        ofStringReplace(source, "%postFragment%", postFragment);
+        ofStringReplace(source, "%custom_uniforms%", customUniforms);
 
 		
-		//add custom textures to header of fragment shader
-		//eg: #define HAS_TEX_NORMAL 1
-		string mExtraTexturesHeader = "";
+        //add custom textures to header of fragment shader
+        //eg: #define HAS_TEX_NORMAL 1
+        string mExtraTexturesHeader = "";
 
-		for( auto & customTex : aTexDefines){
-			if( customTex.second ){
-				mExtraTexturesHeader += "#define "+customTex.first+" 1\n";
-			}
-		}
+        for( auto & customTex : aTexDefines){
+        	if( customTex.second ){
+        		mExtraTexturesHeader += "#define "+customTex.first+" 1\n";
+        	}
+        }
 
         source = shaderHeader(defaultHeader, maxLights, hasTexture, hasColor) + mExtraTexturesHeader + source;
         return source;

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -9,7 +9,7 @@ std::map<ofGLProgrammableRenderer*, std::map<std::string, std::weak_ptr<ofMateri
 
 namespace{
 string vertexSource(string defaultHeader, int maxLights, bool hasTexture, bool hasColor);
-string fragmentSource(string defaultHeader, string customUniforms, string postFragment, int maxLights, bool hasTexture, bool hasColor);
+string fragmentSource(string defaultHeader, string customUniforms, string postFragment, int maxLights, bool hasTexture, bool hasColor, std::map<std::string, bool> aTexDefines = std::map<string, bool>());
 }
 
 
@@ -35,6 +35,8 @@ void ofMaterial::setup(const ofMaterialSettings & settings){
 		uniforms2i.clear();
 		uniforms3i.clear();
 		uniforms4i.clear();
+		mTexDefines.clear();
+		mCustomUniforms.clear();
 	}
 	data = settings;
 }
@@ -57,6 +59,31 @@ void ofMaterial::setEmissiveColor(ofFloatColor oEmissive) {
 
 void ofMaterial::setShininess(float nShininess) {
 	data.shininess = nShininess;
+}
+
+void ofMaterial::setSpecularTexture(const ofTexture & aTex){
+	setCustomUniformTexture("tex_specular", aTex, 2);
+	mTexDefines["HAS_TEX_SPECULAR"] = true;
+}
+
+void ofMaterial::setAmbientTexture(const ofTexture & aTex){
+	setCustomUniformTexture("tex_ambient", aTex, 3);
+	mTexDefines["HAS_TEX_AMBIENT"] = true;
+}
+
+void ofMaterial::setEmissiveTexture(const ofTexture & aTex){
+	setCustomUniformTexture("tex_emissive", aTex, 4);
+	mTexDefines["HAS_TEX_EMISSIVE"] = true;
+}
+
+void ofMaterial::setNormalTexture(const ofTexture & aTex){
+	setCustomUniformTexture("tex_normal", aTex, 5);
+	mTexDefines["HAS_TEX_NORMAL"] = true;
+}
+
+void ofMaterial::setOcclusionTexture(const ofTexture & aTex){
+	setCustomUniformTexture("tex_occlusion", aTex, 6);
+	mTexDefines["HAS_TEX_OCCLUSION"] = true;
 }
 
 void ofMaterial::setData(const ofMaterial::Data &data){
@@ -114,6 +141,13 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
     }
 
     if(shaders[&renderer] == nullptr){
+    
+		//add the custom uniforms to the shader header
+		auto customUniforms = data.customUniforms;
+		for( auto & custom : mCustomUniforms ){
+			customUniforms += custom.second + " " + custom.first + ";\n";
+		}
+    
         #ifndef TARGET_OPENGLES
             string vertexRectHeader = renderer.defaultVertexShaderHeader(GL_TEXTURE_RECTANGLE);
             string fragmentRectHeader = renderer.defaultFragmentShaderHeader(GL_TEXTURE_RECTANGLE);
@@ -124,36 +158,36 @@ void ofMaterial::initShaders(ofGLProgrammableRenderer & renderer) const{
         shaders[&renderer].reset(new Shaders);
         shaders[&renderer]->numLights = numLights;
         shaders[&renderer]->noTexture.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertex2DHeader,numLights,false,false));
-        shaders[&renderer]->noTexture.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, data.customUniforms, data.postFragment,numLights,false,false));
+        shaders[&renderer]->noTexture.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, customUniforms, data.postFragment,numLights,false,false));
         shaders[&renderer]->noTexture.bindDefaults();
         shaders[&renderer]->noTexture.linkProgram();
 
         shaders[&renderer]->texture2D.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertex2DHeader,numLights,true,false));
-        shaders[&renderer]->texture2D.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, data.customUniforms, data.postFragment,numLights,true,false));
+        shaders[&renderer]->texture2D.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, customUniforms, data.postFragment,numLights,true,false,mTexDefines));
         shaders[&renderer]->texture2D.bindDefaults();
         shaders[&renderer]->texture2D.linkProgram();
 
         #ifndef TARGET_OPENGLES
             shaders[&renderer]->textureRect.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertexRectHeader,numLights,true,false));
-            shaders[&renderer]->textureRect.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragmentRectHeader, data.customUniforms, data.postFragment,numLights,true,false));
+            shaders[&renderer]->textureRect.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragmentRectHeader, customUniforms, data.postFragment,numLights,true,false,mTexDefines));
             shaders[&renderer]->textureRect.bindDefaults();
             shaders[&renderer]->textureRect.linkProgram();
         #endif
 
         shaders[&renderer]->color.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertex2DHeader,numLights,false,true));
-        shaders[&renderer]->color.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, data.customUniforms, data.postFragment,numLights,false,true));
+        shaders[&renderer]->color.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, customUniforms, data.postFragment,numLights,false,true));
         shaders[&renderer]->color.bindDefaults();
         shaders[&renderer]->color.linkProgram();
 
 
         shaders[&renderer]->texture2DColor.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertex2DHeader,numLights,true,true));
-        shaders[&renderer]->texture2DColor.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, data.customUniforms, data.postFragment,numLights,true,true));
+        shaders[&renderer]->texture2DColor.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragment2DHeader, customUniforms, data.postFragment,numLights,true,true,mTexDefines));
         shaders[&renderer]->texture2DColor.bindDefaults();
         shaders[&renderer]->texture2DColor.linkProgram();
 
         #ifndef TARGET_OPENGLES
             shaders[&renderer]->textureRectColor.setupShaderFromSource(GL_VERTEX_SHADER,vertexSource(vertexRectHeader,numLights,true,true));
-            shaders[&renderer]->textureRectColor.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragmentRectHeader, data.customUniforms, data.postFragment,numLights,true,true));
+            shaders[&renderer]->textureRectColor.setupShaderFromSource(GL_FRAGMENT_SHADER,fragmentSource(fragmentRectHeader, customUniforms, data.postFragment,numLights,true,true,mTexDefines));
             shaders[&renderer]->textureRectColor.bindDefaults();
             shaders[&renderer]->textureRectColor.linkProgram();
         #endif
@@ -302,50 +336,62 @@ void ofMaterial::setCustomShader( std::shared_ptr<ofShader> aCustomShader) {
 
 void ofMaterial::setCustomUniform1f(const std::string & name, float value){
 	uniforms1f[name] = value;
+	mCustomUniforms[name] = "uniform float";
 }
 
 void ofMaterial::setCustomUniform2f(const std::string & name, glm::vec2 value){
 	uniforms2f[name] = value;
+	mCustomUniforms[name] = "uniform vec2";
 }
 
 void ofMaterial::setCustomUniform3f(const std::string & name, glm::vec3 value) {
 	uniforms3f[name] = value;
+	mCustomUniforms[name] = "uniform vec3";
 }
 
 void ofMaterial::setCustomUniform4f(const std::string & name, glm::vec4 value) {
 	uniforms4f[name] = value;
+	mCustomUniforms[name] = "uniform vec4";
 }
 
 void ofMaterial::setCustomUniform1i(const std::string & name, int value) {
 	uniforms1i[name] = value;
+	mCustomUniforms[name] = "uniform int";
 }
 
 void ofMaterial::setCustomUniform2i(const std::string & name, glm::vec<2,int> value) {
 	uniforms2i[name] = value;
+	mCustomUniforms[name] = "uniform ivec2";
 }
 
 void ofMaterial::setCustomUniform3i(const std::string & name, glm::vec<3, int> value) {
 	uniforms3i[name] = value;
+	mCustomUniforms[name] = "uniform ivec3";
 }
 
 void ofMaterial::setCustomUniform4i(const std::string & name, glm::vec<4, int> value) {
 	uniforms4i[name] = value;
+	mCustomUniforms[name] = "uniform ivec4";
 }
 
 void ofMaterial::setCustomUniformMatrix4f(const std::string & name, glm::mat4 value){
 	uniforms4m[name] = value;
+	mCustomUniforms[name] = "uniform mat4";
 }
 
 void ofMaterial::setCustomUniformMatrix3f(const std::string & name, glm::mat3 value){
 	uniforms3m[name] = value;
+	mCustomUniforms[name] = "uniform mat3";
 }
 
 void ofMaterial::setCustomUniformTexture(const std::string & name, const ofTexture & value, int textureLocation){
 	uniformstex[name] = {value.getTextureData().textureTarget, int(value.getTextureData().textureID), textureLocation};
+	mCustomUniforms[name] = "uniform SAMPLER";
 }
 
 void ofMaterial::setCustomUniformTexture(const string & name, int textureTarget, GLint textureID, int textureLocation){
 	uniformstex[name] = {textureTarget, textureID, textureLocation};
+	mCustomUniforms[name] = "uniform SAMPLER";
 }
 
 #include "shaders/phong.vert"
@@ -371,7 +417,7 @@ namespace{
         return shaderHeader(defaultHeader, maxLights, hasTexture, hasColor) + vertexShader;
     }
 
-    string fragmentSource(string defaultHeader, string customUniforms,  string postFragment, int maxLights, bool hasTexture, bool hasColor){
+    string fragmentSource(string defaultHeader, string customUniforms,  string postFragment, int maxLights, bool hasTexture, bool hasColor, std::map<std::string, bool> aTexDefines){
         auto source = fragmentShader;
         if(postFragment.empty()){
             postFragment = "vec4 postFragment(vec4 localColor){ return localColor; }";
@@ -379,7 +425,18 @@ namespace{
 		ofStringReplace(source, "%postFragment%", postFragment);
 		ofStringReplace(source, "%custom_uniforms%", customUniforms);
 
-        source = shaderHeader(defaultHeader, maxLights, hasTexture, hasColor) + source;
+		
+		//add custom textures to header of fragment shader
+		//eg: #define HAS_TEX_NORMAL 1
+		string mExtraTexturesHeader = "";
+
+		for( auto & customTex : aTexDefines){
+			if( customTex.second ){
+				mExtraTexturesHeader += "#define "+customTex.first+" 1\n";
+			}
+		}
+
+        source = shaderHeader(defaultHeader, maxLights, hasTexture, hasColor) + mExtraTexturesHeader + source;
         return source;
     }
 }

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -100,7 +100,7 @@ struct ofMaterialSettings {
     ofFloatColor emissive{ 0.0f, 0.0f, 0.0f, 1.0f }; ///< emitted light intensity
     float shininess{ 0.2f }; ///< specular exponent
     std::string postFragment;
-    std::string customUniforms;
+    std::string customUniforms; ///set by ofMaterial::setCustomUniform*  not to be set manually
 };
 
 /// \class ofBaseMaterial
@@ -197,6 +197,15 @@ public:
 	
 	/// \brief set the specular exponent
 	void setShininess(float nShininess);
+	
+	/// \brief set additonal textures to use in the shader.
+	// the following shaders are supported by phong.frag
+	// in the future we will add textures for physical based rendering (PBR)
+	void setSpecularTexture(const ofTexture & aTex);
+	void setAmbientTexture(const ofTexture & aTex);
+	void setEmissiveTexture(const ofTexture & aTex);
+	void setNormalTexture(const ofTexture & aTex);
+	void setOcclusionTexture(const ofTexture & aTex);
 
 	// documented in ofBaseMaterial
 	ofFloatColor getDiffuseColor() const;
@@ -217,7 +226,7 @@ public:
 	void begin() const;
 	void end() const;
 
-
+	/// \brief set custom uniforms to be used by the shader. as of 0.12.0 onwards these are added to the shader header
 	void setCustomUniform1f(const std::string & name, float value);
 	void setCustomUniform2f(const std::string & name, glm::vec2 value);
 	void setCustomUniform3f(const std::string & name, glm::vec3 value);
@@ -273,6 +282,6 @@ private:
 	std::map<std::string, glm::mat3> uniforms3m;
 	std::map<std::string, TextureUnifom> uniformstex;
 	
-	std::shared_ptr<ofShader> customShader;
-	bool bHasCustomShader = false;
+	std::map<std::string, bool> mTexDefines;
+	std::map<std::string, std::string> mCustomUniforms;
 };

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -284,4 +284,7 @@ private:
 	
 	std::map<std::string, bool> mTexDefines;
 	std::map<std::string, std::string> mCustomUniforms;
+	
+	std::shared_ptr<ofShader> customShader;
+	bool bHasCustomShader = false;
 };

--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -249,12 +249,12 @@ static const string fragmentShader = R"(
         vec3 diffuse = vec3(0.0,0.0,0.0);
         vec3 specular = vec3(0.0,0.0,0.0);
         
-		vec3 tNormal = v_transformedNormal;
-		#ifdef HAS_TEX_NORMAL
-			tNormal = PerturbNormal(TEXTURE(tex_normal, v_texcoord).rgb, tNormal, v_eyePosition, v_texcoord);
-		#endif
+        vec3 tNormal = v_transformedNormal;
+        #ifdef HAS_TEX_NORMAL
+        	tNormal = PerturbNormal(TEXTURE(tex_normal, v_texcoord).rgb, tNormal, v_eyePosition, v_texcoord);
+        #endif
 			
-		vec3 transformedNormal = normalize(tNormal);
+        vec3 transformedNormal = normalize(tNormal);
 
         for( int i = 0; i < MAX_LIGHTS; i++ ){
             if(lights[i].enabled<0.5) continue;
@@ -271,21 +271,21 @@ static const string fragmentShader = R"(
         
         // apply emmisive texture
         vec4 mat_emissive_color = mat_emissive;
-		#ifdef HAS_TEX_EMISSIVE
-			mat_emissive_color *= TEXTURE(tex_emissive, v_texcoord);
-		#endif
+        #ifdef HAS_TEX_EMISSIVE
+        	mat_emissive_color *= TEXTURE(tex_emissive, v_texcoord);
+        #endif
 		
-		// apply specular texture // these are mostly black and white
-		#ifdef HAS_TEX_SPECULAR
-			vec4 spec_value = TEXTURE(tex_specular, v_texcoord);
-			specular *= spec_value.rgb; //apply the color
-		#endif
+        // apply specular texture // these are mostly black and white
+        #ifdef HAS_TEX_SPECULAR
+        	vec4 spec_value = TEXTURE(tex_specular, v_texcoord);
+        	specular *= spec_value.rgb; //apply the color
+        #endif
 
-		// apply ambient texture // these are mostly black and white
-		#ifdef HAS_TEX_AMBIENT
-			vec4 ambient_value = TEXTURE(tex_ambient, v_texcoord);
-			ambient *= ambient_value.rgb; //apply the color
-		#endif
+        // apply ambient texture // these are mostly black and white
+        #ifdef HAS_TEX_AMBIENT
+        	vec4 ambient_value = TEXTURE(tex_ambient, v_texcoord);
+        	ambient *= ambient_value.rgb; //apply the color
+        #endif
 
         ////////////////////////////////////////////////////////////
         // now add the material info
@@ -303,10 +303,10 @@ static const string fragmentShader = R"(
             vec4 localColor = vec4(ambient,1.0) * mat_ambient + vec4(diffuse,1.0) * mat_diffuse + vec4(specular,1.0) * mat_specular + mat_emissive_color;
         #endif
                 
-		#ifdef HAS_TEX_OCCLUSION
-			float occlusioon = TEXTURE(tex_occlusion, v_texcoord).r;
-			localColor.rgb *= occlusioon;
-		#endif
+        #ifdef HAS_TEX_OCCLUSION
+            float occlusioon = TEXTURE(tex_occlusion, v_texcoord).r;
+            localColor.rgb *= occlusioon;
+        #endif
         
         FRAG_COLOR = clamp( postFragment(localColor), 0.0, 1.0 );
     }

--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -279,6 +279,7 @@ static const string fragmentShader = R"(
         #ifdef HAS_TEX_SPECULAR
         	vec4 spec_value = TEXTURE(tex_specular, v_texcoord);
         	specular *= spec_value.rgb; //apply the color
+        	specular *= spec_value.a; //also apply alpha which is sometimes used as a mask 
         #endif
 
         // apply ambient texture // these are mostly black and white


### PR DESCRIPTION
Been working on making the assimp model loader much more robust and useful. 
( will do a separate PR for that ) 

This PR adds texture support for loading: 
- emissive 
- occlusion 
- normal map / bump map 
- specular 
- ambient 
 
To the ofMaterial phong.frag shader. 
In the future we could add a pbr.frag shader for Physical Based Rendering but for now this adds quite a bit. 

You can see the emissive and normal map support this adds to this model: 

<img width="2032" alt="Screen Shot 2022-10-04 at 1 30 17 PM" src="https://user-images.githubusercontent.com/144000/193926428-55bdab4d-eaf1-482d-aa59-5827d0541615.png">

And some of the details you get from the normal map in this model: 
<img width="2032" alt="Screen Shot 2022-10-04 at 2 02 15 PM" src="https://user-images.githubusercontent.com/144000/193927959-25d1e903-d28f-4363-999c-98bd6d8b3d9d.png">
