### PR TITLE
qtcreator qbs: allow project-based override of cxxLanguageVersion

### DIFF
--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -602,11 +602,16 @@ Module{
         }else{
             return flags.concat(ADDONS.cflags)
         }
-
     }
 
     Properties{
-        coreCxxLanguageVersion: "c++17"
+        coreCxxLanguageVersion: {
+            if(of.cxxLanguageVersion){
+                return of.cxxLanguageVersion;
+            } else {
+                return "c++17"
+            }
+        }
     }
     
     Properties{
@@ -745,6 +750,7 @@ Module{
     property stringList staticLibraries: []
     property stringList dynamicLibraries: []
     property stringList addons
+    property string cxxLanguageVersion
 
     property stringList coreIncludePaths: {
         var flags = CORE.includes


### PR DESCRIPTION
prompted by @edap's question in #7461 i've added a condition to enable a project's `.qbs` to properly override the language version (as qtcreator treats `cxxLanguageVersion` a bit differently than the `std=c++17` flag). so instead of passing the conventional `std=c++??` flag (and risking conflicting flags) if you define `cxxLanguageVersion: 'c++20'` in your `.qbs` it will override the now-default C++17.

that flag is optional, and now that OF is tied to ≥ C++17, older projects will need the C++17 "silent upgrade" anyway (the goal of this cluster of commits was to enable continuity with older projects), but it might be useful to compile a given project in C++20 or 23.