### PR TITLE
Update template main.cpp to std::make_shared

### DIFF
--- a/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
+++ b/addons/ofxAndroid/src/ofAppAndroidWindow.cpp
@@ -129,9 +129,9 @@ void ofAppAndroidWindow::setup(const ofxAndroidWindowSettings & settings){
 	glesVersion = settings.glesVersion;
 	ofLogError() << "setup gles" << glesVersion;
 	if(glesVersion<2){
-		currentRenderer = make_shared<ofGLRenderer>(this);
+		currentRenderer = std::make_shared<ofGLRenderer>(this);
 	}else{
-		currentRenderer = make_shared<ofGLProgrammableRenderer>(this);
+		currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 	}
 
 	jclass javaClass = ofGetJNIEnv()->FindClass("cc/openframeworks/OFAndroid");

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpMeshHelper.cpp
@@ -24,7 +24,7 @@ void ofxAssimpMeshHelper::addTexture(ofxAssimpTexture & aAssimpTex){
 			meshTextures.push_back(shared_ptr<ofxAssimpTexture>(&assimpTexture,[](ofxAssimpTexture*){}));
 		}
 	}else{
-		auto otherTex = make_shared<ofxAssimpTexture>();
+		auto otherTex = std::make_shared<ofxAssimpTexture>();
 		(*otherTex.get()) = aAssimpTex;
 
 		meshTextures.push_back(otherTex);

--- a/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
+++ b/addons/ofxEmscripten/src/ofxAppEmscriptenWindow.cpp
@@ -47,7 +47,7 @@ void ofxAppEmscriptenWindow::setup(const ofGLESWindowSettings & settings){
 	  
     makeCurrent();
 
-    _renderer = make_shared<ofGLProgrammableRenderer>(this);
+    _renderer = std::make_shared<ofGLProgrammableRenderer>(this);
     ((ofGLProgrammableRenderer*)_renderer.get())->setup(2,0);
 
     emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW,this,1,&keydown_cb);

--- a/apps/devApps/random explorer/src/main.cpp
+++ b/apps/devApps/random explorer/src/main.cpp
@@ -10,7 +10,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/3DPrimitivesExample/src/main.cpp
+++ b/examples/3d/3DPrimitivesExample/src/main.cpp
@@ -10,7 +10,7 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/advanced3dExample/src/main.cpp
+++ b/examples/3d/advanced3dExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/assimp3DModelLoaderExample/src/main.cpp
+++ b/examples/3d/assimp3DModelLoaderExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
     auto window = ofCreateWindow(settings);
 
-    ofRunApp(window, make_shared<ofApp>());
+    ofRunApp(window, std::make_shared<ofApp>());
     ofRunMainLoop();
 
 }

--- a/examples/3d/cameraLensOffsetExample/src/main.cpp
+++ b/examples/3d/cameraLensOffsetExample/src/main.cpp
@@ -9,7 +9,7 @@ int main() {
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/cameraParentingExample/src/main.cpp
+++ b/examples/3d/cameraParentingExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/cameraRibbonExample/src/main.cpp
+++ b/examples/3d/cameraRibbonExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/easyCamExample/src/main.cpp
+++ b/examples/3d/easyCamExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/meshFromCameraExample/src/main.cpp
+++ b/examples/3d/meshFromCameraExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/modelNoiseExample/src/main.cpp
+++ b/examples/3d/modelNoiseExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/normalsExample/src/main.cpp
+++ b/examples/3d/normalsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/ofBoxExample/src/main.cpp
+++ b/examples/3d/ofBoxExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/orientationExample/src/main.cpp
+++ b/examples/3d/orientationExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/pathsToMeshesExample/src/main.cpp
+++ b/examples/3d/pathsToMeshesExample/src/main.cpp
@@ -13,7 +13,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/pointCloudExample/src/main.cpp
+++ b/examples/3d/pointCloudExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/pointPickerExample/src/main.cpp
+++ b/examples/3d/pointPickerExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/quaternionArcballExample/src/main.cpp
+++ b/examples/3d/quaternionArcballExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/3d/quaternionLatLongExample/src/main.cpp
+++ b/examples/3d/quaternionLatLongExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/firmataExample/src/main.cpp
+++ b/examples/communication/firmataExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/networkTcpClientExample/src/main.cpp
+++ b/examples/communication/networkTcpClientExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/networkTcpServerExample/src/main.cpp
+++ b/examples/communication/networkTcpServerExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/networkUdpReceiverExample/src/main.cpp
+++ b/examples/communication/networkUdpReceiverExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/networkUdpSenderExample/src/main.cpp
+++ b/examples/communication/networkUdpSenderExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/communication/oscChatSystemExample/src/main.cpp
+++ b/examples/communication/oscChatSystemExample/src/main.cpp
@@ -11,6 +11,6 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/communication/oscReceiveExample/src/main.cpp
+++ b/examples/communication/oscReceiveExample/src/main.cpp
@@ -11,7 +11,7 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/communication/oscSenderExample/src/main.cpp
+++ b/examples/communication/oscSenderExample/src/main.cpp
@@ -11,6 +11,6 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/communication/serialExample/src/main.cpp
+++ b/examples/communication/serialExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/computer_vision/kinectExample/src/main.cpp
+++ b/examples/computer_vision/kinectExample/src/main.cpp
@@ -9,7 +9,7 @@ int main() {
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/computer_vision/opencvExample/src/main.cpp
+++ b/examples/computer_vision/opencvExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/computer_vision/opencvHaarFinderExample/src/main.cpp
+++ b/examples/computer_vision/opencvHaarFinderExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/computer_vision/opencvImageClassification/src/main.cpp
+++ b/examples/computer_vision/opencvImageClassification/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/computer_vision/opencvOpticalFlowExample/src/main.cpp
+++ b/examples/computer_vision/opencvOpticalFlowExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/computer_vision/opencvPeopleDetection/src/main.cpp
+++ b/examples/computer_vision/opencvPeopleDetection/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/advancedEventsExample/src/main.cpp
+++ b/examples/events/advancedEventsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/allEventsExample/src/main.cpp
+++ b/examples/events/allEventsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/customEventExample/src/main.cpp
+++ b/examples/events/customEventExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/rpiTouchExample/src/main.cpp
+++ b/examples/events/rpiTouchExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/simpleEventsExample/src/main.cpp
+++ b/examples/events/simpleEventsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/events/simpleTimerEventExample/src/main.cpp
+++ b/examples/events/simpleTimerEventExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/areaLightExample/src/main.cpp
+++ b/examples/gl/areaLightExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/billboardExample/src/main.cpp
+++ b/examples/gl/billboardExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/billboardRotationExample/src/main.cpp
+++ b/examples/gl/billboardRotationExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/computeShaderParticlesExample/src/main.cpp
+++ b/examples/gl/computeShaderParticlesExample/src/main.cpp
@@ -13,7 +13,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/computeShaderTextureExample/src/main.cpp
+++ b/examples/gl/computeShaderTextureExample/src/main.cpp
@@ -13,7 +13,7 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/fboHighResOutputExample/src/main.cpp
+++ b/examples/gl/fboHighResOutputExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/fboTrailsExample/src/main.cpp
+++ b/examples/gl/fboTrailsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/geometryShaderExample/src/main.cpp
+++ b/examples/gl/geometryShaderExample/src/main.cpp
@@ -15,7 +15,7 @@ int main( ){
 		return 1;
 	}
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/glInfoExample/src/main.cpp
+++ b/examples/gl/glInfoExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/gpuParticleSystemExample/src/main.cpp
+++ b/examples/gl/gpuParticleSystemExample/src/main.cpp
@@ -18,7 +18,7 @@ int main( ){
 		return 1;
 	}
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/materialPBR/src/main.cpp
+++ b/examples/gl/materialPBR/src/main.cpp
@@ -13,7 +13,7 @@ int main( ){
 	
 	auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/materialPBRAdvanced/src/main.cpp
+++ b/examples/gl/materialPBRAdvanced/src/main.cpp
@@ -13,7 +13,7 @@ int main( ){
 	
 	auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/multiLightExample/src/main.cpp
+++ b/examples/gl/multiLightExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/multiTexture3dExample/src/main.cpp
+++ b/examples/gl/multiTexture3dExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 	
 	auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/multiTexture3dExample/src/ofApp.cpp
+++ b/examples/gl/multiTexture3dExample/src/ofApp.cpp
@@ -6,7 +6,7 @@ void ofApp::setup(){
 //	ofSetLogLevel(OF_LOG_VERBOSE);
 	// lets make two lights
 	for( int i = 0; i < 2; i++ ){
-		auto light = make_shared<ofLight>();
+		auto light = std::make_shared<ofLight>();
 		light->setup();
 		if( i == 0 ) {
 			light->setPosition(400, -100, 400);
@@ -29,7 +29,7 @@ void ofApp::setup(){
 	// see TexturePack class for other functions and variables in ofApp.h
 	#ifdef USE_MATERIAL
 	string matPath = "textures/Snow_03/";
-	auto snowMat = make_shared<ofMaterial>();
+	auto snowMat = std::make_shared<ofMaterial>();
 	snowMat->setEmissiveColor(ofFloatColor(211/255.,25/255.,150/255., 0.8));
 	snowMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_AO_ROUGHNESS_METALLIC, matPath+"snow_03_arm.jpg");
 	snowMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_DIFFUSE, matPath+"snow_03_diff.jpg");
@@ -38,7 +38,7 @@ void ofApp::setup(){
 	materials.push_back(snowMat);
 	
 	matPath = "textures/Mud_cracked_dry_03/";
-	auto mudMat = make_shared<ofMaterial>();
+	auto mudMat = std::make_shared<ofMaterial>();
 	mudMat->setEmissiveColor(ofFloatColor(25/255.,221/255.,137/255., 0.8));
 	mudMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_AO_ROUGHNESS_METALLIC, matPath+"mud_cracked_dry_03_arm.jpg");
 	mudMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_DIFFUSE, matPath+"mud_cracked_dry_03_diff.jpg");
@@ -47,7 +47,7 @@ void ofApp::setup(){
 	materials.push_back(mudMat);
 	
 	matPath = "textures/Square_floor/";
-	auto floorMat = make_shared<ofMaterial>();
+	auto floorMat = std::make_shared<ofMaterial>();
 	floorMat->setEmissiveColor(ofColor(237,222,69., 200));
 	floorMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_AO_ROUGHNESS_METALLIC, matPath+"square_floor_arm.jpg");
 	floorMat->loadTexture(ofMaterialTextureType::OF_MATERIAL_TEXTURE_DIFFUSE, matPath+"square_floor_diff.jpg");
@@ -56,26 +56,26 @@ void ofApp::setup(){
 	materials.push_back(floorMat);
 	#else
 	
-	texturePacks.push_back( make_shared<TexturePack>("Snow_03"));
+	texturePacks.push_back( std::make_shared<TexturePack>("Snow_03"));
 	texturePacks.back()->material.setEmissiveColor(ofFloatColor(211/255.,25/255.,150/255., 0.8));
 	texturePacks.back()->material.setSpecularColor(ofFloatColor(1,1,1,0.8));
 	texturePacks.back()->material.setShininess(40);
 	texturePacks.back()->material.setDiffuseColor(ofFloatColor(1,1,1,1.0));
 	
-	texturePacks.push_back( make_shared<TexturePack>("Mud_cracked_dry_03"));
+	texturePacks.push_back( std::make_shared<TexturePack>("Mud_cracked_dry_03"));
 	texturePacks.back()->material.setEmissiveColor(ofFloatColor(25/255.,221/255.,137/255., 0.8));
 	texturePacks.back()->material.setSpecularColor(ofFloatColor(1,1,1,0.05));
 	texturePacks.back()->material.setShininess(1);
 	texturePacks.back()->material.setDiffuseColor(ofFloatColor(1,1,1,0.7));
 	
-	texturePacks.push_back( make_shared<TexturePack>("Square_floor"));
+	texturePacks.push_back( std::make_shared<TexturePack>("Square_floor"));
 	texturePacks.back()->material.setEmissiveColor(ofColor(237,222,69., 200));
 	texturePacks.back()->material.setSpecularColor(ofFloatColor(1,1,1,0.6));
 	texturePacks.back()->material.setShininess(100);
 	texturePacks.back()->material.setDiffuseColor(ofFloatColor(1,1,1,1.0));
 	
 	// load a shader that will be used for mesh manipulation and lighting
-	shader = make_shared<ofShader>();
+	shader = std::make_shared<ofShader>();
 	shader->load("shaders/shader");
 	
 	for( int i = 0; i < texturePacks.size(); i++ ){

--- a/examples/gl/multiTextureShaderExample/src/main.cpp
+++ b/examples/gl/multiTextureShaderExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/pixelBufferExample/src/main.cpp
+++ b/examples/gl/pixelBufferExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/pointLightsExample/src/main.cpp
+++ b/examples/gl/pointLightsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 	
 	auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/pointLightsExample/src/ofApp.cpp
+++ b/examples/gl/pointLightsExample/src/ofApp.cpp
@@ -12,7 +12,7 @@ void ofApp::setup(){
 	float xdist = 1000.0;
 	
 	for( int i = 0; i < numLights; i++ ){
-		auto pointLight = make_shared<ofLight>();
+		auto pointLight = std::make_shared<ofLight>();
 		pointLight->setup();
 		pointLight->enable();
 		pointLight->setPointLight();

--- a/examples/gl/pointsAsTexturesExample/src/main.cpp
+++ b/examples/gl/pointsAsTexturesExample/src/main.cpp
@@ -18,7 +18,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/shaderExample/src/main.cpp
+++ b/examples/gl/shaderExample/src/main.cpp
@@ -15,14 +15,14 @@ int main( ){
 		settings.setGLESVersion(2);
 		
 		auto window = ofCreateWindow(settings);
-		ofRunApp(window, make_shared<ofApp>());
+		ofRunApp(window, std::make_shared<ofApp>());
 	#else
 		ofGLWindowSettings settings;
 		settings.setSize(windowWidth, windowHeight);
 		settings.windowMode = OF_WINDOW; //can also be OF_FULLSCREEN
 
 		auto window = ofCreateWindow(settings);
-		ofRunApp(window, make_shared<ofApp>());
+		ofRunApp(window, std::make_shared<ofApp>());
 	#endif
 	
 	ofRunMainLoop();

--- a/examples/gl/shadowsExample/src/main.cpp
+++ b/examples/gl/shadowsExample/src/main.cpp
@@ -22,7 +22,7 @@ int main( ){
 	settings.windowMode = OF_WINDOW; //can also be OF_FULLSCREEN
 	auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/shadowsExample/src/ofApp.cpp
+++ b/examples/gl/shadowsExample/src/ofApp.cpp
@@ -8,7 +8,7 @@ void ofApp::setup(){
 	// add two lights
 	int numLights = 2;
 	for( int i = 0; i < numLights; i++ ) {
-		auto light = make_shared<ofLight>();
+		auto light = std::make_shared<ofLight>();
 		light->enable();
 		if( i == 0 ) {
 			light->setPointLight();

--- a/examples/gl/slowFastRenderingExample/src/main.cpp
+++ b/examples/gl/slowFastRenderingExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/textureBufferInstancedExample/src/main.cpp
+++ b/examples/gl/textureBufferInstancedExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/textureExample/src/main.cpp
+++ b/examples/gl/textureExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/textureScreengrabExample/src/main.cpp
+++ b/examples/gl/textureScreengrabExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/threadedPixelBufferExample/src/main.cpp
+++ b/examples/gl/threadedPixelBufferExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/transformFeedbackAnimatedExample/src/main.cpp
+++ b/examples/gl/transformFeedbackAnimatedExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/transformFeedbackAnimatedExample/src/ofApp.cpp
+++ b/examples/gl/transformFeedbackAnimatedExample/src/ofApp.cpp
@@ -59,7 +59,7 @@ void ofApp::setup(){
 	// the output of transform feedback 0 will output to vbo[1]
 	// the output of transform feedback 1 will output to vbo[0]
 	for (int i = 0; i < 2; i++) {
-		auto vbo = make_shared<ofVbo>();
+		auto vbo = std::make_shared<ofVbo>();
 		vbo->setVertexData( positionData.data(), numVertices, GL_DYNAMIC_COPY );
 		// since we are using glm::vec4 we can not call the vbo->setColorData function because it is expecting a vector
 		// of ofFloatColor as an argument 

--- a/examples/gl/transformFeedbackExample/src/main.cpp
+++ b/examples/gl/transformFeedbackExample/src/main.cpp
@@ -12,7 +12,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/vboExample/src/main.cpp
+++ b/examples/gl/vboExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gl/vboMeshDrawInstancedExample/src/main.cpp
+++ b/examples/gl/vboMeshDrawInstancedExample/src/main.cpp
@@ -27,6 +27,6 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/gl/viewportExample/src/main.cpp
+++ b/examples/gl/viewportExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/blendingExample/src/main.cpp
+++ b/examples/graphics/blendingExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/colorExample/src/main.cpp
+++ b/examples/graphics/colorExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/colorsExtendedExample/src/main.cpp
+++ b/examples/graphics/colorsExtendedExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/floatingPointImageExample/src/main.cpp
+++ b/examples/graphics/floatingPointImageExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/fontShapesExample/src/main.cpp
+++ b/examples/graphics/fontShapesExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/fontsExample/src/main.cpp
+++ b/examples/graphics/fontsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/graphicsExample/src/main.cpp
+++ b/examples/graphics/graphicsExample/src/main.cpp
@@ -13,7 +13,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/imageSubsectionExample/src/main.cpp
+++ b/examples/graphics/imageSubsectionExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/lutFilterExample/src/main.cpp
+++ b/examples/graphics/lutFilterExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/polygonExample/src/main.cpp
+++ b/examples/graphics/polygonExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/graphics/polylineBlobsExample/src/main.cpp
+++ b/examples/graphics/polylineBlobsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/rectangleAlignmentAndScalingExample/src/main.cpp
+++ b/examples/graphics/rectangleAlignmentAndScalingExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/simpleColorKeyExample/src/main.cpp
+++ b/examples/graphics/simpleColorKeyExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/graphics/vectorGraphicsExample/src/main.cpp
+++ b/examples/graphics/vectorGraphicsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/guiExample/src/main.cpp
+++ b/examples/gui/guiExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/guiFromParametersExample/src/main.cpp
+++ b/examples/gui/guiFromParametersExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/oscParametersReceiverExample/src/main.cpp
+++ b/examples/gui/oscParametersReceiverExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/oscParametersSenderExample/src/main.cpp
+++ b/examples/gui/oscParametersSenderExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/parameterEdgeCasesExample/src/main.cpp
+++ b/examples/gui/parameterEdgeCasesExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/gui/parameterGroupExample/src/main.cpp
+++ b/examples/gui/parameterGroupExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/clipboardExample/src/main.cpp
+++ b/examples/input_output/clipboardExample/src/main.cpp
@@ -9,7 +9,7 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/input_output/dirListExample/src/main.cpp
+++ b/examples/input_output/dirListExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/dragDropExample/src/main.cpp
+++ b/examples/input_output/dragDropExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/fileBufferLoadingCSVExample/src/main.cpp
+++ b/examples/input_output/fileBufferLoadingCSVExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/fileOpenSaveDialogExample/src/main.cpp
+++ b/examples/input_output/fileOpenSaveDialogExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/imageCompressionExample/src/main.cpp
+++ b/examples/input_output/imageCompressionExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/imageLoaderExample/src/main.cpp
+++ b/examples/input_output/imageLoaderExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/imageLoaderWebExample/src/main.cpp
+++ b/examples/input_output/imageLoaderWebExample/src/main.cpp
@@ -11,7 +11,7 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/imageSaverExample/src/main.cpp
+++ b/examples/input_output/imageSaverExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/imageSequenceExample/src/main.cpp
+++ b/examples/input_output/imageSequenceExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/jsonExample/src/main.cpp
+++ b/examples/input_output/jsonExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/loadTextFileExample/src/main.cpp
+++ b/examples/input_output/loadTextFileExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/pdfExample/src/main.cpp
+++ b/examples/input_output/pdfExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/pugiXmlExample/src/main.cpp
+++ b/examples/input_output/pugiXmlExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/svgExample/src/main.cpp
+++ b/examples/input_output/svgExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/systemSpeakExample/src/main.cpp
+++ b/examples/input_output/systemSpeakExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/xmlExample/src/main.cpp
+++ b/examples/input_output/xmlExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/input_output/xmlSettingsExample/src/main.cpp
+++ b/examples/input_output/xmlSettingsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/noise1dExample/src/main.cpp
+++ b/examples/math/noise1dExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/noise1dOctaveExample/src/main.cpp
+++ b/examples/math/noise1dOctaveExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/noiseField2dExample/src/main.cpp
+++ b/examples/math/noiseField2dExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/particlesExample/src/main.cpp
+++ b/examples/math/particlesExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/periodicSignalsExample/src/main.cpp
+++ b/examples/math/periodicSignalsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/randomExample/src/main.cpp
+++ b/examples/math/randomExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/trigonometricMotionExample/src/main.cpp
+++ b/examples/math/trigonometricMotionExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/trigonometryExample/src/main.cpp
+++ b/examples/math/trigonometryExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/math/vectorMathExample/src/main.cpp
+++ b/examples/math/vectorMathExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/shader/01_simpleColorQuad/src/main.cpp
+++ b/examples/shader/01_simpleColorQuad/src/main.cpp
@@ -14,7 +14,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/shader/02_simpleVertexDisplacement/src/main.cpp
+++ b/examples/shader/02_simpleVertexDisplacement/src/main.cpp
@@ -14,6 +14,6 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/shader/03_simpleShaderInteraction/src/main.cpp
+++ b/examples/shader/03_simpleShaderInteraction/src/main.cpp
@@ -14,6 +14,6 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/shader/04_simpleTexturing/src/main.cpp
+++ b/examples/shader/04_simpleTexturing/src/main.cpp
@@ -14,7 +14,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/shader/05_alphaMasking/src/main.cpp
+++ b/examples/shader/05_alphaMasking/src/main.cpp
@@ -14,7 +14,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/shader/06_multiTexture/src/main.cpp
+++ b/examples/shader/06_multiTexture/src/main.cpp
@@ -14,7 +14,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/shader/07_fboAlphaMask/src/main.cpp
+++ b/examples/shader/07_fboAlphaMask/src/main.cpp
@@ -14,6 +14,6 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/shader/08_displacementMap/src/main.cpp
+++ b/examples/shader/08_displacementMap/src/main.cpp
@@ -15,7 +15,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/shader/09_gaussianBlurFilter/src/main.cpp
+++ b/examples/shader/09_gaussianBlurFilter/src/main.cpp
@@ -15,7 +15,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/sound/audioInputExample/src/main.cpp
+++ b/examples/sound/audioInputExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/sound/audioOutputExample/src/main.cpp
+++ b/examples/sound/audioOutputExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/sound/soundBufferExample/src/main.cpp
+++ b/examples/sound/soundBufferExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/sound/soundPlayerExample/src/main.cpp
+++ b/examples/sound/soundPlayerExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/sound/soundPlayerFFTExample/src/main.cpp
+++ b/examples/sound/soundPlayerFFTExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/strings/conversionExample/src/main.cpp
+++ b/examples/strings/conversionExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/strings/ofLogExample/src/main.cpp
+++ b/examples/strings/ofLogExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/strings/regularExpressionExample/src/main.cpp
+++ b/examples/strings/regularExpressionExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/strings/sortingExample/src/main.cpp
+++ b/examples/strings/sortingExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/templates/allAddonsExample/src/main.cpp
+++ b/examples/templates/allAddonsExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/templates/emptyExample/src/main.cpp
+++ b/examples/templates/emptyExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/threads/threadChannelExample/src/main.cpp
+++ b/examples/threads/threadChannelExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/examples/threads/threadExample/src/main.cpp
+++ b/examples/threads/threadExample/src/main.cpp
@@ -9,6 +9,6 @@ int main(){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/threads/threadedImageLoaderExample/src/main.cpp
+++ b/examples/threads/threadedImageLoaderExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/video/asciiVideoExample/src/main.cpp
+++ b/examples/video/asciiVideoExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/video/videoGrabberExample/src/main.cpp
+++ b/examples/video/videoGrabberExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/video/videoPlayerExample/src/main.cpp
+++ b/examples/video/videoPlayerExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/examples/windowing/multiWindowOneAppExample/src/main.cpp
+++ b/examples/windowing/multiWindowOneAppExample/src/main.cpp
@@ -19,7 +19,7 @@ int main( ){
 	auto guiWindow = ofCreateWindow(settings);
 	guiWindow->setVerticalSync(false);
 
-	auto mainApp = make_shared<ofApp>();
+	auto mainApp = std::make_shared<ofApp>();
 	mainApp->setupGui();
 	ofAddListener(guiWindow->events().draw,mainApp.get(),&ofApp::drawGui);
 

--- a/examples/windowing/noWindowExample/src/main.cpp
+++ b/examples/windowing/noWindowExample/src/main.cpp
@@ -4,12 +4,12 @@
 
 int main() {
 
-	auto window = make_shared<ofAppNoWindow>();
+	auto window = std::make_shared<ofAppNoWindow>();
 
 	//to have a normal windowed app comment the line above and uncomment the lines below
 	//ofGLWindowSettings settings;
 	//auto window = ofCreateWindow(settings);
 	
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/examples/windowing/windowExample/src/main.cpp
+++ b/examples/windowing/windowExample/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -473,9 +473,9 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 	nFramesSinceWindowResized = 0;
 
 	if(settings.glesVersion>1){
-		currentRenderer = make_shared<ofGLProgrammableRenderer>(this);
+		currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
 	}else{
-		currentRenderer = make_shared<ofGLRenderer>(this);
+		currentRenderer = std::make_shared<ofGLRenderer>(this);
 	}
 
 	makeCurrent();

--- a/scripts/qtcreator/templates/wizards/openFrameworks/src/main.cpp
+++ b/scripts/qtcreator/templates/wizards/openFrameworks/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/emscripten/src/main.cpp
+++ b/scripts/templates/emscripten/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl3.1/src/main.cpp
+++ b/scripts/templates/gl3.1/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl3.2/src/main.cpp
+++ b/scripts/templates/gl3.2/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl3.3/src/main.cpp
+++ b/scripts/templates/gl3.3/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl4.0/src/main.cpp
+++ b/scripts/templates/gl4.0/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl4.1/src/main.cpp
+++ b/scripts/templates/gl4.1/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl4.2/src/main.cpp
+++ b/scripts/templates/gl4.2/src/main.cpp
@@ -9,6 +9,6 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 }

--- a/scripts/templates/gl4.3/src/main.cpp
+++ b/scripts/templates/gl4.3/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gl4.4/src/main.cpp
+++ b/scripts/templates/gl4.4/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 	
 }

--- a/scripts/templates/gl4.5/src/main.cpp
+++ b/scripts/templates/gl4.5/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/gles2/src/main.cpp
+++ b/scripts/templates/gles2/src/main.cpp
@@ -9,7 +9,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/linux/src/main.cpp
+++ b/scripts/templates/linux/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/linux64/src/main.cpp
+++ b/scripts/templates/linux64/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/linuxarmv6l/src/main.cpp
+++ b/scripts/templates/linuxarmv6l/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/linuxarmv7l/src/main.cpp
+++ b/scripts/templates/linuxarmv7l/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/msys2/src/main.cpp
+++ b/scripts/templates/msys2/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/nowindow/src/main.cpp
+++ b/scripts/templates/nowindow/src/main.cpp
@@ -4,8 +4,8 @@
 
 //========================================================================
 int main( ){
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/scripts/templates/osx/src/main.cpp
+++ b/scripts/templates/osx/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/scripts/templates/unittest/src/main.cpp
+++ b/scripts/templates/unittest/src/main.cpp
@@ -11,8 +11,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/scripts/templates/vs/src/main.cpp
+++ b/scripts/templates/vs/src/main.cpp
@@ -11,7 +11,7 @@ int main( ){
 
 	auto window = ofCreateWindow(settings);
 
-	ofRunApp(window, make_shared<ofApp>());
+	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
 
 }

--- a/tests/addons/networkTcp/src/main.cpp
+++ b/tests/addons/networkTcp/src/main.cpp
@@ -271,8 +271,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/addons/networkUdp/src/main.cpp
+++ b/tests/addons/networkUdp/src/main.cpp
@@ -203,8 +203,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/events/events/src/main.cpp
+++ b/tests/events/events/src/main.cpp
@@ -183,8 +183,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/graphics/pixels/src/main.cpp
+++ b/tests/graphics/pixels/src/main.cpp
@@ -315,8 +315,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/io/loadImage/src/main.cpp
+++ b/tests/io/loadImage/src/main.cpp
@@ -16,8 +16,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/math/ofNodeRegressionTests/src/main.cpp
+++ b/tests/math/ofNodeRegressionTests/src/main.cpp
@@ -152,8 +152,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/math/quaternionTests/src/main.cpp
+++ b/tests/math/quaternionTests/src/main.cpp
@@ -40,8 +40,8 @@ public:
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/types/parameters/src/main.cpp
+++ b/tests/types/parameters/src/main.cpp
@@ -30,8 +30,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
     ofInit();
-    auto window = make_shared<ofAppNoWindow>();
-    auto app = make_shared<ofApp>();
+    auto window = std::make_shared<ofAppNoWindow>();
+    auto app = std::make_shared<ofApp>();
     // this kicks off the running of my app
     // can be OF_WINDOW or OF_FULLSCREEN
     // pass in width and height too:

--- a/tests/utils/logging/src/main.cpp
+++ b/tests/utils/logging/src/main.cpp
@@ -52,8 +52,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:

--- a/tests/utils/strings/src/main.cpp
+++ b/tests/utils/strings/src/main.cpp
@@ -79,8 +79,8 @@ class ofApp: public ofxUnitTestsApp{
 //========================================================================
 int main( ){
 	ofInit();
-	auto window = make_shared<ofAppNoWindow>();
-	auto app = make_shared<ofApp>();
+	auto window = std::make_shared<ofAppNoWindow>();
+	auto app = std::make_shared<ofApp>();
 	// this kicks off the running of my app
 	// can be OF_WINDOW or OF_FULLSCREEN
 	// pass in width and height too:


### PR DESCRIPTION
fixes relying on `using namespace std` for `make_shared<ofApp>()` in many main.cpp and a few other places.