### PR TITLE
forward declaration ofShader

### DIFF
--- a/libs/openFrameworks/gl/ofCubeMap.cpp
+++ b/libs/openFrameworks/gl/ofCubeMap.cpp
@@ -4,6 +4,7 @@
 //  Created by Nick Hardeman on 10/16/22.
 //
 
+#include "ofShader.h"
 #include "ofCubeMap.h"
 #include "ofImage.h"
 #include "ofConstants.h"

--- a/libs/openFrameworks/gl/ofCubeMap.h
+++ b/libs/openFrameworks/gl/ofCubeMap.h
@@ -5,10 +5,8 @@
 //
 
 #pragma once
-#include "ofShader.h"
-#include "ofNode.h"
 #include "ofFbo.h"
-
+class ofShader;
 
 class ofGLProgrammableRenderer;
 


### PR DESCRIPTION
just tiny changes:
moving include "ofShader.h" to cpp
forward declarate ofShader
remove unneeded include "ofNode.h"

Let's see if it works OK in all platforms