### PR TITLE
Fix StdFunctionId public constructor

### DIFF
--- a/libs/openFrameworks/events/ofEvent.h
+++ b/libs/openFrameworks/events/ofEvent.h
@@ -50,9 +50,8 @@ namespace priv{
 		StdFunctionId(uint64_t id)
 		:id(id){}
 	public:
-		StdFunctionId(){
-			id = nextId++;
-		}
+		StdFunctionId()
+		:id(nextId++){}
 
 		virtual ~StdFunctionId();
 


### PR DESCRIPTION
Fixes 
```[unqualified-id before ‘=’ token](https://forum.openframeworks.cc/t/resolved-raspberry-compile-issue-ofevent-h-expected-unqualified-id-before-token/41267)``` 
described under [https://forum.openframeworks.cc/t/resolved-raspberry-compile-issue-ofevent-h-expected-unqualified-id-before-token/41267](https://forum.openframeworks.cc/t/resolved-raspberry-compile-issue-ofevent-h-expected-unqualified-id-before-token/41267)