### PR TITLE
faster sort and option for natural, fast and by date

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1101,11 +1101,18 @@ public:
 	/// This is for backwards compatibility with ofxDirList.
 	void reset();
 	
+	typedef enum{
+            SORT_FAST,
+            SORT_NATURAL,
+            SORT_BY_DATE
+	}SortMode;
+
 	/// Sort the directory contents list alphabetically.
 	///
 	/// \warning Call listDir() before using this function or there will be
 	/// nothing to sort.
-	void sort();
+	/// \param SortMode options are SORT_FAST, SORT_NATURAL (default) or SORT_BY_DATE
+	void sort(const SortMode & mode = SORT_NATURAL);
 	
 	/// Sort the directory contents list by date.
 	///


### PR DESCRIPTION
I didn't end up add sort() to listDir by default as I think at this point macOS users have got used to calling sort(). 

`ofDirectory::sort` defaults to natural - so there is no change in behavior but it is about 10x faster. 
`ofDirectory::sort( ofDirectory::SORT_FAST )` is a little bit faster than ofDirectory::sort( ofDirectory::SORT_NATURAL ) as it does a simple std::sort without a comparison function 

closes #6129 
