### PR TITLE
osx template cleanup AppStore leftover entries

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -295,35 +295,13 @@
 			"lastKnownFileType": "sourcecode.c.h",
 			"sourceTree": "SOURCE_ROOT"
 		},
-		"99FA3DBC1C7456C400CFA0EE": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]": "APPSTORE=1",
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
-				"COPY_PHASE_STRIP": "YES",
-				"OTHER_LDFLAGS": [
-					"$(OF_CORE_LIBS)",
-					"$(OF_CORE_FRAMEWORKS)",
-					"$(LIB_OF)"
-				],
-				"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-				"LIBRARY_SEARCH_PATHS": "$(inherited)"
-			},
-			"name": "AppStore"
-		},
 		"E4B69B4D0A3A1720003C02F2": {
 			"isa": "XCConfigurationList",
 			"defaultConfigurationIsVisible": "0",
 			"defaultConfigurationName": "Release",
 			"buildConfigurations": [
 				"E4B69B4E0A3A1720003C02F2",
-				"E4B69B4F0A3A1720003C02F2",
-				"99FA3DBB1C7456C400CFA0EE"
+				"E4B69B4F0A3A1720003C02F2"
 			]
 		},
 		"E4B69B5F0A3A1757003C02F2": {
@@ -332,8 +310,7 @@
 			"defaultConfigurationName": "Release",
 			"buildConfigurations": [
 				"E4B69B600A3A1757003C02F2",
-				"E4B69B610A3A1757003C02F2",
-				"99FA3DBC1C7456C400CFA0EE"
+				"E4B69B610A3A1757003C02F2"
 			]
 		},
 		"E42962D72163EDD300A6A9E2": {
@@ -841,24 +818,6 @@
 			"name": "ofParameter.h",
 			"lastKnownFileType": "sourcecode.c.h",
 			"sourceTree": "SOURCE_ROOT"
-		},
-		"99FA3DBB1C7456C400CFA0EE": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"GCC_UNROLL_LOOPS": "YES",
-				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
-				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]": "DISTRIBUTION=1",
-				"GCC_OPTIMIZATION_LEVEL": "3",
-				"COPY_PHASE_STRIP": "YES",
-				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
-				"GCC_WARN_UNUSED_VARIABLE": "NO"
-			},
-			"name": "AppStore"
 		},
 		"E42963052163EDD300A6A9E2": {
 			"path": "../../../libs/openFrameworks/utils/ofUtils.h",


### PR DESCRIPTION
this removes some leftover entries, so Header search paths and other fields doesn't show it anymore.