### PR TITLE
ofMesh added more utility in removal functions (start/end index)

### DIFF
--- a/libs/openFrameworks/3d/ofMesh.h
+++ b/libs/openFrameworks/3d/ofMesh.h
@@ -196,6 +196,9 @@ public:
 	/// \brief Removes the vertex at the index in the vector.
 	void removeVertex(ofIndexType index);
 
+	/// \brief Removes the vertices at the startIndex in the vector and the endindex specified
+	void removeVertex(ofIndexType startIndex, ofIndexType endIndex);
+
 	void setVertex(ofIndexType index, const V& v);
 
 	/// \brief Removes all the vertices.
@@ -271,6 +274,9 @@ public:
 
 	/// \brief Remove a normal.
 	void removeNormal(ofIndexType index);
+
+	/// \brief Remove normal's from index to end index from normals vector
+	void removeNormal(ofIndexType startIndex, ofIndexType endIndex);
 
 	/// \todo Documentation.
 	void setNormal(ofIndexType index, const N& n);
@@ -355,6 +361,9 @@ public:
 	/// \brief Remove a color at the index in the colors vector.
 	void removeColor(ofIndexType index);
 
+	/// \brief Remove colors at the index to the end index of the colors vector
+	void removeColor(ofIndexType startIndex, ofIndexType endIndex);
+
 	/// \brief Set the color at the index in the colors vector.
 	void setColor(ofIndexType index, const C& c);
 
@@ -423,6 +432,8 @@ public:
 
 	/// \brief  Remove a Vec2f representing the texture coordinate.
 	void removeTexCoord(ofIndexType index);
+
+	void removeTexCoord(ofIndexType startIndex, ofIndexType endIndex);
 	void setTexCoord(ofIndexType index, const T& t);
 
 	/// \brief  Clear all the texture coordinates.
@@ -514,6 +525,7 @@ public:
 
 	/// \brief Removes an index.
 	void removeIndex(ofIndexType index);
+	void removeIndex(ofIndexType startIndex, ofIndexType endIndex);
 
 	/// \brief This sets the index at i.
 	void setIndex(ofIndexType index, ofIndexType val);

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -359,6 +359,17 @@ void ofMesh_<V,N,C,T>::removeVertex(ofIndexType index){
   }
 }
 
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::removeVertex(ofIndexType startIndex, ofIndexType endIndex){
+	if(startIndex >= vertices.size() || endIndex >= vertices.size()){
+		ofLogError("ofMesh") << "removeVertex(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of vertices is" << vertices.size();
+	}else{
+		vertices.erase(vertices.begin() + startIndex, vertices.begin() + endIndex);
+		bVertsChanged = true;
+		bFacesDirty = true;
+	}
+}
+
 
 
 //--------------------------------------------------------------
@@ -373,6 +384,16 @@ void ofMesh_<V,N,C,T>::removeNormal(ofIndexType index){
   }
 }
 
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::removeNormal(ofIndexType startIndex, ofIndexType endIndex){
+    if(startIndex >= normals.size() || endIndex >= normals.size()){
+        ofLogError("ofMesh") << "removeNormal(): ignoring out of range beginIndex " << startIndex << " endIndex " << endIndex << ", number of normals is" << normals.size();
+    }else{
+        normals.erase(normals.begin() + startIndex, normals.begin() + endIndex);
+        bNormalsChanged = true;
+        bFacesDirty = true;
+    }
+}
 
 
 //--------------------------------------------------------------
@@ -385,6 +406,17 @@ void ofMesh_<V,N,C,T>::removeColor(ofIndexType index){
 	bColorsChanged = true;
 	bFacesDirty = true;
   }
+}
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::removeColor(ofIndexType startIndex, ofIndexType endIndex){
+	if(startIndex >= colors.size() || endIndex >= colors.size()){
+		ofLogError("ofMesh") << "removeColor(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of colors is" << colors.size();
+	}else{
+		colors.erase(colors.begin() + startIndex, colors.begin() + endIndex);
+		bColorsChanged = true;
+		bFacesDirty = true;
+	}
 }
 
 
@@ -401,6 +433,18 @@ void ofMesh_<V,N,C,T>::removeTexCoord(ofIndexType index){
   }
 }
 
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::removeTexCoord(ofIndexType startIndex, ofIndexType endIndex){
+	if(startIndex >= texCoords.size() || endIndex >= texCoords.size()){
+		ofLogError("ofMesh") << "removeTexCoord(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of tex coords is" << texCoords.size();
+	}else{
+		texCoords.erase(texCoords.begin() + startIndex, texCoords.begin() + endIndex);
+		bTexCoordsChanged = true;
+		bFacesDirty = true;
+	}
+}
+
+
 
 
 //--------------------------------------------------------------
@@ -414,6 +458,18 @@ void ofMesh_<V,N,C,T>::removeIndex(ofIndexType index){
 	bFacesDirty = true;
   }
 }
+
+template<class V, class N, class C, class T>
+void ofMesh_<V,N,C,T>::removeIndex(ofIndexType startIndex, ofIndexType endIndex){
+	if(startIndex >= indices.size() || endIndex >= indices.size()){
+		ofLogError("ofMesh") << "removeIndex(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of indices is" << indices.size();;
+	}else{
+		indices.erase(indices.begin() + startIndex, indices.begin() + endIndex);
+		bIndicesChanged = true;
+		bFacesDirty = true;
+	}
+}
+
 
 
 //GETTERS

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -361,7 +361,7 @@ void ofMesh_<V,N,C,T>::removeVertex(ofIndexType index){
 
 template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::removeVertex(ofIndexType startIndex, ofIndexType endIndex){
-	if(startIndex >= vertices.size() || endIndex >= vertices.size()){
+	if(startIndex >= vertices.size() || endIndex > vertices.size()){
 		ofLogError("ofMesh") << "removeVertex(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of vertices is" << vertices.size();
 	}else{
 		vertices.erase(vertices.begin() + startIndex, vertices.begin() + endIndex);
@@ -386,7 +386,7 @@ void ofMesh_<V,N,C,T>::removeNormal(ofIndexType index){
 
 template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::removeNormal(ofIndexType startIndex, ofIndexType endIndex){
-    if(startIndex >= normals.size() || endIndex >= normals.size()){
+    if(startIndex >= normals.size() || endIndex > normals.size()){
         ofLogError("ofMesh") << "removeNormal(): ignoring out of range beginIndex " << startIndex << " endIndex " << endIndex << ", number of normals is" << normals.size();
     }else{
         normals.erase(normals.begin() + startIndex, normals.begin() + endIndex);
@@ -410,7 +410,7 @@ void ofMesh_<V,N,C,T>::removeColor(ofIndexType index){
 
 template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::removeColor(ofIndexType startIndex, ofIndexType endIndex){
-	if(startIndex >= colors.size() || endIndex >= colors.size()){
+	if(startIndex >= colors.size() || endIndex > colors.size()){
 		ofLogError("ofMesh") << "removeColor(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of colors is" << colors.size();
 	}else{
 		colors.erase(colors.begin() + startIndex, colors.begin() + endIndex);
@@ -461,7 +461,7 @@ void ofMesh_<V,N,C,T>::removeIndex(ofIndexType index){
 
 template<class V, class N, class C, class T>
 void ofMesh_<V,N,C,T>::removeIndex(ofIndexType startIndex, ofIndexType endIndex){
-	if(startIndex >= indices.size() || endIndex >= indices.size()){
+	if(startIndex >= indices.size() || endIndex > indices.size()){
 		ofLogError("ofMesh") << "removeIndex(): ignoring out of range startIndex " << startIndex << " endIndex " << endIndex << ", number of indices is" << indices.size();;
 	}else{
 		indices.erase(indices.begin() + startIndex, indices.begin() + endIndex);


### PR DESCRIPTION
Changes to **ofMesh** 

Related to removal of vertices / normals / indices / textures (coords) 
Added new utility of new parameter remove functions to also have ability to remove between range of iterators from start to end.

Note: code is not index bound and uses iterators so > .size() is correct for end index 

Part of the evaluate and fix leaks PRS incoming 
