### PR TITLE
Emscripten video player fix

### DIFF
--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -120,7 +120,7 @@ var LibraryHTML5Video = {
     },
 
     html5video_player_pixel_format: function(id){
-        return allocate(intArrayFromString(VIDEO.players[id].pixelFormat), 'i8', ALLOC_STACK);
+        return allocate(intArrayFromString(VIDEO.players[id].pixelFormat), ALLOC_STACK);
     },
 
     html5video_player_set_pixel_format: function(id, format){
@@ -286,7 +286,7 @@ var LibraryHTML5Video = {
     },
 
     html5video_grabber_pixel_format: function(id){
-        return allocate(intArrayFromString(VIDEO.grabbers[id].pixelFormat), 'i8', ALLOC_STACK);
+        return allocate(intArrayFromString(VIDEO.grabbers[id].pixelFormat), ALLOC_STACK);
     },
 
     html5video_grabber_set_pixel_format: function(id, format){

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -93,7 +93,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1
+PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=allocate
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 


### PR DESCRIPTION
This fixes ofVideoPlayer with Emscripten (and also the 3DPrimitivesExample patch, because it uses the videoGrabber).
Maybe allocate can be replaced with mallloc at some point?
https://github.com/emscripten-core/emscripten/issues/11547

The `assimpExample` patch works too, just not with the first model (which is the preset yet), because there are some shader issues which crashes the patch.
This `loadModel("Astroboy/astroBoy_walk.dae");` and the old man works without issues, the other two have issues, but still load. Did not change anything regarding the assimpExamples in this pull request, just wanted to mention it.