### PR TITLE
Emscripten: wrap generated html into a directory

### DIFF
--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -14,8 +14,8 @@
 #   ifdefs within the openFrameworks core source code.
 ################################################################################
 
-PLATFORM_PROJECT_RELEASE_TARGET = bin/$(BIN_NAME).html
-PLATFORM_PROJECT_DEBUG_TARGET = bin/$(BIN_NAME).html
+PLATFORM_PROJECT_RELEASE_TARGET = bin/$(BIN_NAME)/index.html
+PLATFORM_PROJECT_DEBUG_TARGET = bin/$(BIN_NAME)/index.html
 BYTECODECORE=1
 PLATFORM_CORELIB_DEBUG_TARGET = $(OF_CORE_LIB_PATH)/libopenFrameworksDebug.bc
 PLATFORM_CORELIB_RELEASE_TARGET = $(OF_CORE_LIB_PATH)/libopenFrameworks.bc
@@ -275,7 +275,7 @@ afterplatform: $(TARGET_NAME)
 	@echo "     compiling done"
 	@echo "     to launch the application on the default browser, run:"
 	@echo
-	@echo "     emrun bin/$(BIN_NAME).html"
+	@echo "     emrun bin/$(BIN_NAME)"
 	@echo "     "
 	@echo "     some browsers, like safari, don't support webgl"
 	@echo "     "


### PR DESCRIPTION
adds a layer so the emscripten product is packaged as:
```
bin/$APP_NAME/index.html
```
this makes it possible to directly upload the `bin/APP_NAME` directly on a server, and "implicitly" publish it as `http://server.name/APP_NAME` without renaming anything

(previous behaviour requires renaming the bin directory, and even then would still produce a redundant name such as `http://server.name/APP_NAME/APP_NAME.html`)

fix #7592