### PR TITLE
bugfix ofOSC receiver segfault index out of bounds

### DIFF
--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -141,7 +141,7 @@ bool ofxOscReceiver::getParameter(ofAbstractParameter &parameter){
 			if(p){
 				if(address[i] == p->getEscapedName()){
 					if(p->type() == typeid(ofParameterGroup).name()){
-						if(address.size() >= i+1){
+						if(address.size() > i+1){
 							ofParameterGroup* g = static_cast<ofParameterGroup*>(p);
 							if(g->contains(address[i+1])){
 								p = &g->get(address[i+1]);


### PR DESCRIPTION
only a very small change to fix an issue that occurs for me when receiving a large amount of messages. 

this fixes issue #7473 by correcting the bounds check.

Tested on Linux and Window

this is my first pull request, I'm not sure if this belongs into the master or the patch-release branch.