### PR TITLE
Osc swap

### DIFF
--- a/addons/ofxOsc/src/ofxOscReceiver.cpp
+++ b/addons/ofxOsc/src/ofxOscReceiver.cpp
@@ -28,7 +28,7 @@ ofxOscReceiver& ofxOscReceiver::copy(const ofxOscReceiver &other){
 }
 
 //--------------------------------------------------------------
-bool ofxOscReceiver::setup(int port, std::string host) {
+bool ofxOscReceiver::setup(std::string host, int port) {
 	if(listenSocket){ // already running
 		stop();
 	}

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -31,7 +31,7 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver &other);
 
-    /// set up the receiver with the port to listen for messages through any interface on the given port
+    /// set up the receiver to listen for messages through any hosts on the given port
     /// and start listening
     ///
     /// multiple receivers can share the same port if port reuse is
@@ -40,7 +40,7 @@ public:
     /// \return true if listening started
     bool setup(int port) { return setup( "0.0.0.0", port); }
     
-    /// set up the receiver with the specific host/ip to listen for messages on
+    /// set up the receiver to listen for messages on the specific host/ip
     /// and start listening
     ///
     /// multiple receivers can share the same port if port reuse is

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -31,15 +31,24 @@ public:
 	/// for operator= and copy constructor
 	ofxOscReceiver& copy(const ofxOscReceiver &other);
 
-	/// set up the receiver with the port (and specific host/ip) to listen for messages on
-	/// and start listening
-	///
-	/// multiple receivers can share the same port if port reuse is
-	/// enabled (true by default)
-	///
-	/// \return true if listening started
-	bool setup(int port, std::string host = "0.0.0.0");
-	
+    /// set up the receiver with the port to listen for messages through any interface on the given port
+    /// and start listening
+    ///
+    /// multiple receivers can share the same port if port reuse is
+    /// enabled (true by default)
+    ///
+    /// \return true if listening started
+    bool setup(int port) { return setup( "0.0.0.0", port); }
+    
+    /// set up the receiver with the specific host/ip to listen for messages on
+    /// and start listening
+    ///
+    /// multiple receivers can share the same port if port reuse is
+    /// enabled (true by default)
+    ///
+    /// \return true if listening started
+    bool setup(std::string host, int port);
+    
 	/// set up the receiver with the given settings
 	///
 	/// starts listening if start is true (true by default)


### PR DESCRIPTION
this PR acts on https://github.com/openframeworks/openFrameworks/commit/4b5632acfc4ad42639b29a79f2f63d935925a565#commitcomment-122972734

i understand the "accumulative logic" of adding arguments after existing ones but since a more consistent ordering is possible without disrupting the existing behaviour, it's important enough to fix prior to a release -- unless i'm not seeing something and there is a reason to offer "inverted" args?

@2bbb @ofTheo