### PR TITLE
Emscripten gamepad event draft

### DIFF
--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -310,7 +310,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 }
 
 int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
-	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseX(), wheelEvent->deltaX, wheelEvent->deltaY);
+	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX, wheelEvent->deltaY);
 	return 0;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -12,6 +12,31 @@
 
 using namespace std;
 
+static inline const char* emscripten_event_type_to_string(int eventType) {
+  const char *events[] = { "(invalid)", "(none)", "keypress", "keydown", "keyup", "click", "mousedown", "mouseup", "dblclick", "mousemove", "wheel", "resize", 
+    "scroll", "blur", "focus", "focusin", "focusout", "deviceorientation", "devicemotion", "orientationchange", "fullscreenchange", "pointerlockchange", 
+    "visibilitychange", "touchstart", "touchend", "touchmove", "touchcancel", "gamepadconnected", "gamepaddisconnected", "beforeunload", 
+    "batterychargingchange", "batterylevelchange", "webglcontextlost", "webglcontextrestored", "mouseenter", "mouseleave", "mouseover", "mouseout", "(invalid)" };
+  ++eventType;
+  if (eventType < 0) eventType = 0;
+  if (eventType >= sizeof(events)/sizeof(events[0])) eventType = sizeof(events)/sizeof(events[0])-1;
+  return events[eventType];
+}
+
+const char* emscripten_result_to_string(EMSCRIPTEN_RESULT result) {
+  if (result == EMSCRIPTEN_RESULT_SUCCESS) return "EMSCRIPTEN_RESULT_SUCCESS";
+  if (result == EMSCRIPTEN_RESULT_DEFERRED) return "EMSCRIPTEN_RESULT_DEFERRED";
+  if (result == EMSCRIPTEN_RESULT_NOT_SUPPORTED) return "EMSCRIPTEN_RESULT_NOT_SUPPORTED";
+  if (result == EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED) return "EMSCRIPTEN_RESULT_FAILED_NOT_DEFERRED";
+  if (result == EMSCRIPTEN_RESULT_INVALID_TARGET) return "EMSCRIPTEN_RESULT_INVALID_TARGET";
+  if (result == EMSCRIPTEN_RESULT_UNKNOWN_TARGET) return "EMSCRIPTEN_RESULT_UNKNOWN_TARGET";
+  if (result == EMSCRIPTEN_RESULT_INVALID_PARAM) return "EMSCRIPTEN_RESULT_INVALID_PARAM";
+  if (result == EMSCRIPTEN_RESULT_FAILED) return "EMSCRIPTEN_RESULT_FAILED";
+  if (result == EMSCRIPTEN_RESULT_NO_DATA) return "EMSCRIPTEN_RESULT_NO_DATA";
+  return "Unknown EMSCRIPTEN_RESULT!";
+}
+
+
 ofxAppEmscriptenWindow * ofxAppEmscriptenWindow::instance = NULL;
 
 
@@ -61,6 +86,8 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
 
+    emscripten_set_gamepadconnected_callback(this,1,&gamepadconnected_cb);
+    emscripten_set_gamepaddisconnected_callback(this,1,&gamepaddisconnected_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -78,6 +105,30 @@ void ofxAppEmscriptenWindow::update(){
 		bSetMainLoopTiming = false;
 	}
 	events().notifyUpdate();
+
+	emscripten_sample_gamepad_data();
+	int numGamepads = emscripten_get_num_gamepads();
+	if (numGamepads != prevNumGamepads) {
+		printf("Number of connected gamepads: %d\n", numGamepads);
+		prevNumGamepads = numGamepads;
+	}
+	for(int i = 0; i < numGamepads && i < 32; ++i) {
+		EmscriptenGamepadEvent ge;
+		int ret = emscripten_get_gamepad_status(i, &ge);
+		if (ret == EMSCRIPTEN_RESULT_SUCCESS) {
+			int g = ge.index;
+			for(int j = 0; j < ge.numAxes; ++j) {
+				if (ge.axis[j] != prevState[g].axis[j])
+					printf("Gamepad %d, axis %d: %g\n", g, j, ge.axis[j]);
+				}
+			for(int j = 0; j < ge.numButtons; ++j) {
+				if (ge.analogButton[j] != prevState[g].analogButton[j] || ge.digitalButton[j] != prevState[g].digitalButton[j]) {
+					printf("Gamepad %d, button %d: Digital: %d, Analog: %g\n", g, j, ge.digitalButton[j], ge.analogButton[j]);
+				}
+			}
+			prevState[g] = ge;
+		}
+	}
 }
 
 void ofxAppEmscriptenWindow::draw(){
@@ -361,6 +412,20 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;
+}
+
+int ofxAppEmscriptenWindow::gamepadconnected_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData){
+	printf("%s: timeStamp: %g, connected: %d, index: %ld, numAxes: %d, numButtons: %d, id: \"%s\", mapping: \"%s\"\n",
+	eventType != 0 ? emscripten_event_type_to_string(eventType) : "Gamepad state", gamepadEvent->timestamp, gamepadEvent->connected, gamepadEvent->index, 
+	gamepadEvent->numAxes, gamepadEvent->numButtons, gamepadEvent->id, gamepadEvent->mapping);
+	return 0;
+}
+
+int ofxAppEmscriptenWindow::gamepaddisconnected_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData){
+	printf("%s: timeStamp: %g, connected: %d, index: %ld, numAxes: %d, numButtons: %d, id: \"%s\", mapping: \"%s\"\n",
+	eventType != 0 ? emscripten_event_type_to_string(eventType) : "Gamepad state", gamepadEvent->timestamp, gamepadEvent->connected, gamepadEvent->index, 
+	gamepadEvent->numAxes, gamepadEvent->numButtons, gamepadEvent->id, gamepadEvent->mapping);
+	return 0;
 }
 
 void ofxAppEmscriptenWindow::hideCursor(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -60,7 +60,8 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchend_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
-
+	
+    emscripten_set_wheel_callback("#canvas",this,1,&mousescrolled_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -308,6 +309,11 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 	return 0;
 }
 
+int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
+	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseX(), wheelEvent->deltaX, wheelEvent->deltaY);
+	return 0;
+}
+
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
@@ -363,6 +369,7 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
     return 0;
 }
 
+emscripten_set_wheel_callback("#canvas",this,1,&mousescrolled_cb);
 void ofxAppEmscriptenWindow::hideCursor(){
 	emscripten_hide_mouse();
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -60,8 +60,6 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchend_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
-	
-    emscripten_set_wheel_callback("#canvas",this,1,&mousescrolled_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -306,11 +304,6 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 	}else{
 		instance->events().notifyMouseMoved(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height));
 	}
-	return 0;
-}
-
-int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
-	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX, wheelEvent->deltaY);
 	return 0;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -60,6 +60,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_touchend_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
     emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
+
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -362,7 +363,6 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
     return 0;
 }
 
-emscripten_set_wheel_callback("#canvas",this,1,&mousescrolled_cb);
 void ofxAppEmscriptenWindow::hideCursor(){
 	emscripten_hide_mouse();
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -92,6 +92,8 @@ private:
 	
 	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
 	
+	static int mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData);
+	
 	int id;
 
 	

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -69,7 +69,7 @@ public:
 	void update();
 	void draw();
 
-    virtual void makeCurrent();
+	virtual void makeCurrent();
 	virtual void startRender();
 	virtual void finishRender();
 
@@ -83,24 +83,24 @@ private:
 	static void display_cb();
 	static int keydown_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData);
 	static int keyup_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData);
-	
+
 	static int mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
 	static int mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
 	static int mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
 	static int mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
 	static int mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
-	
-	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
-	
-	int id;
 
-	
+	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
+
+	static int gamepad_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
+
+
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE  context = 0;
 
-    bool bSetMainLoopTiming = true;
-    bool bEnableSetupScreen = true;
-    ofCoreEvents _events;
-    std::shared_ptr<ofBaseRenderer> _renderer;
+	bool bSetMainLoopTiming = true;
+	bool bEnableSetupScreen = true;
+	ofCoreEvents _events;
+	std::shared_ptr<ofBaseRenderer> _renderer;
 };
 
 #endif /* OFAPPEMSCRIPTENWINDOW_H_ */

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -92,7 +92,8 @@ private:
 
 	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
 
-	static int gamepad_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
+	static int gamepadconnected_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
+	static int gamepaddisconnected_cb(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
 
 
 	EMSCRIPTEN_WEBGL_CONTEXT_HANDLE  context = 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.h
@@ -92,8 +92,6 @@ private:
 	
 	static int touch_cb(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
 	
-	static int mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData);
-	
 	int id;
 
 	


### PR DESCRIPTION
This is a (well) working draft for using gamepads with Emscripten (tested with an xbox one controller).
https://emscripten.org/docs/api_reference/html5.h.html#gamepad
I got most of the code from this test / example: https://chromium.googlesource.com/external/github.com/emscripten-core/emscripten/+/refs/tags/1.38.39/tests/test_gamepad.c
Here is a good page for reference: https://gamepad-tester.com/

The event array:
```
static inline const char* emscripten_event_type_to_string(int eventType) {
  const char *events[] = { "(invalid)", "(none)", "keypress", "keydown", "keyup", "click", "mousedown", "mouseup", "dblclick", "mousemove", "wheel", "resize", 
    "scroll", "blur", "focus", "focusin", "focusout", "deviceorientation", "devicemotion", "orientationchange", "fullscreenchange", "pointerlockchange", 
    "visibilitychange", "touchstart", "touchend", "touchmove", "touchcancel", "gamepadconnected", "gamepaddisconnected", "beforeunload", 
    "batterychargingchange", "batterylevelchange", "webglcontextlost", "webglcontextrestored", "mouseenter", "mouseleave", "mouseover", "mouseout", "(invalid)" };
  ++eventType;
  if (eventType < 0) eventType = 0;
  if (eventType >= sizeof(events)/sizeof(events[0])) eventType = sizeof(events)/sizeof(events[0])-1;
  return events[eventType];
}
```
Could be useful for other events to.
The gamepad events need to be updated every draw cycle (or as often as you want to get the output).
Not sure, if I put the things at the right place, but I think its a good start.
Where it hangs again is, that I do not now how to pass those values in the best way to `ofApp.cpp`.
Once I made a simple class, there I used `notify`: https://github.com/Jonathhhan/OF-GUI-library
And then I have a general question about formatting the code correct (in OF style), sometimes not sure where to leave a space and where not etc....
