### PR TITLE
Emscripten focus / blur

### DIFF
--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -61,10 +61,10 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
+    EM_ASM({canvas.onfocus = function() {canvas.focused = true}; canvas.onblur = function() {canvas.focused = false}});
 }
 
 void ofxAppEmscriptenWindow::loop(){
-
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
@@ -429,11 +429,9 @@ void ofxAppEmscriptenWindow::enableSetupScreen(){
 	bEnableSetupScreen = true;
 }
 
-
 void ofxAppEmscriptenWindow::disableSetupScreen(){
 	bEnableSetupScreen = false;
 }
-
 
 ofCoreEvents & ofxAppEmscriptenWindow::events(){
 	return _events;
@@ -456,4 +454,3 @@ void ofxAppEmscriptenWindow::startRender(){
 void ofxAppEmscriptenWindow::finishRender(){
 	renderer()->finishRender();
 }
-

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -61,7 +61,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
-    EM_ASM({setTimeout(function() {canvas.focused = true;}, 0); canvas.onfocus = function() {canvas.focused = true}; canvas.onblur = function() {canvas.focused = false}});
+    EM_ASM({setTimeout(function() {canvas.hasFocus = true;}, 0); canvas.onfocus = function() {canvas.hasFocus = true}; canvas.onblur = function() {canvas.hasFocus = false}});
 }
 
 void ofxAppEmscriptenWindow::loop(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -63,8 +63,6 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
 
     emscripten_set_focus_callback("#canvas",this,1,&focus_cb);    
     emscripten_set_blur_callback("#canvas",this,1,&blur_cb);
-    emscripten_set_focusin_callback("#canvas",this,1,&focusin_cb);
-    emscripten_set_focusout_callback("#canvas",this,1,&focusout_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -371,14 +369,6 @@ int ofxAppEmscriptenWindow::focus_cb(int eventType, const EmscriptenFocusEvent *
 }
 
 int ofxAppEmscriptenWindow::blur_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
-	return 0;
-}
-
-int ofxAppEmscriptenWindow::focusin_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
-	return 0;
-}
-
-int ofxAppEmscriptenWindow::focusout_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
 	return 0;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -61,7 +61,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
-    EM_ASM({setTimeout(function() {canvas.hasFocus = true;}, 0); canvas.onfocus = function() {canvas.hasFocus = true}; canvas.onblur = function() {canvas.hasFocus = false}});
+    EM_ASM({setTimeout(function() {canvas.hasFocus = true; canvas.focus()}, 0); canvas.onfocus = function() {canvas.hasFocus = true}; canvas.onblur = function() {canvas.hasFocus = false}});
 }
 
 void ofxAppEmscriptenWindow::loop(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -61,7 +61,10 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
-    EM_ASM({setTimeout(function() {canvas.hasFocus = true; canvas.focus()}, 0); canvas.onfocus = function() {canvas.hasFocus = true}; canvas.onblur = function() {canvas.hasFocus = false}});
+    emscripten_set_focus_callback("#canvas",this,1,&focus_cb);    
+    emscripten_set_blur_callback("#canvas",this,1,&blur_cb);
+    emscripten_set_focusin_callback("#canvas",this,1,&focusin_cb);
+    emscripten_set_focusout_callback("#canvas",this,1,&focusout_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -361,6 +364,22 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;
+}
+
+int ofxAppEmscriptenWindow::focus_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
+	return 0;
+}
+
+int ofxAppEmscriptenWindow::blur_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
+	return 0;
+}
+
+int ofxAppEmscriptenWindow::focusin_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
+	return 0;
+}
+
+int ofxAppEmscriptenWindow::focusout_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData){
+	return 0;
 }
 
 void ofxAppEmscriptenWindow::hideCursor(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -61,7 +61,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
-    EM_ASM({canvas.onfocus = function() {canvas.focused = true}; canvas.onblur = function() {canvas.focused = false}});
+    EM_ASM({setTimeout(function() {canvas.focused = true;}, 0); canvas.onfocus = function() {canvas.focused = true}; canvas.onblur = function() {canvas.focused = false}});
 }
 
 void ofxAppEmscriptenWindow::loop(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -69,7 +69,7 @@ public:
 	void update();
 	void draw();
 
-    virtual void makeCurrent();
+	virtual void makeCurrent();
 	virtual void startRender();
 	virtual void finishRender();
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -92,15 +92,18 @@ private:
 	
 	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
 	
-	int id;
+	static int focus_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
+	static int blur_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
+	static int focusin_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
+	static int focusout_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
 
-	
+
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE  context = 0;
 
-    bool bSetMainLoopTiming = true;
-    bool bEnableSetupScreen = true;
-    ofCoreEvents _events;
-    std::shared_ptr<ofBaseRenderer> _renderer;
+	bool bSetMainLoopTiming = true;
+	bool bEnableSetupScreen = true;
+	ofCoreEvents _events;
+	std::shared_ptr<ofBaseRenderer> _renderer;
 };
 
 #endif /* OFAPPEMSCRIPTENWINDOW_H_ */

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -107,4 +107,3 @@ private:
 };
 
 #endif /* OFAPPEMSCRIPTENWINDOW_H_ */
-

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -94,8 +94,6 @@ private:
 	
 	static int focus_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
 	static int blur_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
-	static int focusin_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
-	static int focusout_cb(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
 
 
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE  context = 0;


### PR DESCRIPTION
With this line you can get it in `ofApp.cpp`: `int focused = EM_ASM_INT({console.log(canvas.hasFocus); return canvas.hasFocus});`.
Not sure if it makes sense in `ofxAppEmscriptenWindow.cpp`, you can also set that line in the app. And a little drawback: I tried to initialize the value with true, but it does not work. So it is activated with the first interaction with the canvas (a mouse click). I guess, it would need a short delay, because the canvas does not exist yet?