### PR TITLE
ofGetUnixTimeMillis()

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -336,6 +336,10 @@ uint64_t ofGetUnixTime(){
 	return static_cast<uint64_t>(time(nullptr));
 }
 
+uint64_t ofGetUnixTimeMillis() {
+    auto elapsed = std::chrono::system_clock::now().time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+}
 
 //--------------------------------------
 void ofSleepMillis(int millis){

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -32,6 +32,12 @@ void ofResetElapsedTimeCounter();
 /// \returns the floating point elapsed time in seconds.
 float ofGetElapsedTimef();
 
+/// \brief Get the Unix Time in milliseconds.
+///
+/// This returns the milliseconds since Midnight, January 1, 1970.
+///
+/// \returns the milliseconds since Midnight, January 1, 1970.
+uint64_t ofGetUnixTimeMillis();
 
 /// \brief Get the elapsed time in milliseconds.
 ///


### PR DESCRIPTION
as per https://stackoverflow.com/questions/9089842/c-chrono-system-time-in-milliseconds-time-operations and evoked in https://forum.openframeworks.cc/t/ofgetsystemtimemillis-not-working-on-macos/40875