### PR TITLE
Add functionality to Xcode template to bundle dylibs

### DIFF
--- a/scripts/templates/osx/Project.xcconfig
+++ b/scripts/templates/osx/Project.xcconfig
@@ -32,6 +32,7 @@ ICON_FILE = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/$(ICON_NAME)
 //APPSTORE, uncomment next lines to bundle data folder and code sign
 //OF_CODESIGN = 1
 //OF_BUNDLE_DATA_FOLDER = 1
+//OF_BUNDLE_DYLIBS = 1
 
 // BOOST - UNCOMMENT BELOW TO ENABLE BOOST
 //HEADER_BOOST = "$(OF_PATH)/libs/boost/include"

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -477,6 +477,20 @@
 			],
 			"sourceTree": "<group>"
 		},
+		"E935D72329ADADAE00AC8EFD": {
+			"buildActionMask": "2147483647",
+			"runOnlyForDeploymentPostprocessing": "0",
+			"outputPaths": [],
+			"shellPath": "/bin/zsh",
+			"alwaysOutOfDate": "1",
+			"inputFileListPaths": [],
+			"isa": "PBXShellScriptBuildPhase",
+			"shellScript": "# make sure shell above is set to /bin/zsh\n#\n# requires `brew install dylibbundler` (v1.0.5 as of 20230121)\n#\n# activate via flag in Project.xcconfig\n#\n# note: dylib subdependencies (dylibs that load dylibs) will be found\n#\t\trecursively and bundled within the .app but might need doctoring \n#\t\tto work in both bundled or freestanding states.\n#\n\nif [ -z \"$OF_BUNDLE_DYLIBS\" ] ; then\n\techo \"Not bundling dylibs\";\nelse\n\techo \"Bundling dylibs\";\n\n\t\tflags=(${(@s: :)OTHER_LDFLAGS})\n\t\tdeclare -A paths\n\t\tsargs=\"\"\n\n\t# use the keys of an associative array to accumulate unique directories enclosing .dylibs based on OTHER_LDFLAGS\n\tfor ITEM in $flags; do\n\t\tif [[ $ITEM == *'.dylib' ]] then\n\t\t\td=$(dirname \"$ITEM\")\n\t\t\tpaths[$d]=$d\n\t\tfi\n\tdone\n\t\t\n\t# construct a list of -s args for dylibbuilder to find the dylibs\n\tfor key val in \"${(@kv)paths}\"; do\n\t\tsargs+=-s\\ $key\\ \n\tdone\n\n\t# do the thing\n\t/opt/homebrew/bin/dylibbundler -cd -b -x \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\" -d \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/libs\" ${(s[ ])sargs}\n\nfi\n",
+			"files": [],
+			"inputPaths": [],
+			"outputFileListPaths": [],
+			"name": "Run Script — Bundle dylibs"
+		},
 		"E4B69B600A3A1757003C02F2": {
 			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
 			"isa": "XCBuildConfiguration",
@@ -1754,7 +1768,8 @@
 				"E4B6FFFD0C3F9AB9008CF71C",
 				"E4C2427710CC5ABF004149E2",
 				"8466F1851C04CA0E00918B1C",
-				"19D6CF9228F07C000044A7EB"
+				"19D6CF9228F07C000044A7EB",
+				"E935D72329ADADAE00AC8EFD"
 			],
 			"dependencies": [],
 			"name": "emptyExample",


### PR DESCRIPTION
Problem: moving an app between machines requires that (1) all required dylibs to be bundled within the .app and (2) their paths to be tweaked in order to be found at runtime (including paths in dylibs-depending-on-other-dylibs). It's a hairy process to do manually, and also hairy to automate in a manner that survives a PG project update (as all tweaks to the project are lost).

This leverages https://github.com/auriamg/macdylibbundler (commonly available as `brew install dylibbundler`). The script first scans the Xcode project for all referenced dylibs that would be provided by addons and passes them to dylibbundler, who will copy and work recursively from these dylibs, automating the `install_name_tool` dance (and also signs the dylibs). A Project.xcconfig flag enables the script, which is disabled by default.

So as an end user: make a new project in PG; choose an addon that provides macOS .dylibs; activate the flag; build the project; and the dylibs are copied and tweaked within the .app bundle, that you can then copy on another machine. (of how far that translates depend on many factors (are the dylibs ARM+intel, specific project compile flags, OS version, etc).

As an addon writer: collect the required .dylibs inside your addon libs/ directory and doctor them once to play well together (the case of custom dylibs relying on custom dylibs will be correctly tracked by macdylibbundler, however some `install_name_tool`'ing of the "leaf" dylibs might be required to handle both bundled and not bundled).

more at https://github.com/openframeworks/openFrameworks/discussions/7277

NOTE: the problem this solves could have been addressed differently by augmenting the PG/addon with a post-processing step. I recently came about this PR https://github.com/openframeworks/projectGenerator/pull/217 that could solve the problem by enabling the execution of a script that would "inject" another script step into the pbxproj. however it would rely on some less-common software to manipulate the pbxproj. It would also make it brittle against future template modifications. Likewise, a custom template could be made ("Xcode-dylibbundle") but would require future double-management of the Xcode template. 

Having a disabled script tucked within the template is the best compromise. Tested between M1 and M2 machines with macOS12 and 13.

#changelog #osx