### PR TITLE
A dream about fbos summing using += operator

### DIFF
--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -303,6 +303,14 @@ ofFbo::ofFbo(const ofFbo & mom){
 }
 
 //--------------------------------------------------------------
+void ofFbo::operator+=(const ofFbo & mom){
+	this->begin();
+	ofSetColor(255);
+	mom.draw(0,0);
+	this->end();
+}
+
+//--------------------------------------------------------------
 ofFbo & ofFbo::operator=(const ofFbo & mom){
 	if(&mom==this) return *this;
 	clear();

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -48,6 +48,7 @@ public:
 	ofFbo();
 	ofFbo(const ofFbo & mom);
 	ofFbo & operator=(const ofFbo & fbo);
+	void operator+=(const ofFbo & fbo);
     ofFbo(ofFbo && mom);
     ofFbo & operator=(ofFbo && fbo);
 	virtual ~ofFbo();

--- a/libs/openFrameworksCompiled/project/Makefile
+++ b/libs/openFrameworksCompiled/project/Makefile
@@ -14,6 +14,12 @@
 # define the OF_SHARED_MAKEFILES location
 OF_SHARED_MAKEFILES_PATH=./makefileCommon
 
+# PLATFORM_CFLAGS 
+
+# PROJECT_CXX = include-what-you-use
+# PROJECT_CC = include-what-you-use
+# CXX = include-what-you-use
+# CC = include-what-you-use
 
 # include the global configuration file
 include $(OF_SHARED_MAKEFILES_PATH)/config.shared.mk


### PR DESCRIPTION
Last night I dreamt about OF, ofFbo had a += operator so you could sum layers like this
```c++
fbo += fbo2;
```

so I decided to make this quick PR 

example
```c++
#include "ofApp.h"

ofFbo fbo;
ofFbo fbo2;
ofFbo fbo3;

//--------------------------------------------------------------
void ofApp::setup(){
	fbo.allocate(600, 600, GL_RGBA);
	fbo.begin();
	ofClear(0,0);
	ofSetColor(255, 0, 0);
	ofDrawCircle(300, 300, 200);
	fbo.end();
	
	fbo2.allocate(600, 600, GL_RGBA);
	fbo2.begin();
	ofClear(0,0);
	ofSetColor(0, 0, 255);
	ofDrawRectangle(100, 100, 300, 50);
	fbo2.end();

	fbo3.allocate(600, 600, GL_RGBA);
	fbo3.begin();
	ofClear(0,0);
	ofSetColor(0, 255, 0);
	ofDrawRectangle(200, 200, 300, 50);
	fbo3.end();

	fbo += fbo2;
	fbo += fbo3;
}

//--------------------------------------------------------------
void ofApp::update(){

}

//--------------------------------------------------------------
void ofApp::draw(){
	fbo.draw(0,0);
}

void ofApp::keyPressed(int key) {

}

```
![Screen Shot 2022-10-06 at 16 23 03](https://user-images.githubusercontent.com/58289/194400921-97ad57ce-710c-4301-af66-620e7d47cbcb.png)

