### PR TITLE
Emscripten mouse / touch event improvement

### DIFF
--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -345,6 +345,7 @@ int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEv
 	int canvasWidth, canvasHeight;
 	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
         double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
 	instance->events().notifyMouseExited(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	return 0;
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -47,8 +47,8 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     _renderer = make_shared<ofGLProgrammableRenderer>(this);
     ((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
 
-    emscripten_set_keydown_callback("#canvas",this,1,&keydown_cb);
-    emscripten_set_keyup_callback("#canvas",this,1,&keyup_cb);
+    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keydown_cb);
+    emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keyup_cb);
     
     emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousedown_cb);
     emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseup_cb);

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -12,68 +12,68 @@
 
 using namespace std;
 
-ofxAppEmscriptenWindow * ofxAppEmscriptenWindow::instance = NULL;
+ofxAppEmscriptenWindow* ofxAppEmscriptenWindow::instance = NULL;
 
 
-ofxAppEmscriptenWindow::ofxAppEmscriptenWindow(){
+ofxAppEmscriptenWindow::ofxAppEmscriptenWindow() {
 	instance = this;
 }
 
 ofxAppEmscriptenWindow::~ofxAppEmscriptenWindow() {
-	if(context != 0){
-		emscripten_webgl_destroy_context(context);	
+	if (context != 0) {
+		emscripten_webgl_destroy_context(context);
 	}
 }
 
-void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
-    setWindowShape(settings.getWidth(),settings.getHeight());
-    EmscriptenWebGLContextAttributes attrs;
-    emscripten_webgl_init_context_attributes(&attrs);
+void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings& settings) {
+	setWindowShape(settings.getWidth(), settings.getHeight());
+	EmscriptenWebGLContextAttributes attrs;
+	emscripten_webgl_init_context_attributes(&attrs);
 
-/// when setting explicitSwapControl to 0 it is emscripten that is in charge of swapping on each render call.
-    attrs.explicitSwapControl = 0;
-    attrs.depth = 1;
-    attrs.stencil = 1;
-    attrs.antialias = 1;
-    attrs.majorVersion = 2;
-    attrs.minorVersion = 0;
-    attrs.alpha = 0;
+	/// when setting explicitSwapControl to 0 it is emscripten that is in charge of swapping on each render call.
+	attrs.explicitSwapControl = 0;
+	attrs.depth = 1;
+	attrs.stencil = 1;
+	attrs.antialias = 1;
+	attrs.majorVersion = 2;
+	attrs.minorVersion = 0;
+	attrs.alpha = 0;
 
-    context = emscripten_webgl_create_context("#canvas", &attrs);
-    assert(context);
-	  
-    makeCurrent();
+	context = emscripten_webgl_create_context("#canvas", &attrs);
+	assert(context);
 
-    _renderer = make_shared<ofGLProgrammableRenderer>(this);
-    ((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
+	makeCurrent();
 
-    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keydown_cb);
-    emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keyup_cb);
-    
-    emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousedown_cb);
-    emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseup_cb);
-    emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousemoved_cb);
-    emscripten_set_mouseenter_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseenter_cb);
-    emscripten_set_mouseleave_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseleave_cb);
+	_renderer = make_shared<ofGLProgrammableRenderer>(this);
+	((ofGLProgrammableRenderer*)_renderer.get())->setup(2, 0);
 
-    emscripten_set_touchstart_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
-    emscripten_set_touchend_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
-    emscripten_set_touchmove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
-    emscripten_set_touchcancel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
-	
-    emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousescrolled_cb);
+	emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &keydown_cb);
+	emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &keyup_cb);
+
+	emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousedown_cb);
+	emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseup_cb);
+	emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousemoved_cb);
+	emscripten_set_mouseenter_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseenter_cb);
+	emscripten_set_mouseleave_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseleave_cb);
+
+	emscripten_set_touchstart_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
+	emscripten_set_touchend_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
+	emscripten_set_touchmove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
+	emscripten_set_touchcancel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
+
+	emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousescrolled_cb);
 }
 
-void ofxAppEmscriptenWindow::loop(){
+void ofxAppEmscriptenWindow::loop() {
 
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
-	emscripten_set_main_loop( display_cb, -1, 1);
+	emscripten_set_main_loop(display_cb, -1, 1);
 }
 
-void ofxAppEmscriptenWindow::update(){
-        if (bSetMainLoopTiming) {
+void ofxAppEmscriptenWindow::update() {
+	if (bSetMainLoopTiming) {
 		// choose the render speed with the second argument. 1 is for every screen refresh, 2 for every second, 3 for every third. and so on...
 		emscripten_set_main_loop_timing(1, 2);
 		bSetMainLoopTiming = false;
@@ -81,400 +81,486 @@ void ofxAppEmscriptenWindow::update(){
 	events().notifyUpdate();
 }
 
-void ofxAppEmscriptenWindow::draw(){
+void ofxAppEmscriptenWindow::draw() {
 	// set viewport, clear the screen
 	renderer()->startRender();
-	if( bEnableSetupScreen ) renderer()->setupScreen();
+	if (bEnableSetupScreen) renderer()->setupScreen();
 
 	events().notifyDraw();
 
 	renderer()->finishRender();
 }
 
-void ofxAppEmscriptenWindow::display_cb(){
-	if(instance){
+void ofxAppEmscriptenWindow::display_cb() {
+	if (instance) {
 		instance->update();
 		instance->draw();
 	}
 }
 
-int ofxAppEmscriptenWindow::keydown_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData){
+int ofxAppEmscriptenWindow::keydown_cb(int eventType, const EmscriptenKeyboardEvent* keyEvent, void* userData) {
 	int key = keyEvent->key[0];
 	std::string id = keyEvent->key;
-	if(key == 0){
+	if (key == 0) {
 		key = keyEvent->which + 32;
-	}else if(id == "Enter"){
+	}
+	else if (id == "Enter") {
 		key = OF_KEY_RETURN;
-	}else if(id == "Escape"){
+	}
+	else if (id == "Escape") {
 		key = OF_KEY_ESC;
-	}else if(id == "Tab"){
+	}
+	else if (id == "Tab") {
 		key = OF_KEY_TAB;
-	}else if(id == "Backspace"){
+	}
+	else if (id == "Backspace") {
 		key = OF_KEY_BACKSPACE;
-	}else if(id == "Delete"){
+	}
+	else if (id == "Delete") {
 		key = OF_KEY_DEL;
-	}else if(id == "Shift"){
+	}
+	else if (id == "Shift") {
 		key = OF_KEY_SHIFT;
-	}else if(id == "Control"){
+	}
+	else if (id == "Control") {
 		key = OF_KEY_CONTROL;
-	}else if(id == "Meta"){
+	}
+	else if (id == "Meta") {
 		key = OF_KEY_SUPER;
-	}else if(id == "Alt"){
+	}
+	else if (id == "Alt") {
 		key = OF_KEY_LEFT_ALT;
-	}else if(id == "AltGraph"){
+	}
+	else if (id == "AltGraph") {
 		key = OF_KEY_RIGHT_ALT;
-	}else if(id == "F1"){
+	}
+	else if (id == "F1") {
 		key = OF_KEY_F1;
-	}else if(id == "F2"){
+	}
+	else if (id == "F2") {
 		key = OF_KEY_F2;
-	}else if(id == "F3"){
+	}
+	else if (id == "F3") {
 		key = OF_KEY_F3;
-	}else if(id == "F4"){
+	}
+	else if (id == "F4") {
 		key = OF_KEY_F4;
-	}else if(id == "F5"){
+	}
+	else if (id == "F5") {
 		key = OF_KEY_F5;
-	}else if(id == "F6"){
+	}
+	else if (id == "F6") {
 		key = OF_KEY_F6;
-	}else if(id == "F7"){
+	}
+	else if (id == "F7") {
 		key = OF_KEY_F7;
-	}else if(id == "F8"){
+	}
+	else if (id == "F8") {
 		key = OF_KEY_F8;
-	}else if(id == "F9"){
+	}
+	else if (id == "F9") {
 		key = OF_KEY_F9;
-	}else if(id == "F10"){
+	}
+	else if (id == "F10") {
 		key = OF_KEY_F10;
-	}else if(id == "F11"){
+	}
+	else if (id == "F11") {
 		key = OF_KEY_F11;
-	}else if(id == "F12"){
+	}
+	else if (id == "F12") {
 		key = OF_KEY_F12;
-	}else if(id == "ArrowLeft"){
+	}
+	else if (id == "ArrowLeft") {
 		key = OF_KEY_LEFT;
-	}else if(id == "ArrowUp"){
+	}
+	else if (id == "ArrowUp") {
 		key = OF_KEY_UP;
-	}else if(id == "ArrowRight"){
+	}
+	else if (id == "ArrowRight") {
 		key = OF_KEY_RIGHT;
-	}else if(id == "ArrowDown"){
+	}
+	else if (id == "ArrowDown") {
 		key = OF_KEY_DOWN;
-	}else if(id == "PageUp"){
+	}
+	else if (id == "PageUp") {
 		key = OF_KEY_PAGE_UP;
-	}else if(id == "PageDown"){
+	}
+	else if (id == "PageDown") {
 		key = OF_KEY_PAGE_DOWN;
-	}else if(id == "Home"){
+	}
+	else if (id == "Home") {
 		key = OF_KEY_HOME;
-	}else if(id == "End"){
+	}
+	else if (id == "End") {
 		key = OF_KEY_END;
-	}else if(id == "Insert"){
+	}
+	else if (id == "Insert") {
 		key = OF_KEY_INSERT;
-	}else if(id == "ß"){
+	}
+	else if (id == "ß") {
 		key = 223;
-	}else if(id == "§"){
+	}
+	else if (id == "§") {
 		key = 167;
-	}else if(id == "ä"){
+	}
+	else if (id == "ä") {
 		key = 228;
-	}else if(id == "Ä"){
+	}
+	else if (id == "Ä") {
 		key = 196;
-	}else if(id == "ö"){
+	}
+	else if (id == "ö") {
 		key = 246;
-	}else if(id == "Ö"){
+	}
+	else if (id == "Ö") {
 		key = 214;
-	}else if(id == "ü"){
+	}
+	else if (id == "ü") {
 		key = 252;
-	}else if(id == "Ü"){
+	}
+	else if (id == "Ü") {
 		key = 220;
-	}else if(id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0){
+	}
+	else if (id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0) {
 		return 0;
 	}
 	instance->events().notifyKeyPressed(key);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData){
+int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEvent* keyEvent, void* userData) {
 	int key = keyEvent->key[0];
 	std::string id = keyEvent->key;
-	if(key == 0){
+	if (key == 0) {
 		key = keyEvent->which + 32;
-	}else if(id == "Enter"){
+	}
+	else if (id == "Enter") {
 		key = OF_KEY_RETURN;
-	}else if(id == "Escape"){
+	}
+	else if (id == "Escape") {
 		key = OF_KEY_ESC;
-	}else if(id == "Tab"){
+	}
+	else if (id == "Tab") {
 		key = OF_KEY_TAB;
-	}else if(id == "Backspace"){
+	}
+	else if (id == "Backspace") {
 		key = OF_KEY_BACKSPACE;
-	}else if(id == "Delete"){
+	}
+	else if (id == "Delete") {
 		key = OF_KEY_DEL;
-	}else if(id == "Shift"){
+	}
+	else if (id == "Shift") {
 		key = OF_KEY_SHIFT;
-	}else if(id == "Control"){
+	}
+	else if (id == "Control") {
 		key = OF_KEY_CONTROL;
-	}else if(id == "Meta"){
+	}
+	else if (id == "Meta") {
 		key = OF_KEY_SUPER;
-	}else if(id == "Alt"){
+	}
+	else if (id == "Alt") {
 		key = OF_KEY_LEFT_ALT;
-	}else if(id == "AltGraph"){
+	}
+	else if (id == "AltGraph") {
 		key = OF_KEY_RIGHT_ALT;
-	}else if(id == "F1"){
+	}
+	else if (id == "F1") {
 		key = OF_KEY_F1;
-	}else if(id == "F2"){
+	}
+	else if (id == "F2") {
 		key = OF_KEY_F2;
-	}else if(id == "F3"){
+	}
+	else if (id == "F3") {
 		key = OF_KEY_F3;
-	}else if(id == "F4"){
+	}
+	else if (id == "F4") {
 		key = OF_KEY_F4;
-	}else if(id == "F5"){
+	}
+	else if (id == "F5") {
 		key = OF_KEY_F5;
-	}else if(id == "F6"){
+	}
+	else if (id == "F6") {
 		key = OF_KEY_F6;
-	}else if(id == "F7"){
+	}
+	else if (id == "F7") {
 		key = OF_KEY_F7;
-	}else if(id == "F8"){
+	}
+	else if (id == "F8") {
 		key = OF_KEY_F8;
-	}else if(id == "F9"){
+	}
+	else if (id == "F9") {
 		key = OF_KEY_F9;
-	}else if(id == "F10"){
+	}
+	else if (id == "F10") {
 		key = OF_KEY_F10;
-	}else if(id == "F11"){
+	}
+	else if (id == "F11") {
 		key = OF_KEY_F11;
-	}else if(id == "F12"){
+	}
+	else if (id == "F12") {
 		key = OF_KEY_F12;
-	}else if(id == "ArrowLeft"){
+	}
+	else if (id == "ArrowLeft") {
 		key = OF_KEY_LEFT;
-	}else if(id == "ArrowUp"){
+	}
+	else if (id == "ArrowUp") {
 		key = OF_KEY_UP;
-	}else if(id == "ArrowRight"){
+	}
+	else if (id == "ArrowRight") {
 		key = OF_KEY_RIGHT;
-	}else if(id == "ArrowDown"){
+	}
+	else if (id == "ArrowDown") {
 		key = OF_KEY_DOWN;
-	}else if(id == "PageUp"){
+	}
+	else if (id == "PageUp") {
 		key = OF_KEY_PAGE_UP;
-	}else if(id == "PageDown"){
+	}
+	else if (id == "PageDown") {
 		key = OF_KEY_PAGE_DOWN;
-	}else if(id == "Home"){
+	}
+	else if (id == "Home") {
 		key = OF_KEY_HOME;
-	}else if(id == "End"){
+	}
+	else if (id == "End") {
 		key = OF_KEY_END;
-	}else if(id == "Insert"){
+	}
+	else if (id == "Insert") {
 		key = OF_KEY_INSERT;
-	}else if(id == "ß"){
+	}
+	else if (id == "ß") {
 		key = 223;
-	}else if(id == "§"){
+	}
+	else if (id == "§") {
 		key = 167;
-	}else if(id == "ä"){
+	}
+	else if (id == "ä") {
 		key = 228;
-	}else if(id == "Ä"){
+	}
+	else if (id == "Ä") {
 		key = 196;
-	}else if(id == "ö"){
+	}
+	else if (id == "ö") {
 		key = 246;
-	}else if(id == "Ö"){
+	}
+	else if (id == "Ö") {
 		key = 214;
-	}else if(id == "ü"){
+	}
+	else if (id == "ü") {
 		key = 252;
-	}else if(id == "Ü"){
+	}
+	else if (id == "Ü") {
 		key = 220;
-	}else if(id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0){
+	}
+	else if (id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0) {
 		return 0;
 	}
 	instance->events().notifyKeyReleased(key);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
-		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	if (mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight) {
+		instance->events().notifyMousePressed(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(ofGetMousePressed()){
-		instance->events().notifyMouseReleased(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	if (ofGetMousePressed()) {
+		instance->events().notifyMouseReleased(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 0);
-	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
-	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
-		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	if (ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)) {
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 0);
+	}
+	else if (ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)) {
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 1);
+	}
+	else if (ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)) {
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 2);
+	}
+	else if (mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight) {
+		instance->events().notifyMouseMoved(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
+int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent* wheelEvent, void* userData) {
 	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX / 100, wheelEvent->deltaY / 100);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseEntered(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	instance->events().notifyMouseEntered(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	instance->events().notifyMouseExited(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	instance->events().notifyMouseExited(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
 	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-        ofTouchEventArgs::Type touchArgsType;
-        switch (eventType) {
-                    case EMSCRIPTEN_EVENT_TOUCHSTART:
-                        touchArgsType = ofTouchEventArgs::down;
-                        break;
-                    case EMSCRIPTEN_EVENT_TOUCHEND:
-                        touchArgsType = ofTouchEventArgs::up;
-                        break;
-                    case EMSCRIPTEN_EVENT_TOUCHMOVE:
-                        touchArgsType = ofTouchEventArgs::move;
-                        break;
-                    case EMSCRIPTEN_EVENT_TOUCHCANCEL:
-                        touchArgsType = ofTouchEventArgs::cancel;
-                        break;
-                    default:
-                        return 1;
-            }
-        int numTouches = e->numTouches;
-        for (int i = 0; i < numTouches; i++) {
-                ofTouchEventArgs touchArgs;
-                touchArgs.type = touchArgsType;
-                touchArgs.id = i;
-                touchArgs.x =  (e->touches[i].targetX - boundingX) * canvas_width / css_width;
-                touchArgs.y =  (e->touches[i].targetY - boundingY) * canvas_height / css_height;
-                instance->events().notifyTouchEvent(touchArgs);
-           }
-    return 0;
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+	double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	ofTouchEventArgs::Type touchArgsType;
+	switch (eventType) {
+	case EMSCRIPTEN_EVENT_TOUCHSTART:
+		touchArgsType = ofTouchEventArgs::down;
+		break;
+	case EMSCRIPTEN_EVENT_TOUCHEND:
+		touchArgsType = ofTouchEventArgs::up;
+		break;
+	case EMSCRIPTEN_EVENT_TOUCHMOVE:
+		touchArgsType = ofTouchEventArgs::move;
+		break;
+	case EMSCRIPTEN_EVENT_TOUCHCANCEL:
+		touchArgsType = ofTouchEventArgs::cancel;
+		break;
+	default:
+		return 1;
+	}
+	int numTouches = e->numTouches;
+	for (int i = 0; i < numTouches; i++) {
+		ofTouchEventArgs touchArgs;
+		touchArgs.type = touchArgsType;
+		touchArgs.id = i;
+		touchArgs.x = (e->touches[i].targetX - boundingX) * canvasWidth / cssWidth;
+		touchArgs.y = (e->touches[i].targetY - boundingY) * canvasHeight / cssHeight;
+		instance->events().notifyTouchEvent(touchArgs);
+	}
+	return 0;
 }
 
-void ofxAppEmscriptenWindow::hideCursor(){
+void ofxAppEmscriptenWindow::hideCursor() {
 	emscripten_hide_mouse();
 }
 
-void ofxAppEmscriptenWindow::setWindowShape(int w, int h){
-    emscripten_set_canvas_size(w,h);
+void ofxAppEmscriptenWindow::setWindowShape(int w, int h) {
+	emscripten_set_canvas_size(w, h);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getWindowPosition(){
-	return glm::vec2(0,0);
+glm::vec2 ofxAppEmscriptenWindow::getWindowPosition() {
+	return glm::vec2(0, 0);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getWindowSize(){
+glm::vec2 ofxAppEmscriptenWindow::getWindowSize() {
 	int width;
 	int height;
 	emscripten_get_canvas_element_size("#canvas", &width, &height);
-	return glm::vec2(width,height);
+	return glm::vec2(width, height);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getScreenSize(){
+glm::vec2 ofxAppEmscriptenWindow::getScreenSize() {
 	return getWindowSize();
 }
 
-ofOrientation ofxAppEmscriptenWindow::getOrientation(){
+ofOrientation ofxAppEmscriptenWindow::getOrientation() {
 	return OF_ORIENTATION_DEFAULT;
 }
 
-bool ofxAppEmscriptenWindow::doesHWOrientation(){
+bool ofxAppEmscriptenWindow::doesHWOrientation() {
 	return false;
 }
 
 //this is used by ofGetWidth and now determines the window width based on orientation
-int	ofxAppEmscriptenWindow::getWidth(){
+int	ofxAppEmscriptenWindow::getWidth() {
 	return getWindowSize().x;
 }
 
-int	ofxAppEmscriptenWindow::getHeight(){
+int	ofxAppEmscriptenWindow::getHeight() {
 	return getWindowSize().y;
 }
 
-ofWindowMode ofxAppEmscriptenWindow::getWindowMode(){
+ofWindowMode ofxAppEmscriptenWindow::getWindowMode() {
 	return OF_WINDOW;
 }
 
-void ofxAppEmscriptenWindow::setFullscreen(bool fullscreen){
-	if(fullscreen){
+void ofxAppEmscriptenWindow::setFullscreen(bool fullscreen) {
+	if (fullscreen) {
 		emscripten_request_fullscreen("#canvas", 1);
-	}else{
+	}
+	else {
 		emscripten_exit_fullscreen();
 	}
 }
 
-void ofxAppEmscriptenWindow::toggleFullscreen(){
+void ofxAppEmscriptenWindow::toggleFullscreen() {
 	EmscriptenFullscreenChangeEvent fullscreenStatus;
 	emscripten_get_fullscreen_status(&fullscreenStatus);
-	if(fullscreenStatus.isFullscreen){
+	if (fullscreenStatus.isFullscreen) {
 		setFullscreen(false);
-	}else if(fullscreenStatus.fullscreenEnabled){
+	}
+	else if (fullscreenStatus.fullscreenEnabled) {
 		setFullscreen(true);
 	}
 }
 
-void ofxAppEmscriptenWindow::enableSetupScreen(){
+void ofxAppEmscriptenWindow::enableSetupScreen() {
 	bEnableSetupScreen = true;
 }
 
 
-void ofxAppEmscriptenWindow::disableSetupScreen(){
+void ofxAppEmscriptenWindow::disableSetupScreen() {
 	bEnableSetupScreen = false;
 }
 
 
-ofCoreEvents & ofxAppEmscriptenWindow::events(){
+ofCoreEvents& ofxAppEmscriptenWindow::events() {
 	return _events;
 }
 
-shared_ptr<ofBaseRenderer> & ofxAppEmscriptenWindow::renderer(){
+shared_ptr<ofBaseRenderer>& ofxAppEmscriptenWindow::renderer() {
 	return _renderer;
 }
 
-void ofxAppEmscriptenWindow::makeCurrent(){
-	if(context != 0){
-		emscripten_webgl_make_context_current(context);	
+void ofxAppEmscriptenWindow::makeCurrent() {
+	if (context != 0) {
+		emscripten_webgl_make_context_current(context);
 	}
 }
 
-void ofxAppEmscriptenWindow::startRender(){
+void ofxAppEmscriptenWindow::startRender() {
 	renderer()->startRender();
 }
 
-void ofxAppEmscriptenWindow::finishRender(){
+void ofxAppEmscriptenWindow::finishRender() {
 	renderer()->finishRender();
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -281,12 +281,12 @@ int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEven
 int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
-		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	if(mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight){
+		instance->events().notifyMousePressed(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
 	}
 	return 0;
 }
@@ -294,12 +294,12 @@ int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEve
 int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
 	if(ofGetMousePressed()){
-		instance->events().notifyMouseReleased(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
+		instance->events().notifyMouseReleased(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
 	}
 	return 0;
 }
@@ -307,18 +307,18 @@ int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
 	if(ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 0);
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 0);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
-		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 2);
+	}else if(mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight){
+		instance->events().notifyMouseMoved(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	}
 	return 0;
 }
@@ -331,31 +331,31 @@ int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWhee
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseEntered(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
+	instance->events().notifyMouseEntered(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	instance->events().notifyMouseExited(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	instance->events().notifyMouseExited(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
 	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	int canvasWidth, canvasHeight;
+	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
+        double cssWidth, cssHeight;
+	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:
@@ -378,8 +378,8 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 ofTouchEventArgs touchArgs;
                 touchArgs.type = touchArgsType;
                 touchArgs.id = i;
-                touchArgs.x =  (e->touches[i].targetX - boundingX) * canvas_width / css_width;
-                touchArgs.y =  (e->touches[i].targetY - boundingY) * canvas_height / css_height;
+                touchArgs.x =  (e->touches[i].targetX - boundingX) * canvasWidth / cssWidth;
+                touchArgs.y =  (e->touches[i].targetY - boundingY) * canvasHeight / cssHeight;
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -279,36 +279,53 @@ int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEven
 }
 
 int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+	float mouseX = mouseEvent->targetX;
+	float mouseY = mouseEvent->targetY;
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMousePressed((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, mouseEvent->button);
+	if(mouseX - boundingX >= 0 && mouseX - boundingX <= canvas_width && mouseY - boundingY >= 0 && mouseY - boundingY <= canvas_height){
+		instance->events().notifyMousePressed((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, mouseEvent->button);
+	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+	float mouseX = mouseEvent->targetX;
+	float mouseY = mouseEvent->targetY;
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseReleased((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, mouseEvent->button);
+	if(ofGetMousePressed()){
+		instance->events().notifyMouseReleased((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, mouseEvent->button);
+	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+std::cout<<mouseEvent->targetX<<std::endl;
+	float mouseX = mouseEvent->targetX;
+	float mouseY = mouseEvent->targetY;
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if (ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 0);
-	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 1);
-	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 2);
-	}else{
-		instance->events().notifyMouseMoved((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
+	if(ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
+		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 0);
+	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
+		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 1);
+	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
+		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 2);
+	}else if(mouseX - boundingX >= 0 && mouseX - boundingX <= canvas_width && mouseY - boundingY >= 0 && mouseY - boundingY <= canvas_height){
+		instance->events().notifyMouseMoved((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
 	}
 	return 0;
 }
@@ -319,28 +336,36 @@ int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWhee
 }
 
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+	float mouseX = mouseEvent->targetX;
+	float mouseY = mouseEvent->targetY;
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseEntered((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
+	instance->events().notifyMouseEntered((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+	float mouseX = mouseEvent->targetX;
+	float mouseY = mouseEvent->targetY;
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseExited((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
+	instance->events().notifyMouseExited((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
+	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:
@@ -363,8 +388,8 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 ofTouchEventArgs touchArgs;
                 touchArgs.type = touchArgsType;
                 touchArgs.id = i;
-                touchArgs.x =  std::ceil((e->touches[i].targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width);
-                touchArgs.y =  std::ceil((e->touches[i].targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
+                touchArgs.x =  (e->touches[i].targetX - boundingX) * canvas_width / css_width;
+                touchArgs.y =  (e->touches[i].targetY - boundingY) * canvas_height / css_height;
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -317,7 +317,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else{
+	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
 		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -279,52 +279,46 @@ int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEven
 }
 
 int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	float mouseX = mouseEvent->targetX;
-	float mouseY = mouseEvent->targetY;
-	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
-	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
+	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(mouseX - boundingX >= 0 && mouseX - boundingX <= canvas_width && mouseY - boundingY >= 0 && mouseY - boundingY <= canvas_height){
-		instance->events().notifyMousePressed((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, mouseEvent->button);
+	if(mouseX >= 0 && mouseX <= canvas_width && mouseY >= 0 && mouseY <= canvas_height){
+		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	float mouseX = mouseEvent->targetX;
-	float mouseY = mouseEvent->targetY;
-	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
-	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
+	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
 	if(ofGetMousePressed()){
-		instance->events().notifyMouseReleased((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, mouseEvent->button);
+		instance->events().notifyMouseReleased(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	float mouseX = mouseEvent->targetX;
-	float mouseY = mouseEvent->targetY;
-	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
-	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
+	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
 	if(ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 0);
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 0);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 1);
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height, 2);
-	}else if(mouseX - boundingX >= 0 && mouseX - boundingX <= canvas_width && mouseY - boundingY >= 0 && mouseY - boundingY <= canvas_height){
-		instance->events().notifyMouseMoved((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
+	}else if(mouseX >= 0 && mouseX <= canvas_width && mouseY >= 0 && mouseY <= canvas_height){
+		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;
 }
@@ -335,27 +329,23 @@ int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWhee
 }
 
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	float mouseX = mouseEvent->targetX;
-	float mouseY = mouseEvent->targetY;
-	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
-	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
+	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseEntered((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
+	instance->events().notifyMouseEntered(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	float mouseX = mouseEvent->targetX;
-	float mouseY = mouseEvent->targetY;
-	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
-	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
+	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
+	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
-	instance->events().notifyMouseExited((mouseX - boundingX) * canvas_width / css_width, (mouseY - boundingY) * canvas_height / css_height);
+	instance->events().notifyMouseExited(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	return 0;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -285,7 +285,7 @@ int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEve
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width <= canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height <= canvas_height){
+	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
 		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
@@ -317,7 +317,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width <= canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height <= canvas_height){
+	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
 		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -302,7 +302,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 }
 
 int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
-	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX - EM_ASM_INT(return canvas.getBoundingClientRect().left), wheelEvent->deltaY / 100 - EM_ASM_INT(return canvas.getBoundingClientRect().top));
+	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX - EM_ASM_INT(return canvas.getBoundingClientRect().left), wheelEvent->deltaY / 100);
 	return 0;
 }
 

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -355,6 +355,7 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
 	int canvas_width, canvas_height;
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -69,7 +69,7 @@ void ofxAppEmscriptenWindow::loop(){
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
-	emscripten_set_main_loop( display_cb, -1, 1);
+	emscripten_set_main_loop(display_cb, -1, 1);
 }
 
 void ofxAppEmscriptenWindow::update(){

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -12,68 +12,68 @@
 
 using namespace std;
 
-ofxAppEmscriptenWindow* ofxAppEmscriptenWindow::instance = NULL;
+ofxAppEmscriptenWindow * ofxAppEmscriptenWindow::instance = NULL;
 
 
-ofxAppEmscriptenWindow::ofxAppEmscriptenWindow() {
+ofxAppEmscriptenWindow::ofxAppEmscriptenWindow(){
 	instance = this;
 }
 
 ofxAppEmscriptenWindow::~ofxAppEmscriptenWindow() {
-	if (context != 0) {
-		emscripten_webgl_destroy_context(context);
+	if(context != 0){
+		emscripten_webgl_destroy_context(context);	
 	}
 }
 
-void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings& settings) {
-	setWindowShape(settings.getWidth(), settings.getHeight());
-	EmscriptenWebGLContextAttributes attrs;
-	emscripten_webgl_init_context_attributes(&attrs);
+void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
+    setWindowShape(settings.getWidth(),settings.getHeight());
+    EmscriptenWebGLContextAttributes attrs;
+    emscripten_webgl_init_context_attributes(&attrs);
 
-	/// when setting explicitSwapControl to 0 it is emscripten that is in charge of swapping on each render call.
-	attrs.explicitSwapControl = 0;
-	attrs.depth = 1;
-	attrs.stencil = 1;
-	attrs.antialias = 1;
-	attrs.majorVersion = 2;
-	attrs.minorVersion = 0;
-	attrs.alpha = 0;
+/// when setting explicitSwapControl to 0 it is emscripten that is in charge of swapping on each render call.
+    attrs.explicitSwapControl = 0;
+    attrs.depth = 1;
+    attrs.stencil = 1;
+    attrs.antialias = 1;
+    attrs.majorVersion = 2;
+    attrs.minorVersion = 0;
+    attrs.alpha = 0;
 
-	context = emscripten_webgl_create_context("#canvas", &attrs);
-	assert(context);
+    context = emscripten_webgl_create_context("#canvas", &attrs);
+    assert(context);
+	  
+    makeCurrent();
 
-	makeCurrent();
+    _renderer = make_shared<ofGLProgrammableRenderer>(this);
+    ((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
 
-	_renderer = make_shared<ofGLProgrammableRenderer>(this);
-	((ofGLProgrammableRenderer*)_renderer.get())->setup(2, 0);
+    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keydown_cb);
+    emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keyup_cb);
+    
+    emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousedown_cb);
+    emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseup_cb);
+    emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousemoved_cb);
+    emscripten_set_mouseenter_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseenter_cb);
+    emscripten_set_mouseleave_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseleave_cb);
 
-	emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &keydown_cb);
-	emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &keyup_cb);
-
-	emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousedown_cb);
-	emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseup_cb);
-	emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousemoved_cb);
-	emscripten_set_mouseenter_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseenter_cb);
-	emscripten_set_mouseleave_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mouseleave_cb);
-
-	emscripten_set_touchstart_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
-	emscripten_set_touchend_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
-	emscripten_set_touchmove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
-	emscripten_set_touchcancel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &touch_cb);
-
-	emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, this, 1, &mousescrolled_cb);
+    emscripten_set_touchstart_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchend_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchmove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchcancel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+	
+    emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousescrolled_cb);
 }
 
-void ofxAppEmscriptenWindow::loop() {
+void ofxAppEmscriptenWindow::loop(){
 
 	instance->events().notifySetup();
 
 	// Emulate loop via callbacks
-	emscripten_set_main_loop(display_cb, -1, 1);
+	emscripten_set_main_loop( display_cb, -1, 1);
 }
 
-void ofxAppEmscriptenWindow::update() {
-	if (bSetMainLoopTiming) {
+void ofxAppEmscriptenWindow::update(){
+        if (bSetMainLoopTiming) {
 		// choose the render speed with the second argument. 1 is for every screen refresh, 2 for every second, 3 for every third. and so on...
 		emscripten_set_main_loop_timing(1, 2);
 		bSetMainLoopTiming = false;
@@ -81,486 +81,400 @@ void ofxAppEmscriptenWindow::update() {
 	events().notifyUpdate();
 }
 
-void ofxAppEmscriptenWindow::draw() {
+void ofxAppEmscriptenWindow::draw(){
 	// set viewport, clear the screen
 	renderer()->startRender();
-	if (bEnableSetupScreen) renderer()->setupScreen();
+	if( bEnableSetupScreen ) renderer()->setupScreen();
 
 	events().notifyDraw();
 
 	renderer()->finishRender();
 }
 
-void ofxAppEmscriptenWindow::display_cb() {
-	if (instance) {
+void ofxAppEmscriptenWindow::display_cb(){
+	if(instance){
 		instance->update();
 		instance->draw();
 	}
 }
 
-int ofxAppEmscriptenWindow::keydown_cb(int eventType, const EmscriptenKeyboardEvent* keyEvent, void* userData) {
+int ofxAppEmscriptenWindow::keydown_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData){
 	int key = keyEvent->key[0];
 	std::string id = keyEvent->key;
-	if (key == 0) {
+	if(key == 0){
 		key = keyEvent->which + 32;
-	}
-	else if (id == "Enter") {
+	}else if(id == "Enter"){
 		key = OF_KEY_RETURN;
-	}
-	else if (id == "Escape") {
+	}else if(id == "Escape"){
 		key = OF_KEY_ESC;
-	}
-	else if (id == "Tab") {
+	}else if(id == "Tab"){
 		key = OF_KEY_TAB;
-	}
-	else if (id == "Backspace") {
+	}else if(id == "Backspace"){
 		key = OF_KEY_BACKSPACE;
-	}
-	else if (id == "Delete") {
+	}else if(id == "Delete"){
 		key = OF_KEY_DEL;
-	}
-	else if (id == "Shift") {
+	}else if(id == "Shift"){
 		key = OF_KEY_SHIFT;
-	}
-	else if (id == "Control") {
+	}else if(id == "Control"){
 		key = OF_KEY_CONTROL;
-	}
-	else if (id == "Meta") {
+	}else if(id == "Meta"){
 		key = OF_KEY_SUPER;
-	}
-	else if (id == "Alt") {
+	}else if(id == "Alt"){
 		key = OF_KEY_LEFT_ALT;
-	}
-	else if (id == "AltGraph") {
+	}else if(id == "AltGraph"){
 		key = OF_KEY_RIGHT_ALT;
-	}
-	else if (id == "F1") {
+	}else if(id == "F1"){
 		key = OF_KEY_F1;
-	}
-	else if (id == "F2") {
+	}else if(id == "F2"){
 		key = OF_KEY_F2;
-	}
-	else if (id == "F3") {
+	}else if(id == "F3"){
 		key = OF_KEY_F3;
-	}
-	else if (id == "F4") {
+	}else if(id == "F4"){
 		key = OF_KEY_F4;
-	}
-	else if (id == "F5") {
+	}else if(id == "F5"){
 		key = OF_KEY_F5;
-	}
-	else if (id == "F6") {
+	}else if(id == "F6"){
 		key = OF_KEY_F6;
-	}
-	else if (id == "F7") {
+	}else if(id == "F7"){
 		key = OF_KEY_F7;
-	}
-	else if (id == "F8") {
+	}else if(id == "F8"){
 		key = OF_KEY_F8;
-	}
-	else if (id == "F9") {
+	}else if(id == "F9"){
 		key = OF_KEY_F9;
-	}
-	else if (id == "F10") {
+	}else if(id == "F10"){
 		key = OF_KEY_F10;
-	}
-	else if (id == "F11") {
+	}else if(id == "F11"){
 		key = OF_KEY_F11;
-	}
-	else if (id == "F12") {
+	}else if(id == "F12"){
 		key = OF_KEY_F12;
-	}
-	else if (id == "ArrowLeft") {
+	}else if(id == "ArrowLeft"){
 		key = OF_KEY_LEFT;
-	}
-	else if (id == "ArrowUp") {
+	}else if(id == "ArrowUp"){
 		key = OF_KEY_UP;
-	}
-	else if (id == "ArrowRight") {
+	}else if(id == "ArrowRight"){
 		key = OF_KEY_RIGHT;
-	}
-	else if (id == "ArrowDown") {
+	}else if(id == "ArrowDown"){
 		key = OF_KEY_DOWN;
-	}
-	else if (id == "PageUp") {
+	}else if(id == "PageUp"){
 		key = OF_KEY_PAGE_UP;
-	}
-	else if (id == "PageDown") {
+	}else if(id == "PageDown"){
 		key = OF_KEY_PAGE_DOWN;
-	}
-	else if (id == "Home") {
+	}else if(id == "Home"){
 		key = OF_KEY_HOME;
-	}
-	else if (id == "End") {
+	}else if(id == "End"){
 		key = OF_KEY_END;
-	}
-	else if (id == "Insert") {
+	}else if(id == "Insert"){
 		key = OF_KEY_INSERT;
-	}
-	else if (id == "ß") {
+	}else if(id == "ß"){
 		key = 223;
-	}
-	else if (id == "§") {
+	}else if(id == "§"){
 		key = 167;
-	}
-	else if (id == "ä") {
+	}else if(id == "ä"){
 		key = 228;
-	}
-	else if (id == "Ä") {
+	}else if(id == "Ä"){
 		key = 196;
-	}
-	else if (id == "ö") {
+	}else if(id == "ö"){
 		key = 246;
-	}
-	else if (id == "Ö") {
+	}else if(id == "Ö"){
 		key = 214;
-	}
-	else if (id == "ü") {
+	}else if(id == "ü"){
 		key = 252;
-	}
-	else if (id == "Ü") {
+	}else if(id == "Ü"){
 		key = 220;
-	}
-	else if (id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0) {
+	}else if(id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0){
 		return 0;
 	}
 	instance->events().notifyKeyPressed(key);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEvent* keyEvent, void* userData) {
+int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData){
 	int key = keyEvent->key[0];
 	std::string id = keyEvent->key;
-	if (key == 0) {
+	if(key == 0){
 		key = keyEvent->which + 32;
-	}
-	else if (id == "Enter") {
+	}else if(id == "Enter"){
 		key = OF_KEY_RETURN;
-	}
-	else if (id == "Escape") {
+	}else if(id == "Escape"){
 		key = OF_KEY_ESC;
-	}
-	else if (id == "Tab") {
+	}else if(id == "Tab"){
 		key = OF_KEY_TAB;
-	}
-	else if (id == "Backspace") {
+	}else if(id == "Backspace"){
 		key = OF_KEY_BACKSPACE;
-	}
-	else if (id == "Delete") {
+	}else if(id == "Delete"){
 		key = OF_KEY_DEL;
-	}
-	else if (id == "Shift") {
+	}else if(id == "Shift"){
 		key = OF_KEY_SHIFT;
-	}
-	else if (id == "Control") {
+	}else if(id == "Control"){
 		key = OF_KEY_CONTROL;
-	}
-	else if (id == "Meta") {
+	}else if(id == "Meta"){
 		key = OF_KEY_SUPER;
-	}
-	else if (id == "Alt") {
+	}else if(id == "Alt"){
 		key = OF_KEY_LEFT_ALT;
-	}
-	else if (id == "AltGraph") {
+	}else if(id == "AltGraph"){
 		key = OF_KEY_RIGHT_ALT;
-	}
-	else if (id == "F1") {
+	}else if(id == "F1"){
 		key = OF_KEY_F1;
-	}
-	else if (id == "F2") {
+	}else if(id == "F2"){
 		key = OF_KEY_F2;
-	}
-	else if (id == "F3") {
+	}else if(id == "F3"){
 		key = OF_KEY_F3;
-	}
-	else if (id == "F4") {
+	}else if(id == "F4"){
 		key = OF_KEY_F4;
-	}
-	else if (id == "F5") {
+	}else if(id == "F5"){
 		key = OF_KEY_F5;
-	}
-	else if (id == "F6") {
+	}else if(id == "F6"){
 		key = OF_KEY_F6;
-	}
-	else if (id == "F7") {
+	}else if(id == "F7"){
 		key = OF_KEY_F7;
-	}
-	else if (id == "F8") {
+	}else if(id == "F8"){
 		key = OF_KEY_F8;
-	}
-	else if (id == "F9") {
+	}else if(id == "F9"){
 		key = OF_KEY_F9;
-	}
-	else if (id == "F10") {
+	}else if(id == "F10"){
 		key = OF_KEY_F10;
-	}
-	else if (id == "F11") {
+	}else if(id == "F11"){
 		key = OF_KEY_F11;
-	}
-	else if (id == "F12") {
+	}else if(id == "F12"){
 		key = OF_KEY_F12;
-	}
-	else if (id == "ArrowLeft") {
+	}else if(id == "ArrowLeft"){
 		key = OF_KEY_LEFT;
-	}
-	else if (id == "ArrowUp") {
+	}else if(id == "ArrowUp"){
 		key = OF_KEY_UP;
-	}
-	else if (id == "ArrowRight") {
+	}else if(id == "ArrowRight"){
 		key = OF_KEY_RIGHT;
-	}
-	else if (id == "ArrowDown") {
+	}else if(id == "ArrowDown"){
 		key = OF_KEY_DOWN;
-	}
-	else if (id == "PageUp") {
+	}else if(id == "PageUp"){
 		key = OF_KEY_PAGE_UP;
-	}
-	else if (id == "PageDown") {
+	}else if(id == "PageDown"){
 		key = OF_KEY_PAGE_DOWN;
-	}
-	else if (id == "Home") {
+	}else if(id == "Home"){
 		key = OF_KEY_HOME;
-	}
-	else if (id == "End") {
+	}else if(id == "End"){
 		key = OF_KEY_END;
-	}
-	else if (id == "Insert") {
+	}else if(id == "Insert"){
 		key = OF_KEY_INSERT;
-	}
-	else if (id == "ß") {
+	}else if(id == "ß"){
 		key = 223;
-	}
-	else if (id == "§") {
+	}else if(id == "§"){
 		key = 167;
-	}
-	else if (id == "ä") {
+	}else if(id == "ä"){
 		key = 228;
-	}
-	else if (id == "Ä") {
+	}else if(id == "Ä"){
 		key = 196;
-	}
-	else if (id == "ö") {
+	}else if(id == "ö"){
 		key = 246;
-	}
-	else if (id == "Ö") {
+	}else if(id == "Ö"){
 		key = 214;
-	}
-	else if (id == "ü") {
+	}else if(id == "ü"){
 		key = 252;
-	}
-	else if (id == "Ü") {
+	}else if(id == "Ü"){
 		key = 220;
-	}
-	else if (id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0) {
+	}else if(id == "Dead" || id == "NumLock" || id == "ScrollLock" || id == "CapsLock" || id == "Pause" || key < 0){
 		return 0;
 	}
 	instance->events().notifyKeyReleased(key);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
+int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	if (mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight) {
-		instance->events().notifyMousePressed(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
+		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
+int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	if (ofGetMousePressed()) {
-		instance->events().notifyMouseReleased(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, mouseEvent->button);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	if(ofGetMousePressed()){
+		instance->events().notifyMouseReleased(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
+int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	if (ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)) {
-		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 0);
-	}
-	else if (ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)) {
-		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 1);
-	}
-	else if (ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)) {
-		instance->events().notifyMouseDragged(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight, 2);
-	}
-	else if (mouseX * canvasWidth / cssWidth >= 0 && mouseX * canvasWidth / cssWidth < canvasWidth && mouseY * canvasHeight / cssHeight >= 0 && mouseY * canvasHeight / cssHeight < canvasHeight) {
-		instance->events().notifyMouseMoved(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	if(ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 0);
+	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
+	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
+		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
+	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
+		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent* wheelEvent, void* userData) {
+int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
 	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX / 100, wheelEvent->deltaY / 100);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
+int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	instance->events().notifyMouseEntered(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	instance->events().notifyMouseEntered(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	return 0;
 }
 
-int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent* mouseEvent, void* userData) {
+int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
 	float mouseX = mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float mouseY = mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	instance->events().notifyMouseExited(mouseX * canvasWidth / cssWidth, mouseY * canvasHeight / cssHeight);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	instance->events().notifyMouseExited(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
 	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);
 	float boundingY = EM_ASM_INT(return canvas.getBoundingClientRect().top);
-	int canvasWidth, canvasHeight;
-	emscripten_get_canvas_element_size("#canvas", &canvasWidth, &canvasHeight);
-	double cssWidth, cssHeight;
-	emscripten_get_element_css_size("#canvas", &cssWidth, &cssHeight);
-	ofTouchEventArgs::Type touchArgsType;
-	switch (eventType) {
-	case EMSCRIPTEN_EVENT_TOUCHSTART:
-		touchArgsType = ofTouchEventArgs::down;
-		break;
-	case EMSCRIPTEN_EVENT_TOUCHEND:
-		touchArgsType = ofTouchEventArgs::up;
-		break;
-	case EMSCRIPTEN_EVENT_TOUCHMOVE:
-		touchArgsType = ofTouchEventArgs::move;
-		break;
-	case EMSCRIPTEN_EVENT_TOUCHCANCEL:
-		touchArgsType = ofTouchEventArgs::cancel;
-		break;
-	default:
-		return 1;
-	}
-	int numTouches = e->numTouches;
-	for (int i = 0; i < numTouches; i++) {
-		ofTouchEventArgs touchArgs;
-		touchArgs.type = touchArgsType;
-		touchArgs.id = i;
-		touchArgs.x = (e->touches[i].targetX - boundingX) * canvasWidth / cssWidth;
-		touchArgs.y = (e->touches[i].targetY - boundingY) * canvasHeight / cssHeight;
-		instance->events().notifyTouchEvent(touchArgs);
-	}
-	return 0;
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+        ofTouchEventArgs::Type touchArgsType;
+        switch (eventType) {
+                    case EMSCRIPTEN_EVENT_TOUCHSTART:
+                        touchArgsType = ofTouchEventArgs::down;
+                        break;
+                    case EMSCRIPTEN_EVENT_TOUCHEND:
+                        touchArgsType = ofTouchEventArgs::up;
+                        break;
+                    case EMSCRIPTEN_EVENT_TOUCHMOVE:
+                        touchArgsType = ofTouchEventArgs::move;
+                        break;
+                    case EMSCRIPTEN_EVENT_TOUCHCANCEL:
+                        touchArgsType = ofTouchEventArgs::cancel;
+                        break;
+                    default:
+                        return 1;
+            }
+        int numTouches = e->numTouches;
+        for (int i = 0; i < numTouches; i++) {
+                ofTouchEventArgs touchArgs;
+                touchArgs.type = touchArgsType;
+                touchArgs.id = i;
+                touchArgs.x =  (e->touches[i].targetX - boundingX) * canvas_width / css_width;
+                touchArgs.y =  (e->touches[i].targetY - boundingY) * canvas_height / css_height;
+                instance->events().notifyTouchEvent(touchArgs);
+           }
+    return 0;
 }
 
-void ofxAppEmscriptenWindow::hideCursor() {
+void ofxAppEmscriptenWindow::hideCursor(){
 	emscripten_hide_mouse();
 }
 
-void ofxAppEmscriptenWindow::setWindowShape(int w, int h) {
-	emscripten_set_canvas_size(w, h);
+void ofxAppEmscriptenWindow::setWindowShape(int w, int h){
+    emscripten_set_canvas_size(w,h);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getWindowPosition() {
-	return glm::vec2(0, 0);
+glm::vec2 ofxAppEmscriptenWindow::getWindowPosition(){
+	return glm::vec2(0,0);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getWindowSize() {
+glm::vec2 ofxAppEmscriptenWindow::getWindowSize(){
 	int width;
 	int height;
 	emscripten_get_canvas_element_size("#canvas", &width, &height);
-	return glm::vec2(width, height);
+	return glm::vec2(width,height);
 }
 
-glm::vec2 ofxAppEmscriptenWindow::getScreenSize() {
+glm::vec2 ofxAppEmscriptenWindow::getScreenSize(){
 	return getWindowSize();
 }
 
-ofOrientation ofxAppEmscriptenWindow::getOrientation() {
+ofOrientation ofxAppEmscriptenWindow::getOrientation(){
 	return OF_ORIENTATION_DEFAULT;
 }
 
-bool ofxAppEmscriptenWindow::doesHWOrientation() {
+bool ofxAppEmscriptenWindow::doesHWOrientation(){
 	return false;
 }
 
 //this is used by ofGetWidth and now determines the window width based on orientation
-int	ofxAppEmscriptenWindow::getWidth() {
+int	ofxAppEmscriptenWindow::getWidth(){
 	return getWindowSize().x;
 }
 
-int	ofxAppEmscriptenWindow::getHeight() {
+int	ofxAppEmscriptenWindow::getHeight(){
 	return getWindowSize().y;
 }
 
-ofWindowMode ofxAppEmscriptenWindow::getWindowMode() {
+ofWindowMode ofxAppEmscriptenWindow::getWindowMode(){
 	return OF_WINDOW;
 }
 
-void ofxAppEmscriptenWindow::setFullscreen(bool fullscreen) {
-	if (fullscreen) {
+void ofxAppEmscriptenWindow::setFullscreen(bool fullscreen){
+	if(fullscreen){
 		emscripten_request_fullscreen("#canvas", 1);
-	}
-	else {
+	}else{
 		emscripten_exit_fullscreen();
 	}
 }
 
-void ofxAppEmscriptenWindow::toggleFullscreen() {
+void ofxAppEmscriptenWindow::toggleFullscreen(){
 	EmscriptenFullscreenChangeEvent fullscreenStatus;
 	emscripten_get_fullscreen_status(&fullscreenStatus);
-	if (fullscreenStatus.isFullscreen) {
+	if(fullscreenStatus.isFullscreen){
 		setFullscreen(false);
-	}
-	else if (fullscreenStatus.fullscreenEnabled) {
+	}else if(fullscreenStatus.fullscreenEnabled){
 		setFullscreen(true);
 	}
 }
 
-void ofxAppEmscriptenWindow::enableSetupScreen() {
+void ofxAppEmscriptenWindow::enableSetupScreen(){
 	bEnableSetupScreen = true;
 }
 
 
-void ofxAppEmscriptenWindow::disableSetupScreen() {
+void ofxAppEmscriptenWindow::disableSetupScreen(){
 	bEnableSetupScreen = false;
 }
 
 
-ofCoreEvents& ofxAppEmscriptenWindow::events() {
+ofCoreEvents & ofxAppEmscriptenWindow::events(){
 	return _events;
 }
 
-shared_ptr<ofBaseRenderer>& ofxAppEmscriptenWindow::renderer() {
+shared_ptr<ofBaseRenderer> & ofxAppEmscriptenWindow::renderer(){
 	return _renderer;
 }
 
-void ofxAppEmscriptenWindow::makeCurrent() {
-	if (context != 0) {
-		emscripten_webgl_make_context_current(context);
+void ofxAppEmscriptenWindow::makeCurrent(){
+	if(context != 0){
+		emscripten_webgl_make_context_current(context);	
 	}
 }
 
-void ofxAppEmscriptenWindow::startRender() {
+void ofxAppEmscriptenWindow::startRender(){
 	renderer()->startRender();
 }
 
-void ofxAppEmscriptenWindow::finishRender() {
+void ofxAppEmscriptenWindow::finishRender(){
 	renderer()->finishRender();
 }

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -309,7 +309,6 @@ int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent
 }
 
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-std::cout<<mouseEvent->targetX<<std::endl;
 	float mouseX = mouseEvent->targetX;
 	float mouseY = mouseEvent->targetY;
 	float boundingX = EM_ASM_INT(return canvas.getBoundingClientRect().left);

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -50,18 +50,18 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
     emscripten_set_keydown_callback("#canvas",this,1,&keydown_cb);
     emscripten_set_keyup_callback("#canvas",this,1,&keyup_cb);
     
-    emscripten_set_mousedown_callback("#canvas",this,1,&mousedown_cb);
-    emscripten_set_mouseup_callback("#canvas",this,1,&mouseup_cb);
-    emscripten_set_mousemove_callback("#canvas",this,1,&mousemoved_cb);
-    emscripten_set_mouseenter_callback("#canvas",this,1,&mouseenter_cb);
-    emscripten_set_mouseleave_callback("#canvas",this,1,&mouseleave_cb);
+    emscripten_set_mousedown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousedown_cb);
+    emscripten_set_mouseup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseup_cb);
+    emscripten_set_mousemove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousemoved_cb);
+    emscripten_set_mouseenter_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseenter_cb);
+    emscripten_set_mouseleave_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mouseleave_cb);
 
-    emscripten_set_touchstart_callback("#canvas",this,1,&touch_cb);
-    emscripten_set_touchend_callback("#canvas",this,1,&touch_cb);
-    emscripten_set_touchmove_callback("#canvas",this,1,&touch_cb);
-    emscripten_set_touchcancel_callback("#canvas",this,1,&touch_cb);
+    emscripten_set_touchstart_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchend_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchmove_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
+    emscripten_set_touchcancel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&touch_cb);
 	
-    emscripten_set_wheel_callback("#canvas",this,1,&mousescrolled_cb);
+    emscripten_set_wheel_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&mousescrolled_cb);
 }
 
 void ofxAppEmscriptenWindow::loop(){
@@ -279,71 +279,44 @@ int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEven
 }
 
 int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMousePressed(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), mouseEvent->button);
+	instance->events().notifyMousePressed(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), mouseEvent->button);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseReleased(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), mouseEvent->button);
+	instance->events().notifyMouseReleased(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), mouseEvent->button);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
 	if (ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), 0);
+		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 0);
 	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), 1);
+		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 1);
 	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), 2);
+		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 2);
 	}else{
-		instance->events().notifyMouseMoved(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height));
+		instance->events().notifyMouseMoved(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
 	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
-	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX, wheelEvent->deltaY / 100);
+	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX - EM_ASM_INT(return canvas.getBoundingClientRect().left), wheelEvent->deltaY / 100 - EM_ASM_INT(return canvas.getBoundingClientRect().top));
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseEntered(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height));
-	if(mouseEvent->buttons == 0){
-		instance->events().notifyMouseReleased(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height), mouseEvent->button);
-	}	
+	instance->events().notifyMouseEntered(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	instance->events().notifyMouseExited(mouseEvent->targetX * (canvas_width / css_width), mouseEvent->targetY * (canvas_height / css_height));
+	instance->events().notifyMouseExited(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
-	int canvas_width, canvas_height;
-	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
-        double css_width, css_height;
-	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:
@@ -366,8 +339,8 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 ofTouchEventArgs touchArgs;
                 touchArgs.type = touchArgsType;
                 touchArgs.id = i;
-                touchArgs.x =  std::ceil(e->touches[i].targetX * (canvas_width / css_width));
-                touchArgs.y =  std::ceil(e->touches[i].targetY* (canvas_height / css_height));
+                touchArgs.x =  std::ceil(e->touches[i].targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left));
+                touchArgs.y =  std::ceil(e->touches[i].targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;
@@ -466,4 +439,3 @@ void ofxAppEmscriptenWindow::startRender(){
 void ofxAppEmscriptenWindow::finishRender(){
 	renderer()->finishRender();
 }
-

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -279,44 +279,68 @@ int ofxAppEmscriptenWindow::keyup_cb(int eventType, const EmscriptenKeyboardEven
 }
 
 int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	instance->events().notifyMousePressed(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), mouseEvent->button);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	instance->events().notifyMousePressed((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, mouseEvent->button);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseup_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	instance->events().notifyMouseReleased(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), mouseEvent->button);
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	instance->events().notifyMouseReleased((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, mouseEvent->button);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
 	if (ofGetMousePressed(OF_MOUSE_BUTTON_LEFT)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 0);
+		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 0);
 	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_MIDDLE)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 1);
+		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 1);
 	}else if (ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
-		instance->events().notifyMouseDragged(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), 2);
+		instance->events().notifyMouseDragged((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height, 2);
 	}else{
-		instance->events().notifyMouseMoved(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
+		instance->events().notifyMouseMoved((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
 	}
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mousescrolled_cb(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData){
-	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX - EM_ASM_INT(return canvas.getBoundingClientRect().left), wheelEvent->deltaY / 100);
+	instance->events().notifyMouseScrolled(ofGetMouseX(), ofGetMouseY(), wheelEvent->deltaX / 100, wheelEvent->deltaY / 100);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseenter_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	instance->events().notifyMouseEntered(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	instance->events().notifyMouseEntered((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::mouseleave_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
-	instance->events().notifyMouseExited(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
+	instance->events().notifyMouseExited((mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width, (mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
 	return 0;
 }
 
 int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* e, void* userData) {
+	int canvas_width, canvas_height;
+	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
+        double css_width, css_height;
+	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
         ofTouchEventArgs::Type touchArgsType;
         switch (eventType) {
                     case EMSCRIPTEN_EVENT_TOUCHSTART:
@@ -339,8 +363,8 @@ int ofxAppEmscriptenWindow::touch_cb(int eventType, const EmscriptenTouchEvent* 
                 ofTouchEventArgs touchArgs;
                 touchArgs.type = touchArgsType;
                 touchArgs.id = i;
-                touchArgs.x =  std::ceil(e->touches[i].targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left));
-                touchArgs.y =  std::ceil(e->touches[i].targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top));
+                touchArgs.x =  std::ceil((e->touches[i].targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left)) * canvas_width / css_width);
+                touchArgs.y =  std::ceil((e->touches[i].targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top)) * canvas_height / css_height);
                 instance->events().notifyTouchEvent(touchArgs);
            }
     return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -285,7 +285,7 @@ int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEve
 	emscripten_get_canvas_element_size("#canvas", &canvas_width, &canvas_height);
         double css_width, css_height;
 	emscripten_get_element_css_size("#canvas", &css_width, &css_height);
-	if(mouseX >= 0 && mouseX <= canvas_width && mouseY >= 0 && mouseY <= canvas_height){
+	if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width <= canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height <= canvas_height){
 		instance->events().notifyMousePressed(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, mouseEvent->button);
 	}
 	return 0;
@@ -317,7 +317,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else if(mouseX >= 0 && mouseX <= canvas_width && mouseY >= 0 && mouseY <= canvas_height){
+	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width <= canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height <= canvas_height){
 		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -317,7 +317,7 @@ int ofxAppEmscriptenWindow::mousemoved_cb(int eventType, const EmscriptenMouseEv
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 1);
 	}else if(ofGetMousePressed(OF_MOUSE_BUTTON_RIGHT)){
 		instance->events().notifyMouseDragged(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height, 2);
-	}else if(mouseX * canvas_width / css_width >= 0 && mouseX * canvas_width / css_width < canvas_width && mouseY * canvas_height / css_height >= 0 && mouseY * canvas_height / css_height < canvas_height){
+	}else{
 		instance->events().notifyMouseMoved(mouseX * canvas_width / css_width, mouseY * canvas_height / css_height);
 	}
 	return 0;


### PR DESCRIPTION
This PR enables mouse / touch events outside of the canvas. Maybe needs to be tested a little more, because it does not behave exactly like the desktop app. But it solves a problem that was bugging me for some time.
Maybe it would be the best solution to limit the mousePressed and mouseMoved events to the canvas?
I already tried it with an if condition:
```
int ofxAppEmscriptenWindow::mousedown_cb(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData){
float x = EM_ASM_INT(return canvas.getBoundingClientRect().left);
float y = EM_ASM_INT(return canvas.getBoundingClientRect().top);
if(mouseEvent->targetX - x >= 0 && mouseEvent->targetX - x <= EM_ASM_INT(return canvas.width) && mouseEvent->targetY - y >= 0 && mouseEvent->targetY - y <= EM_ASM_INT(return canvas.height)){
	instance->events().notifyMousePressed(mouseEvent->targetX - EM_ASM_INT(return canvas.getBoundingClientRect().left), mouseEvent->targetY - EM_ASM_INT(return canvas.getBoundingClientRect().top), mouseEvent->button);
	return 0;
	}
}
```
But somehow that does not work...