### PR TITLE
ofxAssimpModelLoader - fix ambiguous load

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -45,7 +45,7 @@ class ofxAssimpModelLoader{
         bool load(std::string modelName, int assimpOptimizeFlags=OPTIMIZE_DEFAULT);
         bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
-        OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(std::string modelName, bool optimize=false));
+        OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(std::string modelName, bool optimize));
         OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(ofBuffer & buffer, bool optimize=false, const char * extension=""));
 
         OF_DEPRECATED_MSG("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.", bool loadModel(std::string modelName, bool optimize=false));

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -46,7 +46,7 @@ class ofxAssimpModelLoader{
         bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
         OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(std::string modelName, bool optimize));
-        OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(ofBuffer & buffer, bool optimize=false, const char * extension=""));
+        OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(ofBuffer & buffer, bool optimize, const char * extension));
 
         OF_DEPRECATED_MSG("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.", bool loadModel(std::string modelName, bool optimize=false));
         OF_DEPRECATED_MSG("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.", bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension=""));


### PR DESCRIPTION
remove the default value from the deprecated function. Reasoning is, that the deprecated function should not be the default one, and at the same time old code using the deprecated function should still work.

Fix #7165