### PR TITLE
ofTexture map to unordered_map

### DIFF
--- a/libs/openFrameworks/gl/ofTexture.cpp
+++ b/libs/openFrameworks/gl/ofTexture.cpp
@@ -5,7 +5,7 @@
 #include "ofGLBaseTypes.h"
 #include "ofBufferObject.h"
 #include "ofMesh.h"
-#include <map>
+#include <unordered_map>
 
 #ifdef TARGET_ANDROID
 #include "ofAppAndroidWindow.h"
@@ -121,8 +121,8 @@ void ofDisableArbTex(){
 }
 
 
-static std::map<GLuint,int> & getTexturesIndex(){
-	static std::map<GLuint,int> * textureReferences = new std::map<GLuint,int>;
+static std::unordered_map<GLuint,int> & getTexturesIndex(){
+	static std::unordered_map<GLuint,int> * textureReferences = new std::unordered_map<GLuint,int>;
 	return *textureReferences;
 }
 


### PR DESCRIPTION
unordered_map can have an improvement performane over map, with the same funcionality less the automatic reordering.