### PR TITLE
Bugfix Cubemap PBR for mobile devices

### DIFF
--- a/examples/gl/materialPBR/src/main.cpp
+++ b/examples/gl/materialPBR/src/main.cpp
@@ -4,7 +4,7 @@
 //========================================================================
 int main( ){
 // PBR only works with the programmable renderer
-#ifdef TARGET_OPENGLES
+#ifdef TARGET_EMSCRIPTEN
 	ofGLESWindowSettings settings;
 	settings.glesVersion = 3;
 #else

--- a/examples/gl/materialPBR/src/main.cpp
+++ b/examples/gl/materialPBR/src/main.cpp
@@ -3,17 +3,21 @@
 
 //========================================================================
 int main( ){
-
+// PBR only works with the programmable renderer
+#ifdef TARGET_OPENGLES
+	ofGLESWindowSettings settings;
+	settings.glesVersion = 3;
+#else
 	//Use ofGLFWWindowSettings for more options like multi-monitor fullscreen
 	ofGLWindowSettings settings;
 	settings.setSize(1200, 768);
-	// PBR Materials only work with programmable renderer
 	settings.setGLVersion(3,2);
-	settings.windowMode = OF_WINDOW; //can also be OF_FULLSCREEN
+#endif
 	
+	settings.windowMode = OF_WINDOW; //can also be OF_FULLSCREEN
 	auto window = ofCreateWindow(settings);
 	
 	ofRunApp(window, std::make_shared<ofApp>());
 	ofRunMainLoop();
-
+	
 }

--- a/examples/gl/materialPBR/src/ofApp.h
+++ b/examples/gl/materialPBR/src/ofApp.h
@@ -30,5 +30,6 @@ class ofApp : public ofBaseApp{
 		#endif
 	
 		int cubeMapMode = 1;
+		float prefilterRoughness = 0.25;
 		
 };

--- a/libs/openFrameworks/gl/ofCubeMap.cpp
+++ b/libs/openFrameworks/gl/ofCubeMap.cpp
@@ -333,12 +333,18 @@ bool ofCubeMap::load( ofCubeMapSettings aSettings ) {
 			bLoadOk = true;
 #if defined(TARGET_OPENGLES)
 			// GL_RGB32F, GL_RGBA32F and GL_RGB16F is not supported in Emscripten opengl es, so we need to set to GL_RGBA16F or GL_RGBA32F. But GL_RGBA32F is not supported via opengl es on most mobile devices as of right now.
+			#if defined(GL_RGBA16F)
 			mGLInternalFormat = GL_RGBA16F;
+			#endif
 #elif !defined(TARGET_OPENGLES)
+			#if defined(GL_RGB16F)
 			mGLInternalFormat = GL_RGB16F;
+			#endif
 			if(aSettings.useMaximumPrecision) {
+				#if defined(GL_RGB32F)
 				ofLogVerbose("ofCubeMap :: load : using maximum precision: GL_RGB32F");
 				mGLInternalFormat = GL_RGB32F;
+				#endif
 			}
 #endif
 			

--- a/libs/openFrameworks/gl/ofCubeMap.cpp
+++ b/libs/openFrameworks/gl/ofCubeMap.cpp
@@ -14,6 +14,7 @@
 #include "ofCubeMapShaders.h"
 #include "ofFbo.h"
 #include "ofConstants.h"
+#include "ofTexture.h"
 
 #define GLM_FORCE_CTOR_INIT
 #include "glm/gtx/transform.hpp"
@@ -203,7 +204,7 @@ ofCubeMap::ofCubeMap(const ofCubeMap & mom) {
 		data->settings = mom.data->settings;
 	}
 	_checkSetup(); // grab a new slot in ofCubeMapsData
-	texFormat = mom.texFormat;
+	mGLInternalFormat = mom.mGLInternalFormat;
 }
 
 //----------------------------------------
@@ -211,7 +212,7 @@ ofCubeMap::ofCubeMap(ofCubeMap && mom) {
 	clear();
 	// taking ownership of the data shared_ptr
 	data = mom.data;
-	texFormat = mom.texFormat;
+	mGLInternalFormat = mom.mGLInternalFormat;
 }
 
 //----------------------------------------
@@ -247,7 +248,7 @@ ofCubeMap & ofCubeMap::operator=(const ofCubeMap & mom){
 	}
 	data->index = -1;
 	_checkSetup(); // grab a new slot in ofCubeMapsData
-	texFormat = mom.texFormat;
+	mGLInternalFormat = mom.mGLInternalFormat;
 	
 	return *this;
 }
@@ -256,7 +257,7 @@ ofCubeMap & ofCubeMap::operator=(const ofCubeMap & mom){
 ofCubeMap& ofCubeMap::operator=(ofCubeMap && mom) {
 	clear();
 	data = mom.data;
-	texFormat = mom.texFormat;
+	mGLInternalFormat = mom.mGLInternalFormat;
 	return *this;
 }
 
@@ -311,55 +312,94 @@ bool ofCubeMap::load( ofCubeMapSettings aSettings ) {
 	std::string ext = ofToLower(aSettings.filePath.extension().string());
 	bool hdr = (ext == ".hdr" || ext == ".exr");
 	
-#if defined(TARGET_OPENGLES) && !defined(TARGET_EMSCRIPTEN)
-	if( hdr ) {
-		ofLogError("ofCubeMap :: load : hdr and exr not supported on OPENGL_ES");
+	if( hdr && !doesSupportHdr() ) {
+		ofLogError("ofCubeMap :: load : hdr and exr not supported with this setup.");
 		return false;
 	}
-#endif
 	
 	bool bLoadOk = false;
 	data->settings = aSettings;
 	
 	ofTexture srcTex;
+	bool bSrcTexIdGenerated = false;
+	GLuint srcTexId;
 	
 	bool bArbTexEnabled = ofGetUsingArbTex();
 	ofDisableArbTex();
 	if( hdr ) {
 		ofFloatPixels fpix;
 		if( ofLoadImage(fpix, data->settings.filePath) ) {
-			ofLogNotice("ofCubeMap::load : loaded ") << ext << " image.";
+			ofLogVerbose("ofCubeMap::load : loaded ") << ext << " image.";
 			bLoadOk = true;
-#if defined(TARGET_EMSCRIPTEN)
-			// GL_RGB32F GL_RGB16F &&  is not supported in Emscripten opengl es, so we need to set to GL_RGBA16F or GL_RGBA32F
-			// ofFloatPixels uses 32F and is supported via Emscripten, so we switch to that in the _load functions.
-			texFormat = GL_RGBA16F;
-			// just in case, we need to make sure that it's 4 channels
-			if( fpix.getNumChannels() != 4 ) {
-				fpix.setImageType( OF_IMAGE_COLOR_ALPHA );
-			}
+#if defined(TARGET_OPENGLES)
+			// GL_RGB32F, GL_RGBA32F and GL_RGB16F is not supported in Emscripten opengl es, so we need to set to GL_RGBA16F or GL_RGBA32F. But GL_RGBA32F is not supported via opengl es on most mobile devices as of right now.
+			mGLInternalFormat = GL_RGBA16F;
 #elif !defined(TARGET_OPENGLES)
-			if( fpix.getNumChannels() != 3 ) {
+			mGLInternalFormat = GL_RGB16F;
+			if(aSettings.useMaximumPrecision) {
+				ofLogVerbose("ofCubeMap :: load : using maximum precision: GL_RGB32F");
+				mGLInternalFormat = GL_RGB32F;
+			}
+#endif
+			
+			if(getNumPixelChannels() > 3 ) {
+				// set alpha to 1.
+				fpix.setImageType( OF_IMAGE_COLOR );
+				fpix.setImageType( OF_IMAGE_COLOR_ALPHA );
+			} else {
 				fpix.setImageType( OF_IMAGE_COLOR );
 			}
-			texFormat = GL_RGB32F;
-#endif
-			srcTex.loadData(fpix);
+			
+			if( isMediumPrecision() ) {
+				int fw = fpix.getWidth();
+				int fh = fpix.getHeight();
+				
+				ofLogVerbose("ofCubeMap :: loading the pixel data from hdr image as medium precision: ") << fw << " x " << fh;
+				
+				auto glFormat = getGLFormatFromInternalFormat();
+				auto glType = getGLTypeFromInternalFormat();
+				
+				float* fPixData = fpix.getData();
+				unsigned int numFs = fw * fh * fpix.getNumChannels();
+				for( unsigned int i = 0; i < numFs; i++ ) {
+					// clamp to the maximum value of float16, medium precision
+					if(fPixData[i] > 65504.f) {
+						fPixData[i] = 65504.f;
+					}
+				}
+				
+				
+				bSrcTexIdGenerated = true;
+				glGenTextures(1, &srcTexId );
+				glBindTexture(GL_TEXTURE_2D, srcTexId);
+				
+				glTexImage2D(GL_TEXTURE_2D, 0, mGLInternalFormat, fw, fh, 0, glFormat, glType, fPixData );
+				
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+				
+				glBindTexture(GL_TEXTURE_2D, 0);
+				
+			} else {
+				srcTex.loadData(fpix);
+				srcTexId = srcTex.texData.textureID;
+			}
 		}
 	} else {
 		ofPixels ipix;
 		if( ofLoadImage(ipix, data->settings.filePath) ) {
 			bLoadOk = true;
-			texFormat = GL_RGB;
+			mGLInternalFormat = GL_RGB;
 			srcTex.loadData(ipix);
+			srcTexId = srcTex.texData.textureID;
 		}
 	}
 	if( !bLoadOk ) {
-		ofLogWarning("ofCubeMap :: failed to load image from ") << data->settings.filePath;
+		ofLogError("ofCubeMap :: failed to load image from ") << data->settings.filePath;
 	} else {
-		srcTex.setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
-		srcTex.setTextureMinMagFilter(GL_LINEAR, GL_LINEAR);
-#if !defined(TARGET_OPENGLES) && defined(GL_TEXTURE_CUBE_MAP_SEAMLESS)
+#if defined(GL_TEXTURE_CUBE_MAP_SEAMLESS)
 		glEnable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
 #endif
 		
@@ -376,25 +416,22 @@ bool ofCubeMap::load( ofCubeMapSettings aSettings ) {
 			data->settings.preFilterRes = ofNextPow2(data->settings.preFilterRes);
 		}
 		
-		_createCubeMap(srcTex);
+		_createCubeMap(srcTexId);
 		if( isHdr() ) {
 			
 			int srcCubeFSize = std::max(256, data->settings.preFilterRes);
-			GLuint cubeFid = _createFloatCubeMap(srcTex, srcCubeFSize );
-			
+			GLuint cubeFid = _createFloatCubeMap(srcTexId, srcCubeFSize );
 			// figure out the number of mip maps //
-			data->maxMipLevels = log2(data->settings.preFilterRes) + 1;
+			data->maxMipLevels = log2(srcCubeFSize)+1;
 			
 			auto encFolder = data->settings.cacheDirectory;
 			if( !encFolder.empty() ) {
 				if( !ofDirectory::doesDirectoryExist( data->settings.cacheDirectory )) {
-					#if !defined(TARGET_OPENGLES)
+					#if !defined(TARGET_EMSCRIPTEN)
 					if(!ofDirectory::createDirectory( data->settings.cacheDirectory )) {
 						ofLogWarning("ofCubeMap :: load : unable to create directory: ") << data->settings.cacheDirectory;
 					}
 					#endif
-				} else {
-					
 				}
 				encFolder = data->settings.cacheDirectory;
 			}
@@ -404,9 +441,16 @@ bool ofCubeMap::load( ofCubeMapSettings aSettings ) {
 			of::filesystem::path cachePrefilterName { baseName };
 			cachePrefilterName += ("_pre_"+ofToString(data->settings.preFilterRes,0)+".exr");
 			
+			#if defined(TARGET_EMSCRIPTEN)
+			if(data->settings.overwriteCache){
+				data->settings.overwriteCache = false;
+				ofLogNotice("ofCubeMap :: data->settings.overwriteCache is not supported on EMSCRIPTEN: ");
+			}
+			#endif
+			
 			bool bHasCachedIrr = false;
 			bool bHasCachedPre = false;
-			if( data->settings.useCache && !data->settings.overwriteCache ) {
+			if( data->settings.useCache && !data->settings.overwriteCache ){
 				bHasCachedIrr = _loadIrradianceMap(encFolder / cacheIrrName);
 				ofLogVerbose("ofCubeMap :: _loadIrradianceMap: ") << bHasCachedIrr;
 				bHasCachedPre = _loadPrefilterMap(encFolder / cachePrefilterName);
@@ -419,18 +463,23 @@ bool ofCubeMap::load( ofCubeMapSettings aSettings ) {
 			bMakeCache = false;
 			#endif
 			
-			if( !bHasCachedIrr ) {
+			if(!bHasCachedIrr){
 				ofLogVerbose("ofCubeMap :: going to create irradiance map");
-				_createIrradianceMap(cubeFid,bMakeCache, encFolder / cacheIrrName);
+				_createIrradianceMap(cubeFid, bMakeCache, encFolder / cacheIrrName);
 			}
 			
-			if( !bHasCachedPre ) {
+			if(!bHasCachedPre){
 				ofLogVerbose("ofCubeMap :: going to create pre filtered cube map");
 				_createPrefilteredCubeMap(cubeFid, srcCubeFSize,bMakeCache,encFolder / cachePrefilterName );
 			}
 			
 			glDeleteTextures(1, &cubeFid );
 		}
+	}
+	
+	if(bSrcTexIdGenerated) {
+		// clean up the texture that was generated for the cube map if opengl es
+		glDeleteTextures(1, &srcTexId);
 	}
 	
 	if( bArbTexEnabled ) {
@@ -529,43 +578,63 @@ bool ofCubeMap::hasPrefilteredMap() {
 }
 
 //--------------------------------------------------------------
-bool ofCubeMap::hasIrradianceMap() {
+bool ofCubeMap::hasIrradianceMap(){
 	if( !data ) return false;
 	return data->bIrradianceAllocated;
 }
 
 //--------------------------------------------------------------
-GLuint ofCubeMap::getTextureId() {
+GLuint ofCubeMap::getTextureId(){
 	if( !data ) return 0;
 	return data->cubeMapId;
 }
 
 //--------------------------------------------------------------
-bool ofCubeMap::isHdr() {
-#if defined(TARGET_OPENGLES) && !defined(TARGET_EMSCRIPTEN)
+bool ofCubeMap::doesSupportHdr(){
+#if !defined(GL_FLOAT)
 	return false;
-#else
-	#ifdef GL_RGBA32F_EXT
-	if( texFormat == GL_RGBA32F_EXT ) {
-		return true;
-	}
-	#endif
-	#ifdef GL_RGB32F_EXT
-	if( texFormat == GL_RGB32F_EXT ) {
-		return true;
-	}
-	#endif
-	#ifdef GL_RGBA16F
-	if( texFormat == GL_RGBA16F ) {
-		return true;
-	}
-	#endif
-	return (texFormat == GL_RGBA32F || texFormat == GL_RGB32F);
 #endif
+#if defined(GL_RGB16F) || defined(GL_RGBA16F) || defined(GL_RGB32F) || defined(GL_RGBA32F)
+	return true;
+#endif
+	return false;
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::setUseBrdfLutTexture( bool ab ) {
+bool ofCubeMap::isHdr(){
+	auto glType = getGLTypeFromInternalFormat();
+	#if defined(GL_FLOAT)
+	if(glType == GL_FLOAT) {
+		return true;
+	}
+	#endif
+	#if defined(GL_HALF_FLOAT)
+	if(glType == GL_HALF_FLOAT) {
+		return true;
+	}
+	#endif
+	
+	return false;
+}
+
+//--------------------------------------------------------------
+bool ofCubeMap::isMediumPrecision(){
+#if defined(GL_RGB16F)
+	if(mGLInternalFormat == GL_RGB16F ) {
+		return true;
+	}
+#endif
+	
+#if defined(GL_RGBA16F)
+	if(mGLInternalFormat == GL_RGBA16F ) {
+		return true;
+	}
+#endif
+	return false;
+}
+
+//--------------------------------------------------------------
+void ofCubeMap::setUseBrdfLutTexture(bool ab){
 	#ifdef TARGET_OPENGLES
 	data->settings.useLutTex = false;
 	ofLogWarning("ofCubeMap::setUseBrdfLutTexture") << " brdf lut texture not supported on GLES.";
@@ -579,38 +648,39 @@ void ofCubeMap::setUseBrdfLutTexture( bool ab ) {
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::_createCubeMap(ofTexture& aSrcTex) {
+void ofCubeMap::_createCubeMap(GLuint aSrcTexId) {
 	
 	if( !data->bCubeMapAllocated ) {
 		data->bCubeMapAllocated = true;
 		glGenTextures(1, &data->cubeMapId );
 		retain(data->cubeMapId);
 	}
+	
+	auto internalFormat = mGLInternalFormat;
+	auto glFormat = getGLFormatFromInternalFormat();
+	auto glType = getGLTypeFromInternalFormat();
 		
-	GLuint internalFormat = ofGetGLInternalFormatFromPixelFormat(OF_PIXELS_RGB);
+	internalFormat = ofGetGLInternalFormatFromPixelFormat(OF_PIXELS_RGB);
 	#ifdef TARGET_OPENGLES
 	internalFormat = ofGetGLInternalFormatFromPixelFormat(OF_PIXELS_RGBA);
 	#endif
-	
-	GLuint texStorageFormat = GL_UNSIGNED_BYTE;
-	GLuint gFormat = GL_RGB;
+
+	glType = GL_UNSIGNED_BYTE;
+	glFormat = GL_RGB;
 	#ifdef TARGET_OPENGLES
-	gFormat = GL_RGBA;
+	glFormat = GL_RGBA;
 	#endif
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, data->cubeMapId);
 	
 	for (GLint i = 0 ; i < 6 ; i++) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, internalFormat, data->settings.resolution, data->settings.resolution, 0, gFormat, texStorageFormat, NULL);
+		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, internalFormat, data->settings.resolution, data->settings.resolution, 0, glFormat, glType, NULL);
 	}
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 	
 	_configureCubeTextures( data->cubeMapId, true );
-	
-	
-	_equiRectToCubeMap( data->cubeMapId, aSrcTex, data->settings.resolution, true );
-	
+	_equiRectToCubeMap( data->cubeMapId, aSrcTexId, data->settings.resolution, true );
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, data->cubeMapId);
 	glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
@@ -619,7 +689,7 @@ void ofCubeMap::_createCubeMap(ofTexture& aSrcTex) {
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::_configureCubeTextures(GLuint aCubeMapId, bool abLinearMipLinear) {
+void ofCubeMap::_configureCubeTextures(GLuint aCubeMapId, bool abLinearMipLinear){
 	
 	GLenum textureTarget = getTextureTarget();
 	glBindTexture(textureTarget, aCubeMapId );
@@ -629,7 +699,9 @@ void ofCubeMap::_configureCubeTextures(GLuint aCubeMapId, bool abLinearMipLinear
 	} else {
 		glTexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	}
+	
 	glTexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	
 	glTexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 #ifdef GL_TEXTURE_WRAP_R
@@ -639,35 +711,35 @@ void ofCubeMap::_configureCubeTextures(GLuint aCubeMapId, bool abLinearMipLinear
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::_initEmptyTextures(GLuint aCubeMapId, int aSize) {
+void ofCubeMap::_initEmptyTextures(GLuint aCubeMapId, int aSize){
 	
 	GLenum textureTarget = getTextureTarget();
 	glBindTexture(textureTarget, aCubeMapId );
-	GLuint texStorageFormat = getTexStorageFormat();
-	GLuint gFormat = getGlTypeFromInternalFormat();
+	auto glFormat = getGLFormatFromInternalFormat();
+	auto glType = getGLTypeFromInternalFormat();
 	
 	for (unsigned int i = 0; i < 6; i++) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, texFormat, aSize, aSize, 0, gFormat, texStorageFormat, nullptr );
+		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, mGLInternalFormat, aSize, aSize, 0, glFormat, glType, nullptr );
 	}
 	
 	glBindTexture(getTextureTarget(), 0);
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::_initEmptyTextures(GLuint aCubeMapId, GLuint aInternalFormat, int aSize, int aNumMipMaps ) {
+void ofCubeMap::_initEmptyTextures(GLuint aCubeMapId, GLint aInternalFormat, int aSize, int aNumMipMaps ){
 	GLenum textureTarget = getTextureTarget();
 	glBindTexture(textureTarget, aCubeMapId );
-	GLuint texStorageFormat = getTexStorageFormat(aInternalFormat);
-	GLuint gFormat = getGlTypeFromInternalFormat(aInternalFormat);
+	auto glFormat = getGLFormatFromInternalFormat(aInternalFormat);
+	auto glType = getGLTypeFromInternalFormat(aInternalFormat);
 	
 	for (int mip = 0; mip < data->maxMipLevels; mip++) {
 		// reisze framebuffer according to mip-level size.
-		unsigned int mipWidth  = static_cast<unsigned int>(data->settings.preFilterRes * std::pow(0.5, mip));
+		unsigned int mipWidth  = static_cast<unsigned int>(aSize * std::pow(0.5, mip));
 		if(mipWidth < 1 ) {
 			mipWidth = 1;
 		}
 		for (unsigned int i = 0; i < 6; i++) {
-			glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, aInternalFormat, mipWidth, mipWidth, 0, gFormat, texStorageFormat, nullptr );
+			glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, aInternalFormat, mipWidth, mipWidth, 0, glFormat, glType, nullptr );
 		}
 	}
 	
@@ -675,33 +747,41 @@ void ofCubeMap::_initEmptyTextures(GLuint aCubeMapId, GLuint aInternalFormat, in
 }
 
 //--------------------------------------------------------------
-GLuint ofCubeMap::_createFloatCubeMap(ofTexture& aSrcTex, int aSrcRes) {
+GLuint ofCubeMap::_createFloatCubeMap(GLuint aSrcTexId, int aSrcRes){
 	GLuint cubeTexF;
 	glGenTextures(1, &cubeTexF );
-			
-	GLuint texStorageFormat = getTexStorageFormat();
-	GLuint gFormat = getGlTypeFromInternalFormat();
+	
+	auto glFormat = getGLFormatFromInternalFormat();
+	auto glType = getGLTypeFromInternalFormat();
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, cubeTexF );
 	
 	for (GLint i = 0 ; i < 6 ; i++) {
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, texFormat, aSrcRes, aSrcRes, 0, gFormat, texStorageFormat, NULL);
+		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, mGLInternalFormat, aSrcRes, aSrcRes, 0, glFormat, glType, NULL);
 	}
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 	
 	_configureCubeTextures( cubeTexF, true );
-	_equiRectToCubeMap( cubeTexF, aSrcTex, aSrcRes, false );
+	_equiRectToCubeMap( cubeTexF, aSrcTexId, aSrcRes, false );
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, cubeTexF);
 	glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
 	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 	
+	
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if( status != GL_FRAMEBUFFER_COMPLETE ) {
+		ofLogError("ofCubeMap :: _createFloatCubeMap : fbo ERROR");
+	} else {
+		ofLogVerbose("ofCubeMap :: _createFloatCubeMap : fbo COMPLETE");
+	}
+	
 	return cubeTexF;
 }
 
 //--------------------------------------------------------------
-void ofCubeMap::_equiRectToCubeMap( GLuint& aCubeTexId, ofTexture& aSrcTex, int aSrcRes, bool aBConvertToNonFloat ) {
+void ofCubeMap::_equiRectToCubeMap( GLuint& aCubeTexId, GLuint aSrcTexId, int aSrcRes, bool aBConvertToNonFloat ) {
 	bool bShaderLoaded = _loadEquiRectToCubeMapShader();
 	if( !bShaderLoaded ) {
 		ofLogError("ofCubeMap::_equiRectToCubeMap : error loading shader");
@@ -711,9 +791,9 @@ void ofCubeMap::_equiRectToCubeMap( GLuint& aCubeTexId, ofTexture& aSrcTex, int 
 	_allocateCubeMesh();
 	std::vector<glm::mat4> views = _getViewMatrices( glm::vec3(0,0,0) );
 	
-	unsigned int captureFBO;
+	GLuint captureFBO;
 	glGenFramebuffers(1, &captureFBO);
-	glBindFramebuffer(GL_FRAMEBUFFER, captureFBO );
+	glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)captureFBO );
 	
 	ofSetColor( 255 );
 		
@@ -721,11 +801,11 @@ void ofCubeMap::_equiRectToCubeMap( GLuint& aCubeTexId, ofTexture& aSrcTex, int 
 	ofViewport(0, 0, aSrcRes, aSrcRes, false);
 	
 	shaderEquiRectToCubeMap.begin();
-	shaderEquiRectToCubeMap.setUniformTexture("uEquirectangularTex", aSrcTex, 0 );
+	shaderEquiRectToCubeMap.setUniformTexture("uEquirectangularTex", GL_TEXTURE_2D, aSrcTexId, 0);
 	shaderEquiRectToCubeMap.setUniformMatrix4f("uProjection", projectionMat );
 	shaderEquiRectToCubeMap.setUniform1f("uFlipY", data->settings.flipVertically ? 1.0f : 0.0f );
 	shaderEquiRectToCubeMap.setUniform1f("uConvertToNonFloat", aBConvertToNonFloat ? 1.0f : 0.0f );
-	
+		
 	for (unsigned int i = 0; i < 6; i++) {
 		shaderEquiRectToCubeMap.setUniformMatrix4f("uView", views[i]);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, aCubeTexId, 0);
@@ -734,6 +814,13 @@ void ofCubeMap::_equiRectToCubeMap( GLuint& aCubeTexId, ofTexture& aSrcTex, int 
 	}
 	shaderEquiRectToCubeMap.end();
 	ofPopView();
+	
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+	if( status != GL_FRAMEBUFFER_COMPLETE ) {
+		ofLogError("ofCubeMap :: _equiRectToCubeMap : fbo ERROR");
+	} else {
+		ofLogVerbose("ofCubeMap :: _equiRectToCubeMap : fbo COMPLETE; resolution: ") << aSrcRes;
+	}
 	
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glDeleteFramebuffers(1, &captureFBO);
@@ -764,7 +851,7 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 	
 	if( aBMakeCache ) {
 				
-		ofLogNotice("ofCubeMap :: _createIrradianceMap : making cache");
+		ofLogVerbose("ofCubeMap :: _createIrradianceMap : making cache");
 		
 		ofFbo tfbo;
 		//	fbo.clear();
@@ -775,7 +862,7 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 		//	fboSettings.numColorbuffers = 6;
 		fboSettings.useDepth = false;
 //		fboSettings.textureTarget = GL_TEXTURE_2D;
-		fboSettings.internalformat = texFormat;
+		fboSettings.internalformat = mGLInternalFormat;
 		tfbo.allocate(fboSettings);
 				
 		ofSetColor( 255 );
@@ -805,11 +892,11 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 		if(bAllPixelsCreated) {
 			GLenum textureTarget = getTextureTarget();
 			glBindTexture(textureTarget, data->irradianceMapId );
-			GLuint texStorageFormat = getTexStorageFormat();
-			GLuint gFormat = getGlTypeFromInternalFormat();
+			auto glFormat = getGLFormatFromInternalFormat();
+			auto glType = getGLTypeFromInternalFormat();
 			// we need to create a single image //
 			for (unsigned int i = 0; i < 6; i++) {
-				glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, texFormat, fpixels[i].getWidth(), fpixels[i].getHeight(), 0, gFormat, texStorageFormat, fpixels[i].getData() );
+				glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, mGLInternalFormat, fpixels[i].getWidth(), fpixels[i].getHeight(), 0, glFormat, glType, fpixels[i].getData() );
 			}
 			glBindTexture(textureTarget, 0 );
 			
@@ -826,7 +913,7 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 			tfbo.allocate( fboSettings );
 			ofSetColor(255);
 			tfbo.begin(); {
-				ofClear(0);
+				ofClear(0, 255);
 				ofTexture ftex;
 				for (unsigned int j = 0; j < 6; j++) {
 					ftex.loadData( fpixels[j] );
@@ -851,8 +938,7 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 		_initEmptyTextures(data->irradianceMapId, data->settings.irradianceRes );
 		_configureCubeTextures(data->irradianceMapId, false);
 		
-		unsigned int captureFBO;
-
+		GLuint captureFBO;
 		glGenFramebuffers(1, &captureFBO);
 		glBindFramebuffer(GL_FRAMEBUFFER, captureFBO );
 
@@ -872,6 +958,13 @@ void ofCubeMap::_createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const
 		}
 
 		shaderIrradianceMap.end();
+		
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		if( status != GL_FRAMEBUFFER_COMPLETE ) {
+			ofLogError("ofCubeMap :: _createIrradianceMap : fbo ERROR");
+		} else {
+			ofLogVerbose("ofCubeMap :: _createIrradianceMap : fbo COMPLETE");
+		}
 
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 		glDeleteFramebuffers(1, &captureFBO);
@@ -903,9 +996,7 @@ bool ofCubeMap::_loadIrradianceMap(const of::filesystem::path & aCachePath) {
 		glGenTextures(1, &data->irradianceMapId );
 		retain(data->irradianceMapId);
 	}
-	
-//	_configureCubeTextures(data->irradianceMapId, false);
-	
+		
 	int texSize = fullPix.getWidth() / 3;
 	
 	ofFloatPixels fpix;
@@ -916,13 +1007,10 @@ bool ofCubeMap::_loadIrradianceMap(const of::filesystem::path & aCachePath) {
 	
 	glBindTexture(textureTarget, data->irradianceMapId );
 	
-	GLuint loadTexFormat = texFormat;
-#if defined(TARGET_EMSCRIPTEN)
-	loadTexFormat = GL_RGBA32F;
-#endif
+	auto loadTexGLInternalFormat = mGLInternalFormat;
 	
-	GLuint texStorageFormat = getTexStorageFormat(loadTexFormat);
-	GLuint gFormat = getGlTypeFromInternalFormat(loadTexFormat);
+	auto glFormat = getGLFormatFromInternalFormat(loadTexGLInternalFormat);
+	auto glType = getGLTypeFromInternalFormat(loadTexGLInternalFormat);
 	
 	for(unsigned int j = 0; j < 6; j++ ) {
 		//cropTo(ofPixels_<PixelType> &toPix, size_t x, size_t y, size_t _width, size_t _height)
@@ -930,7 +1018,7 @@ bool ofCubeMap::_loadIrradianceMap(const of::filesystem::path & aCachePath) {
 		if( fpix.getNumChannels() != numChannels ) {
 			fpix.setNumChannels(numChannels);
 		}
-		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + j, 0, loadTexFormat, fpix.getWidth(), fpix.getHeight(), 0, gFormat, texStorageFormat, fpix.getData() );
+		glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + j, 0, loadTexGLInternalFormat, fpix.getWidth(), fpix.getHeight(), 0, glFormat, glType, fpix.getData() );
 	}
 	glBindTexture(textureTarget, 0 );
 	
@@ -951,17 +1039,17 @@ void ofCubeMap::_createPrefilteredCubeMap(GLuint aSrcCubeFid, int aSrcRes, bool 
 	retain(data->preFilteredMapId);
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, data->preFilteredMapId);
-
-	GLuint texStorageFormat = getTexStorageFormat();
-	GLuint gFormat = getGlTypeFromInternalFormat();
+	
+	auto glFormat = getGLFormatFromInternalFormat();
+	auto glType = getGLTypeFromInternalFormat();
 	
 	// generate all of the textures and mip maps at once ...
-	//glTexStorage2D(GL_TEXTURE_CUBE_MAP, data->maxMipLevels, texFormat, data->settings.preFilterRes, data->settings.preFilterRes);
+	//glTexStorage2D(GL_TEXTURE_CUBE_MAP, data->maxMipLevels, mGLInternalFormat, data->settings.preFilterRes, data->settings.preFilterRes);
 	// create all of the textures with mip maps //
 	
 	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 	
-	_initEmptyTextures( data->preFilteredMapId, texFormat, data->settings.preFilterRes, data->maxMipLevels );
+	_initEmptyTextures( data->preFilteredMapId, mGLInternalFormat, data->settings.preFilterRes, data->maxMipLevels );
 	
 	_configureCubeTextures(data->preFilteredMapId, true);
 	
@@ -983,7 +1071,7 @@ void ofCubeMap::_createPrefilteredCubeMap(GLuint aSrcCubeFid, int aSrcRes, bool 
 		fboSettings.height = fboSettings.width;
 		fboSettings.numSamples = 0;
 		fboSettings.useDepth = false;
-		fboSettings.internalformat = texFormat;
+		fboSettings.internalformat = mGLInternalFormat;
 		
 		cacheFbo.allocate(fboSettings);
 		cacheFbo.begin(); {
@@ -1018,7 +1106,7 @@ void ofCubeMap::_createPrefilteredCubeMap(GLuint aSrcCubeFid, int aSrcRes, bool 
 			
 			for (unsigned int i = 0; i < 6; ++i) {
 				tfbo.begin();
-				ofClear(0);
+				ofClear(0,255);
 				shaderPreFilterMap.begin();
 				shaderPreFilterMap.setUniformTexture("environmentMap", getTextureTarget(), aSrcCubeFid, 0 );
 				shaderPreFilterMap.setUniformMatrix4f("uProjection", projectionMat );
@@ -1047,7 +1135,7 @@ void ofCubeMap::_createPrefilteredCubeMap(GLuint aSrcCubeFid, int aSrcRes, bool 
 			for (unsigned int i = 0; i < 6; ++i) {
 				if( fpixels[i].getWidth() > 0 && fpixels[i].getHeight() > 0 ) {
 //					// must use glTexSubImage with glTexStorage2D
-					glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, 0, 0, mipWidth, mipWidth, gFormat, texStorageFormat,fpixels[i].getData());
+					glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, 0, 0, mipWidth, mipWidth, glFormat, glType,fpixels[i].getData());
 
 				}
 			}
@@ -1120,15 +1208,11 @@ bool ofCubeMap::_loadPrefilterMap( const of::filesystem::path & aCachePath ) {
 	retain(data->preFilteredMapId);
 	
 	
-	GLuint loadTexFormat = texFormat;
-#if defined(TARGET_EMSCRIPTEN)
-	loadTexFormat = GL_RGBA32F;
-#endif
+	auto loadTexGLInternalFormat = mGLInternalFormat;
+	auto glFormat = getGLFormatFromInternalFormat(loadTexGLInternalFormat);
+	auto glType = getGLTypeFromInternalFormat(loadTexGLInternalFormat);
 	
-	GLuint texStorageFormat = getTexStorageFormat(loadTexFormat);
-	GLuint gFormat = getGlTypeFromInternalFormat(loadTexFormat);
-	
-	_initEmptyTextures( data->preFilteredMapId, loadTexFormat, data->settings.preFilterRes, data->maxMipLevels );
+	_initEmptyTextures( data->preFilteredMapId, loadTexGLInternalFormat, data->settings.preFilterRes, data->maxMipLevels );
 	
 	//glBindTexture(GL_TEXTURE_CUBE_MAP, data->preFilteredMapId);
 	//glTexStorage2D(GL_TEXTURE_CUBE_MAP, data->maxMipLevels, loadTexFormat, data->settings.preFilterRes, data->settings.preFilterRes);
@@ -1157,7 +1241,7 @@ bool ofCubeMap::_loadPrefilterMap( const of::filesystem::path & aCachePath ) {
 			if( fpix.getNumChannels() != numChannels ) {
 				fpix.setNumChannels(numChannels);
 			}
-			glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, 0, 0, mipWidth, mipWidth, gFormat, texStorageFormat,fpix.getData());
+			glTexSubImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, mip, 0, 0, mipWidth, mipWidth, glFormat, glType, fpix.getData());
 		}
 		
 		if( mip > 0 ) {
@@ -1258,20 +1342,59 @@ std::vector<glm::mat4> ofCubeMap::_getViewMatrices(const glm::vec3& apos ) {
 }
 
 //--------------------------------------------------------------
-GLuint ofCubeMap::getTexStorageFormat() {
-	return getTexStorageFormat(texFormat);
+GLenum ofCubeMap::getGLFormatFromInternalFormat() {
+	return getGLFormatFromInternalFormat(mGLInternalFormat);
 }
 
 //--------------------------------------------------------------
-GLuint ofCubeMap::getTexStorageFormat(GLuint aInternalFormat) {
-	#if !defined(TARGET_OPENGLES) || defined(TARGET_EMSCRIPTEN)
+GLenum ofCubeMap::getGLFormatFromInternalFormat(GLint aInternalFormat) {
+#if defined(GL_RGBA32F)
+	if( aInternalFormat == GL_RGBA32F ) {
+		return GL_RGBA;
+	}
+#endif
+#if defined(GL_RGBA16F)
+	if( aInternalFormat == GL_RGBA16F ) {
+		return GL_RGBA;
+	}
+#endif
+	
+#ifdef GL_RGBA32F_EXT
+	if( aInternalFormat == GL_RGBA32F_EXT ) {
+		return GL_RGBA;
+	}
+#endif
+	return GL_RGB;
+}
+
+//--------------------------------------------------------------
+GLenum ofCubeMap::getGLTypeFromInternalFormat(){
+	return getGLTypeFromInternalFormat(mGLInternalFormat);
+}
+
+//--------------------------------------------------------------
+GLenum ofCubeMap::getGLTypeFromInternalFormat(GLint aInternalFormat){
+	#if defined(GL_RGB32F)
 	if( aInternalFormat == GL_RGB32F ) {
 		return GL_FLOAT;
-	} else if( aInternalFormat == GL_RGBA32F ) {
-		return GL_FLOAT;
-	} else if( aInternalFormat == GL_RGBA16F ) {
-		return GL_HALF_FLOAT;
 	}
+	#endif
+	#if defined(GL_RGBA32F)
+	if( aInternalFormat == GL_RGBA32F ) {
+		return GL_FLOAT;
+	}
+	#endif
+	#if defined(GL_RGBA16F)
+	if( aInternalFormat == GL_RGBA16F ) {
+		return GL_FLOAT;
+	}
+	#endif
+	#if defined(GL_RGB16F)
+	if( aInternalFormat == GL_RGB16F ) {
+		return GL_FLOAT;
+	}
+	#endif
+	
 	#ifdef GL_RGBA32F_EXT
 	if( aInternalFormat == GL_RGBA32F_EXT ) {
 		return GL_FLOAT;
@@ -1282,42 +1405,13 @@ GLuint ofCubeMap::getTexStorageFormat(GLuint aInternalFormat) {
 		return GL_FLOAT;
 	}
 	#endif
-	#endif
+	
 	return GL_UNSIGNED_BYTE;
 }
 
 //--------------------------------------------------------------
-GLuint ofCubeMap::getGlTypeFromInternalFormat() {
-	return getGlTypeFromInternalFormat(texFormat);
-}
-
-//--------------------------------------------------------------
-GLuint ofCubeMap::getGlTypeFromInternalFormat(GLuint aInternalFormat) {
-	#if !defined(TARGET_OPENGLES) || defined(TARGET_EMSCRIPTEN)
-		if( aInternalFormat == GL_RGBA32F ) {
-			return GL_RGBA;
-		}
-		if( aInternalFormat == GL_RGBA16F ) {
-			return GL_RGBA;
-		}
-	
-		#ifdef GL_RGBA32F_EXT
-		if( aInternalFormat == GL_RGBA32F_EXT ) {
-			return GL_RGBA;
-		}
-		#endif
-		#ifdef GL_RGB32F_EXT
-		if( aInternalFormat == GL_RGB32F_EXT ) {
-			return GL_RGB;
-		}
-		#endif
-	#endif
-	return GL_RGB;
-}
-
-//--------------------------------------------------------------
-int ofCubeMap::getNumPixelChannels() {
-	GLuint glType = getGlTypeFromInternalFormat();
+int ofCubeMap::getNumPixelChannels(){
+	GLenum glType = getGLFormatFromInternalFormat();
 	if( glType == GL_RGBA ) {
 		return 4;
 	}
@@ -1346,9 +1440,10 @@ bool ofCubeMap::_loadEquiRectToCubeMapShader() {
 			return true;
 		} else {
 			shaderEquiRectToCubeMap.unload();
-			ofLogNotice("ofCubeMap::_loadEquiRectToCubeMapShader : unable to create shaderEquiRectToCubeMap shader ");
+			ofLogError("ofCubeMap::_loadEquiRectToCubeMapShader : unable to create shaderEquiRectToCubeMap shader ");
 			return false;
 		}
 	}
 	return true;
 }
+

--- a/libs/openFrameworks/gl/ofCubeMap.h
+++ b/libs/openFrameworks/gl/ofCubeMap.h
@@ -24,6 +24,7 @@ public:
 		bool useCache = false;
 		bool useLutTex = false;
 		bool flipVertically = true;
+		bool useMaximumPrecision = false;
 				
 		int resolution = 512;
 #ifdef TARGET_OPENGLES
@@ -104,7 +105,9 @@ public:
 	
 	int getFaceResolution() { return data->settings.resolution; }
 	GLuint getTextureId();
+	bool doesSupportHdr();
 	bool isHdr();
+	bool isMediumPrecision();
 	
 	void setExposure(float aExposure);
 	float getExposure() { return data->exposure; }
@@ -123,9 +126,9 @@ protected:
 	void _drawCubeEnd();
 	
 	void _checkSetup();
-	void _createCubeMap(ofTexture& aSrcTex);
-	GLuint _createFloatCubeMap(ofTexture& aSrcTex, int aSrcRes);
-	void _equiRectToCubeMap( GLuint& aCubeTexId, ofTexture& aSrcTex, int aSrcRes, bool aBConvertToNonFloat );
+	void _createCubeMap(GLuint aSrcTexId);
+	GLuint _createFloatCubeMap(GLuint aSrcTexId, int aSrcRes);
+	void _equiRectToCubeMap( GLuint& aCubeTexId, GLuint aSrcTexId, int aSrcRes, bool aBConvertToNonFloat );
 	
 	void _createIrradianceMap(GLuint aSrcCubeFid, bool aBMakeCache, const of::filesystem::path & aCachePath);
 	bool _loadIrradianceMap( const of::filesystem::path & aCachePath );
@@ -135,30 +138,33 @@ protected:
 	
 	static void _createBrdfLUT();
 	
-	
 	void _configureCubeTextures(GLuint aCubeMapId,bool abLinearMipLinear);
 	void _initEmptyTextures(GLuint aCubeMapId, int aSize);
-	void _initEmptyTextures(GLuint aCubeMapId, GLuint aInternalFormat, int aSize, int aNumMipMaps );
+	void _initEmptyTextures(GLuint aCubeMapId, GLint aInternalFormat, int aSize, int aNumMipMaps );
 	void _allocateCubeMesh();
 	std::vector<glm::mat4> _getViewMatrices(const glm::vec3& apos);
 	
 	bool _loadRenderShader();
 	bool _loadEquiRectToCubeMapShader();
 	
-	GLuint getTexStorageFormat();
-	GLuint getTexStorageFormat( GLuint aInternalFormat );
+	/// \brief get the GL format from the internalFormat, ie. GL_RGB, GL_RGBA
+	/// \return the GL format as GLenum
+	GLenum getGLFormatFromInternalFormat();
+	GLenum getGLFormatFromInternalFormat(GLint aInternalFormat);
 	
-	GLuint getGlTypeFromInternalFormat();
-	GLuint getGlTypeFromInternalFormat(GLuint aInternalFormat);
+	/// \brief get the GL type from the internalFormat, ie. GL_FLOAT
+	/// \return the GL type as GLenum
+	GLenum getGLTypeFromInternalFormat();
+	GLenum getGLTypeFromInternalFormat( GLint aInternalFormat );
+	
 	int getNumPixelChannels();
 	
-	GLuint texFormat = GL_RGB;
+	GLint mGLInternalFormat;
 	
 	glm::mat4 projectionMat;
 	
 	static ofTexture sBrdfLutTex;
 	static ofVboMesh sCubeMesh;
-	//ofMesh sCubeMesh;
 	ofShader shaderEquiRectToCubeMap;
 	ofShader shaderRender;
 	ofShader shaderIrradianceMap;


### PR DESCRIPTION
Some shader optimizations, naming conventions and support for float16 textures to work properly on open gl es mobile devices. 

I have checked on iOS via Safari and DuckDuckGo.
https://nickhardeman.com/temp/OFExamples/MaterialPBR/

This is what should be output
![image](https://github.com/openframeworks/openFrameworks/assets/142694/e13c4cd3-0fd1-4f76-9faa-34bc97f6962c)
