### PR TITLE
One audioContext

### DIFF
--- a/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
+++ b/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
@@ -4,13 +4,13 @@ extern "C"{
 	typedef void (*html5audio_stream_callback)(int bufferSize, int inputChannels, int outputChannels, void * userData);
 
 	extern int html5audio_context_create();
-	extern int html5audio_context_start(int context);
-	extern int html5audio_context_stop(int context);
-	extern int html5audio_context_samplerate(int context);
+	extern int html5audio_context_start();
+	extern int html5audio_context_stop();
+	extern int html5audio_context_samplerate();
 	extern void html5audio_context_spectrum(int context, int bands, float * spectrum);
 
-	extern int html5audio_sound_load(int context, const char* url);
-	extern void html5audio_sound_play(int context, int sound, double offset);
+	extern int html5audio_sound_load(const char* url);
+	extern void html5audio_sound_play(int sound, double offset);
 	extern void html5audio_sound_stop(int sound);
 	extern void html5audio_sound_pause(int sound);
 	extern double html5audio_sound_rate(int sound);
@@ -23,7 +23,7 @@ extern "C"{
 	extern void html5audio_sound_set_gain(int sound, double volume);
 	extern void html5audio_sound_free(int sound);
 
-	extern int html5audio_stream_create(int context_id, int bufferSize, int inputChannels, int outputChannels, float * inbuffer, float * outbuffer, html5audio_stream_callback callback, void * userData);
-	extern int html5audio_stream_free(int stream);
+	extern int html5audio_stream_create(int bufferSize, int inputChannels, int outputChannels, float * inbuffer, float * outbuffer, html5audio_stream_callback callback, void * userData);
+	extern int html5audio_stream_free();
 	extern bool html5audio_sound_is_loaded(int sound);
 }

--- a/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
+++ b/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
@@ -7,7 +7,7 @@ extern "C"{
 	extern int html5audio_context_start();
 	extern int html5audio_context_stop();
 	extern int html5audio_context_samplerate();
-	extern void html5audio_context_spectrum(int context, int bands, float * spectrum);
+	extern void html5audio_context_spectrum(int bands, float * spectrum);
 
 	extern int html5audio_sound_load(const char* url);
 	extern void html5audio_sound_play(int sound, double offset);

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -187,7 +187,7 @@ double ofxEmscriptenSoundPlayer::getDurationSecs() const{
 
 float * ofxEmscriptenSoundPlayer::getSystemSpectrum(int bands){
 	systemSpectrum.resize(bands);
-	html5audio_context_spectrum(ofxEmscriptenAudioContext(),bands,&systemSpectrum[0]);
+	html5audio_context_spectrum(bands, &systemSpectrum[0]);
 	for(size_t i=0;i<systemSpectrum.size();i++){
 		systemSpectrum[i] = (systemSpectrum[i]+100)*0.01;
 	}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -41,7 +41,7 @@ ofxEmscriptenSoundPlayer::~ofxEmscriptenSoundPlayer(){
 
 bool ofxEmscriptenSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
 	if(context!=-1){
-		sound = html5audio_sound_load(context,ofToDataPath(fileName).c_str());
+		sound = html5audio_sound_load(ofToDataPath(fileName).c_str());
 	}
 	return sound!=-1;
 }
@@ -56,7 +56,7 @@ void ofxEmscriptenSoundPlayer::play(){
 		if(playing && !multiplay && !html5audio_sound_done(sound)){
 			html5audio_sound_stop(sound);
 		}
-		html5audio_sound_play(context,sound,0);
+		html5audio_sound_play(sound,0);
 		html5audio_sound_set_rate(sound,speed);
 		html5audio_sound_set_gain(sound,volume);
 		playing = true;
@@ -92,7 +92,7 @@ void ofxEmscriptenSoundPlayer::setSpeed(float spd){
 void ofxEmscriptenSoundPlayer::setPaused(bool bP){
 	if(sound!=-1){
 		if(bP) html5audio_sound_pause(sound);
-		else html5audio_sound_play(context,sound,0);
+		else html5audio_sound_play(sound,0);
 	}
 }
 
@@ -124,7 +124,7 @@ void ofxEmscriptenSoundPlayer::setPositionSecs(double s){
 		if(playing && !multiplay && !html5audio_sound_done(sound)){
 			html5audio_sound_stop(sound);
 		}
-		html5audio_sound_play(context,sound,s);
+		html5audio_sound_play(sound,s);
 		html5audio_sound_set_rate(sound,speed);
 		playing = true;
 	}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -16,7 +16,6 @@ int ofxEmscriptenAudioContext();
 
 ofxEmscriptenSoundStream::ofxEmscriptenSoundStream()
 :context(ofxEmscriptenAudioContext())
-,stream(-1)
 ,tickCount(0)
 {
 
@@ -35,7 +34,7 @@ bool ofxEmscriptenSoundStream::setup(const ofSoundStreamSettings & settings) {
 	inbuffer.allocate(settings.bufferSize, settings.numInputChannels);
 	outbuffer.allocate(settings.bufferSize, settings.numOutputChannels);
 	this->settings = settings;
-	stream = html5audio_stream_create(context,settings.bufferSize,settings.numInputChannels,settings.numOutputChannels,inbuffer.getBuffer().data(),outbuffer.getBuffer().data(),&audio_cb,this);
+	stream = html5audio_stream_create(settings.bufferSize,settings.numInputChannels,settings.numOutputChannels,inbuffer.getBuffer().data(),outbuffer.getBuffer().data(),&audio_cb,this);
 	return true;
 }
 
@@ -57,16 +56,15 @@ ofSoundDevice ofxEmscriptenSoundStream::getOutDevice() const{
 }
 
 void ofxEmscriptenSoundStream::start() {
-	html5audio_context_start(context);
+	html5audio_context_start();
 }
 
 void ofxEmscriptenSoundStream::stop() {
-	html5audio_context_stop(context);
+	html5audio_context_stop();
 }
 
 void ofxEmscriptenSoundStream::close() {
-	stream = -1;
-	html5audio_stream_free(stream);
+	html5audio_stream_free();
 }
 
 uint64_t ofxEmscriptenSoundStream::getTickCount() const{
@@ -82,7 +80,7 @@ int ofxEmscriptenSoundStream::getNumOutputChannels() const{
 }
 
 int ofxEmscriptenSoundStream::getSampleRate() const{
-	return html5audio_context_samplerate(context);
+	return html5audio_context_samplerate();
 }
 
 int ofxEmscriptenSoundStream::getBufferSize() const{

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,12 +261,8 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
-	#define GL_GLEXT_PROTOTYPES
-	#include <GLES/gl.h>
-	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
-
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -261,8 +261,12 @@ enum ofTargetPlatform{
 #endif
 
 #ifdef TARGET_EMSCRIPTEN
+	#define GL_GLEXT_PROTOTYPES
+	#include <GLES/gl.h>
+	#include <GLES/glext.h>
 	#include <GLES2/gl2.h>
 	#include <GLES2/gl2ext.h>
+
 	#include "EGL/egl.h"
 	#include "EGL/eglext.h"
 


### PR DESCRIPTION
This pull request is more like a suggestion, because I am not sure if I removed too much.
There is now only one audioContext, one ffft, one stream and one mediaElement intead of arrays.
My guess is, that more is not needed. And it seems to work quite well (without issues) so far.
