### PR TITLE
MSYS2: remove clang warning when compiling with mingw64

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#pragma clang diagnostic ignored "-Wformat-security"
+#if defined(__clang__)
+	#pragma clang diagnostic ignored "-Wformat-security"
+#endif
 
 #include "ofConstants.h"
 #if !defined(TARGET_MINGW) 


### PR DESCRIPTION
Fix #7390 

add __clang__ guard on pragma