### PR TITLE
List devices 2

### DIFF
--- a/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
+++ b/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
@@ -2,8 +2,7 @@
 
 extern "C"{
 	typedef void (*html5audio_stream_callback)(int bufferSize, int inputChannels, int outputChannels, void * userData);
-	
-	extern void html5audio_list_devices();
+
 	extern int html5audio_context_create();
 	extern int html5audio_context_start(int context);
 	extern int html5audio_context_stop(int context);

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -27,26 +27,6 @@ var LibraryHTML5Audio = {
     	}
     },
 
-    html5audio_list_devices: function(){
-        if (!navigator.mediaDevices.enumerateDevices) {
-            console.log("enumerateDevices() not supported.");
-        } else {
-            // List cameras and microphones.
-            navigator.mediaDevices.enumerateDevices()
-            .then((devices) => {
-                devices.forEach((device) => {
-                    if(device.kind == "audioinput"){
-                        console.log(`${device.kind}: ${device.label} id = ${device.deviceId}`);
-                    }
-                });
-                return devices;
-            })
-            .catch((err) => {
-                console.error(`${err.name}: ${err.message}`);
-            });
-        }
-    },
-
     html5audio_context_create: function(){
     	try {
 			// Fix up for prefixing

--- a/addons/ofxEmscripten/libs/html5video/include/html5video.h
+++ b/addons/ofxEmscripten/libs/html5video/include/html5video.h
@@ -28,7 +28,6 @@ extern "C"{
     extern int html5video_player_loop(int id);
 
 
-    extern void html5video_list_devices();
     extern int html5video_grabber_create();
     extern void html5video_grabber_init(int id, int w, int h, int framerate=-1);
     extern const char* html5video_grabber_pixel_format(int it);

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -120,7 +120,11 @@ var LibraryHTML5Video = {
     },
 
     html5video_player_pixel_format: function(id){
-        return allocate(intArrayFromString(VIDEO.players[id].pixelFormat), ALLOC_STACK);
+        var string = VIDEO.players[id].pixelFormat;
+        var size = lengthBytesUTF8(string) + 1;
+        var stringPointer = stackAlloc(size);
+        stringToUTF8Array(string, HEAP8, stringPointer, size);
+        return stringPointer;
     },
 
     html5video_player_set_pixel_format: function(id, format){
@@ -294,7 +298,11 @@ var LibraryHTML5Video = {
     },
 
     html5video_grabber_pixel_format: function(id){
-        return allocate(intArrayFromString(VIDEO.grabbers[id].pixelFormat), ALLOC_STACK);
+        var string = VIDEO.grabbers[id].pixelFormat;
+        var size = lengthBytesUTF8(string) + 1;
+        var stringPointer = stackAlloc(size);
+        stringToUTF8Array(string, HEAP8, stringPointer, size);
+        return stringPointer;
     },
 
     html5video_grabber_set_pixel_format: function(id, format){

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -70,25 +70,6 @@ var LibraryHTML5Video = {
         }
     },
 
-    html5video_list_devices: function(){
-        if (!navigator.mediaDevices.enumerateDevices) {
-            console.log("enumerateDevices() not supported.");
-        } else {
-            // List cameras and microphones.
-            navigator.mediaDevices.enumerateDevices()
-            .then((devices) => {
-                devices.forEach((device) => {
-                    if(device.kind == "videoinput"){
-                        console.log(`${device.kind}: ${device.label} id = ${device.deviceId}`);
-                    }
-                });
-            })
-            .catch((err) => {
-                console.error(`${err.name}: ${err.message}`);
-            });
-        }
-    },
-
     html5video_player_create: function(){
         var video = document.createElement('video');
         video.loop = true;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -68,7 +68,7 @@ void ofxAppEmscriptenWindow::loop(){
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
-	emscripten_set_main_loop(display_cb, -1, 0);
+	emscripten_set_main_loop(display_cb, -1, 1);
 }
 
 void ofxAppEmscriptenWindow::update(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -68,7 +68,7 @@ void ofxAppEmscriptenWindow::loop(){
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
-	emscripten_set_main_loop( display_cb, -1, 1);
+	emscripten_set_main_loop(display_cb, -1, 0);
 }
 
 void ofxAppEmscriptenWindow::update(){

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -9,6 +9,7 @@
 #include "html5audio.h"
 #include "ofBaseApp.h"
 #include "ofLog.h"
+#include "emscripten.h"
 
 using namespace std;
 

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -43,7 +43,7 @@ EM_ASYNC_JS(const char*, html5audio_list_devices_em_async_js, (), {
 });
 
 std::vector<ofSoundDevice> ofxEmscriptenSoundplayer::listDevices() const{
-	std::string devices = html5video_list_devices_em_async_js();
+	std::string devices = html5audio_list_devices_em_async_js();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){
 		ofLogNotice() << device << std::endl;

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -47,7 +47,7 @@ std::vector<ofSoundDevice> ofxEmscriptenSoundStream::getDeviceList(ofSoundDevice
 	std::string devices = html5audio_list_devices_em_async_js();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){
-		ofLogNotice() << device << std::endl;
+		ofLogNotice() << device;
 	}
 	return vector<ofSoundDevice>(); // does nothing
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -43,7 +43,7 @@ EM_ASYNC_JS(const char*, html5audio_list_devices_em_async_js, (), {
 	return allocate(intArrayFromString(string, ALLOC_STACK -1));
 });
 
-std::vector<ofSoundDevice> ofxEmscriptenSoundStream::listDevices() const{
+std::vector<ofSoundDevice> ofxEmscriptenSoundStream::getDeviceList(ofSoundDevice::Api api) const{
 	std::string devices = html5audio_list_devices_em_async_js();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -35,7 +35,7 @@ EM_ASYNC_JS(const char*, html5audio_list_devices_em_async_js, (), {
 		// List cameras and microphones.
 		var devices = await (navigator.mediaDevices.enumerateDevices());
 		devices.forEach((device) => {
-			if(device.kind == "audioinput"){
+			if (device.kind == "audioinput" || device.kind == "audiooutput"){
 				string = string.concat(",", `${device.kind}: ${device.label} id = ${device.deviceId}`);
 			}
 		});

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -43,7 +43,7 @@ EM_ASYNC_JS(const char*, html5audio_list_devices_em_async_js, (), {
 	return allocate(intArrayFromString(string, ALLOC_STACK -1));
 });
 
-std::vector<ofSoundDevice> ofxEmscriptenSoundplayer::listDevices() const{
+std::vector<ofSoundDevice> ofxEmscriptenSoundStream::listDevices() const{
 	std::string devices = html5audio_list_devices_em_async_js();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -40,7 +40,10 @@ EM_ASYNC_JS(const char*, html5audio_list_devices_em_async_js, (), {
 			}
 		});
 	}
-	return allocate(intArrayFromString(string, ALLOC_STACK -1));
+	var size = lengthBytesUTF8(string) + 1;
+  	var stringPointer = stackAlloc(size);
+  	stringToUTF8Array(string, HEAP8, stringPointer, size);
+  	return stringPointer;
 });
 
 std::vector<ofSoundDevice> ofxEmscriptenSoundStream::getDeviceList(ofSoundDevice::Api api) const{

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -16,7 +16,7 @@ public:
 	ofxEmscriptenSoundStream();
 	~ofxEmscriptenSoundStream();
 
-	std::vector<ofSoundDevice> getDeviceList(ofSoundDevice::Api api) const;
+	std::vector<ofSoundDevice> listDevices() const;
 	bool setup(const ofSoundStreamSettings & settings);
 	void setInput(ofBaseSoundInput * soundInput);
 	void setOutput(ofBaseSoundOutput * soundOutput);

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -16,7 +16,7 @@ public:
 	ofxEmscriptenSoundStream();
 	~ofxEmscriptenSoundStream();
 
-	std::vector<ofSoundDevice> listDevices() const;
+	std::vector<ofSoundDevice> getDeviceList(ofSoundDevice::Api api) const;
 	bool setup(const ofSoundStreamSettings & settings);
 	void setInput(ofBaseSoundInput * soundInput);
 	void setOutput(ofBaseSoundOutput * soundOutput);

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -44,7 +44,10 @@ EM_ASYNC_JS(const char*, html5video_list_devices, (), {
 			}
 		});
 	}
-	return allocate(intArrayFromString(string, ALLOC_STACK -1));
+	var size = lengthBytesUTF8(string) + 1;
+  	var stringPointer = stackAlloc(size);
+  	stringToUTF8Array(string, HEAP8, stringPointer, size);
+  	return stringPointer;
 });
 
 vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -51,7 +51,7 @@ vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{
 	std::string devices = html5video_list_devices();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){
-		ofLogNotice() << device << std::endl;
+		ofLogNotice() << device;
 	}
 	return vector<ofVideoDevice>(); // does nothing
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -30,9 +30,29 @@ ofxEmscriptenVideoGrabber::~ofxEmscriptenVideoGrabber() {
 	// TODO Auto-generated destructor stub
 }
 
+EM_ASYNC_JS(const char*, html5video_list_devices_em_async_js, (), {
+	var string = "";
+	if (!navigator.mediaDevices.enumerateDevices) {
+		console.log("enumerateDevices() not supported.");
+	} else {
+		// List cameras and microphones.
+		var devices = await (navigator.mediaDevices.enumerateDevices());
+		devices.forEach((device) => {
+			if(device.kind == "videoinput"){
+				string = string.concat(",", `${device.kind}: ${device.label} id = ${device.deviceId}`);
+			}
+		});
+	}
+	return allocate(intArrayFromString(string, ALLOC_STACK -1));
+});
+
 vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{
-	html5video_list_devices();
-	return vector<ofVideoDevice>();
+	std::string devices = html5video_list_devices_em_async_js();
+	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
+	for (auto&& device : deviceList){
+		ofLogNotice() << device << std::endl;
+	}
+	return vector<ofVideoDevice>(); // does nothing
 }
 
 bool ofxEmscriptenVideoGrabber::setup(int w, int h){

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -39,7 +39,7 @@ EM_ASYNC_JS(const char*, html5video_list_devices_em_async_js, (), {
 		// List cameras and microphones.
 		var devices = await (navigator.mediaDevices.enumerateDevices());
 		devices.forEach((device) => {
-			if(device.kind == "videoinput"){
+			if (device.kind == "videoinput"){
 				string = string.concat(",", `${device.kind}: ${device.label} id = ${device.deviceId}`);
 			}
 		});

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -31,7 +31,7 @@ ofxEmscriptenVideoGrabber::~ofxEmscriptenVideoGrabber() {
 	// TODO Auto-generated destructor stub
 }
 
-EM_ASYNC_JS(const char*, html5video_list_devices_em_async_js, (), {
+EM_ASYNC_JS(const char*, html5video_list_devices, (), {
 	var string = "";
 	if (!navigator.mediaDevices.enumerateDevices) {
 		console.log("enumerateDevices() not supported.");
@@ -48,7 +48,7 @@ EM_ASYNC_JS(const char*, html5video_list_devices_em_async_js, (), {
 });
 
 vector<ofVideoDevice> ofxEmscriptenVideoGrabber::listDevices() const{
-	std::string devices = html5video_list_devices_em_async_js();
+	std::string devices = html5video_list_devices();
 	std::vector<std::string> deviceList = ofSplitString(devices, ",", true);
 	for (auto&& device : deviceList){
 		ofLogNotice() << device << std::endl;

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoGrabber.cpp
@@ -7,6 +7,7 @@
 
 #include "ofxEmscriptenVideoGrabber.h"
 #include "html5video.h"
+#include "emscripten.h"
 
 using namespace std;
 

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -36,7 +36,7 @@ void ofApp::setup(){
 
 	// or by name
 #ifdef TARGET_LINUX
-	auto devices = soundStream.getMatchingDevices("default"); // this prints the device list too, also with linux.
+	auto devices = soundStream.getMatchingDevices("default");
 	if(!devices.empty()){
 		settings.setInDevice(devices[0]);
 	}

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -35,18 +35,19 @@ void ofApp::setup(){
 	// settings.api = ofSoundDevice::Api::PULSE;
 
 	// or by name
-	auto devices = soundStream.getMatchingDevices("default");
+#ifdef TARGET_LINUX
+	auto devices = soundStream.getMatchingDevices("default"); // this prints the device list too, also with linux.
 	if(!devices.empty()){
 		settings.setInDevice(devices[0]);
 	}
-
+#endif
 	settings.setInListener(this);
 	settings.sampleRate = 44100;
-	#ifdef TARGET_EMSCRIPTEN
-		settings.numOutputChannels = 2;
-	#else
-		settings.numOutputChannels = 0;
-	#endif
+#ifdef TARGET_EMSCRIPTEN
+	settings.numOutputChannels = 2;
+#else
+	settings.numOutputChannels = 0;
+#endif
 	settings.numInputChannels = 2;
 	settings.bufferSize = bufferSize;
 	soundStream.setup(settings);

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -40,18 +40,15 @@ void ofApp::setup(){
 	if(!devices.empty()){
 		settings.setInDevice(devices[0]);
 	}
+	settings.numOutputChannels = 0;
+#else
+	settings.numOutputChannels = 2;
 #endif
 	settings.setInListener(this);
 	settings.sampleRate = 44100;
-#ifdef TARGET_EMSCRIPTEN
-	settings.numOutputChannels = 2;
-#else
-	settings.numOutputChannels = 0;
-#endif
 	settings.numInputChannels = 2;
 	settings.bufferSize = bufferSize;
 	soundStream.setup(settings);
-
 }
 
 //--------------------------------------------------------------

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -35,7 +35,7 @@ void ofApp::setup(){
 	// settings.api = ofSoundDevice::Api::PULSE;
 
 	// or by name
-#ifdef TARGET_LINUX
+#ifndef TARGET_EMSCRIPTEN
 	auto devices = soundStream.getMatchingDevices("default");
 	if(!devices.empty()){
 		settings.setInDevice(devices[0]);

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -40,7 +40,7 @@ void ofBaseSoundStream::printDeviceList() const {
 		}
 	#else
 		ofSoundDevice::Api api = (ofSoundDevice::Api)0;
-		getDeviceList(api);	
+		getDeviceList(api); // only trigger the Java Script funtion once.
 	#endif
 }
 

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -40,7 +40,7 @@ void ofBaseSoundStream::printDeviceList() const {
 		}
 	#else
 		ofSoundDevice::Api api = (ofSoundDevice::Api)0;
-		getDeviceList(api); // only trigger the Java Script function once.
+		getDeviceList(api); // only trigger the java script function once.
 	#endif
 }
 

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -40,7 +40,7 @@ void ofBaseSoundStream::printDeviceList() const {
 		}
 	#else
 		ofSoundDevice::Api api = (ofSoundDevice::Api)0;
-		getDeviceList(api); // only trigger the Java Script funtion once.
+		getDeviceList(api); // only trigger the Java Script function once.
 	#endif
 }
 

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -29,19 +29,19 @@ std::string toString(ofSoundDevice::Api api){
 
 void ofBaseSoundStream::printDeviceList() const {
 	ofLogNotice("ofBaseSoundStream::printDeviceList") << std::endl;
-	#ifndef TARGET_EMSCRIPTEN
-		for(int i=ofSoundDevice::ALSA; i<ofSoundDevice::NUM_APIS; ++i){
-			ofSoundDevice::Api api = (ofSoundDevice::Api)i;
-			auto devices = getDeviceList(api);
-			if(!devices.empty()){
-				ofLogNotice("ofBaseSoundStream::printDeviceList") << "Api: " << toString(api);
-				ofLogNotice("ofBaseSoundStream::printDeviceList") << devices;
-			}
+#ifndef TARGET_EMSCRIPTEN
+	for(int i=ofSoundDevice::ALSA; i<ofSoundDevice::NUM_APIS; ++i){
+		ofSoundDevice::Api api = (ofSoundDevice::Api)i;
+		auto devices = getDeviceList(api);
+		if(!devices.empty()){
+			ofLogNotice("ofBaseSoundStream::printDeviceList") << "Api: " << toString(api);
+			ofLogNotice("ofBaseSoundStream::printDeviceList") << devices;
 		}
-	#else
-		ofSoundDevice::Api api = (ofSoundDevice::Api)0;
-		getDeviceList(api); // only trigger the java script function once.
-	#endif
+	}
+#else
+	ofSoundDevice::Api api = (ofSoundDevice::Api)0;
+	getDeviceList(api); // only trigger the java script function once.
+#endif
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -29,14 +29,19 @@ std::string toString(ofSoundDevice::Api api){
 
 void ofBaseSoundStream::printDeviceList() const {
 	ofLogNotice("ofBaseSoundStream::printDeviceList") << std::endl;
-	for(int i=ofSoundDevice::ALSA; i<ofSoundDevice::NUM_APIS; ++i){
-		ofSoundDevice::Api api = (ofSoundDevice::Api)i;
-		auto devices = getDeviceList(api);
-		if(!devices.empty()){
+	#ifndef TARGET_EMSCRIPTEN
+		for(int i=ofSoundDevice::ALSA; i<ofSoundDevice::NUM_APIS; ++i){
+			ofSoundDevice::Api api = (ofSoundDevice::Api)i;
+			auto devices = getDeviceList(api);
+			if(!devices.empty()){
 				ofLogNotice("ofBaseSoundStream::printDeviceList") << "Api: " << toString(api);
 				ofLogNotice("ofBaseSoundStream::printDeviceList") << devices;
+			}
 		}
-	}
+	#else
+		ofSoundDevice::Api api = (ofSoundDevice::Api)0;
+		getDeviceList(api);	
+	#endif
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -93,7 +93,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=allocate -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s ASYNCIFY=1
+PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s ASYNCIFY=1
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -93,7 +93,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=allocate -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2
+PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s EXPORTED_RUNTIME_METHODS=allocate -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s ASYNCIFY=1
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 


### PR DESCRIPTION
@ofTheo maybe I found with `EM_ASYNC_JS` a good solution for async loading with Emscripten. Its now in the .cpp files, because if its in the .js files the method needs to be added to  `-s ASYNCIFY_IMPORTS=html5video_list_devices`. If its in the cpp file called with `EM_ASYNC_JS` I only need to add the `-s ASYNCIFY=1` flag.
The problem now is, that I cannot change the return type of ofxEmscriptenVideoGrabber::listDevices() (same for the sound player). The type is `vector<ofVideoDevice> / vector<ofAudioDevice>` and I have a `vector<std::string>`. I also tried to make an additional method `ofxEmscriptenVideoGrabber::listDevices2() ` which works, but it needs ofxEmscriptenVideoGrabber to be defined and it breaks apps that are not made for Emscripten. Maybe the best solution would be to construct an `ofVideoDevice` instance from the string information? Then the return type can stay the same and it does break any apps?
And somehow I realized that I need `ALLOC_STACK -1` for returning a string correctly, maybe its for the other cases (get pixel format for example) also true.
`return allocate(intArrayFromString(string, ALLOC_STACK -1));`

(I guess, `EM_ASYNC_JS` makes also loading local files much easier...)