### PR TITLE
std::map to unordered_map

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -21,6 +21,7 @@
 #include "ofMath.h"
 #include "ofConstants.h"
 #include <assimp/Importer.hpp>
+#include <unordered_map>
 
 struct aiScene;
 struct aiNode;
@@ -177,7 +178,7 @@ class ofxAssimpModelLoader{
 		glm::mat4 modelMatrix; // { glm::mat4() }
 
 		std::vector<ofLight> lights;
-		std::map<
+		std::unordered_map<
 			of::filesystem::path,
 			std::shared_ptr<ofTexture>
 		> textures;

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -22,6 +22,7 @@
 #include "ofConstants.h"
 #include <assimp/Importer.hpp>
 #include <unordered_map>
+#include <map>
 
 struct aiScene;
 struct aiNode;
@@ -178,7 +179,7 @@ class ofxAssimpModelLoader{
 		glm::mat4 modelMatrix; // { glm::mat4() }
 
 		std::vector<ofLight> lights;
-		std::unordered_map<
+		std::map<
 			of::filesystem::path,
 			std::shared_ptr<ofTexture>
 		> textures;

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -8,7 +8,7 @@
 #include "ofMath.h"
 #include "ofMathConstants.h"
 #include "ofLog.h"
-#include <map>
+#include <unordered_map>
 
 //--------------------------------------------------------------
 template<class V, class N, class C, class T>
@@ -1560,8 +1560,8 @@ void ofMesh_<V,N,C,T>::mergeDuplicateVertices() {
 	//so we are going to create a new list of points and new indexes - we will use a map to map old index values to the new ones
 	std::vector <V> newPoints;
 	std::vector <ofIndexType> newIndexes;
-	std::map <ofIndexType, bool> ptCreated;
-	std::map <ofIndexType, ofIndexType> oldIndexNewIndex;
+	std::unordered_map <ofIndexType, bool> ptCreated;
+	std::unordered_map <ofIndexType, ofIndexType> oldIndexNewIndex;
 
 	std::vector<ofFloatColor> newColors;
 	std::vector<ofFloatColor>& colors = getColors();
@@ -1788,7 +1788,7 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 			}
 		}
 
-		std::map<int, int> removeIds;
+		std::unordered_map<int, int> removeIds;
 
 		float epsilon = .01f;
 		for(ofIndexType i = 0; i < verts.size()-1; i++) {
@@ -1807,7 +1807,7 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 		}
 
 		// string of vertex in 3d space to triangle index //
-		std::map<std::string, std::vector<int> > vertHash;
+		std::unordered_map<std::string, std::vector<int> > vertHash;
 
 		//ofLogNotice("ofMesh") << "smoothNormals(): num verts = " << verts.size() << " tris size = " << triangles.size();
 
@@ -1833,8 +1833,8 @@ void ofMesh_<V,N,C,T>::smoothNormals( float angle ) {
 			}
 		}
 
-//		for( std::map<std::string, std::vector<int> >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
-//			//for( std::map<std::string, int >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
+//		for( std::unordered_map<std::string, std::vector<int> >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
+//			//for( std::unordered_map<std::string, int >::iterator it = vertHash.begin(); it != vertHash.end(); ++it) {
 //			ofLogNotice("ofMesh") << "smoothNormals(): " << it->first << "  num = " << it->second.size();
 //		}
 

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofEvents.h"
-#include <map>
+#include <unordered_map>
 
 class ofBaseApp;
 class ofAppBaseWindow;
@@ -48,7 +48,7 @@ public:
 	ofEvent<void> loopEvent;
 private:
 	void keyPressed(ofKeyEventArgs & key);
-	std::map<std::shared_ptr<ofAppBaseWindow>, std::shared_ptr<ofBaseApp> > windowsApps;
+	std::unordered_map<std::shared_ptr<ofAppBaseWindow>, std::shared_ptr<ofBaseApp> > windowsApps;
 	bool bShouldClose;
 	std::weak_ptr<ofAppBaseWindow> currentWindow;
 	int status;

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -4,7 +4,7 @@
 #include "ofGraphics.h"
 #include "ofGLRenderer.h"
 #include "ofConstants.h"
-#include <map>
+#include <unordered_map>
 
 #ifdef TARGET_OPENGLES
 #include <dlfcn.h>
@@ -13,7 +13,7 @@
 #include "ofxAndroidUtils.h"
 #endif
 
-using std::map;
+using std::unordered_map;
 using std::vector;
 
 /*
@@ -165,8 +165,8 @@ bool ofFboSettings::operator!=(const ofFboSettings & other){
 }
 
 //--------------------------------------------------------------
-static map<GLuint,int> & getIdsFB(){
-	static map<GLuint,int> * idsFB = new map<GLuint,int>;
+static unordered_map<GLuint,int> & getIdsFB(){
+	static unordered_map<GLuint,int> * idsFB = new unordered_map<GLuint,int>;
 	return *idsFB;
 }
 
@@ -194,8 +194,8 @@ static void releaseFB(GLuint id){
 }
 
 //--------------------------------------------------------------
-static map<GLuint,int> & getIdsRB(){
-	static map<GLuint,int> * idsRB = new map<GLuint,int>;
+static unordered_map<GLuint,int> & getIdsRB(){
+	static unordered_map<GLuint,int> * idsRB = new unordered_map<GLuint,int>;
 	return *idsRB;
 }
 

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -9,7 +9,7 @@
 using std::shared_ptr;
 using std::string;
 
-std::map<ofGLProgrammableRenderer*, std::map<std::string, std::weak_ptr<ofMaterial::Shaders>>> ofMaterial::shadersMap;
+std::unordered_map<ofGLProgrammableRenderer*, std::unordered_map<std::string, std::weak_ptr<ofMaterial::Shaders>>> ofMaterial::shadersMap;
 
 namespace{
 string vertexSource(bool bPBR, string defaultHeader, int maxLights, bool hasTexture, bool hasColor, std::string addShaderSrc,const ofMaterialSettings& adata);

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -400,8 +400,8 @@ private:
 	TextureUnifom getCustomUniformTexture(const ofMaterialTextureType& aMaterialTextureType);
 	TextureUnifom getCustomUniformTexture(const std::string & name);
 
-	mutable std::unordered_map<ofGLProgrammableRenderer*,std::shared_ptr<Shaders>> shaders;
-	static std::unordered_map<ofGLProgrammableRenderer*, std::unordered_map<std::string,std::weak_ptr<Shaders>>> shadersMap;
+	mutable std::unordered_map<ofGLProgrammableRenderer*, std::shared_ptr<Shaders>> shaders;
+	static std::unordered_map<ofGLProgrammableRenderer*, std::unordered_map<std::string, std::weak_ptr<Shaders>>> shadersMap;
 //	static std::string vertexShader;
 //	static std::string fragmentShader;
 	std::unordered_map<std::string, float> uniforms1f;

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -400,28 +400,28 @@ private:
 	TextureUnifom getCustomUniformTexture(const ofMaterialTextureType& aMaterialTextureType);
 	TextureUnifom getCustomUniformTexture(const std::string & name);
 
-	mutable std::map<ofGLProgrammableRenderer*,std::shared_ptr<Shaders>> shaders;
-	static std::map<ofGLProgrammableRenderer*, std::map<std::string,std::weak_ptr<Shaders>>> shadersMap;
+	mutable std::unordered_map<ofGLProgrammableRenderer*,std::shared_ptr<Shaders>> shaders;
+	static std::unordered_map<ofGLProgrammableRenderer*, std::unordered_map<std::string,std::weak_ptr<Shaders>>> shadersMap;
 //	static std::string vertexShader;
 //	static std::string fragmentShader;
-	std::map<std::string, float> uniforms1f;
-	std::map<std::string, glm::vec2> uniforms2f;
-	std::map<std::string, glm::vec3> uniforms3f;
-	std::map<std::string, glm::vec4> uniforms4f;
-	std::map<std::string, float> uniforms1i;
-	std::map<std::string, glm::vec<2, int, glm::precision::defaultp>> uniforms2i;
-	std::map<std::string, glm::vec<3, int, glm::precision::defaultp>> uniforms3i;
-	std::map<std::string, glm::vec<4, int, glm::precision::defaultp>> uniforms4i;
-	std::map<std::string, glm::mat4> uniforms4m;
-	std::map<std::string, glm::mat3> uniforms3m;
-	std::map<std::string, TextureUnifom> uniformstex;
+	std::unordered_map<std::string, float> uniforms1f;
+	std::unordered_map<std::string, glm::vec2> uniforms2f;
+	std::unordered_map<std::string, glm::vec3> uniforms3f;
+	std::unordered_map<std::string, glm::vec4> uniforms4f;
+	std::unordered_map<std::string, float> uniforms1i;
+	std::unordered_map<std::string, glm::vec<2, int, glm::precision::defaultp>> uniforms2i;
+	std::unordered_map<std::string, glm::vec<3, int, glm::precision::defaultp>> uniforms3i;
+	std::unordered_map<std::string, glm::vec<4, int, glm::precision::defaultp>> uniforms4i;
+	std::unordered_map<std::string, glm::mat4> uniforms4m;
+	std::unordered_map<std::string, glm::mat3> uniforms3m;
+	std::unordered_map<std::string, TextureUnifom> uniformstex;
 	
-	std::map<std::string, std::string> mCustomUniforms;
-	std::map<std::string, std::string> mDefines;
+	std::unordered_map<std::string, std::string> mCustomUniforms;
+	std::unordered_map<std::string, std::string> mDefines;
 
-	mutable std::map<std::string, int> mShaderIdsToRemove;
+	mutable std::unordered_map<std::string, int> mShaderIdsToRemove;
 	
-	std::map<ofMaterialTextureType, std::shared_ptr<ofTexture> > mLocalTextures;
+	std::unordered_map<ofMaterialTextureType, std::shared_ptr<ofTexture> > mLocalTextures;
 	
 	std::shared_ptr<ofShader> customShader;
 	bool bHasCustomShader = false;

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -9,15 +9,15 @@
 #include "ofParameterGroup.h"
 #include "ofParameter.h"
 #include "ofBufferObject.h"
-#include <regex>
-#ifdef TARGET_ANDROID
-#include "ofxAndroidUtils.h"
-#endif
 #include "ofShadow.h"
 #include "ofLight.h"
 #include "ofCubeMap.h"
+#ifdef TARGET_ANDROID
+#include "ofxAndroidUtils.h"
+#endif
+#include <regex>
 
-using std::map;
+using std::unordered_map;
 using std::vector;
 using std::string;
 using std::endl;
@@ -30,13 +30,13 @@ static const string POSITION_ATTRIBUTE="position";
 static const string NORMAL_ATTRIBUTE="normal";
 static const string TEXCOORD_ATTRIBUTE="texcoord";
 
-static map<GLuint,int> & getShaderIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static unordered_map<GLuint,int> & getShaderIds(){
+	static unordered_map<GLuint,int> * ids = new unordered_map<GLuint,int>;
 	return *ids;
 }
 
-static map<GLuint,int> & getProgramIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static unordered_map<GLuint,int> & getProgramIds(){
+	static unordered_map<GLuint,int> * ids = new unordered_map<GLuint,int>;
 	return *ids;
 }
 

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -10,6 +10,7 @@
 #include "ofFileUtils.h"
 #include "ofConstants.h"
 #include "glm/fwd.hpp"
+#include <map>
 #include <unordered_map>
 
 class ofTexture;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -10,7 +10,6 @@
 #include "ofFileUtils.h"
 #include "ofConstants.h"
 #include "glm/fwd.hpp"
-#include <map>
 #include <unordered_map>
 
 class ofTexture;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -11,7 +11,6 @@
 #include "ofConstants.h"
 #include "glm/fwd.hpp"
 #include <unordered_map>
-#include <map>
 
 class ofTexture;
 class ofMatrix3x3;
@@ -26,10 +25,10 @@ typedef ofColor_<float> ofFloatColor;
 enum ofLogLevel: short;
 
 struct ofShaderSettings {
-    std::map<GLuint, of::filesystem::path> shaderFiles;
-    std::map<GLuint, std::string> shaderSources;
-    std::map<std::string, int> intDefines;
-    std::map<std::string, float> floatDefines;
+    std::unordered_map<GLuint, of::filesystem::path> shaderFiles;
+    std::unordered_map<GLuint, std::string> shaderSources;
+    std::unordered_map<std::string, int> intDefines;
+    std::unordered_map<std::string, float> floatDefines;
     of::filesystem::path sourceDirectoryPath;
     bool bindDefaults = true;
 };
@@ -49,8 +48,8 @@ class ofShader {
 		std::string source;
 		std::string expandedSource;
 		of::filesystem::path directoryPath;
-		std::map<std::string, int>   intDefines;
-		std::map<std::string, float> floatDefines;
+		std::unordered_map<std::string, int>   intDefines;
+		std::unordered_map<std::string, float> floatDefines;
 	};
 
 public:
@@ -69,11 +68,11 @@ public:
 
 #if !defined(TARGET_OPENGLES) || defined(TARGET_EMSCRIPTEN)
 	struct TransformFeedbackSettings {
-		std::map<GLuint, of::filesystem::path> shaderFiles;
-		std::map<GLuint, std::string> shaderSources;
+		std::unordered_map<GLuint, of::filesystem::path> shaderFiles;
+		std::unordered_map<GLuint, std::string> shaderSources;
 		std::vector<std::string> varyingsToCapture;
-		std::map<std::string, int> intDefines;
-		std::map<std::string, float> floatDefines;
+		std::unordered_map<std::string, int> intDefines;
+		std::unordered_map<std::string, float> floatDefines;
 		of::filesystem::path sourceDirectoryPath;
 		bool bindDefaults = true;
 		GLuint bufferMode = GL_INTERLEAVED_ATTRIBS; // GL_INTERLEAVED_ATTRIBS or GL_SEPARATE_ATTRIBS

--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -16,11 +16,10 @@
 #include "ofAppAndroidWindow.h"
 #endif
 
+using std::unordered_map;
 
 bool ofVbo::vaoSupported=true;
 bool ofVbo::vaoChecked=false;
-
-using std::map;
 
 #ifdef TARGET_OPENGLES
 	#include <dlfcn.h>
@@ -37,8 +36,8 @@ using std::map;
 	#define glBindVertexArray								glBindVertexArrayFunc
 #endif
 
-static map<GLuint,int> & getVAOIds(){
-	static map<GLuint,int> * ids = new map<GLuint,int>;
+static unordered_map<GLuint,int> & getVAOIds(){
+	static unordered_map<GLuint,int> * ids = new unordered_map<GLuint,int>;
 	return *ids;
 }
 
@@ -935,7 +934,7 @@ void ofVbo::bind() const{
             indexAttribute.bind();
         }
 
-		map<int,VertexAttribute>::const_iterator it;
+		unordered_map<int,VertexAttribute>::const_iterator it;
 		for(it = customAttributes.begin();it!=customAttributes.end();it++){
 			it->second.enable();
 		}

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -5,7 +5,7 @@
 #include "ofGraphicsConstants.h"
 #include "ofBufferObject.h"
 #include "ofConstants.h"
-#include <map>
+#include <unordered_map>
 
 template<typename T>
 class ofColor_;
@@ -205,7 +205,7 @@ private:
 	VertexAttribute colorAttribute;
 	VertexAttribute texCoordAttribute;
 	VertexAttribute normalAttribute;
-	std::map<int,VertexAttribute> customAttributes;
+	std::unordered_map<int,VertexAttribute> customAttributes;
 	
 	static bool vaoChecked;
 	static bool vaoSupported;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -252,9 +252,9 @@ static string osxFontPathByName(const string& fontname){
 #endif
 
 #ifdef TARGET_WIN32
-#include <map>
+#include <unordered_map>
 // font font face -> file name name mapping
-static std::map<string, string> fonts_table;
+static std::unordered_map<string, string> fonts_table;
 // read font linking information from registry, and store in std::map
 //------------------------------------------------------------------
 void initWindows(){
@@ -317,6 +317,7 @@ void initWindows(){
 			string curr_face = value_name_char;
 			string font_file = value_data_char;
 			curr_face = curr_face.substr(0, curr_face.find('(') - 1);
+			curr_face = ofToLower(curr_face);
 			fonts_table[curr_face] = fontsDir + font_file;
 	}
 
@@ -328,13 +329,7 @@ void initWindows(){
 
 
 static string winFontPathByName(const string& fontname ){
-	if(fonts_table.find(fontname)!=fonts_table.end()){
-		return fonts_table[fontname];
-	}
-	for(std::map<string,string>::iterator it = fonts_table.begin(); it!=fonts_table.end(); it++){
-		if(ofIsStringInString(ofToLower(it->first),ofToLower(fontname))) return it->second;
-	}
-	return "";
+	return fonts_table[fontname];
 }
 #endif
 


### PR DESCRIPTION
it has better performance as unordered_map doesn't need to be shuffling things around all the time when new data is inserted. 
I think this change can be significant in ofMesh and windowsApps

From everything I've read it doesn't matter anywhere if the data is sorted by key.  But it would be great if somebody else could proofread and check if I missed something important

Other files that can be changed to unordered_map in my opinion are ofShadow / ofCubeMap ones
