### PR TITLE
Update build-macos.yml

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -84,7 +84,7 @@ jobs:
     
     - name: Build
       run:
-        if [ "$TARGET" = "osx" ] && [ "$OPT" = "makefiles" ]; then
+        if [ "$TARGET" = "osx" ] && [ "$OPT" = "xcode" ]; then
           scripts/ci/$TARGET/build.sh $OPT;
         else
           scripts/ci/$TARGET/run_tests.sh;


### PR DESCRIPTION
logic for makefile and Xcode was inverted. 
makefile is running the xcodebuild commands and Xcode is doing the tests via makefile.  
