### PR TITLE
Emscripten ofxVectorGraphics fix

### DIFF
--- a/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
+++ b/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
@@ -314,7 +314,7 @@ void ofxVectorGraphics::arc(float x, float y, float radius, float offsetAngleDeg
 				for(int i = 0; i < arcResolution; i++){
 					xpos	= cos(angle) * radius;
 					ypos	= sin(angle) * radius; 
-					mesh.addVertex(ofVec3f(x + xpos, y + ypos,0));						
+					mesh.addVertex(ofVec3f(x + xpos, y + ypos, 0));						
 					angle += step;
 				}
 			mesh.draw();
@@ -323,7 +323,7 @@ void ofxVectorGraphics::arc(float x, float y, float radius, float offsetAngleDeg
 				for(int i = 0; i < arcResolution; i++){
 					xpos	= cos(angle) * radius;
 					ypos	= sin(angle) * radius; 
-					mesh.addVertex(ofVec3f(x + xpos, y + ypos,0));						
+					mesh.addVertex(ofVec3f(x + xpos, y + ypos, 0));						
 					mesh.addVertex(ofVec3f(x, y,0));														
 					angle += step;
 				}

--- a/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
+++ b/addons/ofxVectorGraphics/src/ofxVectorGraphics.cpp
@@ -307,28 +307,27 @@ void ofxVectorGraphics::arc(float x, float y, float radius, float offsetAngleDeg
 		float	angle = DEG_TO_RAD * offsetAngleDegrees;
 			
 		float	xpos, ypos;
-
-		if(!bFill){
-	
-			glBegin(GL_LINE_STRIP);
-				for(int i = 0; i < arcResolution; i++){
-					xpos	= cos(angle) * radius;
-					ypos	= sin(angle) * radius; 
-					glVertex2f(x + xpos, y + ypos);						
-					angle += step;
-				}
-			glEnd();
+		ofMesh mesh;
 		
-		}else{
-			glBegin(GL_TRIANGLE_STRIP);
+		if(!bFill){		
+    			mesh.setMode(OF_PRIMITIVE_LINE_STRIP);
 				for(int i = 0; i < arcResolution; i++){
 					xpos	= cos(angle) * radius;
 					ypos	= sin(angle) * radius; 
-					glVertex2f(x + xpos, y + ypos);						
-					glVertex2f(x, y);														
+					mesh.addVertex(ofVec3f(x + xpos, y + ypos,0));						
 					angle += step;
 				}
-			glEnd();
+			mesh.draw();
+		}else{
+    			mesh.setMode(OF_PRIMITIVE_TRIANGLE_STRIP);
+				for(int i = 0; i < arcResolution; i++){
+					xpos	= cos(angle) * radius;
+					ypos	= sin(angle) * radius; 
+					mesh.addVertex(ofVec3f(x + xpos, y + ypos,0));						
+					mesh.addVertex(ofVec3f(x, y,0));														
+					angle += step;
+				}
+			mesh.draw();
 		}
 	}
 	if(bRecord){


### PR DESCRIPTION
Makes the vectorGraphicsExample work with Emscripten...
And I actually wonder, why some of the GL methods are not recognized by Emscripten, while their OF counterpart is (like `glBegin(GL_LINE_STRIP)` and `ofMesh.SetMode(OF_PRIMITIVE_LINE_STRIP)`. It would be much better to make them work in Emscripten too, instead of changing examples and other addons because of that.