### PR TITLE
Emscripten  audio / video player filesystem fix

### DIFF
--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.cpp
@@ -38,12 +38,18 @@ ofxEmscriptenSoundPlayer::~ofxEmscriptenSoundPlayer(){
 	html5audio_sound_free(sound);
 }
 
-
 bool ofxEmscriptenSoundPlayer::load(const std::filesystem::path& fileName, bool stream){
-	if(context!=-1){
+	if(context != -1){
 		sound = html5audio_sound_load(context,ofToDataPath(fileName).c_str());
 	}
 	return sound!=-1;
+}
+
+bool ofxEmscriptenSoundPlayer::load(std::string fileName, bool stream){
+	if(context != -1){
+		sound = html5audio_sound_load(fileName.c_str());
+	}
+	return sound != -1;
 }
 
 void ofxEmscriptenSoundPlayer::unload(){

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundPlayer.h
@@ -10,6 +10,7 @@ public:
 
 
 	bool load(const std::filesystem::path& fileName, bool stream = false);
+	bool load(const std::string& fileName, bool stream = false);
 	void unload();
 	void play();
 	void stop();

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
@@ -31,7 +31,11 @@ ofxEmscriptenVideoPlayer::~ofxEmscriptenVideoPlayer() {
 }
 
 bool ofxEmscriptenVideoPlayer::load(string name){
-	html5video_player_load(id,ofToDataPath(name).c_str());
+	if (name.substr(0, 12) == "blob:http://" || name.substr(0, 13) == "blob:https://"){
+		html5video_player_load(id, name.c_str());
+	} else{
+		html5video_player_load(id, ofToDataPath(name).c_str());
+	}
 	return true;
 }
 


### PR DESCRIPTION
I seperated this PR from https://github.com/Jonathhhan/openFrameworks/blob/Emscripten-audioVideo-Revision, it makes it possible to load both, local files and filesystem files (in Emscriptens Data folder).
It also works to load local files, if I set the path from "data" to "" in `ofFileUtils.cpp`, but then the filesystem does not work anymore. The fix is only needed for the audio / video player (as far as I can tell), loading images, for example, works without changes from both locations.
```
    //--------------------------------------------------
    string defaultDataPath(){
    #if defined TARGET_OSX
        try{
            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
        }catch(...){
            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
        }
    #elif defined TARGET_ANDROID
        return string("sdcard/");
    #else
        try{
            return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/")).make_preferred().string();
        }catch(...){
            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "data/");
        }
    #endif
    } 
```
I do not like, that I need to create an additional method for ofxEmscriptenSoundPlayer, and also the solution for the video player is not perfect.
So maybe, there is a better solution?