### PR TITLE
fix models with normal maps not working in opengles

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -2331,7 +2331,7 @@ static string defaultShaderHeader(string header, GLenum textureTarget, int major
 		ofStringReplace(header,"%extensions%","");
 	}
 #else 
-	ofStringReplace(header,"%extensions%","");
+	ofStringReplace(header,"%extensions%","#extension GL_OES_standard_derivatives : enable");
 #endif
 	if(textureTarget==GL_TEXTURE_2D){
 		header += "#define SAMPLER sampler2D\n";

--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -10,10 +10,6 @@ static const string fragmentShader = R"(
     IN vec4 v_color;
 #endif
 
-// needed for Perturb Normal on emscripten GLES
-#ifdef TARGET_OPENGLES
-    #extension GL_OES_standard_derivatives : enable
-#endif
 
     struct lightData
     {

--- a/libs/openFrameworks/gl/shaders/phong.frag
+++ b/libs/openFrameworks/gl/shaders/phong.frag
@@ -10,6 +10,10 @@ static const string fragmentShader = R"(
     IN vec4 v_color;
 #endif
 
+// needed for Perturb Normal on emscripten GLES
+#ifdef TARGET_OPENGLES
+    #extension GL_OES_standard_derivatives : enable
+#endif
 
     struct lightData
     {


### PR DESCRIPTION
models with normal maps weren't loading because `dFdx` and `dFdy` aren't defined by default in OpenGL ES. 
with this change you get much nicer rendering of the 2nd model. 

<img width="2031" alt="Screen Shot 2022-11-22 at 8 09 47 PM" src="https://user-images.githubusercontent.com/144000/203468288-e91706cc-d82b-46b5-845f-fc1a65f48f04.png">
