### PR TITLE
audioInputExample update 

### DIFF
--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -47,7 +47,7 @@ void ofApp::setup(){
 	#else
 		settings.numOutputChannels = 0;
 	#endif
-	settings.numInputChannels = 2;
+	settings.numInputChannels = 1;
 	settings.bufferSize = bufferSize;
 	soundStream.setup(settings);
 


### PR DESCRIPTION
inputchannels = 1 instead of 2
Apple computers stopped accepting input with two channels, so this change is needed