### PR TITLE
ofxAssimpModelLoader rm using namespace std and other changes

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpAnimation.cpp
@@ -7,9 +7,7 @@
 #include "ofAppRunner.h"
 #include "ofMath.h"
 
-using namespace std;
-
-ofxAssimpAnimation::ofxAssimpAnimation(shared_ptr<const aiScene> scene, aiAnimation * animation) {
+ofxAssimpAnimation::ofxAssimpAnimation(std::shared_ptr<const aiScene> scene, aiAnimation * animation) {
     this->scene = scene;
     this->animation = animation;
     animationCurrTime = 0;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.cpp
@@ -6,6 +6,9 @@
 #include "ofxAssimpMeshHelper.h"
 #include "ofxAssimpUtils.h"
 
+using std::make_shared;
+using std::shared_ptr;
+
 void ofxAssimpMeshHelper::addTexture(ofxAssimpTexture & aAssimpTex){
 	
     if( aAssimpTex.getTextureType() == aiTextureType_DIFFUSE ){

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
@@ -5,16 +5,13 @@
 
 #pragma once
 
-//#include "ofConstants.h"
 #include "ofMaterial.h"
-//#include "ofGraphics.h"
 #include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include "ofxAssimpTexture.h"
 #include "ofVbo.h"
 #include "ofMesh.h"
-// #include "ofMatrix4x4.h"
 #include "glm/mat4x4.hpp"
 
 struct aiMesh;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.h
@@ -5,16 +5,17 @@
 
 #pragma once
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofMaterial.h"
-#include "ofGraphics.h"
+//#include "ofGraphics.h"
 #include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include "ofxAssimpTexture.h"
 #include "ofVbo.h"
 #include "ofMesh.h"
-#include "ofMatrix4x4.h"
+// #include "ofMatrix4x4.h"
+#include "glm/mat4x4.hpp"
 
 struct aiMesh;
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -2,12 +2,17 @@
 #include "ofxAssimpUtils.h"
 #include "ofLight.h"
 #include "ofImage.h"
+#include "ofGraphics.h"
+#include "ofConstants.h"
 
 #include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include <assimp/config.h>
 #include <assimp/DefaultLogger.hpp>
+
+using std::shared_ptr;
+using std::vector;
 
 ofxAssimpModelLoader::ofxAssimpModelLoader(){
     clear();
@@ -213,7 +218,7 @@ void ofxAssimpModelLoader::calculateDimensions(){
     normalizedScale = MAX(scene_max.y - scene_min.y,normalizedScale);
     normalizedScale = MAX(scene_max.z - scene_min.z,normalizedScale);
     if (abs(normalizedScale) < std::numeric_limits<float>::epsilon()){
-        ofLogWarning("ofxAssimpModelLoader") << "Error calculating normalized scale of scene" << endl;
+        ofLogWarning("ofxAssimpModelLoader") << "Error calculating normalized scale of scene" << std::endl;
         normalizedScale = 1.0;
     } else {
         normalizedScale = 1.f / normalizedScale;
@@ -417,7 +422,7 @@ void ofxAssimpModelLoader::loadGLResources(){
                     << file.getFileName() + "\" from \"" << realPath << "\"" << " adding texture as " << assimpTexture.getTextureTypeAsString() ;
                 } else {
                     
-                    shared_ptr<ofTexture> texture = make_shared<ofTexture>();
+                    shared_ptr<ofTexture> texture = std::make_shared<ofTexture>();
                     
                     if( bHasEmbeddedTexture ){
                         

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.cpp
@@ -9,9 +9,7 @@
 #include "ofConstants.h"
 #include "ofLog.h"
 
-using namespace std;
-
-void ofxAssimpTexture::setup(const ofTexture & texture, string texturePath, bool bTexRepeat) {
+void ofxAssimpTexture::setup(const ofTexture & texture, std::string texturePath, bool bTexRepeat) {
     this->texture = texture;
     if( bTexRepeat ){
         this->texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
@@ -45,7 +43,7 @@ ofTexture & ofxAssimpTexture::getTextureRef() {
     return texture;
 }
 
-string ofxAssimpTexture::getTexturePath() {
+std::string ofxAssimpTexture::getTexturePath() {
     return texturePath;
 }
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-//#include "ofConstants.h"
 #include "ofTexture.h"
 #include <assimp/material.h>
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpTexture.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofTexture.h"
 #include <assimp/material.h>
 

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
@@ -6,12 +6,13 @@
 
 #pragma once
 
-#include "ofMain.h"
+// #include "ofMain.h"
 #include "ofxAssimpMeshHelper.h"
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 
-using namespace std;
+using std::string;
+using std::vector;
 
 //--------------------------------------------------------------
 inline ofFloatColor aiColorToOfColor(const aiColor4D& c){

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpUtils.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-// #include "ofMain.h"
 #include "ofxAssimpMeshHelper.h"
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>


### PR DESCRIPTION
in this PR I removed using namespace std, removed unused headers from .h files
and moved some headers to cpp files, so it is a little bit cleaner for .h includes

changed from ofMatrix4x4.h to the simpler glm/mat4x4.hpp include too
and finally removed ofMain.h which includes the whole OF project + namespace std