### PR TITLE
GLES includes for Emscripten

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,12 +261,8 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
-	#define GL_GLEXT_PROTOTYPES
-	#include <GLES/gl.h>
-	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
-
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -266,7 +266,7 @@ enum ofTargetPlatform{
 	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
-
+	#include <GLES3/gl3.h>
 	#include <GL/glew.h>
 
 	#include "EGL/egl.h"

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -267,6 +267,8 @@ enum ofTargetPlatform{
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
 
+	#include <GL/glew.h>
+
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,8 +261,12 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
+	#define GL_GLEXT_PROTOTYPES
+	#include <GLES/gl.h>
+	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
+
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 


### PR DESCRIPTION
This commit enables some GL methods for Emscripten. `glEnable(GL_POINT_SMOOTH)` for example works now (could not test if it does something, but at least the error is gone), but `glPointSize()` still not. And also the glInfoExample works now (even if not all of the given information is correct).

Just, there are some redefinition warnings now, like:
```
/home/jonathan/Desktop/openFrameworks-emscripten_ofxgui-fix/libs/openFrameworks/gl/ofGLUtils.h:147:17: warning: 'GL_DEPTH_COMPONENT32' macro redefined [-Wmacro-redefined]
        #define GL_DEPTH_COMPONENT32                                            GL_DEPTH_COMPONENT32_OES
                ^
/home/jonathan/emsdk_3.1.26/upstream/emscripten/cache/sysroot/include/GL/glext.h:326:9: note: previous definition is here
#define GL_DEPTH_COMPONENT32              0x81A7
```
And, not sure if any of these additional `#includes` is not necessary.