### PR TITLE
 add support to maintain/recall an init value within ofParameters

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -505,8 +505,10 @@ public:
 
 	ParameterType getMin() const;
 
-	ParameterType getMax() const;
+    ParameterType getMax() const;
 
+    ParameterType getInit() const;
+    void reInit();
 
 	std::string toString() const;
 	void fromString(const std::string & name);
@@ -572,7 +574,8 @@ public:
 	ofParameter<ParameterType> & setWithoutEventNotifications(const ParameterType & v);
 
 	void setMin(const ParameterType & min);
-	void setMax(const ParameterType & max);
+    void setMax(const ParameterType & max);
+    void setInit(const ParameterType & init);
 
 	void setSerializable(bool serializable);
 	std::shared_ptr<ofAbstractParameter> newReference() const;
@@ -606,6 +609,7 @@ private:
 
 		Value(ParameterType v)
 		:value(v)
+        ,init(v)
 		,min(of::priv::TypeInfo<ParameterType>::min())
 		,max(of::priv::TypeInfo<ParameterType>::max())
 		,bInNotify(false)
@@ -613,6 +617,7 @@ private:
 
 		Value(std::string name, ParameterType v)
 		:name(name)
+        ,init(v)
 		,value(v)
 		,min(of::priv::TypeInfo<ParameterType>::min())
 		,max(of::priv::TypeInfo<ParameterType>::max())
@@ -621,6 +626,7 @@ private:
 
 		Value(std::string name, ParameterType v, ParameterType min, ParameterType max)
 		:name(name)
+        ,init(v)
 		,value(v)
 		,min(min)
 		,max(max)
@@ -629,7 +635,7 @@ private:
 
 		std::string name;
 		ParameterType value;
-		ParameterType min, max;
+		ParameterType min, max, init;
 		ofEvent<ParameterType> changedE;
 		bool bInNotify;
 		bool serializable;
@@ -697,6 +703,7 @@ ofParameter<ParameterType> & ofParameter<ParameterType>::set(const std::string& 
 	set(value);
 	setMin(min);
 	setMax(max);
+    setInit(value);
 	return *this;
 }
 
@@ -803,12 +810,27 @@ ParameterType ofParameter<ParameterType>::getMin() const {
 
 template<typename ParameterType>
 void ofParameter<ParameterType>::setMax(const ParameterType & max){
-	obj->max = max;
+    obj->max = max;
 }
 
 template<typename ParameterType>
 ParameterType ofParameter<ParameterType>::getMax() const {
-	return obj->max;
+    return obj->max;
+}
+
+template<typename ParameterType>
+void ofParameter<ParameterType>::setInit(const ParameterType & init){
+    obj->init = init;
+}
+
+template<typename ParameterType>
+ParameterType ofParameter<ParameterType>::getInit() const {
+    return obj->init;
+}
+
+template<typename ParameterType>
+void ofParameter<ParameterType>::reInit() {
+    set(obj->init);
 }
 
 template<typename ParameterType>
@@ -1165,7 +1187,8 @@ protected:
 	ofReadOnlyParameter<ParameterType,Friend>& set(const std::string& name, const ParameterType & value, const ParameterType & min, const ParameterType & max);
 
 	void setMin(const ParameterType & min);
-	void setMax(const ParameterType & max);
+    void setMax(const ParameterType & max);
+    void setInit(const ParameterType & init);
 
 	void fromString(const std::string & str);
 
@@ -1462,6 +1485,10 @@ inline void ofReadOnlyParameter<ParameterType,Friend>::setMax(const ParameterTyp
 	parameter.setMax(max);
 }
 
+template<typename ParameterType,typename Friend>
+inline void ofReadOnlyParameter<ParameterType,Friend>::setInit(const ParameterType & init){
+    parameter.setInit(init);
+}
 
 template<typename ParameterType,typename Friend>
 inline void ofReadOnlyParameter<ParameterType,Friend>::fromString(const std::string & str){


### PR DESCRIPTION
i find myself merging this functionality in half my ofParameter-using projects: a T member value to store the init value, and a reInit() method to bring back the value. 

this adds some model power to ofParameters and lowers code duplication risks of having to store the "default values" in another structure that mirrors the ofParameter hierarchy. there is also a getInit() which is useful to perform scaling centred on the default value (which might not be in the geometric center of a given T range, but needs to be at the center of knob, for instance).

the value is stored transparently and the reInit() method uses the parameter's set() to propagate the events (so for instance ofxGui responds as expected) -- it does the right thing with default-constructed and "not-setup" ofParameters (ex: a naked ofParameter<float> will be set back to 0 and an ofColor to white). as far as i can tell it is fully backwards-compatible as it does not modify existing behavior, and only adds the footprint of one T.

navigating ofParameter.h is not so explicit... I matched the setMax()/getMax() behavior, plus the assignments where a value is passed. I chose the label "Init" (over "default") as it's short and works as well as a noun (variable) and a verb (methods).

```C++
ofParameter<float> zoom {"zoom", 1.0f, 0.1f, 10.0f}; // no difference from current usage
// mess with the zoom, then:
zoom.reInit();
```

#changelog #types