### PR TITLE
Emscripten true type font fix

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -629,7 +629,12 @@ bool ofTrueTypeFont::loadFont(string filename, int fontSize, bool bAntiAliased, 
 //-----------------------------------------------------------
 ofTrueTypeFont::glyph ofTrueTypeFont::loadGlyph(uint32_t utf8) const{
 	glyph aGlyph;
-	auto err = FT_Load_Glyph( face.get(), FT_Get_Char_Index( face.get(), utf8 ), settings.antialiased ?  FT_LOAD_FORCE_AUTOHINT : FT_LOAD_DEFAULT );
+	bool autoHint = settings.antialiased;
+	#ifdef TARGET_EMSCRIPTEN
+		autoHint = false;
+	#endif
+	
+	auto err = FT_Load_Glyph( face.get(), FT_Get_Char_Index( face.get(), utf8 ), autoHint ?  FT_LOAD_FORCE_AUTOHINT : FT_LOAD_DEFAULT );
 	if(err){
 		ofLogError("ofTrueTypeFont") << "loadFont(): FT_Load_Glyph failed for utf8 code " << utf8 << ": FT_Error " << err;
 		return aGlyph;


### PR DESCRIPTION
This pull request is related to this issue: https://github.com/openframeworks/openFrameworks/pull/6764
I seem to need it to make the fontExample work. Just wonder why it works for @themancalledjakob without this fix... 
https://dev.pointer.click/of/
So maybe I miss something, and this fix is not needed?