### PR TITLE
Emscripten mute video

### DIFF
--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -150,8 +150,8 @@ var LibraryHTML5Video = {
             GLctx.texParameteri(GLctx.TEXTURE_2D, GLctx.TEXTURE_WRAP_T, GLctx.CLAMP_TO_EDGE);
             VIDEO.player[player_id].textureId = texId;
             
-            if (typeof VIDEO.player[player_id].audioTracks == "undefined") {
-                VIDEO.player[player_id].muted = true;
+            if (!(VIDEO.players[player_id].mozHasAudio || Boolean(VIDEO.players[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.players[player_id].audioTracks && VIDEO.players[player_id].audioTracks.length))) {
+                VIDEO.players[player_id].muted = true;
             }
 
             // Check the file size
@@ -259,11 +259,6 @@ var LibraryHTML5Video = {
 
     html5video_player_set_volume: function(player_id, volume) {
         VIDEO.player[player_id].volume = volume;
-        if( volume <= 0 ){
-            VIDEO.player[player_id].muted = true;
-        }else{
-            VIDEO.player[player_id].muted = false;
-        }
     },
 
     html5video_player_set_loop: function(player_id, loop) {

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -150,8 +150,8 @@ var LibraryHTML5Video = {
             GLctx.texParameteri(GLctx.TEXTURE_2D, GLctx.TEXTURE_WRAP_T, GLctx.CLAMP_TO_EDGE);
             VIDEO.player[player_id].textureId = texId;
             
-            if (!(VIDEO.players[player_id].mozHasAudio || Boolean(VIDEO.players[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.players[player_id].audioTracks && VIDEO.players[player_id].audioTracks.length))) {
-                VIDEO.players[player_id].muted = true;
+            if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
+                VIDEO.player[player_id].muted = true;
             }
 
             // Check the file size

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -92,9 +92,11 @@ var LibraryHTML5Video = {
 	VIDEO.player[player_id].soundPan = AUDIO.context.createStereoPanner();
 	source.connect(VIDEO.player[player_id].soundPan).connect(AUDIO.fft);
 	video.onloadeddata = function (e){
-                if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
-                    VIDEO.player[player_id].muted = true;
-                }
+                setTimeout(() => {
+                    if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
+                        VIDEO.player[player_id].muted = true;
+                    }
+                }, 0);
         	VIDEO.player[player_id].width = this.videoWidth;
         	VIDEO.player[player_id].height = this.videoHeight;
 		var videoImage = document.createElement( 'canvas' );

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -91,7 +91,10 @@ var LibraryHTML5Video = {
 	var source = AUDIO.context.createMediaElementSource(VIDEO.player[player_id]); 
 	VIDEO.player[player_id].soundPan = AUDIO.context.createStereoPanner();
 	source.connect(VIDEO.player[player_id].soundPan).connect(AUDIO.fft);
-	video.onloadedmetadata = function (e){
+	video.onloadeddata = function (e){
+                if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
+                    VIDEO.player[player_id].muted = true;
+                }
         	VIDEO.player[player_id].width = this.videoWidth;
         	VIDEO.player[player_id].height = this.videoHeight;
 		var videoImage = document.createElement( 'canvas' );
@@ -149,10 +152,6 @@ var LibraryHTML5Video = {
             GLctx.texParameteri(GLctx.TEXTURE_2D, GLctx.TEXTURE_WRAP_S, GLctx.CLAMP_TO_EDGE);
             GLctx.texParameteri(GLctx.TEXTURE_2D, GLctx.TEXTURE_WRAP_T, GLctx.CLAMP_TO_EDGE);
             VIDEO.player[player_id].textureId = texId;
-            
-            if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
-                VIDEO.player[player_id].muted = true;
-            }
 
             // Check the file size
             //console.log('File size:' + fileSizeInBytes);

--- a/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
+++ b/addons/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
@@ -96,7 +96,7 @@ var LibraryHTML5Video = {
                     if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
                         VIDEO.player[player_id].muted = true;
                     }
-                }, 0);
+                }, 100);
         	VIDEO.player[player_id].width = this.videoWidth;
         	VIDEO.player[player_id].height = this.videoHeight;
 		var videoImage = document.createElement( 'canvas' );


### PR DESCRIPTION
@ofTheo this is working for me.

```
            if (!(VIDEO.player[player_id].mozHasAudio || Boolean(VIDEO.player[player_id].webkitAudioDecodedByteCount) || Boolean(VIDEO.player[player_id].audioTracks && VIDEO.player[player_id].audioTracks.length))) {
                VIDEO.player[player_id].muted = true;
            }
```
I think it is not needed for ` html5video_player_load_url`, because there needs to be some user action before, which should enable autoplay too. 
And I removed muting if volume <= 0 because its silent anyway (not sure about that).