### PR TITLE
Actions - cache to v3 in android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,12 +30,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Cache projectGenerator folder
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: '~/projectGenerator'
         key: ${{ runner.os }}-pg-${{matrix.cfg.gradle_target}}
     - name: Cache NDK
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: '~/android-ndk-r15c'
         key: ${{ runner.os }}-android-ndk-${{matrix.cfg.gradle_target}}


### PR DESCRIPTION
this will fix deprecation warnings

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.