### PR TITLE
Emscripten_pointCloudExample fix

### DIFF
--- a/examples/3d/pointCloudExample/src/ofApp.cpp
+++ b/examples/3d/pointCloudExample/src/ofApp.cpp
@@ -28,8 +28,8 @@ void ofApp::setup() {
 
 	ofEnableDepthTest();
 	#ifndef TARGET_EMSCRIPTEN
-	glEnable(GL_POINT_SMOOTH); // use circular points instead of square points
-	glPointSize(3); // make the points bigger
+		glEnable(GL_POINT_SMOOTH); // use circular points instead of square points
+		glPointSize(3); // make the points bigger
 	#endif
 }
 

--- a/examples/3d/pointCloudExample/src/ofApp.cpp
+++ b/examples/3d/pointCloudExample/src/ofApp.cpp
@@ -27,10 +27,8 @@ void ofApp::setup() {
 	}
 
 	ofEnableDepthTest();
-	#ifndef TARGET_EMSCRIPTEN
 	glEnable(GL_POINT_SMOOTH); // use circular points instead of square points
 	glPointSize(3); // make the points bigger
-	#endif
 }
 
 //--------------------------------------------------------------

--- a/examples/3d/pointCloudExample/src/ofApp.cpp
+++ b/examples/3d/pointCloudExample/src/ofApp.cpp
@@ -27,8 +27,10 @@ void ofApp::setup() {
 	}
 
 	ofEnableDepthTest();
+	#ifndef TARGET_EMSCRIPTEN
 	glEnable(GL_POINT_SMOOTH); // use circular points instead of square points
 	glPointSize(3); // make the points bigger
+	#endif
 }
 
 //--------------------------------------------------------------

--- a/examples/3d/pointPickerExample/src/ofApp.cpp
+++ b/examples/3d/pointPickerExample/src/ofApp.cpp
@@ -22,7 +22,7 @@ void ofApp::draw(){
 	mesh.drawWireframe();
 	
 	#ifndef TARGET_EMSCRIPTEN
-	glPointSize(2);
+		glPointSize(2);
 	#endif
 	ofSetColor(ofColor::white);
 	mesh.drawVertices();

--- a/examples/3d/pointPickerExample/src/ofApp.cpp
+++ b/examples/3d/pointPickerExample/src/ofApp.cpp
@@ -21,7 +21,9 @@ void ofApp::draw(){
 	ofSetColor(ofColor::gray);
 	mesh.drawWireframe();
 	
+	#ifndef TARGET_EMSCRIPTEN
 	glPointSize(2);
+	#endif
 	ofSetColor(ofColor::white);
 	mesh.drawVertices();
 	cam.end();


### PR DESCRIPTION
Not ideal because the points are very small now, but it seems that `GL_POINT_SMOOTH` and `glPointSize()` do not exits in WebGL. https://stackoverflow.com/questions/66781512/why-doesnt-pointsize-default-to-a-standard-value-in-webgl
Same with the pointPickerExample.