### PR TITLE
add linuxaarch64 to ofxKinect to support kinect on raspberrypi 64 bit

### DIFF
--- a/addons/ofxKinect/addon_config.mk
+++ b/addons/ofxKinect/addon_config.mk
@@ -158,6 +158,21 @@ linuxarmv7l:
 	ADDON_INCLUDES_EXCLUDE = libs/libfreenect/platform/%
 	ADDON_INCLUDES_EXCLUDE += libs/libusb-1.0/%
 
+linuxaarch64:
+	# linux only, any library that should be included in the project using
+	# pkg-config
+	ADDON_PKG_CONFIG_LIBRARIES = libusb-1.0
+
+	# when parsing the file system looking for sources exclude this for all or
+	# a specific platform
+	ADDON_SOURCES_EXCLUDE = libs/libfreenect/platform/%
+
+
+	# when parsing the file system looking for include paths exclude this for all or
+	# a specific platform
+	ADDON_INCLUDES_EXCLUDE = libs/libfreenect/platform/%
+	ADDON_INCLUDES_EXCLUDE += libs/libusb-1.0/%	
+
 android/armeabi:
 
 android/armeabi-v7a:


### PR DESCRIPTION
While testing compatibility on linuxaarch64 on raspberrypi, ofxKinect needed to have the sames conditions as other linuxarm architecture to compile without error.