### PR TITLE
iOS examples - audioInputExample update

### DIFF
--- a/examples/ios/audioInputExample/src/ofApp.h
+++ b/examples/ios/audioInputExample/src/ofApp.h
@@ -24,13 +24,11 @@ public:
 	void gotMemoryWarning();
 	void deviceOrientationChanged(int newOrientation);
 
-//	void audioIn(float * input, int bufferSize, int nChannels);
 	void audioIn(ofSoundBuffer & input);
 
 	int	bufferSize = 512;
 	int	drawCounter;
 	int bufferCounter;
-//	float * buffer;
 	float buffer[512] = { 0 };
 	
 	ofSoundPlayer sound;

--- a/examples/ios/audioInputExample/src/ofApp.h
+++ b/examples/ios/audioInputExample/src/ofApp.h
@@ -24,14 +24,17 @@ public:
 	void gotMemoryWarning();
 	void deviceOrientationChanged(int newOrientation);
 
-	void audioIn(float * input, int bufferSize, int nChannels);
+//	void audioIn(float * input, int bufferSize, int nChannels);
+	void audioIn(ofSoundBuffer & input);
 
-	int	initialBufferSize;
-	int	sampleRate;
+	int	bufferSize = 512;
 	int	drawCounter;
 	int bufferCounter;
-	float * buffer;
+//	float * buffer;
+	float buffer[512] = { 0 };
 	
 	ofSoundPlayer sound;
+	ofSoundStream soundStream;
+
 };
 

--- a/examples/ios/audioInputExample/src/ofApp.mm
+++ b/examples/ios/audioInputExample/src/ofApp.mm
@@ -2,37 +2,29 @@
 
 #include "ofApp.h"
 
-//  IMPORTANT!!! if your sound doesn't work in the simulator
-//	read this post => http://www.cocos2d-iphone.org/forum/topic/4159
-//  which requires you set the input stream to 24bit!!
-
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofSetFrameRate(60);
 	ofBackground(255);
 	ofSetOrientation(OF_ORIENTATION_90_RIGHT);//Set iOS to Orientation Landscape Right
 
-	//for some reason on the iphone simulator 256 doesn't work - it comes in as 512!
-	//so we do 512 - otherwise we crash
-	initialBufferSize = 512;
-	sampleRate = 44100;
 	drawCounter = 0;
 	bufferCounter = 0;
-	
-	buffer = new float[initialBufferSize];
-	memset(buffer, 0, initialBufferSize * sizeof(float));
 
-	// 0 output channels,
-	// 1 input channels
-	// 44100 samples per second
-	// 512 samples per buffer
-	// 1 buffer
-	ofSoundStreamSetup(0, 1, this, sampleRate, initialBufferSize, 1);
-	
 	sound.load("sounds/beat.caf");
 	sound.setLoop(true);
 	sound.play();
 	sound.setVolume(0);
+	
+	ofSoundStreamSettings settings;
+	settings.setInListener(this);
+	settings.sampleRate = 44100;
+	settings.numOutputChannels = 0;
+	settings.numInputChannels = 1;
+	settings.numBuffers = 1;
+	settings.bufferSize = bufferSize;
+	soundStream.setup(settings);
+
 }
 
 //--------------------------------------------------------------
@@ -51,8 +43,8 @@ void ofApp::draw(){
 	float y1 = ofGetHeight() * 0.5;
 	ofDrawLine(0, y1, ofGetWidth(), y1);
 	
-	for(int i=0; i<initialBufferSize; i++){
-		float p = i / (float)(initialBufferSize-1);
+	for(int i=0; i<bufferSize; i++){
+		float p = i / (float)(bufferSize-1);
 		float x = p * ofGetWidth();
 		float y2 = y1 + buffer[i] * 200;
 
@@ -69,21 +61,17 @@ void ofApp::draw(){
 }
 
 //--------------------------------------------------------------
-void ofApp::exit(){
-	//
+void ofApp::audioIn(ofSoundBuffer & input){
+	for(int i=0; i<input.getNumFrames(); i++) {
+		buffer[i] = input[i];
+	}
+	
+	bufferCounter++;
 }
 
 //--------------------------------------------------------------
-void ofApp::audioIn(float * input, int bufferSize, int nChannels){
-	if(initialBufferSize < bufferSize){
-		ofLog(OF_LOG_ERROR, "your buffer size was set to %i - but the stream needs a buffer size of %i", initialBufferSize, bufferSize);
-	}	
-
-	int minBufferSize = MIN(initialBufferSize, bufferSize);
-	for(int i=0; i<minBufferSize; i++) {
-		buffer[i] = input[i];
-	}
-	bufferCounter++;
+void ofApp::exit(){
+	//
 }
 
 //--------------------------------------------------------------
@@ -92,13 +80,13 @@ void ofApp::touchDown(ofTouchEventArgs & touch){
 }
 
 //--------------------------------------------------------------
-void ofApp::touchMoved(ofTouchEventArgs & touch){
-	
+void ofApp::touchUp(ofTouchEventArgs & touch){
+	sound.setVolume(0.0);
 }
 
 //--------------------------------------------------------------
-void ofApp::touchUp(ofTouchEventArgs & touch){
-	sound.setVolume(0.0);
+void ofApp::touchMoved(ofTouchEventArgs & touch){
+	
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
There are some changes in this example. maybe more than necessary but just to open some discussion:

the modernization of ofSoundStream object and audioIn function

change of buffer memory from heap to the stack, fixed array, zero initialized instead of memset.
it seems the example was meant to have buffer changing on the fly but it doesn't, so I removed the bufferSize check in audioIn

removed the comments regarding ios simulator because it is not working actually on OF, so we don't even know if the limitations present in the comments are still valid. 