### PR TITLE
Old Linux - gcc5 fix

### DIFF
--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -115,9 +115,9 @@ if [ "$ARCH" == "" ]; then
         if [ "$ARCH" == "x86_64" ]; then
             GCC_VERSION=$(gcc -dumpversion | cut -f1 -d.)
             if [ $GCC_VERSION -eq 4 ]; then
-                ARCH=64gcc4
+                ARCH=64gcc6 # we just have gcc6 libraries now
             elif [ $GCC_VERSION -eq 5 ]; then
-                ARCH=64gcc5
+                ARCH=64gcc6 # we just have gcc6 libraries now
             else
                 ARCH=64gcc6
             fi


### PR DESCRIPTION
I've noticed nightly builds runs great in an old linux distro here (GCC5) but installing from git doesn't work because of scripts. as we don't have gcc5 in the name of the libraries I'm proposing an update in scripts, so they all download gcc6 ones and it seems to work great here.