### PR TITLE
macOS, update template, addons

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 			"name": "Release"
 		},
 		"BB4B014C10F69532006C3DED": {
+			"path": "../../../addons",
 			"isa": "PBXGroup",
 			"name": "addons",
 			"children": [],


### PR DESCRIPTION
now addons will show the right folder when right clicking the folder inside xcode.
the same can be done later to addon folders, but it is a PG change