### PR TITLE
Emscripten fboHighResOutputExample fix

### DIFF
--- a/examples/gl/fboHighResOutputExample/src/ofApp.cpp
+++ b/examples/gl/fboHighResOutputExample/src/ofApp.cpp
@@ -13,7 +13,11 @@ void ofApp::setup(){
 	int fboWidth = MIN(8192,maxSize);
 	int fboHeight = MIN(8192,maxSize);
 	//allocate our fbo with 3 color channels and 4x multisample
-	fboOutput.allocate(fboWidth, fboHeight, GL_RGB, 4);
+	#ifdef TARGET_EMSCRIPTEN
+		fboOutput.allocate(fboWidth, fboHeight, GL_RGB);
+	#else
+		fboOutput.allocate(fboWidth, fboHeight, GL_RGB, 4);
+	#endif
 	// another way to allocate an fbo is by using ofFboSettings
 //	ofFboSettings fboSettings;
 //	fboSettings.numSamples = 4;


### PR DESCRIPTION
Because openGL ES does not support multisampling.
`[warning] ofFbo: allocate(): multisampling not supported in OpenGL ES`
