### PR TITLE
ofBufferToFile is missing const in first argument

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -281,7 +281,7 @@ ofBuffer ofBufferFromFile(const of::filesystem::path & path, bool binary=true);
 /// \param buffer data source to write from
 /// \param binary set to false if you are writing a text file & want lines
 /// split at endline characters automatically
-bool ofBufferToFile(of::filesystem::path & path, const ofBuffer& buffer, bool binary=true);
+bool ofBufferToFile(const of::filesystem::path & path, const ofBuffer& buffer, bool binary=true);
 
 //--------------------------------------------------
 /// \class ofFilePath


### PR DESCRIPTION
The missing of const broke previous functionality.