### PR TITLE
Emscripten audioInputExample and opencvImageClassification fix

### DIFF
--- a/examples/computer_vision/opencvImageClassification/src/ofApp.cpp
+++ b/examples/computer_vision/opencvImageClassification/src/ofApp.cpp
@@ -37,7 +37,9 @@ void ofApp::draw(){
 
 	ofSetColor(255);
 	#ifdef TARGET_EMSCRIPTEN
-		grabber.getTexture().draw(0, 0);
+		if(grabber.getTexture().isAllocated()){
+			grabber.getTexture().draw(0, 0);
+		}
 	#else
 		grabber.draw(0, 0);
 	#endif

--- a/examples/computer_vision/opencvImageClassification/src/ofApp.cpp
+++ b/examples/computer_vision/opencvImageClassification/src/ofApp.cpp
@@ -36,7 +36,11 @@ void ofApp::update(){
 void ofApp::draw(){
 
 	ofSetColor(255);
-	grabber.draw(0, 0);
+	#ifdef TARGET_EMSCRIPTEN
+		grabber.getTexture().draw(0, 0);
+	#else
+		grabber.draw(0, 0);
+	#endif
 	
 	//draw the detected objects on top of the webcam image 
 	ofNoFill();

--- a/examples/shader/06_multiTexture/src/ofApp.cpp
+++ b/examples/shader/06_multiTexture/src/ofApp.cpp
@@ -69,7 +69,7 @@ void ofApp::draw(){
 	//------------------------------------------- 
 	ofSetColor(255);
 	#ifdef TARGET_EMSCRIPTEN
-		if (camera.getTexture().isAllocated()){
+		if(camera.getTexture().isAllocated()){
 			camera.getTexture().draw(5,5,320,240);
 		}
 	#else

--- a/examples/shader/06_multiTexture/src/ofApp.cpp
+++ b/examples/shader/06_multiTexture/src/ofApp.cpp
@@ -68,7 +68,13 @@ void ofApp::draw(){
 	
 	//------------------------------------------- 
 	ofSetColor(255);
-	camera.draw(5,5,320,240);
+	#ifdef TARGET_EMSCRIPTEN
+		if (camera.getTexture().isAllocated()){
+			camera.getTexture().draw(5,5,320,240);
+		}
+	#else
+		camera.draw(5,5,320,240);
+	#endif
 	ofSetColor(ofColor::red);
 	ofDrawBitmapString("RED", 5+30, 5+30);
 	

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -42,7 +42,11 @@ void ofApp::setup(){
 
 	settings.setInListener(this);
 	settings.sampleRate = 44100;
-	settings.numOutputChannels = 0;
+	#ifdef TARGET_EMSCRIPTEN
+		settings.numOutputChannels = 2;
+	#else
+		settings.numOutputChannels = 0;
+	#endif
 	settings.numInputChannels = 2;
 	settings.bufferSize = bufferSize;
 	soundStream.setup(settings);


### PR DESCRIPTION
If the videoGrabber is fixed the `opencvImageClassification` example changes are not needed anymore (the same for other examples that use ofVideoGrabber).