### PR TITLE
macOS: search for data within .app bundle if not found besides app

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -31,7 +31,12 @@ namespace{
         try{
             return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/")).string();
         }catch(...){
-            return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
+			try{
+			return std::filesystem::canonical(ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../Resources/data/")).string();
+			}catch(...){
+			
+				return ofFilePath::join(ofFilePath::getCurrentExeDir(),  "../../../data/");
+			}
         }
     #elif defined TARGET_ANDROID
         return string("sdcard/");


### PR DESCRIPTION
(this started as an issue, morphed into a discussion, but since I had super-circumscribed and functional code on hand to support the argument I went for the PR)

when bundling stuff with `OF_BUNDLE_DATA_FOLDER = 1` in macOS, things in there are not automatically found at runtime. 

this PR augments defaultDataPath() to check if there is a `../Resources/data/` if the usual one fails.

NOTE: this means that a `data` directory besides an app will override one that would have been internally bundled -- it could lead to confusion if by coincidence a user has a `data` folder besides the app. however there is also value to being able to conveniently override the internal data (less hassle than fishing in the package contents).

1. maybe it should be the other way around? (bundled has precedence if it exists? no confusion possible) but then it means most of the times exceptions are triggered to fall back on the traditional external data. (maybe not dramatic as file access is generally not a hot spot?)

 2. or maybe a compile-time #define would switch between cases based on if `OF_BUNDLE_DATA_FOLDER = 1`? so the app is built coherently for only one case? not sure what would be the pattern for that.

 3. BUT... **maybe the real fix is to work at higher level and allow multiple data folders**: not look for the existence of a `data` folder but the existence of the actual file within a list of potential `data` folders (like the good old MaxMSP "search paths"). this would allow to have a bundled data for required ressources (ex: shaders, interface elements, etc), and an external data for user ressources (ex: movies). with a configurable list, a few places could be searched, like `~/Documents/AppName/` to keep the app and data separated in some good practice manner (looking at iCloud)... also maybe bridge `ofxiPhoneGetDocumentsDirectory()` (useful for file sharing) & al.

it could be argued that a developper toggling `OF_BUNDLE_DATA_FOLDER = 1` is aware that the stuff will be elsewhere and could then be expected to call `ofSetDataPathRoot("../Resources/data/")` to fish the ressources there but it's an additional step to perform "consciously" (and it changes the default data path), and thinking about this at this point I find that (3) - (multiple data folders) is interesting as a general feature (but requires more design and work than the scope of this PR) 

SO: the current PR makes it so that a bundled data folder works transparently, with no impact on "normal" macOS apps (and a very slight risk of confusion for bundled apps users, which is much better than not working), holding the fort until a generalized multi-datapath strategy is implemented, if that is determined to be a good idea.

#changelog #osx