### PR TITLE
Fix for Header files missing in Windows for some first-party addons (#7169)

### DIFF
--- a/scripts/vs/download_libs.ps1
+++ b/scripts/vs/download_libs.ps1
@@ -13,7 +13,7 @@ $libsDir = $scriptPath + "\..\..\libs"
 
 function DownloadPackage{
     $pkg = $args[0]
-    $url = "http://ci.openframeworks.cc/libs/$pkg"
+    $url = " https://github.com/openframeworks/apothecary/releases/download/nightly/$pkg"
     If(Test-Path "$pkg") {
         echo "Deleting old package"
         Remove-Item $pkg

--- a/scripts/vs/download_libs.ps1
+++ b/scripts/vs/download_libs.ps1
@@ -122,9 +122,7 @@ function moveAddonLib {
 
     echo "Moving addon lib: $lib_name"
 
-    robocopy.exe "..\..\libs\64\$lib_name\lib\vs\x64" "..\..\addons\$addon_path\$lib_name\lib\vs\x64" /MOVE /NFL /R:5 /S
-    Remove-Item  "..\..\libs\64\$lib_name" -Force -Recurse
-
+    robocopy.exe "..\..\libs\64\$lib_name" "..\..\addons\$addon_path\$lib_name" /MOVE /NFL /R:5 /S
 }
 
 echo "Moving addons libs"


### PR DESCRIPTION
Fix for #7169 

The download_libs.ps1 script was only copying the VS lib files of downloaded addon libs, which left out anything else, such as include directories. This fixes the script so that the complete library is copied.

It also updates the download URL to point to Github Releases.
