### PR TITLE
Custom shaders during a shadow pass.

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -1290,6 +1290,19 @@ void ofGLProgrammableRenderer::bind(const ofShader & shader){
     if(currentShader && *currentShader==shader){
 		return;
     }
+	
+	if(bIsShadowDepthPass) {
+		// if we are not the shadow shader, lets unbind it
+		if(!settingDefaultShader && currentShadow && currentShader ) {
+			// lets assume it's bound?
+			if(!bCustomShadowShader) {
+				glUseProgram(0);
+			}
+			// we are assuming that since it's a custom depth shader, it all will be taken care of ...
+			bCustomShadowShader=true;
+		}
+	}
+	
 	glUseProgram(shader.getProgram());
 
 	currentShader = &shader;
@@ -1304,6 +1317,7 @@ void ofGLProgrammableRenderer::bind(const ofShader & shader){
 void ofGLProgrammableRenderer::unbind(const ofShader & shader){
 	glUseProgram(0);
 	usingCustomShader = false;
+	bCustomShadowShader=false;
 	beginDefaultShader();
 }
 
@@ -1434,6 +1448,7 @@ void ofGLProgrammableRenderer::unbind(const ofBaseMaterial &){
 void ofGLProgrammableRenderer::unbind(const ofShadow & shadow) {
 	currentShadow = nullptr;
 	bIsShadowDepthPass = false;
+	bCustomShadowShader = false;
 	beginDefaultShader();
 }
 
@@ -1569,11 +1584,12 @@ void ofGLProgrammableRenderer::setDefaultUniforms(){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::beginDefaultShader(){
 	if(usingCustomShader && !currentMaterial && !currentShadow)	return;
+	if( currentShadow && bCustomShadowShader ) return;
 
 	const ofShader * nextShader = nullptr;
 
 	if(!uniqueShader || currentMaterial || currentShadow ){
-		if( currentShadow ) {
+		if(currentShadow) {
 			nextShader = &currentShadow->getDepthShader(*this);
 		} else if(currentMaterial){
 //			std::cout << "ofGLProgrammableRenderer::beginDefaultShader: " << currentTextureTarget << " | " << ofGetFrameNum() << std::endl;

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -285,6 +285,7 @@ private:
 	const ofShadow* currentShadow;
 	bool bIsShadowDepthPass;
 	GLenum shadowCubeFace;
+	bool bCustomShadowShader = false;
 
 	ofStyle currentStyle;
 	std::deque <ofStyle> styleHistory;

--- a/libs/openFrameworks/gl/ofShadow.h
+++ b/libs/openFrameworks/gl/ofShadow.h
@@ -165,6 +165,8 @@ public:
 	std::string getShadowTypeAsString();
 		
 	const ofShader & getDepthShader(ofGLProgrammableRenderer & renderer) const;
+	bool setupShadowDepthShader(ofShader& ashader, const std::string aShaderMain);
+	bool setupShadowDepthShader(ofShader& ashader, int aLightType, const std::string aShaderMain);
 	void updateDepth(const ofShader & shader,ofGLProgrammableRenderer & renderer) const;
 	void updateDepth(const ofShader & shader,GLenum aCubeFace,ofGLProgrammableRenderer & renderer) const;
 	

--- a/libs/openFrameworks/gl/shaders/shadowDepth.vert
+++ b/libs/openFrameworks/gl/shaders/shadowDepth.vert
@@ -1,13 +1,6 @@
 
 static const std::string depthVertexShaderSource = R"(
 
-//#version 330
-
-in vec4 position;
-
-// these are passed in from OF programmable renderer
-uniform mat4 modelMatrix;
-
 // depth camera's view projection matrix
 #if defined(SINGLE_PASS) || defined(CUBE_MAP_MULTI_PASS)
 uniform mat4 lightsViewProjectionMatrix;
@@ -17,21 +10,37 @@ uniform mat4 lightsViewProjectionMatrix;
 out vec3 v_worldPosition;
 #endif
 
-void main() {
-	
+void sendShadowDepthWorldPosition(in vec3 aWorldPos) {
 #if defined(SINGLE_PASS)
-	vec3 worldPosition = (modelMatrix * vec4(position.xyz, 1.0)).xyz;
-	gl_Position = lightsViewProjectionMatrix * vec4(worldPosition, 1.0);
+	gl_Position = lightsViewProjectionMatrix * vec4(aWorldPos, 1.0);
 #endif
 	
 #ifdef CUBE_MAP_SINGLE_PASS
-	gl_Position = modelMatrix * vec4(position.xyz, 1.0);
+	gl_Position = vec4(aWorldPos, 1.0);
 #endif
 	
 #if defined(CUBE_MAP_MULTI_PASS)
-	v_worldPosition = (modelMatrix * vec4(position.xyz, 1.0)).xyz;
-	gl_Position = lightsViewProjectionMatrix * vec4(v_worldPosition, 1.0);
+	v_worldPosition = aWorldPos;
+	gl_Position = lightsViewProjectionMatrix * vec4(aWorldPos, 1.0);
 #endif
-	
 }
+
+void sendShadowDepthWorldPosition(in vec4 aWorldPos) {
+	sendShadowDepthWorldPosition(aWorldPos.xyz);
+}
+
+)";
+
+
+static const std::string depthVertexShader_Main = R"(
+in vec4 position;
+
+// these are passed in from OF programmable renderer
+uniform mat4 modelMatrix;
+
+void main() {
+	vec3 worldPosition = (modelMatrix * vec4(position.xyz, 1.0)).xyz;
+	sendShadowDepthWorldPosition(worldPosition);
+}
+
 )";


### PR DESCRIPTION
This allows using custom shaders during a shadow pass. The materials do not support custom shadow passes yet. Maybe that can be addressed in the next minor release. I tested using the shadow and material examples but could probably use a bit more.

Shadow shader functions have been added, so you can setup a shader using a function within the shadow class
`shadow.setupShadowDepthShader(ofShader& ashader, const std::string aShaderMain);`

The shader function for sending to the frag shader accepts a world position
```
vec3 worldPosition = (modelMatrix * vec4(position.xyz, 1.0)).xyz;
sendShadowDepthWorldPosition(worldPosition);
```

An example vert shader based on the MaterialPBRAdvanced Example
```
#if defined(SHADOW_DEPTH_PASS)
uniform mat4 modelMatrix;
in vec4 position;
uniform float iElapsedTime;
#else
OUT vec3 v_localPos;
#endif

void main (void){
	vec4 npos = position;
	npos.xyz += 3.0 * vec3( cos(iElapsedTime+position.y*1.25), 0.0, 0.0);
#if defined(SHADOW_DEPTH_PASS)
	vec3 worldPosition = (modelMatrix * vec4(npos.xyz, 1.0)).xyz;
	sendShadowDepthWorldPosition(worldPosition);
#else
	v_localPos = position.xyz;
	sendVaryings(npos);
	gl_Position = modelViewProjectionMatrix * npos;
#endif
	
}
```

Example usage:
```
if( light.shouldRenderShadowDepthPass() ) {
	int numShadowPasses = light.getNumShadowDepthPasses();
	light.beginShadowDepthPass();
	mDepthShader.begin();
	mDepthShader.setUniform1f("iElapsedTime", ofGetElapsedTimef());
	renderScene(true);
	mDepthShader.end();
	light.endShadowDepthPass();
}
```

