### PR TITLE
Archlinux install script: use -S instead of -Sy

### DIFF
--- a/scripts/linux/archlinux/install_codecs.sh
+++ b/scripts/linux/archlinux/install_codecs.sh
@@ -1,2 +1,2 @@
-pacman -Sy --needed mpg123 gst-plugins-ugly
+pacman -S --needed mpg123 gst-plugins-ugly
 

--- a/scripts/linux/archlinux/install_dependencies.sh
+++ b/scripts/linux/archlinux/install_dependencies.sh
@@ -4,19 +4,18 @@ if [ $EUID != 0 ]; then
 	echo "this script must be run as root"
 	echo ""
 	echo "usage:"
-	echo "su -"
-	echo "./install_dependencies.sh"
+	echo "sudo ./install_dependencies.sh"
 	exit $exit_code
    exit 1
 fi
 
 ROOT=$(cd $(dirname $0); pwd -P)
 
-pacman -Sy --needed make pkgconf gcc openal glew freeglut freeimage gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav opencv libxcursor assimp boost glfw-x11 uriparser curl pugixml rtaudio poco
+pacman -S --needed make pkgconf gcc openal glew freeglut freeimage gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav opencv libxcursor assimp boost glfw-x11 uriparser curl pugixml rtaudio poco
 
 exit_code=$?
 if [ $exit_code != 0 ]; then
-	echo "error installing packages, there could be an error with your internet connection"
+	echo "error installing packages, there could be an error with your internet connection, or you system might be too out of date (run pacman -Syu before running this script)""
 	exit $exit_code
 fi
 

--- a/scripts/linux/archlinux_armv7/install_dependencies.sh
+++ b/scripts/linux/archlinux_armv7/install_dependencies.sh
@@ -8,22 +8,21 @@ if [ $EUID != 0 ]; then
 	echo "this script must be run as root"
 	echo ""
 	echo "usage:"
-	echo "su -"
-	echo "./install_dependencies.sh"
+	echo "sudo ./install_dependencies.sh"
 	exit $exit_code
    exit 1
 fi
 
 ROOT=$(cd $(dirname $0); pwd -P)
 
-pacman -Sy --needed make pkg-config gcc openal glew freeglut freeimage freetype2 cairo poco gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav raspberrypi-firmware gst-omx-rpi assimp boost libxcursor opencv assimp glfw-x11  uriparser curl pugixml
+pacman -S --needed make pkg-config gcc openal glew freeglut freeimage freetype2 cairo poco gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav raspberrypi-firmware gst-omx-rpi assimp boost libxcursor opencv assimp glfw-x11  uriparser curl pugixml
 
 downloader http://ci.openframeworks.cc/rtaudio-armv7hf.tar.bz2
 tar xjf rtaudio-armv7hf.tar.bz2 -C /
 
 exit_code=$?
 if [ $exit_code != 0 ]; then
-	echo "error installing packages, there could be an error with your internet connection"
+	echo "error installing packages, there could be an error with your internet connection, or you system might be too out of date (run pacman -Syu before running this script)""
 	exit $exit_code
 fi
 


### PR DESCRIPTION
The Arch linux install scripts use -Sy arguments to pacman, which is an unsupported combo as mentioned on the arch wiki:

> Avoid doing [partial upgrades](https://wiki.archlinux.org/title/system_maintenance#Partial_upgrades_are_unsupported). In other words, never run pacman -Sy

Over the weekend [openssl got upgraded from 1.1.1 to 3.0](https://bbs.archlinux.org/viewtopic.php?id=281005). Running the openframeworks script trickles down to updating openssl to 3, which removes 1.1.1. The rest of the system (not updated because not -u) still looks for 1.1.1 and breaks. Without openssl, rebooting halts very early in the process and requires a trip to the USB archboot to re-run pacman in chroot.

We don't want a sudo script that silently updates a whole system, so in addition to changing the argument to -S (which means "use the version of the packages as of last synchronization"), if pacman fails i suggest a bit of text to inform of the need to update the system (if the currently held versions are not in the mirrors anymore it will manifest as 404 on the package URLs). 

