### PR TITLE
make pthreads not on by default for emscripten. add notes in config.make

### DIFF
--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -64,8 +64,8 @@ PLATFORM_REQUIRED_ADDONS = ofxEmscripten
 ################################################################################
 
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
-PLATFORM_CFLAGS = -pthread
-PLATFORM_CXXFLAGS = -Wall -std=c++17 -Wno-warn-absolute-paths -pthread
+PLATFORM_CFLAGS =
+PLATFORM_CXXFLAGS = -Wall -std=c++17 -Wno-warn-absolute-paths
 
 ################################################################################
 # PLATFORM LDFLAGS
@@ -93,7 +93,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 -s FULL_ES2 -sFULL_ES3=1 -pthread
+PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 -s FULL_ES2 -sFULL_ES3=1
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 

--- a/scripts/templates/emscripten/config.make
+++ b/scripts/templates/emscripten/config.make
@@ -1,3 +1,12 @@
+####
+# EMSCRIPTEN THREADING NOTE
+# To enable threading in your emscripten project uncomment the two PROJECT_LDFLAGS
+# and PROJECT_CFLAGS in the lines below ( PROJECT_CFLAGS=-pthread etc )
+# You will need to add a .htaccess file to your project directory if hosting online
+# With the following lines:
+# Header set Cross-Origin-Embedder-Policy "require-corp"
+# Header set Cross-Origin-Opener-Policy "same-origin"
+
 ################################################################################
 # CONFIGURE PROJECT MAKEFILE (optional)
 #   This file is where we make project specific configurations.
@@ -79,6 +88,9 @@
 # TODO: should this be a default setting?
 # PROJECT_LDFLAGS=-Wl,-rpath=./libs
 
+# To add threading support uncomment this line:
+# PROJECT_LDFLAGS=-pthread
+
 ################################################################################
 # PROJECT DEFINES
 #   Create a space-delimited list of DEFINES. The list will be converted into 
@@ -105,7 +117,10 @@
 #
 #   Note: Leave a leading space when adding list items with the += operator
 ################################################################################
-# PROJECT_CFLAGS = 
+# PROJECT_CFLAGS =
+
+# To add threading support uncomment this line:
+# PROJECT_CFLAGS=-pthread
 
 ################################################################################
 # PROJECT OPTIMIZATION CFLAGS


### PR DESCRIPTION
closes #7421
closes #7412  

@Jonathhhan this code below works for me.  
Basically you just need to uncomment two lines in the project config.make - so that way you can build some projects with pthreads if needed and others without. 

Happy if there is another / better way to enable threading, but given that it errors unless you set the server up correctly feels like we should default to off for now. 