### PR TITLE
Fixing GLFW issue in Ubuntu 16.04 - GLFW_TRANSPARENT_FRAMEBUFFER

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -197,7 +197,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		}
 		if(settings.glVersionMajor>=3){
 			glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-#if !(GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR == 1 && GLFW_VERSION_REVISION == 2)
+#if (GLFW_VERSION_MAJOR >= 3 && GLFW_VERSION_MINOR > 2) || (GLFW_VERSION_MAJOR > 3 )
 			glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, settings.transparent);
 #endif
 			currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -197,7 +197,9 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings){
 		}
 		if(settings.glVersionMajor>=3){
 			glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+#if !(GLFW_VERSION_MAJOR == 3 && GLFW_VERSION_MINOR == 1 && GLFW_VERSION_REVISION == 2)
 			glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, settings.transparent);
+#endif
 			currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 		}else{
 			currentRenderer = std::make_shared<ofGLRenderer>(this);


### PR DESCRIPTION
Ubuntu 16.04 parked GLFW in version 3.1.2
so this PR checks if the version is exactly 3.1.2 and ignores the line causing error.
