### PR TITLE
macOS GLFW - no shadow when fullscreen

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -716,11 +716,13 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
     #if defined(TARGET_OSX)
 	NSWindow * cocoaWindow = glfwGetCocoaWindow(windowP);
  	if (([cocoaWindow styleMask] & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen) {
-                settings.windowMode = OF_FULLSCREEN;
- 		if (targetWindowMode == OF_WINDOW) {
-                    [cocoaWindow toggleFullScreen:nil];
- 		}
- 	}
+		settings.windowMode = OF_FULLSCREEN;
+		if (targetWindowMode == OF_WINDOW) {
+			[cocoaWindow toggleFullScreen:nil];
+		}
+	} else {
+		[cocoaWindow setHasShadow:NO];
+	}
     #endif
 
 	//we only want to change window mode if the requested window is different to the current one.


### PR DESCRIPTION
Motivation. I'm using a multiwindow app with some secondary monitors fullscreen sending data to LED panels.
gui app is on main monitor and I can toggle fullscreen on and off.
When I switch to fullscreen I notice a dark gradient in the next window. Disabling cocoa window shadow on fullscreen solve the issue, and no drawbacks because nobody needs shadow bleeding to a second monitor.

Related discussion:
https://github.com/openframeworks/openFrameworks/issues/6895#issuecomment-1111554345