### PR TITLE
Revert "Emscripten meshFromCameraExample fix"

### DIFF
--- a/examples/3d/meshFromCameraExample/src/ofApp.cpp
+++ b/examples/3d/meshFromCameraExample/src/ofApp.cpp
@@ -19,12 +19,13 @@ void ofApp::setup(){
 	ofSetFrameRate(60);
 	ofBackground(66,66,66);
 	
-	int width = 320;
-	int height = 240;
-	
 	//initialize the video grabber
 	vidGrabber.setVerbose(true);
-	vidGrabber.initGrabber(width,height);
+	vidGrabber.setup(320,240);
+
+	//store the width and height for convenience
+	int width = vidGrabber.getWidth();
+	int height = vidGrabber.getHeight();
 	
 	//add one vertex to the mesh for each pixel
 	for (int y = 0; y < height; y++){


### PR DESCRIPTION
Reverts openframeworks/openFrameworks#7185

@Jonathhhan 
Think actually we can't solve it this way as other platform grabbers will sometimes not return the requested size but the closest matching.  

I think we should probably figure out a way for emscripten to return the requested size immediately instead. 