### PR TITLE
fix for emscripten not loading the first model

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -383,7 +383,7 @@ void ofxAssimpModelLoader::loadGLResources(){
                 auto ogPath = texPathStr;
                 bool bHasEmbeddedTexture = false;
                 
-                string modelFolder = ofFilePath::getEnclosingDirectory( file.getAbsolutePath() );
+                string modelFolder = ofFilePath::getEnclosingDirectory( file.path() );
                 string relTexPath = ofFilePath::getEnclosingDirectory(texPathStr,false);
                 string texFile = ofFilePath::getFileName(texPathStr);
                 string realPath = ofFilePath::join(ofFilePath::join(modelFolder, relTexPath), texFile);


### PR DESCRIPTION
the absolute path was breaking the file loading when the file didn't exist. 
this fixes it