### PR TITLE
Actions - update osx, more folders added to cache

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,7 +33,11 @@ jobs:
       env:
         cache-name: cache-keep-compile
       with:
-        path: libs/openFrameworksCompiled/lib/osx/**/
+        path: |
+          libs/openFrameworksCompiled/lib/osx/*.a
+          libs/openFrameworksCompiled/lib/osx/**/
+          addons/obj/osx/**/
+
         key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('**/*.cpp') }}
         restore-keys: |
           ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-


### PR DESCRIPTION
Now we are adding addons/obj files to the cache too, so addons don't need to be totally recompiled if not needed in a PR.
