### PR TITLE
fix(msys2): icon compilation

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
@@ -251,6 +251,7 @@ $(OF_PROJECT_OBJ_OUTPUT_PATH)%.o: $(PROJECT_ROOT)/%.S $(OF_PROJECT_OBJ_OUTPUT_PA
 #Rules to create and compile resource file to include icon
 $(OF_PROJECT_OBJ_OUTPUT_PATH)%.res: $(ICON)
 	@echo "Compiling Resource" $<
+	@mkdir -p $(@D)
 #Need to build an intermediate .rc file with Windows-like file path (C:/myproject/theIcon.ico)
 	@echo MAINICON ICON \"$(shell cygpath -m $<)\" > $(OF_PROJECT_OBJ_OUTPUT_PATH)$*.rc
 	@$(RESOURCE_COMPILER) $(OF_PROJECT_OBJ_OUTPUT_PATH)$*.rc -O coff -o $@


### PR DESCRIPTION
Fix #7249 
Cannot create icon.rc when destination folder is not present
Force creation of destination folder