### PR TITLE
Emscripten isFrameNew()

### DIFF
--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -59,7 +59,7 @@ bool ofxEmscriptenVideoGrabber::setup(int w, int h){
 }
 
 bool ofxEmscriptenVideoGrabber::isInitialized() const{
-	return texture.isAllocated();
+	return html5video_grabber_ready_state(id)>=HAVE_METADATA;
 }
 
 void ofxEmscriptenVideoGrabber::update(){

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -94,7 +94,8 @@ void ofxEmscriptenVideoGrabber::update(){
 }
 
 bool ofxEmscriptenVideoGrabber::isFrameNew() const{
-	return html5video_grabber_ready_state(id)>=HAVE_METADATA;
+	// does not work with Emscripten
+	return true;
 }
 
 ofPixels & ofxEmscriptenVideoGrabber::getPixels(){

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
@@ -20,9 +20,7 @@ enum ReadyState{
 
 ofxEmscriptenVideoPlayer::ofxEmscriptenVideoPlayer()
 :id(html5video_player_create())
-,gotFirstFrame(false)
 ,usePixels(true){
-
 
 }
 
@@ -38,12 +36,9 @@ bool ofxEmscriptenVideoPlayer::load(string name){
 void ofxEmscriptenVideoPlayer::close(){
 	html5video_player_delete(id);
 	id = html5video_player_create();
-	gotFirstFrame = false;
 }
 
-
 void ofxEmscriptenVideoPlayer::update(){
-	gotFirstFrame = pixels.isAllocated();
 	if(html5video_player_update(id,pixels.isAllocated() && usePixels,pixels.getData())){
 		if(texture.texData.width!=html5video_player_width(id) || texture.texData.height!=html5video_player_height(id)){
 			texture.texData.width = html5video_player_width(id);
@@ -90,19 +85,17 @@ void ofxEmscriptenVideoPlayer::update(){
 	}
 }
 
-
-
 void ofxEmscriptenVideoPlayer::play(){
 	html5video_player_play(id);
 }
-
 
 void ofxEmscriptenVideoPlayer::stop(){
 	html5video_player_stop(id);
 }
 
 bool ofxEmscriptenVideoPlayer::isFrameNew() const{
-	return gotFirstFrame;
+	// does not work with Emscripten
+	return true;
 }
 
 ofPixels & ofxEmscriptenVideoPlayer::getPixels(){
@@ -136,7 +129,6 @@ bool ofxEmscriptenVideoPlayer::isLoaded() const{
 bool ofxEmscriptenVideoPlayer::isPlaying() const{
 	return !isPaused();
 }
-
 
 bool ofxEmscriptenVideoPlayer::setPixelFormat(ofPixelFormat pixelFormat){
 	switch(pixelFormat){
@@ -185,7 +177,6 @@ bool ofxEmscriptenVideoPlayer::getIsMovieDone() const{
 	return html5video_player_ended(id);
 }
 
-
 void ofxEmscriptenVideoPlayer::setPaused(bool bPause){
 	if(bPause){
 		html5video_player_pause(id);
@@ -218,7 +209,6 @@ void ofxEmscriptenVideoPlayer::setFrame(int frame){
 
 }
 
-
 int	ofxEmscriptenVideoPlayer::getCurrentFrame() const{
 	return 0;
 }
@@ -230,7 +220,6 @@ int	ofxEmscriptenVideoPlayer::getTotalNumFrames() const{
 ofLoopType ofxEmscriptenVideoPlayer::getLoopState() const{
 	return html5video_player_loop(id)?OF_LOOP_NORMAL:OF_LOOP_NONE;
 }
-
 
 void ofxEmscriptenVideoPlayer::firstFrame(){
 	html5video_player_set_current_time(id,0);

--- a/examples/3d/3DPrimitivesExample/src/ofApp.cpp
+++ b/examples/3d/3DPrimitivesExample/src/ofApp.cpp
@@ -10,7 +10,7 @@ void ofApp::setup(){
 	ofDisableArbTex();
 	texture.load("of.png");
 	texture.getTexture().setTextureWrap( GL_REPEAT, GL_REPEAT );
-	vidGrabber.initGrabber(640, 480);
+	vidGrabber.setup(640, 480);
 
 	bFill       = true;
 	bWireframe  = true;

--- a/examples/graphics/polylineBlobsExample/src/ofApp.cpp
+++ b/examples/graphics/polylineBlobsExample/src/ofApp.cpp
@@ -7,7 +7,7 @@ void ofApp::setup() {
 	camWidth = 640;
 	camHeight = 480;
 
-	cam.initGrabber(camWidth, camHeight);
+	cam.setup(camWidth, camHeight);
 	cvImgColor.allocate(camWidth, camHeight);
 	cvImgGrayscale.allocate(camWidth, camHeight);
 

--- a/examples/shader/06_multiTexture/src/ofApp.cpp
+++ b/examples/shader/06_multiTexture/src/ofApp.cpp
@@ -17,7 +17,7 @@ void ofApp::setup(){
 	int camHeight = 240;
 	
 	camera.setVerbose(false);
-	camera.initGrabber(camWidth, camHeight);
+	camera.setup(camWidth, camHeight);
 	
 	movie.load("movie.mov");
 	movie.play();

--- a/examples/video/slitscanRadialClockExample/src/ofApp.cpp
+++ b/examples/video/slitscanRadialClockExample/src/ofApp.cpp
@@ -50,7 +50,7 @@ void ofApp::setup(){
     // set up our camera and video grabber object
     vidGrabber.setDeviceID(0); // set the ID of the camera you want to use
     vidGrabber.setDesiredFrameRate(30); // set how fast we will grab frames from the camera
-    vidGrabber.initGrabber(camWidth, camHeight); // set the width and height of the camera
+    vidGrabber.setup(camWidth, camHeight); // set the width and height of the camera
     videoPixels.allocate(camWidth, camHeight, OF_PIXELS_RGB); // set up our pixel object to be the same size as our camera object
     videoTexture.allocate(videoPixels);
     
@@ -76,24 +76,20 @@ void ofApp::update(){
         pixels.mirror(false, true);
     }
     
-    if (ofGetSeconds() > seconds && pixels.size()){ // one second has elapsed
+    if (ofGetSeconds() > seconds){ // one second has elapsed
         seconds = ofGetSeconds();
         
         if (ofGetMinutes() >  minutes){
             minutes = ofGetMinutes();
-        } else {
-            if (ofGetMinutes() == 0){
-                minutes = 0;
-            }
+        } else if (ofGetMinutes() == 0){
+            minutes = 0;
         }
         
         if (ofGetHours() > hours){
             seconds = minutes = 0 ;
             hours = ofGetHours();
-        } else {
-            if (ofGetHours() == 0){
-                hours = 0;
-            }
+        } else if (ofGetHours() == 0) {
+            hours = 0;
         }
         
         if (numOfHours == 0){
@@ -103,12 +99,10 @@ void ofApp::update(){
         calculateTime();
         
         xSteps = 0; // step on to the next line.
-    } else {
-        if (ofGetSeconds() == 0){
-            seconds = 0;
-            calculateTime();
-        }
-    }
+     } else if(ofGetSeconds() == 0) {
+         seconds = 0;
+         calculateTime();
+     }
     
     switch (scanStyle) {
         case 1: // scan horizontal 'push' ribbon from centre. grabbing only the vertical pixels at the centre of the camera image


### PR DESCRIPTION
Since `isFrameNew()` does not work in Emscripten I decided to return true, so it does not break apps that were made with `isFrameNew()`. Instead `ofxEmscriptenVideoGrabber::isInitialized()` returns `html5video_grabber_ready_state(id)>=HAVE_ENOUGH_DATA` (like `ofxEmscriptenVideoPlayer::isLoaded()`).
I also changed all `initGrabber()` that I found to `setup()`.