### PR TITLE
Fix linux testallexamples

### DIFF
--- a/scripts/linux/testAllExamples.sh
+++ b/scripts/linux/testAllExamples.sh
@@ -11,7 +11,7 @@ do
     cd $category
     for example in $( ls . )
     do
-        if [[ "$example" == osx* ]]
+        if [[ "$example" == osx* ]] || [[ "$example" != *Example ]]
         then
             continue
         fi    

--- a/scripts/linux/testAllExamples.sh
+++ b/scripts/linux/testAllExamples.sh
@@ -5,7 +5,7 @@ cd ../../examples
 
 for category in $( ls . )
 do
-    if [ "$category" = "android" -o "$category" = "ios" -o "$category" = "gles" ]; then
+    if [ ! -d "$category" -o "$category" = "android" -o "$category" = "ios" -o "$category" = "gles" ]; then
             continue
     fi
     cd $category


### PR DESCRIPTION
testAllExamples.sh stumbled over README.md (and eventual qtCreator build-* directories), and then failed.

fix #6742