### PR TITLE
add setup argument to listen on specific ip

### DIFF
--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -28,11 +28,12 @@ ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver &other){
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::setup(int port){
+bool ofxOscReceiver::setup(int port, std::string host) {
 	if(listenSocket){ // already running
 		stop();
 	}
 	settings.port = port;
+    settings.host = host;
 	return start();
 }
 
@@ -62,7 +63,7 @@ bool ofxOscReceiver::start() {
 	// create socket
 	osc::UdpListeningReceiveSocket *socket = nullptr;
 	try{
-		osc::IpEndpointName name(osc::IpEndpointName::ANY_ADDRESS, settings.port);
+		osc::IpEndpointName name(settings.host.c_str(), settings.port);
 		socket = new osc::UdpListeningReceiveSocket(name, this, settings.reuse);
 		auto deleter = [](osc::UdpListeningReceiveSocket*socket){
 			// tell the socket to shutdown

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -13,9 +13,10 @@
 /// \struct ofxOscSenderSettings
 /// \brief OSC message sender settings
 struct ofxOscReceiverSettings {
-	int port = 0;            ///< port to listen on
-	bool reuse = true;       ///< should the port be reused by other receivers?
-	bool start = true;       ///< start listening after setup?
+	int port = 0;                 ///< port to listen on
+    std::string host = "0.0.0.0"; ///< host to listen on
+    bool reuse = true;            ///< should the port be reused by other receivers?
+	bool start = true;            ///< start listening after setup?
 };
 
 /// \class ofxOscReceiver
@@ -30,14 +31,14 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver &other);
 
-	/// set up the receiver with the port to listen for messages on
+	/// set up the receiver with the port (and specific host/ip) to listen for messages on
 	/// and start listening
 	///
 	/// multiple receivers can share the same port if port reuse is
 	/// enabled (true by default)
 	///
 	/// \return true if listening started
-	bool setup(int port);
+	bool setup(int port, std::string host = "0.0.0.0");
 	
 	/// set up the receiver with the given settings
 	///


### PR DESCRIPTION
for example:

let's setup 2 receiver with

```cpp
        receiver1.setup(26666, "localhost"); // same to receiver1.setup(26666, "127.0.0.1");
        receiver2.setup(26666, "192.168.2.105");
```

then we can receive message on same port with different receivers like:

```cpp
        while(receiver1.hasWaitingMessages()) {
            ofxOscMessage m;
            receiver1.getNextMessage(m);
            ofLogNotice("receiver1") << m;
        }
        
        while(receiver2.hasWaitingMessages()) {
            ofxOscMessage m;
            receiver2.getNextMessage(m);
            ofLogNotice("receiver2") << m;
        }
```

I think this feature is helpful to make secure on large systems and complex network structures.
and this update is compatible simple `setup` with only given port.