### PR TITLE
ofIsCurrentThreadTheMainThread

### DIFF
--- a/examples/threads/threadExample/src/ofApp.cpp
+++ b/examples/threads/threadExample/src/ofApp.cpp
@@ -4,6 +4,7 @@
 void ofApp::setup(){
 	threadedObject.setup();
 	doLock = false;
+	ofLogNotice("main thread Id") << ofGetMainThreadId();
 }
 
 //--------------------------------------------------------------
@@ -39,6 +40,12 @@ void ofApp::draw(){
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
 	if (key == 'a'){
+		if (ofIsCurrentThreadTheMainThread()) {
+			ofLogNotice("ofApp::keyPressed") << "processed in main thread";
+		} else {
+			// will never happen but to document the branch:
+			ofLogNotice("ofApp::keyPressed") << "processed in other thread";
+		}
 		threadedObject.start();
 	}else if (key == 's'){
 		threadedObject.stop();

--- a/examples/threads/threadExample/src/threadedObject.h
+++ b/examples/threads/threadExample/src/threadedObject.h
@@ -51,6 +51,12 @@ public:
 	/// other tasks.
 	void threadedFunction(){
 		while(isThreadRunning()){
+			if (ofIsCurrentThreadTheMainThread()) {
+				// will never happen but to document the branch:
+				ofLogNotice("ThreadedObject::threadedFunction") << "processed in main thread";
+			} else {
+				ofLogNotice("ThreadedObject::threadedFunction") << "processed in other thread";
+			}
 			// since we are only writting to the frame number from one thread
 			// and there's no calculations that depend on it we can just write to
 			// it without locking

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -324,6 +324,11 @@ ofBaseApp * ofGetAppPtr(){
 }
 
 //--------------------------------------
+bool ofIsCurrentThreadTheMainThread() {
+	return ofGetMainLoop()->thread_id == std::this_thread::get_id();
+}
+
+//--------------------------------------
 ofAppBaseWindow * ofGetWindowPtr(){
 	return mainLoop()->getCurrentWindow().get();
 }

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -324,8 +324,12 @@ ofBaseApp * ofGetAppPtr(){
 }
 
 //--------------------------------------
+std::thread::id ofGetMainThreadId() {
+	return ofGetMainLoop()->get_thread_id() ;
+}
+
 bool ofIsCurrentThreadTheMainThread() {
-	return ofGetMainLoop()->thread_id == std::this_thread::get_id();
+	return ofGetMainThreadId() == std::this_thread::get_id();
 }
 
 //--------------------------------------

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -52,6 +52,8 @@ ofBaseApp * ofGetAppPtr();
 
 void		ofExit(int status=0);
 
+bool 		ofIsCurrentThreadTheMainThread();
+
 //-------------------------- time
 float 		ofGetFrameRate();
 float 		ofGetTargetFrameRate();

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -53,6 +53,7 @@ ofBaseApp * ofGetAppPtr();
 void		ofExit(int status=0);
 
 bool 		ofIsCurrentThreadTheMainThread();
+std::thread::id ofGetMainThreadId();
 
 //-------------------------- time
 float 		ofGetFrameRate();

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -46,6 +46,9 @@ public:
 
 	ofEvent<void> exitEvent;
 	ofEvent<void> loopEvent;
+	
+	std::thread::id thread_id { std::this_thread::get_id() };
+
 private:
 	void keyPressed(ofKeyEventArgs & key);
 	std::unordered_map<std::shared_ptr<ofAppBaseWindow>, std::shared_ptr<ofBaseApp> > windowsApps;

--- a/libs/openFrameworks/app/ofMainLoop.h
+++ b/libs/openFrameworks/app/ofMainLoop.h
@@ -47,9 +47,11 @@ public:
 	ofEvent<void> exitEvent;
 	ofEvent<void> loopEvent;
 	
-	std::thread::id thread_id { std::this_thread::get_id() };
+	std::thread::id get_thread_id() { return thread_id; };
 
 private:
+	std::thread::id thread_id { std::this_thread::get_id() };
+
 	void keyPressed(ofKeyEventArgs & key);
 	std::unordered_map<std::shared_ptr<ofAppBaseWindow>, std::shared_ptr<ofBaseApp> > windowsApps;
 	bool bShouldClose;


### PR DESCRIPTION
while #4040 discusses that `ofThread` should not attempt to maintain a specific relationship to main thread as part of it's design, it is nevertheless useful to be able to determine (without running in a debugger) if a piece of code is called from the main thread or not (especially for monitoring & troubleshooting events, callbacks, notifications and other async constructs)

it is trivial to do so, but requires prior knowledge of the main thread id. this PR stores `ofMainLoop::thread_id` as part of `ofMainLoop` construction, and provides a standardized `ofAppRunner` function that compares it to the current thread::id.

tested on macOS and linux — works, with the presumption that the "main thread" does not change over app lifetime. (is it even possible that something moves the execution of ofMainLoop to another thread? I don't think so but if it happens to be the case `ofMainLoop::thread_id` should be updated after the change).

(PS not 100% sure of the function name... difficult to find a balance between terse and self-documenting)

[edit]: not sure why msys2 is failing but seems unrelated?