### PR TITLE
Use floats for colors internally. 

### DIFF
--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -151,23 +151,23 @@ private:
 	void setDepthTest(bool){};
 
 	// color options
-	void setColor(int r, int g, int b){}; // 0-255
-	void setColor(int r, int g, int b, int a){}; // 0-255
-	void setColor(const ofColor & color){};
-	void setColor(const ofColor & color, int _a){};
-	void setColor(int gray){}; // new set a color as grayscale with one argument
+	void setColor(float r, float g, float b){}; // 0-1
+	void setColor(float r, float g, float b, float a){}; // 0-1
+	void setColor(const ofFloatColor & color){};
+	void setColor(const ofFloatColor & color, float _a){};
+	void setColor(float gray){}; // new set a color as grayscale with one argument
 	void setHexColor( int hexColor ){}; // hex, like web 0xFF0033;
 
 	// bg color
-	ofColor getBackgroundColor(){return ofColor(200);}
-	void setBackgroundColor(const ofColor & color){}
+	ofFloatColor getBackgroundColor(){return ofFloatColor(200.f/255.f);}
+	void setBackgroundColor(const ofFloatColor & color){}
 	bool getBackgroundAuto(){
 		return true;
 	}
-	void background(const ofColor & c){};
+	void background(const ofFloatColor & c){};
 	void background(float brightness){};
-	void background(int hexColor, float _a=255.0f){};
-	void background(int r, int g, int b, int a=255){};
+	void background(int hexColor, int _a=255){};
+	void background(float r, float g, float b, float a=1.f){};
 
 	void setBackgroundAuto(bool bManual){};		// default is true
 

--- a/libs/openFrameworks/gl/ofGLBaseTypes.h
+++ b/libs/openFrameworks/gl/ofGLBaseTypes.h
@@ -319,7 +319,7 @@ public:
 	/// \brief Set the global ambient light color.
 	///
 	/// \param c The color to set this renderer to use as ambient lighting.
-	virtual void setGlobalAmbientColor(const ofColor& c)=0;
+	virtual void setGlobalAmbientColor(const ofFloatColor& c)=0;
 
 	/// \brief Enable a light at a specific index.
 	///

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -328,7 +328,7 @@ void ofGLProgrammableRenderer::draw(const ofPolyline & poly) const{
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::draw(const ofPath & shape) const{
-	ofColor prevColor;
+	ofFloatColor prevColor;
 	if(shape.getUseShapeColor()){
 		prevColor = currentStyle.color;
 	}
@@ -848,33 +848,33 @@ glm::mat4 ofGLProgrammableRenderer::getCurrentOrientationMatrix() const {
 	return matrixStack.getOrientationMatrix();
 }
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setColor(const ofColor & color){
+void ofGLProgrammableRenderer::setColor(const ofFloatColor & color){
 	setColor(color.r,color.g,color.b,color.a);
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setColor(const ofColor & color, int _a){
+void ofGLProgrammableRenderer::setColor(const ofFloatColor & color, float _a){
 	setColor(color.r,color.g,color.b,_a);
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setColor(int _r, int _g, int _b){
-	setColor(_r, _g, _b, 255);
+void ofGLProgrammableRenderer::setColor(float _r, float _g, float _b){
+	setColor(_r, _g, _b, 1.f);
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setColor(int _r, int _g, int _b, int _a){
-	ofColor newColor(_r,_g,_b,_a);
+void ofGLProgrammableRenderer::setColor(float _r, float _g, float _b, float _a){
+	ofFloatColor newColor(_r,_g,_b,_a);
 	if(newColor!=currentStyle.color){
         currentStyle.color = newColor;
 		if(currentShader){
-			currentShader->setUniform4f(COLOR_UNIFORM,_r/255.,_g/255.,_b/255.,_a/255.);
+			currentShader->setUniform4f(COLOR_UNIFORM,_r,_g,_b,_a);
 		}
 	}
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setColor(int gray){
+void ofGLProgrammableRenderer::setColor(float gray){
 	setColor(gray, gray, gray);
 }
 
@@ -883,7 +883,7 @@ void ofGLProgrammableRenderer::setHexColor(int hexColor){
 	int r = (hexColor >> 16) & 0xff;
 	int g = (hexColor >> 8) & 0xff;
 	int b = (hexColor >> 0) & 0xff;
-	setColor(r,g,b);
+	setColor((float)r/255.f,(float)g/255.f,(float)b/255.f);
 }
 
 //----------------------------------------------------------
@@ -898,7 +898,7 @@ void ofGLProgrammableRenderer::clear(){
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::clear(float r, float g, float b, float a) {
-	glClearColor(r / 255., g / 255., b / 255., a / 255.);
+	glClearColor(r, g, b, a);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
@@ -926,35 +926,39 @@ bool ofGLProgrammableRenderer::getBackgroundAuto(){
 }
 
 //----------------------------------------------------------
-ofColor ofGLProgrammableRenderer::getBackgroundColor(){
+ofFloatColor ofGLProgrammableRenderer::getBackgroundColor(){
 	return currentStyle.bgColor;
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::setBackgroundColor(const ofColor & c){
+void ofGLProgrammableRenderer::setBackgroundColor(const ofFloatColor & c){
 	currentStyle.bgColor = c;
-	glClearColor(currentStyle.bgColor[0]/255., currentStyle.bgColor[1]/255., currentStyle.bgColor[2]/255., currentStyle.bgColor[3]/255.);
+	glClearColor(currentStyle.bgColor[0], currentStyle.bgColor[1], currentStyle.bgColor[2], currentStyle.bgColor[3]);
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::background(const ofColor & c){
+void ofGLProgrammableRenderer::background(const ofFloatColor & c){
 	setBackgroundColor(c);
 	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 }
 
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::background(float brightness) {
-	background(ofColor(brightness));
+	background(ofFloatColor(brightness));
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::background(int hexColor, float _a){
-	background ( (hexColor >> 16) & 0xff, (hexColor >> 8) & 0xff, (hexColor >> 0) & 0xff, _a);
+void ofGLProgrammableRenderer::background(int hexColor, int _a){
+	int r = (hexColor >> 16) & 0xff;
+	int g = (hexColor >> 8) & 0xff;
+	int b = (hexColor >> 0) & 0xff;
+	background( (float)r/255.f, (float)g/255.f, (float)b/255.f, _a/255.f );
+//	background ( (hexColor >> 16) & 0xff, (hexColor >> 8) & 0xff, (hexColor >> 0) & 0xff, _a);
 }
 
 //----------------------------------------------------------
-void ofGLProgrammableRenderer::background(int r, int g, int b, int a){
-	background(ofColor(r,g,b,a));
+void ofGLProgrammableRenderer::background(float r, float g, float b, float a){
+	background(ofFloatColor(r,g,b,a));
 }
 
 //----------------------------------------------------------
@@ -1562,7 +1566,7 @@ void ofGLProgrammableRenderer::uploadMatrices(){
 //----------------------------------------------------------
 void ofGLProgrammableRenderer::setDefaultUniforms(){
 	if(!currentShader) return;
-	currentShader->setUniform4f(COLOR_UNIFORM, currentStyle.color.r/255.,currentStyle.color.g/255.,currentStyle.color.b/255.,currentStyle.color.a/255.);
+	currentShader->setUniform4f(COLOR_UNIFORM, currentStyle.color.r,currentStyle.color.g,currentStyle.color.b,currentStyle.color.a);
 	bool usingTexture = texCoordsEnabled & (currentTextureTarget!=OF_NO_TEXTURE);
 	currentShader->setUniform1f(USE_TEXTURE_UNIFORM,usingTexture);
 	currentShader->setUniform1f(USE_COLORS_UNIFORM,colorsEnabled);

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -133,29 +133,29 @@ public:
 	void disableAntiAliasing();
     
 	// color options
-	void setColor(int r, int g, int b); // 0-255
-	void setColor(int r, int g, int b, int a); // 0-255
-	void setColor(const ofColor & color);
-	void setColor(const ofColor & color, int _a);
-	void setColor(int gray); // new set a color as grayscale with one argument
+	void setColor(float r, float g, float b); // 0-1
+	void setColor(float r, float g, float b, float a); // 0-1
+	void setColor(const ofFloatColor & color);
+	void setColor(const ofFloatColor & color, float _a);
+	void setColor(float gray); // new set a color as grayscale with one argument
 	void setHexColor( int hexColor ); // hex, like web 0xFF0033;
 
 	void setBitmapTextMode(ofDrawBitmapMode mode);
     
 	// bg color
-	ofColor getBackgroundColor();
-	void setBackgroundColor(const ofColor & c);
-	void background(const ofColor & c);
+	ofFloatColor getBackgroundColor();
+	void setBackgroundColor(const ofFloatColor & c);
+	void background(const ofFloatColor & c);
 	void background(float brightness);
-	void background(int hexColor, float _a=255.0f);
-	void background(int r, int g, int b, int a=255);
+	void background(int hexColor, int _a=255);
+	void background(float r, float g, float b, float a=1.f);
 
 	bool getBackgroundAuto();
 	void setBackgroundAuto(bool bManual);		// default is true
     
 	void clear();
-	void clear(float r, float g, float b, float a=0);
-	void clear(float brightness, float a=0);
+	void clear(float r, float g, float b, float a=0.f);
+	void clear(float brightness, float a=0.f);
 	void clearAlpha();
     
     
@@ -217,7 +217,7 @@ public:
     void enableSeparateSpecularLight(){}
     void disableSeparateSpecularLight(){}
 	void setSmoothLighting(bool b){}
-	void setGlobalAmbientColor(const ofColor& c){}
+	void setGlobalAmbientColor(const ofFloatColor& c){}
     void enableLight(int lightIndex);
     void disableLight(int lightIndex);
 	void setLightSpotlightCutOff(int lightIndex, float spotCutOff){}

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -283,7 +283,7 @@ void ofGLRenderer::draw(const ofPolyline & poly) const{
 
 //----------------------------------------------------------
 void ofGLRenderer::draw(const ofPath & shape) const{
-	ofColor prevColor;
+	ofFloatColor prevColor;
 	if(shape.getUseShapeColor()){
 		prevColor = currentStyle.color;
 	}
@@ -1045,19 +1045,19 @@ glm::mat4 ofGLRenderer::getCurrentNormalMatrix() const{
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setColor(const ofColor & color){
+void ofGLRenderer::setColor(const ofFloatColor & color){
 	setColor(color.r,color.g,color.b,color.a);
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setColor(const ofColor & color, int _a){
+void ofGLRenderer::setColor(const ofFloatColor & color, float _a){
 	setColor(color.r,color.g,color.b,_a);
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setColor(int r, int g, int b){
+void ofGLRenderer::setColor(float r, float g, float b){
 	currentStyle.color.set(r,g,b);
-	glColor4f(r/255.f,g/255.f,b/255.f,1.f);
+	glColor4f(r,g,b,1.f);
 	if(lightingEnabled && !materialBound){
 #ifndef TARGET_OPENGLES
 		glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
@@ -1068,9 +1068,9 @@ void ofGLRenderer::setColor(int r, int g, int b){
 
 
 //----------------------------------------------------------
-void ofGLRenderer::setColor(int r, int g, int b, int a){
+void ofGLRenderer::setColor(float r, float g, float b, float a){
 	currentStyle.color.set(r,g,b,a);
-	glColor4f(r/255.f,g/255.f,b/255.f,a/255.f);
+	glColor4f(r,g,b,a);
 	if(lightingEnabled && !materialBound){
 #ifndef TARGET_OPENGLES
 		glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
@@ -1080,7 +1080,7 @@ void ofGLRenderer::setColor(int r, int g, int b, int a){
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setColor(int gray){
+void ofGLRenderer::setColor(float gray){
 	setColor(gray, gray, gray);
 }
 
@@ -1089,7 +1089,7 @@ void ofGLRenderer::setHexColor(int hexColor){
 	int r = (hexColor >> 16) & 0xff;
 	int g = (hexColor >> 8) & 0xff;
 	int b = (hexColor >> 0) & 0xff;
-	setColor(r,g,b);
+	setColor((float)r/255.f,(float)g/255.f,(float)b/255.f);
 }
 
 //----------------------------------------------------------
@@ -1099,7 +1099,7 @@ void ofGLRenderer::clear(){
 
 //----------------------------------------------------------
 void ofGLRenderer::clear(float r, float g, float b, float a) {
-	glClearColor(r / 255., g / 255., b / 255., a / 255.);
+	glClearColor(r, g, b, a);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
@@ -1127,35 +1127,38 @@ bool ofGLRenderer::getBackgroundAuto(){
 }
 
 //----------------------------------------------------------
-ofColor ofGLRenderer::getBackgroundColor(){
+ofFloatColor ofGLRenderer::getBackgroundColor(){
 	return currentStyle.bgColor;
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setBackgroundColor(const ofColor & color){
+void ofGLRenderer::setBackgroundColor(const ofFloatColor & color){
 	currentStyle.bgColor = color;
-	glClearColor(currentStyle.bgColor[0]/255.,currentStyle.bgColor[1]/255.,currentStyle.bgColor[2]/255., currentStyle.bgColor[3]/255.);
+	glClearColor(currentStyle.bgColor[0],currentStyle.bgColor[1],currentStyle.bgColor[2], currentStyle.bgColor[3]);
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::background(const ofColor & c){
+void ofGLRenderer::background(const ofFloatColor & c){
 	setBackgroundColor(c);
 	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
 //----------------------------------------------------------
 void ofGLRenderer::background(float brightness) {
-	background(ofColor(brightness));
+	background(ofFloatColor(brightness));
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::background(int hexColor, float _a){
-	background ( (hexColor >> 16) & 0xff, (hexColor >> 8) & 0xff, (hexColor >> 0) & 0xff, _a);
+void ofGLRenderer::background(int hexColor, int _a){
+	int r = (hexColor >> 16) & 0xff;
+	int g = (hexColor >> 8) & 0xff;
+	int b = (hexColor >> 0) & 0xff;
+	background ( (float)r/255.f, (float)g/255.f, (float)b/255.f, _a/255.f);
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::background(int r, int g, int b, int a){
-	background(ofColor(r,g,b,a));
+void ofGLRenderer::background(float r, float g, float b, float a){
+	background(ofFloatColor(r,g,b,a));
 }
 
 //----------------------------------------------------------
@@ -1818,8 +1821,8 @@ void ofGLRenderer::setSmoothLighting(bool b){
 }
 
 //----------------------------------------------------------
-void ofGLRenderer::setGlobalAmbientColor(const ofColor& c){
-	GLfloat cc[] = {c.r/255.f, c.g/255.f, c.b/255.f, c.a/255.f};
+void ofGLRenderer::setGlobalAmbientColor(const ofFloatColor& c){
+	GLfloat cc[] = {c.r, c.g, c.b, c.a};
 	glLightModelfv(GL_LIGHT_MODEL_AMBIENT, cc);
 }
 

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -120,22 +120,22 @@ public:
 	void disableAntiAliasing();
 
 	// color options
-	void setColor(int r, int g, int b); // 0-255
-	void setColor(int r, int g, int b, int a); // 0-255
-	void setColor(const ofColor & color);
-	void setColor(const ofColor & color, int _a);
-	void setColor(int gray); // new set a color as grayscale with one argument
+	void setColor(float r, float g, float b); // 0-1
+	void setColor(float r, float g, float b, float a); // 0-1
+	void setColor(const ofFloatColor & color);
+	void setColor(const ofFloatColor & color, float _a);
+	void setColor(float gray); // new set a color as grayscale with one argument
 	void setHexColor( int hexColor ); // hex, like web 0xFF0033;
 
 	void setBitmapTextMode(ofDrawBitmapMode mode);
 
 	// bg color
-	ofColor getBackgroundColor();
-	void setBackgroundColor(const ofColor & c);
-	void background(const ofColor & c);
+	ofFloatColor getBackgroundColor();
+	void setBackgroundColor(const ofFloatColor & c);
+	void background(const ofFloatColor & c);
 	void background(float brightness);
-	void background(int hexColor, float _a=255.0f);
-	void background(int r, int g, int b, int a=255);
+	void background(int hexColor, int _a=255);
+	void background(float r, float g, float b, float a=1.f);
 
 	void setBackgroundAuto(bool bManual);		// default is true
 	bool getBackgroundAuto();
@@ -176,7 +176,7 @@ public:
 	void disableSeparateSpecularLight();
 	bool getLightingEnabled();
 	void setSmoothLighting(bool b);
-	void setGlobalAmbientColor(const ofColor& c);
+	void setGlobalAmbientColor(const ofFloatColor& c);
 
 	// lighting per light
 	void enableLight(int lightIndex);

--- a/libs/openFrameworks/gl/ofLight.cpp
+++ b/libs/openFrameworks/gl/ofLight.cpp
@@ -84,9 +84,9 @@ ofLight::Data::Data(){
 ofLight::Data::~Data(){
 	if(glIndex==-1) return;
 	if ( auto r = rendererP.lock() ){
-		r->setLightAmbientColor( glIndex, ofColor( 0, 0, 0, 255 ) );
-		r->setLightDiffuseColor( glIndex, ofColor( 0, 0, 0, 255 ) );
-		r->setLightSpecularColor( glIndex, ofColor( 0, 0, 0, 255 ) );
+		r->setLightAmbientColor( glIndex, ofFloatColor( 0.f, 0.f, 0.f, 1.f ) );
+		r->setLightDiffuseColor( glIndex, ofFloatColor( 0.f, 0.f, 0.f, 1.f ) );
+		r->setLightSpecularColor( glIndex, ofFloatColor( 0.f, 0.f, 0.f, 1.f ) );
 		r->setLightPosition( glIndex, glm::vec4( 0, 0, 1, 0 ) );
 		r->disableLight( glIndex );
 	}
@@ -95,9 +95,9 @@ ofLight::Data::~Data(){
 //----------------------------------------
 ofLight::ofLight()
 :data(new Data){
-    setAmbientColor(ofColor(0,0,0));
-    setDiffuseColor(ofColor(255,255,255));
-    setSpecularColor(ofColor(255,255,255));
+    setAmbientColor(ofFloatColor(0.f,0.f,0.f));
+    setDiffuseColor(ofFloatColor(1.f,1.f,1.f));
+    setSpecularColor(ofFloatColor(1.f,1.f,1.f));
 	setPointLight();
     
     // assume default attenuation factors //

--- a/libs/openFrameworks/graphics/of3dGraphics.cpp
+++ b/libs/openFrameworks/graphics/of3dGraphics.cpp
@@ -382,16 +382,16 @@ void of3dGraphics::drawAxis(float size) const{
 //--------------------------------------------------------------
 void of3dGraphics::drawGrid(float stepSize, size_t numberOfSteps, bool labels, bool x, bool y, bool z) const{
 
-	ofColor c;
-	ofColor prevColor = renderer->getStyle().color;
+	ofFloatColor c;
+	ofFloatColor prevColor = renderer->getStyle().color;
 
 	if (x) {
-		c.setHsb(0.0f, 200.0f, 255.0f);
+		c.setHsb(0.0f, 200.0f/255.f, 1.f);
 		renderer->setColor(c);
 		drawGridPlane(stepSize, numberOfSteps, labels);
 	}
 	if (y) {
-		c.setHsb(255.0f / 3.0f, 200.0f, 255.0f);
+		c.setHsb((255.0f / 3.0f)/255.f, 200.0f/255.f, 1.f);
 		renderer->setColor(c);
 		glm::mat4 m = glm::rotate(glm::mat4(1.0), glm::half_pi<float>(), glm::vec3(0,0,-1));
 		renderer->pushMatrix();
@@ -400,7 +400,7 @@ void of3dGraphics::drawGrid(float stepSize, size_t numberOfSteps, bool labels, b
 		renderer->popMatrix();
 	}
 	if (z) {
-		c.setHsb(255.0f * 2.0f / 3.0f, 200.0f, 255.0f);
+		c.setHsb((255.0f * 2.0f / 3.0f)/255.f, 200.0f/255.f, 1.f);
 		renderer->setColor(c);
 		glm::mat4 m = glm::rotate(glm::mat4(1.0), glm::half_pi<float>(), glm::vec3(0,1,0));
 		renderer->pushMatrix();
@@ -411,7 +411,7 @@ void of3dGraphics::drawGrid(float stepSize, size_t numberOfSteps, bool labels, b
 
 	if (labels) {
 		ofDrawBitmapMode mode = renderer->getStyle().drawBitmapMode;
-		renderer->setColor(255, 255, 255);
+		renderer->setColor(1.f, 1.f, 1.f);
 		float labelPos = stepSize * (numberOfSteps + 0.5);
 		renderer->setBitmapTextMode(OF_BITMAPMODE_MODEL_BILLBOARD);
 		renderer->drawString("x", labelPos, 0, 0);
@@ -455,10 +455,10 @@ void of3dGraphics::drawGridPlane(float stepSize, size_t numberOfSteps, bool labe
 
 	if (labels) {
 		//draw numbers on axes
-		ofColor prevColor = renderer->getStyle().color;
+		ofFloatColor prevColor = renderer->getStyle().color;
 		ofDrawBitmapMode mode = renderer->getStyle().drawBitmapMode;
 
-		renderer->setColor(255, 255, 255);
+		renderer->setColor(1.f, 1.f, 1.f);
 		renderer->setBitmapTextMode(OF_BITMAPMODE_MODEL_BILLBOARD);
 
 		renderer->drawString(ofToString(0), 0, 0, 0);

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -157,7 +157,7 @@ void ofCairoRenderer::finishRender(){
 
 void ofCairoRenderer::setStyle(const ofStyle & style){
 	//color
-	setColor((int)style.color.r, (int)style.color.g, (int)style.color.b, (int)style.color.a);
+	setColor(style.color.r, style.color.g, style.color.b, style.color.a);
 
 	//bg color
 	setBackgroundColor(style.bgColor);
@@ -211,16 +211,16 @@ void ofCairoRenderer::draw(const ofPath & shape) const{
 	cairo_set_fill_rule(cr,cairo_poly_mode);
 
 
-	ofColor prevColor;
+	ofFloatColor prevColor;
 	if(shape.getUseShapeColor()){
 		prevColor = currentStyle.color;
 	}
 
 	if(shape.isFilled()){
 		if(shape.getUseShapeColor()){
-			ofColor c = shape.getFillColor();
+			ofFloatColor c = shape.getFillColor();
 			c.a = shape.getFillColor().a;
-			cairo_set_source_rgba(cr, (float)c.r/255.0, (float)c.g/255.0, (float)c.b/255.0, (float)c.a/255.0);
+			cairo_set_source_rgba(cr, c.r, c.g, c.b, c.a);
 		}
 
 		if(shape.hasOutline()){
@@ -232,9 +232,9 @@ void ofCairoRenderer::draw(const ofPath & shape) const{
 	if(shape.hasOutline()){
 		float lineWidth = currentStyle.lineWidth;
 		if(shape.getUseShapeColor()){
-			ofColor c = shape.getStrokeColor();
+			ofFloatColor c = shape.getStrokeColor();
 			c.a = shape.getStrokeColor().a;
-			cairo_set_source_rgba(cr, (float)c.r/255.0, (float)c.g/255.0, (float)c.b/255.0, (float)c.a/255.0);
+			cairo_set_source_rgba(cr, c.r, c.g, c.b, c.a);
 		}
 		cairo_set_line_width( cr, shape.getStrokeWidth() );
 		cairo_stroke( cr );
@@ -711,29 +711,29 @@ void ofCairoRenderer::setLineSmoothing(bool smooth){
 
 // color options
 //--------------------------------------------
-void ofCairoRenderer::setColor(int r, int g, int b){
-	setColor(r,g,b,255);
+void ofCairoRenderer::setColor(float r, float g, float b){
+	setColor(r,g,b,1.f);
 };
 
 //--------------------------------------------
-void ofCairoRenderer::setColor(int r, int g, int b, int a){
-	cairo_set_source_rgba(cr, (float)r/255.0, (float)g/255.0, (float)b/255.0, (float)a/255.0);
+void ofCairoRenderer::setColor(float r, float g, float b, float a){
+	cairo_set_source_rgba(cr, r, g, b, a);
 	currentStyle.color.set(r,g,b,a);
 };
 
 //--------------------------------------------
-void ofCairoRenderer::setColor(const ofColor & c){
+void ofCairoRenderer::setColor(const ofFloatColor & c){
 	setColor(c.r,c.g,c.b,c.a);
 };
 
 //--------------------------------------------
-void ofCairoRenderer::setColor(const ofColor & c, int _a){
+void ofCairoRenderer::setColor(const ofFloatColor & c, float _a){
 	setColor(c.r,c.g,c.b,_a);
 };
 
 //--------------------------------------------
-void ofCairoRenderer::setColor(int gray){
-	setColor(gray,gray,gray,255);
+void ofCairoRenderer::setColor(float gray){
+	setColor(gray,gray,gray,1.f);
 };
 
 //--------------------------------------------
@@ -741,7 +741,7 @@ void ofCairoRenderer::setHexColor( int hexColor ){
 	int r = (hexColor >> 16) & 0xff;
 	int g = (hexColor >> 8) & 0xff;
 	int b = (hexColor >> 0) & 0xff;
-	setColor(r,g,b);
+	setColor((float)r/255.f,(float)g/255.f,(float)b/255.f);
 };
 
 //--------------------------------------------
@@ -1161,7 +1161,7 @@ void ofCairoRenderer::setupGraphicDefaults(){
 //----------------------------------------------------------
 void ofCairoRenderer::clear(){
 	if(!surface || ! cr) return;
-	cairo_set_source_rgba(cr,currentStyle.bgColor.r/255., currentStyle.bgColor.g/255., currentStyle.bgColor.b/255., currentStyle.bgColor.a/255.);
+	cairo_set_source_rgba(cr,currentStyle.bgColor.r, currentStyle.bgColor.g, currentStyle.bgColor.b, currentStyle.bgColor.a);
 	cairo_paint(cr);
 	setColor(currentStyle.color);
 }
@@ -1169,7 +1169,7 @@ void ofCairoRenderer::clear(){
 //----------------------------------------------------------
 void ofCairoRenderer::clear(float r, float g, float b, float a) {
 	if(!surface || ! cr) return;
-	cairo_set_source_rgba(cr,r/255., g/255., b/255., a/255.);
+	cairo_set_source_rgba(cr,r, g, b, a);
 	cairo_paint(cr);
 	setColor(currentStyle.color);
 
@@ -1221,34 +1221,38 @@ bool ofCairoRenderer::getBackgroundAuto(){
 }
 
 //----------------------------------------------------------
-void ofCairoRenderer::setBackgroundColor(const ofColor & c){
+void ofCairoRenderer::setBackgroundColor(const ofFloatColor & c){
 	currentStyle.bgColor = c;
 }
 
 //----------------------------------------------------------
-ofColor ofCairoRenderer::getBackgroundColor(){
+ofFloatColor ofCairoRenderer::getBackgroundColor(){
 	return currentStyle.bgColor;
 }
 
 //----------------------------------------------------------
-void ofCairoRenderer::background(const ofColor & c){
+void ofCairoRenderer::background(const ofFloatColor & c){
 	setBackgroundColor(c);
 	clear(c.r,c.g,c.b,c.a);
 }
 
 //----------------------------------------------------------
 void ofCairoRenderer::background(float brightness) {
-	background(ofColor(brightness));
+	background(ofFloatColor(brightness));
 }
 
 //----------------------------------------------------------
-void ofCairoRenderer::background(int hexColor, float _a){
-	background ( (hexColor >> 16) & 0xff, (hexColor >> 8) & 0xff, (hexColor >> 0) & 0xff, _a);
+void ofCairoRenderer::background(int hexColor, int _a){
+	int r = (hexColor >> 16) & 0xff;
+	int g = (hexColor >> 8) & 0xff;
+	int b = (hexColor >> 0) & 0xff;
+	background ( (float)r/255.f, (float)g/255.f, (float)b/255.f, _a/255.f);
+//	background ( (hexColor >> 16) & 0xff, (hexColor >> 8) & 0xff, (hexColor >> 0) & 0xff, _a);
 }
 
 //----------------------------------------------------------
-void ofCairoRenderer::background(int r, int g, int b, int a){
-	background(ofColor(r,g,b,a));
+void ofCairoRenderer::background(float r, float g, float b, float a){
+	background(ofFloatColor(r,g,b,a));
 }
 
 

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -112,20 +112,20 @@ public:
 	void setupScreen();
 
 	// color options
-	void setColor(int r, int g, int b); // 0-255
-	void setColor(int r, int g, int b, int a); // 0-255
-	void setColor(const ofColor & color);
-	void setColor(const ofColor & color, int _a);
-	void setColor(int gray); // new set a color as grayscale with one argument
+	void setColor(float r, float g, float b); // 0-1
+	void setColor(float r, float g, float b, float a); // 0-1
+	void setColor(const ofFloatColor & color);
+	void setColor(const ofFloatColor & color, float _a);
+	void setColor(float gray); // new set a color as grayscale with one argument
 	void setHexColor( int hexColor ); // hex, like web 0xFF0033;
 
 	// bg color
-	void setBackgroundColor(const ofColor & c);
-	ofColor getBackgroundColor();
-	void background(const ofColor & c);
+	void setBackgroundColor(const ofFloatColor & c);
+	ofFloatColor getBackgroundColor();
+	void background(const ofFloatColor & c);
 	void background(float brightness);
-	void background(int hexColor, float _a=255.0f);
-	void background(int r, int g, int b, int a=255);
+	void background(int hexColor, int _a=255);
+	void background(float r, float g, float b, float a=1.f);
 
 	void setBackgroundAuto(bool bManual);		// default is true
 	bool getBackgroundAuto();

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -319,7 +319,7 @@ void ofClear(float r, float g, float b, float a){
 }
 
 //----------------------------------------------------------
-void ofClear(float r, float g, float b) {
+void ofClear(float r, float g, float b){
 	ofClear( r, g, b, 255.f );
 }
 
@@ -339,17 +339,17 @@ void ofClear(const ofColor & c){
 }
 
 //----------------------------------------------------------
-void ofClear(const ofFloatColor & c) {
+void ofClear(const ofFloatColor & c){
 	ofClearFloat(c.r,c.g,c.b,c.a);
 }
 
 //----------------------------------------------------------
-void ofClearFloat(float r, float g, float b) {
+void ofClearFloat(float r, float g, float b){
 	ofClearFloat(r,g,b,1.f);
 }
 
 //----------------------------------------------------------
-void ofClearFloat(float r, float g, float b, float a) {
+void ofClearFloat(float r, float g, float b, float a){
 	ofGetCurrentRenderer()->clear(r,g,b,a);
 }
 
@@ -359,8 +359,13 @@ void ofClearFloat(float brightness, float a) {
 }
 
 //----------------------------------------------------------
-void ofClearFloat(float brightness) {
+void ofClearFloat(float brightness){
 	ofClearFloat(brightness, brightness, brightness, 1.f);
+}
+
+//----------------------------------------------------------
+void ofClearFloat(const ofFloatColor & c){
+	ofClearFloat(c.r, c.g, c.b, c.aX);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -316,17 +316,52 @@ glm::mat4 ofGetCurrentViewMatrix(){
 
 //----------------------------------------------------------
 void ofClear(float r, float g, float b, float a){
-	ofGetCurrentRenderer()->clear(r,g,b,a);
+	ofGetCurrentRenderer()->clear(r/255.f,g/255.f,b/255.f,a/255.f);
+}
+
+//----------------------------------------------------------
+void ofClear(float r, float g, float b) {
+	ofClear( r, g, b, 255.f );
 }
 
 //----------------------------------------------------------
 void ofClear(float brightness, float a){
-	ofGetCurrentRenderer()->clear(brightness, brightness, brightness, a);
+	ofClear(brightness, brightness, brightness, a);
+}
+
+//----------------------------------------------------------
+void ofClear(float brightness){
+	ofClear(brightness, brightness, brightness, 255.f);
 }
 
 //----------------------------------------------------------
 void ofClear(const ofColor & c){
-	ofGetCurrentRenderer()->clear(c.r, c.g, c.b, c.a);
+	ofClear( c.r, c.g, c.b, c.a );
+}
+
+//----------------------------------------------------------
+void ofClear(const ofFloatColor & c) {
+	ofClearFloat(c.r,c.g,c.b,c.a);
+}
+
+//----------------------------------------------------------
+void ofClearFloat(float r, float g, float b) {
+	ofClearFloat(r,g,b,1.f);
+}
+
+//----------------------------------------------------------
+void ofClearFloat(float r, float g, float b, float a) {
+	ofGetCurrentRenderer()->clear(r,g,b,a);
+}
+
+//----------------------------------------------------------
+void ofClearFloat(float brightness, float a) {
+	ofClearFloat(brightness, brightness, brightness, a);
+}
+
+//----------------------------------------------------------
+void ofClearFloat(float brightness) {
+	ofClearFloat(brightness, brightness, brightness, 1.f);
 }
 
 //----------------------------------------------------------
@@ -339,6 +374,7 @@ void ofSetBackgroundAuto(bool bAuto){
 	ofGetCurrentRenderer()->setBackgroundAuto(bAuto);
 }
 
+
 bool ofGetBackgroundAuto(){
 	return ofGetCurrentRenderer()->getBackgroundAuto();
 }
@@ -349,12 +385,12 @@ bool ofbClearBg(){
 }
 
 //----------------------------------------------------------
-ofColor ofGetBackground(){
+ofFloatColor ofGetBackground(){
 	return ofGetCurrentRenderer()->getBackgroundColor();
 }
 
 //----------------------------------------------------------
-ofColor ofGetBackgroundColor(){
+ofFloatColor ofGetBackgroundColor(){
 	return ofGetCurrentRenderer()->getBackgroundColor();
 }
 
@@ -364,8 +400,13 @@ void ofBackground(int brightness, int alpha){
 }
 
 //----------------------------------------------------------
+void ofBackground(int r, int g, int b, int a){
+	ofGetCurrentRenderer()->background( r/255.f, g/255.f, b/255.f, a/255.f);
+}
+
+//----------------------------------------------------------
 void ofBackground(const ofColor & c){
-	ofBackground ( c.r, c.g, c.b, c.a);
+	ofBackground( c.r, c.g, c.b, c.a);
 }
 
 //----------------------------------------------------------
@@ -374,12 +415,7 @@ void ofBackgroundHex(int hexColor, int alpha){
 }
 
 //----------------------------------------------------------
-void ofBackground(int r, int g, int b, int a){
-	ofGetCurrentRenderer()->background(r,g,b,a);
-}
-
-//----------------------------------------------------------
-void ofBackgroundGradient(const ofColor& start, const ofColor& end, ofGradientMode mode) {
+void ofBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) {
 	float w = ofGetViewportWidth(), h = ofGetViewportHeight();
 	gradientMesh.clear();
 	gradientMesh.setMode(OF_PRIMITIVE_TRIANGLE_FAN);
@@ -454,11 +490,11 @@ void ofSetBackgroundColorHex(int hexColor, int alpha){
 
 //----------------------------------------------------------
 void ofSetBackgroundColor(int r, int g, int b, int a){
-	ofSetBackgroundColor (ofColor(r,g,b,a));
+	ofSetBackgroundColor(ofFloatColor(r/255.f,g/255.f,b/255.f,a/255.f));
 }
 
 //----------------------------------------------------------
-void ofSetBackgroundColor(const ofColor & c){
+void ofSetBackgroundColor(const ofFloatColor & c){
 	ofGetCurrentRenderer()->setBackgroundColor(c);
 }
 
@@ -545,7 +581,7 @@ void ofSetColor(int r, int g, int b){
 
 //----------------------------------------------------------
 void ofSetColor(int r, int g, int b, int a){
-	ofGetCurrentRenderer()->setColor(r,g,b,a);
+	ofGetCurrentRenderer()->setColor(r/255.f, g/255.f, b/255.f, a/255.f );
 }
 
 //----------------------------------------------------------
@@ -557,6 +593,41 @@ void ofSetColor(int gray){
 }
 
 //----------------------------------------------------------
+void ofSetColor(const ofFloatColor & color) {
+	ofGetCurrentRenderer()->setColor(color.r,color.g,color.b,color.a);
+}
+
+//----------------------------------------------------------
+void ofSetColor(const ofFloatColor & color, float _a) {
+	ofGetCurrentRenderer()->setColor(color.r,color.g,color.b,_a);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(float r, float g, float b) {
+	ofSetFloatColor( r, g, b, 1.f);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(float r, float g, float b, float a) {
+	ofGetCurrentRenderer()->setColor(r,g,b,a);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(float gray) {
+	ofSetFloatColor( gray, gray, gray);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(const ofFloatColor & color) {
+	ofSetFloatColor(color.r,color.g,color.b,color.a);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(const ofFloatColor & color, float _a) {
+	ofSetFloatColor(color.r,color.g,color.b,_a);
+}
+
+//----------------------------------------------------------
 void ofSetHexColor(int hexColor){
 	int r = (hexColor >> 16) & 0xff;
 	int g = (hexColor >> 8) & 0xff;
@@ -565,7 +636,6 @@ void ofSetHexColor(int hexColor){
 }
 
 //----------------------------------------------------------
-
 void ofEnableBlendMode(ofBlendMode blendMode){
 	ofGetCurrentRenderer()->setBlendMode(blendMode);
 }

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -601,6 +601,11 @@ void ofSetFloatColor(float gray){
 }
 
 //----------------------------------------------------------
+void ofSetFloatColor(float gray, float _a) {
+	ofSetFloatColor(gray, gray, gray, _a);
+}
+
+//----------------------------------------------------------
 void ofSetHexColor(int hexColor){
 	int r = (hexColor >> 16) & 0xff;
 	int g = (hexColor >> 8) & 0xff;

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -581,8 +581,8 @@ void ofSetColor(int gray){
 }
 
 //----------------------------------------------------------
-void ofSetColor(const ofColor& acolor, int _a){
-	ofSetFloatColor( acolor.r / 255.f, acolor.g / 255.f, acolor.b/255.f, _a / 255.f );
+void ofSetColor(const ofColor& acolor, int a){
+	ofSetFloatColor( acolor.r/255.f, acolor.g/255.f, acolor.b/255.f, a/255.f );
 }
 
 //----------------------------------------------------------
@@ -601,8 +601,13 @@ void ofSetFloatColor(float gray){
 }
 
 //----------------------------------------------------------
-void ofSetFloatColor(float gray, float _a) {
-	ofSetFloatColor(gray, gray, gray, _a);
+void ofSetFloatColor(const ofFloatColor& acolor, float a){
+	ofSetFloatColor( acolor.r, acolor.g, acolor.b, a);
+}
+
+//----------------------------------------------------------
+void ofSetFloatColor(const ofFloatColor& acolor){
+	ofSetFloatColor( acolor.r, acolor.g, acolor.b, acolor.a);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -330,7 +330,7 @@ void ofClear(float brightness, float a){
 
 //----------------------------------------------------------
 void ofClear(float brightness){
-	ofClear(brightness, brightness, brightness, 255.f);
+	ofClear(brightness, brightness, brightness, 0.f);
 }
 
 //----------------------------------------------------------
@@ -356,11 +356,6 @@ void ofClearFloat(float r, float g, float b, float a){
 //----------------------------------------------------------
 void ofClearFloat(float brightness, float a) {
 	ofClearFloat(brightness, brightness, brightness, a);
-}
-
-//----------------------------------------------------------
-void ofClearFloat(float brightness){
-	ofClearFloat(brightness, brightness, brightness, 1.f);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -365,7 +365,7 @@ void ofClearFloat(float brightness){
 
 //----------------------------------------------------------
 void ofClearFloat(const ofFloatColor & c){
-	ofClearFloat(c.r, c.g, c.b, c.aX);
+	ofClearFloat(c.r, c.g, c.b, c.a);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -2,7 +2,6 @@
 #include "ofRendererCollection.h"
 #include "ofGLRenderer.h"
 
-
 #ifndef TARGET_WIN32
     #define CALLBACK
 #endif
@@ -564,20 +563,9 @@ void ofSetCircleResolution(int res){
 }
 
 //----------------------------------------------------------
-void ofSetColor(const ofColor & color){
-	ofSetColor(color.r,color.g,color.b,color.a);
-}
-
-//----------------------------------------------------------
-void ofSetColor(const ofColor & color, int _a){
-	ofSetColor(color.r,color.g,color.b,_a);
-}
-
-//----------------------------------------------------------
 void ofSetColor(int r, int g, int b){
 	ofSetColor(r,g,b,255);
 }
-
 
 //----------------------------------------------------------
 void ofSetColor(int r, int g, int b, int a){
@@ -593,38 +581,23 @@ void ofSetColor(int gray){
 }
 
 //----------------------------------------------------------
-void ofSetColor(const ofFloatColor & color) {
-	ofGetCurrentRenderer()->setColor(color.r,color.g,color.b,color.a);
+void ofSetColor(const ofColor& acolor, int _a){
+	ofSetFloatColor( acolor.r / 255.f, acolor.g / 255.f, acolor.b/255.f, _a / 255.f );
 }
 
 //----------------------------------------------------------
-void ofSetColor(const ofFloatColor & color, float _a) {
-	ofGetCurrentRenderer()->setColor(color.r,color.g,color.b,_a);
-}
-
-//----------------------------------------------------------
-void ofSetFloatColor(float r, float g, float b) {
+void ofSetFloatColor(float r, float g, float b){
 	ofSetFloatColor( r, g, b, 1.f);
 }
 
 //----------------------------------------------------------
-void ofSetFloatColor(float r, float g, float b, float a) {
+void ofSetFloatColor(float r, float g, float b, float a){
 	ofGetCurrentRenderer()->setColor(r,g,b,a);
 }
 
 //----------------------------------------------------------
-void ofSetFloatColor(float gray) {
-	ofSetFloatColor( gray, gray, gray);
-}
-
-//----------------------------------------------------------
-void ofSetFloatColor(const ofFloatColor & color) {
-	ofSetFloatColor(color.r,color.g,color.b,color.a);
-}
-
-//----------------------------------------------------------
-void ofSetFloatColor(const ofFloatColor & color, float _a) {
-	ofSetFloatColor(color.r,color.g,color.b,_a);
+void ofSetFloatColor(float gray){
+	ofSetFloatColor( gray, gray, gray, 1.f);
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -54,7 +54,7 @@ void ofSetColor(int r, int g, int b);
 /// ~~~~
 void ofSetColor(int r, int g, int b, int a);
 void ofSetColor(int gray);
-void ofSetColor(const ofColor& acolor, int _a);
+void ofSetColor(const ofColor& acolor, int a);
 
 /// \brief Sets the draw color with r,g,b,a 0-1.
 ///
@@ -64,11 +64,13 @@ void ofSetColor(const ofColor& acolor, int _a);
 void ofSetFloatColor(float r, float g, float b);
 void ofSetFloatColor(float r, float g, float b, float a);
 void ofSetFloatColor(float gray);
-void ofSetFloatColor(float gray, float _a);
+void ofSetFloatColor(const ofFloatColor& acolor, float a);
+void ofSetFloatColor(const ofFloatColor& acolor);
 
 template<typename T>
 void ofSetColor( const ofColor_<T>& acolor ) {
 	float limit = ofColor_<T>::limit();
+	std::cout << "ofSetColor :: limit : " << limit << " color: " << acolor << std::endl;
 	ofSetFloatColor( acolor.r / limit, acolor.g / limit, acolor.b/limit, acolor.a / limit );
 }
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -73,7 +73,6 @@ void ofSetColor( const ofColor_<T>& acolor ) {
 	ofSetFloatColor( acolor.r / limit, acolor.g / limit, acolor.b/limit, acolor.a / limit );
 }
 
-
 /// Sets the draw color with r,g,b, passed in as a hex. Hex is a conventient
 /// way to write colors.
 ///
@@ -301,6 +300,8 @@ void ofClearFloat(float r, float g, float b);
 void ofClearFloat(float r, float g, float b, float a);
 void ofClearFloat(float brightness, float a);
 void ofClearFloat(float brightness);
+void ofClearFloat(const ofFloatColor & c);
+
 
 // OF's access to settings (bgAuto, origin, corner mode):
 OF_DEPRECATED_MSG("Use ofGetBackgroundAuto instead",bool ofbClearBg());

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -64,6 +64,7 @@ void ofSetColor(const ofColor& acolor, int _a);
 void ofSetFloatColor(float r, float g, float b);
 void ofSetFloatColor(float r, float g, float b, float a);
 void ofSetFloatColor(float gray);
+void ofSetFloatColor(float gray, float _a);
 
 template<typename T>
 void ofSetColor( const ofColor_<T>& acolor ) {

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -70,7 +70,6 @@ void ofSetFloatColor(const ofFloatColor& acolor);
 template<typename T>
 void ofSetColor( const ofColor_<T>& acolor ) {
 	float limit = ofColor_<T>::limit();
-	std::cout << "ofSetColor :: limit : " << limit << " color: " << acolor << std::endl;
 	ofSetFloatColor( acolor.r / limit, acolor.g / limit, acolor.b/limit, acolor.a / limit );
 }
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -56,6 +56,14 @@ void ofSetColor(int r, int g, int b, int a);
 void ofSetColor(const ofColor & color);
 void ofSetColor(const ofColor & color, int _a);
 void ofSetColor(int gray);
+void ofSetColor(const ofFloatColor & color);
+void ofSetColor(const ofFloatColor & color, float _a);
+
+void ofSetFloatColor(float r, float g, float b);
+void ofSetFloatColor(float r, float g, float b, float a);
+void ofSetFloatColor(float gray);
+void ofSetFloatColor(const ofFloatColor & color);
+void ofSetFloatColor(const ofFloatColor & color, float _a);
 
 /// Sets the draw color with r,g,b, passed in as a hex. Hex is a conventient
 /// way to write colors.
@@ -95,8 +103,8 @@ ofFillFlag ofGetFill();
 /// \{
 
 /// \brief Returns the current background color as an ofColor.
-ofColor ofGetBackgroundColor();
-OF_DEPRECATED_MSG("Use ofGetBackgroundColor instead",ofColor ofGetBackground());
+ofFloatColor ofGetBackgroundColor();
+OF_DEPRECATED_MSG("Use ofGetBackgroundColor instead",ofFloatColor ofGetBackground());
 
 
 /// \brief Sets the background color.
@@ -174,7 +182,7 @@ void ofBackgroundHex(int hexColor, int alpha = 255);
 ///       // Sets the background to a bar gradient
 /// }
 /// ~~~~
-void ofBackgroundGradient(const ofColor& start, const ofColor& end, ofGradientMode mode = OF_GRADIENT_CIRCULAR);
+void ofBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode = OF_GRADIENT_CIRCULAR);
 
 /// \brief Sets the background color. It takes as input r,g,b (0-255). The
 /// background is cleared automatically, just before the draw() command, so
@@ -189,7 +197,7 @@ void ofBackgroundGradient(const ofColor& start, const ofColor& end, ofGradientMo
 /// ~~~~
 void ofSetBackgroundColor(int r, int g, int b, int a=255);
 void ofSetBackgroundColor(int brightness, int alpha = 255);
-void ofSetBackgroundColor(const ofColor & c);
+void ofSetBackgroundColor(const ofFloatColor & c);
 
 /// \brief Sets the background color using a hex color value.
 /// ~~~~{.cpp}
@@ -251,7 +259,8 @@ bool ofGetBackgroundAuto();
 ///
 /// [1]: http://www.openframeworks.cc/documentation/gl/ofFbo.html
 /// [2]: http://www.opengl.org/sdk/docs/man/xhtml/glClear.xml
-void ofClear(float r, float g, float b, float a=0);
+void ofClear(float r, float g, float b, float a);
+void ofClear(float r, float g, float b);
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with a
 /// grayscale value.
@@ -262,7 +271,8 @@ void ofClear(float r, float g, float b, float a=0);
 ///     // Clears current screen and replaces it with a grayscale value.
 /// }
 /// ~~~~
-void ofClear(float brightness, float a=0);
+void ofClear(float brightness, float a);
+void ofClear(float brightness);
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with
 /// an ofColor.
@@ -274,9 +284,14 @@ void ofClear(float brightness, float a=0);
 ///     // Clears current screen and replaces it with myColor.
 /// }
 /// ~~~~
-
 void ofClear(const ofColor & c);
+void ofClear(const ofFloatColor & c);
 void ofClearAlpha();
+
+void ofClearFloat(float r, float g, float b);
+void ofClearFloat(float r, float g, float b, float a);
+void ofClearFloat(float brightness, float a);
+void ofClearFloat(float brightness);
 
 // OF's access to settings (bgAuto, origin, corner mode):
 OF_DEPRECATED_MSG("Use ofGetBackgroundAuto instead",bool ofbClearBg());

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -280,7 +280,7 @@ void ofClear(float r, float g, float b);
 /// }
 /// ~~~~
 void ofClear(float brightness, float a);
-void ofClear(float brightness);
+OF_DEPRECATED_MSG("Use ofClear(brightness, alpha) instead",void ofClear(float brightness));
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with
 /// an ofColor.
@@ -299,7 +299,6 @@ void ofClearAlpha();
 void ofClearFloat(float r, float g, float b);
 void ofClearFloat(float r, float g, float b, float a);
 void ofClearFloat(float brightness, float a);
-void ofClearFloat(float brightness);
 void ofClearFloat(const ofFloatColor & c);
 
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -53,17 +53,24 @@ void ofSetColor(int r, int g, int b);
 /// }
 /// ~~~~
 void ofSetColor(int r, int g, int b, int a);
-void ofSetColor(const ofColor & color);
-void ofSetColor(const ofColor & color, int _a);
 void ofSetColor(int gray);
-void ofSetColor(const ofFloatColor & color);
-void ofSetColor(const ofFloatColor & color, float _a);
+void ofSetColor(const ofColor& acolor, int _a);
 
+/// \brief Sets the draw color with r,g,b,a 0-1.
+///
+/// For alpha (transparency), you must first enable transparent blending
+/// (turned off by default for performance reasons) with
+/// ofEnableAlphaBlending()
 void ofSetFloatColor(float r, float g, float b);
 void ofSetFloatColor(float r, float g, float b, float a);
 void ofSetFloatColor(float gray);
-void ofSetFloatColor(const ofFloatColor & color);
-void ofSetFloatColor(const ofFloatColor & color, float _a);
+
+template<typename T>
+void ofSetColor( const ofColor_<T>& acolor ) {
+	float limit = ofColor_<T>::limit();
+	ofSetFloatColor( acolor.r / limit, acolor.g / limit, acolor.b/limit, acolor.a / limit );
+}
+
 
 /// Sets the draw color with r,g,b, passed in as a hex. Hex is a conventient
 /// way to write colors.

--- a/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
+++ b/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
@@ -66,7 +66,7 @@ class ofStyle{
 			#else
 				drawBitmapMode		= OF_BITMAPMODE_MODEL_BILLBOARD;
 			#endif
-			bgColor.set(60, 60, 60);
+			bgColor.set(60.f/255.f, 60.f/255.f, 60.f/255.f);
 			//depthTest = false;
 		}
 
@@ -76,10 +76,10 @@ class ofStyle{
 		/// \brief The color used when rendering.
 		///
 		/// This style depends on the state of the ofStyle::bFill.
-		ofColor color;
+		ofFloatColor color;
 
 		/// \brief The background color used when rendering.
-		ofColor bgColor;
+		ofFloatColor bgColor;
 
 		/// \brief The current rendering mode for polygons.
 		///
@@ -826,42 +826,42 @@ public:
 	/// The renderer will continue using a color set by setColor() until another
 	/// call to setColor() changes the drawing color.
 	///
-	/// \param r The red value between 0 and 255 to use when drawing.
-	/// \param g The green value between 0 and 255 to use when drawing.
-	/// \param b The blue value between 0 and 255 to use when drawing.
-	virtual void setColor(int r, int g, int b)=0;
+	/// \param r The red value between 0 and 1 to use when drawing.
+	/// \param g The green value between 0 and 1 to use when drawing.
+	/// \param b The blue value between 0 and 1 to use when drawing.
+	virtual void setColor(float r, float g, float b)=0;
 	/// \brief Set the global color this renderer will use when drawing.
 	///
 	/// The renderer will continue using a color set by setColor() until another
 	/// call to setColor() changes the drawing color.
 	///
-	/// \param r The red value between 0 and 255 to use when drawing.
-	/// \param g The green value between 0 and 255 to use when drawing.
-	/// \param b The blue value between 0 and 255 to use when drawing.
-	/// \param a The alpha value between 0 and 255 to use when drawing.
-	virtual void setColor(int r, int g, int b, int a)=0;
-	/// \brief Set the global color this renderer will use when drawing.
-	///
-	/// The renderer will continue using a color set by setColor() until another
-	/// call to setColor() changes the drawing color.
-	///
-	/// \param color The color to use when drawing.
-	virtual void setColor(const ofColor & color)=0;
+	/// \param r The red value between 0 and 1 to use when drawing.
+	/// \param g The green value between 0 and 1 to use when drawing.
+	/// \param b The blue value between 0 and 1 to use when drawing.
+	/// \param a The alpha value between 0 and 1 to use when drawing.
+	virtual void setColor(float r, float g, float b, float a)=0;
 	/// \brief Set the global color this renderer will use when drawing.
 	///
 	/// The renderer will continue using a color set by setColor() until another
 	/// call to setColor() changes the drawing color.
 	///
 	/// \param color The color to use when drawing.
-	/// \param _a The alpha value between 0 and 255 to use when drawing.
-	virtual void setColor(const ofColor & color, int _a)=0;
+	virtual void setColor(const ofFloatColor & color)=0;
 	/// \brief Set the global color this renderer will use when drawing.
 	///
 	/// The renderer will continue using a color set by setColor() until another
 	/// call to setColor() changes the drawing color.
 	///
-	/// \param gray The grayscale value to use when drawing.
-	virtual void setColor(int gray)=0;
+	/// \param color The color to use when drawing.
+	/// \param _a The alpha value between 0 and 1 to use when drawing.
+	virtual void setColor(const ofFloatColor & color, float _a)=0;
+	/// \brief Set the global color this renderer will use when drawing.
+	///
+	/// The renderer will continue using a color set by setColor() until another
+	/// call to setColor() changes the drawing color.
+	///
+	/// \param gray The grayscale value from 0 and 1 to use when drawing.
+	virtual void setColor(float gray)=0;
 	/// \brief Set the global color this renderer will use when drawing.
 	///
 	/// The renderer will continue using a color set by setColor() until another
@@ -886,10 +886,10 @@ public:
 
 	/// \brief Get this renderer's current background color.
 	/// \returns This renderer's current background color.
-	virtual ofColor getBackgroundColor()=0;
+	virtual ofFloatColor getBackgroundColor()=0;
 	/// \brief Set this renderer's background color.
 	/// \param c The color to request this renderer to use.
-	virtual void setBackgroundColor(const ofColor & c)=0;
+	virtual void setBackgroundColor(const ofFloatColor & c)=0;
 
 	/// \brief Immediately paint a background color to the screen.
 	///
@@ -898,14 +898,14 @@ public:
 	/// this color each frame.
 	///
 	/// \param c The color to paint the background with.
-	virtual void background(const ofColor & c)=0;
+	virtual void background(const ofFloatColor & c)=0;
 	/// \brief Immediately paint a grayscale background color to the screen.
 	///
 	/// If automatic background drawing is enabled (which it is by default) this
 	/// method called from ofApp::setup() will also repaint the background with
 	/// this color each frame.
 	///
-	/// \param brightness The grayscale value between 0 and 255 to paint the
+	/// \param brightness The grayscale value between 0 and 1 to paint the
 	/// background with.
 	virtual void background(float brightness)=0;
 	/// \brief Immediately paint a grayscale background color to the screen.
@@ -918,14 +918,14 @@ public:
 	/// background with.
 	/// \param _a The alpha value between 0 and 255 to apply to \p hexColor when
 	/// when painting the background.
-	virtual void background(int hexColor, float _a=255.0f)=0;
+	virtual void background(int hexColor, int _a=255)=0;
 	/// \brief Immediately paint a background color to the screen.
 	///
-	/// \param r The red value between 0 and 255 to use for the background.
-	/// \param g The green value between 0 and 255 to use for the background.
-	/// \param b The blue value between 0 and 255 to use for the background.
-	/// \param a The alpha value between 0 and 255 to use for the background.
-	virtual void background(int r, int g, int b, int a=255)=0;
+	/// \param r The red value between 0 and 1 to use for the background.
+	/// \param g The green value between 0 and 1 to use for the background.
+	/// \param b The blue value between 0 and 1 to use for the background.
+	/// \param a The alpha value between 0 and 1 to use for the background.
+	virtual void background(float r, float g, float b, float a=1.f)=0;
 
 	/// \brief Enable/disable automatic redrawing of the background each frame.
 	/// \param bManual False to disable automatic background redrawing.
@@ -944,21 +944,21 @@ public:
 	///
 	/// clear() will clear the screen entirely.
 	///
-	/// \param r The red value between 0 and 255 to use when clearing the
+	/// \param r The red value between 0 and 1 to use when clearing the
 	/// screen.
-	/// \param g The green value between 0 and 255 to use when clearing the
+	/// \param g The green value between 0 and 1 to use when clearing the
 	/// screen.
-	/// \param b The blue value between 0 and 255 use when clearing the screen.
-	/// \param a The alpha value between 0 and 255 use when clearing the screen.
+	/// \param b The blue value between 0 and 1 use when clearing the screen.
+	/// \param a The alpha value between 0 and 1 use when clearing the screen.
 	/// Defaults to 0.
 	virtual void clear(float r, float g, float b, float a=0)=0;
 	/// \brief Clear this renderer's color and bit depths replacing them.
 	///
 	/// clear() will clear the screen entirely.
 	///
-	/// \param brightness The grayscale value between 0 and 255 to use when
+	/// \param brightness The grayscale value between 0 and 1 to use when
 	/// clearing the screen.
-	/// \param a The alpha value between 0 and 255 to use when clearing the
+	/// \param a The alpha value between 0 and 1 to use when clearing the
 	/// screen. Defaults to 0.
 	virtual void clear(float brightness, float a=0)=0;
 	/// \brief Restore the alpha color to its full opacity value.

--- a/libs/openFrameworks/graphics/ofPath.cpp
+++ b/libs/openFrameworks/graphics/ofPath.cpp
@@ -573,12 +573,12 @@ bool ofPath::isFilled() const{
 }
 
 //----------------------------------------------------------
-ofColor ofPath::getFillColor() const{
+ofFloatColor ofPath::getFillColor() const{
 	return fillColor;
 }
 
 //----------------------------------------------------------
-ofColor ofPath::getStrokeColor() const{
+ofFloatColor ofPath::getStrokeColor() const{
 	return strokeColor;
 }
 
@@ -743,7 +743,7 @@ bool ofPath::getUseShapeColor() const {
 }
 
 //----------------------------------------------------------
-void ofPath::setColor( const ofColor& color ) {
+void ofPath::setColor( const ofFloatColor& color ) {
 	setFillColor( color );
 	setStrokeColor( color );
 }
@@ -754,7 +754,7 @@ void ofPath::setHexColor( int hex ) {
 }
 
 //----------------------------------------------------------
-void ofPath::setFillColor(const ofColor & color){
+void ofPath::setFillColor(const ofFloatColor & color){
 	setUseShapeColor(true);
 	fillColor = color;
 }
@@ -765,7 +765,7 @@ void ofPath::setFillHexColor( int hex ) {
 }
 
 //----------------------------------------------------------
-void ofPath::setStrokeColor(const ofColor & color){
+void ofPath::setStrokeColor(const ofFloatColor & color){
 	setUseShapeColor(true);
 	strokeColor = color;
 }

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -252,7 +252,7 @@ public:
 	/// \brief Set the color of the path. This affects both the line if the
 	/// path is drawn as wireframe and the fill if the path is drawn with
 	/// fill. All subpaths are affected.
-	void setColor( const ofColor& color );
+	void setColor( const ofFloatColor& color );
 
 	/// \brief Set the color of the path. This affects both the line if the path is
 	/// drawn as wireframe and the fill if the path is drawn with fill. All
@@ -261,7 +261,7 @@ public:
 
 	/// \brief Set the fill color of the path. This has no affect if the path is
 	/// drawn as wireframe.
-	void setFillColor(const ofColor & color);
+	void setFillColor(const ofFloatColor & color);
 
 	/// \brief Set the fill color of the path. This has no affect if the path is
 	/// drawn as wireframe.
@@ -269,7 +269,7 @@ public:
 
 	/// \brief Set the stroke color of the path. This has no affect if the path
 	/// is drawn filled.
-	void setStrokeColor(const ofColor & color);
+	void setStrokeColor(const ofFloatColor & color);
 
 	/// \brief Set the stroke color of the path. This has no affect if the path
 	/// is drawn filled.
@@ -280,11 +280,11 @@ public:
 	/// The default value is `true`
 	bool isFilled() const;
 
-	/// \brief Get the ofColor fill of the ofPath
-	ofColor getFillColor() const;
+	/// \brief Get the ofFloatColor fill of the ofPath
+	ofFloatColor getFillColor() const;
 
-	/// \brief Get the stroke color of the ofPath
-	ofColor getStrokeColor() const;
+	/// \brief Get the stroke ofFloatColor of the ofPath
+	ofFloatColor getStrokeColor() const;
 
 	/// \brief Get the stroke width of the ofPath
 	///
@@ -413,8 +413,8 @@ private:
 	//vector<ofSubPath>		paths;
 	std::vector<Command> 	commands;
 	ofPolyWindingMode 	windingMode;
-	ofColor 			fillColor;
-	ofColor				strokeColor;
+	ofFloatColor 		fillColor;
+	ofFloatColor		strokeColor;
 	float				strokeWidth;
 	bool				bFill;
 	bool				bUseShapeColor;

--- a/libs/openFrameworks/graphics/ofRendererCollection.cpp
+++ b/libs/openFrameworks/graphics/ofRendererCollection.cpp
@@ -386,31 +386,31 @@ void ofRendererCollection::setupScreen(){
 }
 
 // color options
-void ofRendererCollection::setColor(int r, int g, int b){
+void ofRendererCollection::setColor(float r, float g, float b){
    for(auto renderer: renderers){
 	   renderer->setColor(r,g,b);
 	}
 }
 
-void ofRendererCollection::setColor(int r, int g, int b, int a){
+void ofRendererCollection::setColor(float r, float g, float b, float a){
    for(auto renderer: renderers){
 	   renderer->setColor(r,g,b,a);
 	}
 }
 
-void ofRendererCollection::setColor(const ofColor & color){
+void ofRendererCollection::setColor(const ofFloatColor & color){
    for(auto renderer: renderers){
 	   renderer->setColor(color);
 	}
 }
 
-void ofRendererCollection::setColor(const ofColor & color, int _a){
+void ofRendererCollection::setColor(const ofFloatColor & color, float _a){
    for(auto renderer: renderers){
 	   renderer->setColor(color,_a);
 	}
 }
 
-void ofRendererCollection::setColor(int gray){
+void ofRendererCollection::setColor(float gray){
    for(auto renderer: renderers){
 	   renderer->setColor(gray);
 	}
@@ -423,15 +423,15 @@ void ofRendererCollection::ofRendererCollection::setHexColor( int hexColor ){
 } // hex, like web 0xFF0033;
 
 // bg color
-ofColor ofRendererCollection::getBackgroundColor(){
+ofFloatColor ofRendererCollection::getBackgroundColor(){
 	if(renderers.size()){
 		return renderers[0]->getBackgroundColor();
 	}else{
-		return ofColor(200);
+		return ofFloatColor(200.f/255.f);
 	}
 }
 
-void ofRendererCollection::setBackgroundColor(const ofColor & color){
+void ofRendererCollection::setBackgroundColor(const ofFloatColor & color){
    for(auto renderer: renderers){
 	   renderer->setBackgroundColor(color);
 	}
@@ -445,7 +445,7 @@ bool ofRendererCollection::getBackgroundAuto(){
 	}
 }
 
-void ofRendererCollection::background(const ofColor & c){
+void ofRendererCollection::background(const ofFloatColor & c){
    for(auto renderer: renderers){
 	   renderer->background(c);
 	}
@@ -457,13 +457,13 @@ void ofRendererCollection::background(float brightness){
 	}
 }
 
-void ofRendererCollection::background(int hexColor, float _a){
+void ofRendererCollection::background(int hexColor, int _a){
    for(auto renderer: renderers){
 	   renderer->background(hexColor,_a);
 	}
 }
 
-void ofRendererCollection::background(int r, int g, int b, int a){
+void ofRendererCollection::background(float r, float g, float b, float a){
    for(auto renderer: renderers){
 	   renderer->background(r,g,b,a);
 	}

--- a/libs/openFrameworks/graphics/ofRendererCollection.h
+++ b/libs/openFrameworks/graphics/ofRendererCollection.h
@@ -133,32 +133,32 @@ public:
 	 void setupScreen();
 
 	// color options
-	void setColor(int r, int g, int b);
+	void setColor(float r, float g, float b);
 
-	void setColor(int r, int g, int b, int a);
+	void setColor(float r, float g, float b, float a);
 
-	void setColor(const ofColor & color);
+	void setColor(const ofFloatColor & color);
 
-	void setColor(const ofColor & color, int _a);
+	void setColor(const ofFloatColor & color, float _a);
 
-	void setColor(int gray);
+	void setColor(float gray);
 
 	void setHexColor( int hexColor );
 
 	// bg color
-	ofColor getBackgroundColor();
+	ofFloatColor getBackgroundColor();
 
-	void setBackgroundColor(const ofColor & color);
+	void setBackgroundColor(const ofFloatColor & color);
 
 	bool getBackgroundAuto();
 
-	void background(const ofColor & c);
+	void background(const ofFloatColor & c);
 
 	void background(float brightness);
 
-	void background(int hexColor, float _a=255.0f);
+	void background(int hexColor, int _a=255);
 
-	void background(int r, int g, int b, int a=255);
+	void background(float r, float g, float b, float a=1.f);
 
 	void setBackgroundAuto(bool bManual);
 


### PR DESCRIPTION
All of the renderers accept floats for color arguments in the range 0-1 and use ofFloatColor instead of ofColor. 

ofSetColor functions that receive an ofFloatColor argument:
```
void ofSetColor(const ofFloatColor & color);
void ofSetColor(const ofFloatColor & color, float _a);
```

ofSetFloatColor functions have been added to accept floats between 0-1 or ofFloatColor
```
void ofSetFloatColor(float r, float g, float b);
void ofSetFloatColor(float r, float g, float b, float a);
void ofSetFloatColor(float gray);
void ofSetFloatColor(const ofFloatColor & color);
void ofSetFloatColor(const ofFloatColor & color, float _a);
```

Similar for ofClear
`void ofClear(const ofFloatColor & c);`

```
void ofClearFloat(float r, float g, float b);
void ofClearFloat(float r, float g, float b, float a);
void ofClearFloat(float brightness, float a);
void ofClearFloat(float brightness);
```