### PR TITLE
Emscripten glInfoExampleFix

### DIFF
--- a/examples/gl/glInfoExample/src/ofApp.cpp
+++ b/examples/gl/glInfoExample/src/ofApp.cpp
@@ -246,14 +246,15 @@ void ofApp::keyPressed(int key){
 
 	if (key == ' '){
 
-// todo: rewrite this with ofLog:
+		// todo: rewrite this with ofLog:
+		
 		#ifndef TARGET_EMSCRIPTEN
-		FILE *fp;
+			FILE *fp;
 
-		if((fp=freopen(ofToDataPath("openglReport.txt").c_str(), "w" ,stdout))==NULL) {
-			cout << "Cannot open file.\n";
-			return;
-		}
+			if((fp=freopen(ofToDataPath("openglReport.txt").c_str(), "w" ,stdout))==NULL) {
+				cout << "Cannot open file.\n";
+				return;
+			}
 		#endif
 
 		cout << "-------------------------------------------------\n";

--- a/examples/gl/glInfoExample/src/ofApp.cpp
+++ b/examples/gl/glInfoExample/src/ofApp.cpp
@@ -246,16 +246,15 @@ void ofApp::keyPressed(int key){
 
 	if (key == ' '){
 
-		// todo: rewrite this with ofLog:
-
+// todo: rewrite this with ofLog:
+		#ifndef TARGET_EMSCRIPTEN
 		FILE *fp;
-
 
 		if((fp=freopen(ofToDataPath("openglReport.txt").c_str(), "w" ,stdout))==NULL) {
 			cout << "Cannot open file.\n";
 			return;
 		}
-
+		#endif
 
 		cout << "-------------------------------------------------\n";
 		cout << "opengl info\n";
@@ -296,20 +295,22 @@ void ofApp::keyPressed(int key){
 
 
 		printGlewInfo();
+		
+		#ifndef TARGET_EMSCRIPTEN
+			fclose(fp);
 
-		fclose(fp);
-
-		#ifdef TARGET_WIN32
-		string command = "start " + ofToString(ofToDataPath("openglReport.txt").c_str());
-		#elif defined(TARGET_LINUX)
-		string command = "xdg-open " + ofToString(ofToDataPath("openglReport.txt").c_str());
-		#else
-		string command = "open " + ofToString(ofToDataPath("openglReport.txt").c_str());
+			#ifdef TARGET_WIN32
+				string command = "start " + ofToString(ofToDataPath("openglReport.txt").c_str());
+			#elif defined(TARGET_LINUX)
+				string command = "xdg-open " + ofToString(ofToDataPath("openglReport.txt").c_str());
+			#else
+				string command = "open " + ofToString(ofToDataPath("openglReport.txt").c_str());
+			#endif
+		
+			if (0 != system(command.c_str())){
+				ofLogWarning() << "Command " << command.c_str() << " did not return 0. Something may have gone wrong.";
+			}
 		#endif
-
-		if (0 != system(command.c_str())){
-			ofLogWarning() << "Command " << command.c_str() << " did not return 0. Something may have gone wrong.";
-		}
 	}
 }
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,12 +261,8 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
-	#define GL_GLEXT_PROTOTYPES
-	#include <GLES/gl.h>
-	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
-
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,8 +261,12 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
+	#define GL_GLEXT_PROTOTYPES
+	#include <GLES/gl.h>
+	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
+
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 


### PR DESCRIPTION
The advanced version would be to use the Emscripten filesystem and download the glInfo as a .txt file (right now it just prints). 