### PR TITLE
ofxSvg::fixSvgString(): addition to xml preprocessor

### DIFF
--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -1,14 +1,14 @@
-#include "ofxSvg.h"
 #include "ofConstants.h"
+#include "ofxSvg.h"
 #include <locale>
 
 using std::string;
 using std::vector;
 
-extern "C"{
-	#include "svgtiny.h"
+extern "C" {
+#include "svgtiny.h"
 }
-ofxSvg::~ofxSvg(){
+ofxSvg::~ofxSvg() {
 	paths.clear();
 }
 
@@ -20,14 +20,14 @@ float ofxSvg::getHeight() const {
 	return height;
 }
 
-int ofxSvg::getNumPath(){
+int ofxSvg::getNumPath() {
 	return paths.size();
 }
-ofPath & ofxSvg::getPathAt(int n){
+ofPath & ofxSvg::getPathAt(int n) {
 	return paths[n];
 }
 
-void ofxSvg::load(of::filesystem::path fileName){
+void ofxSvg::load(of::filesystem::path fileName) {
 	// fileName = ofToDataPath(fileName);
 	std::string file = ofToDataPath(fileName);
 
@@ -39,58 +39,57 @@ void ofxSvg::load(of::filesystem::path fileName){
 	// }
 
 	// ofBuffer buffer = ofBufferFromFile(fileName);
-	
+
 	// loadFromString(buffer.getText(), fileName);
 
-	if(file.compare("") == 0){
+	if (file.compare("") == 0) {
 		ofLogError("ofxSVG") << "load(): path does not exist: \"" << file << "\"";
 		return;
 	}
 
 	ofBuffer buffer = ofBufferFromFile(file);
-	
-	loadFromString(buffer.getText(), file);
 
+	loadFromString(buffer.getText(), file);
 }
 
-void ofxSvg::loadFromString(std::string stringdata, std::string urlstring){
-	
+void ofxSvg::loadFromString(std::string stringdata, std::string urlstring) {
+
 	// goes some way to improving SVG compatibility
 	fixSvgString(stringdata);
 
-	const char* data = stringdata.c_str();
+	const char * data = stringdata.c_str();
 	int size = stringdata.size();
-	const char* url = urlstring.c_str();
+	const char * url = urlstring.c_str();
 
 	struct svgtiny_diagram * diagram = svgtiny_create();
 	// Switch to "C" locale as svgtiny expect it to parse floating points (issue 6644)
-	std::locale prev_locale = std::locale::global( std::locale::classic() );
+	std::locale prev_locale = std::locale::global(std::locale::classic());
 	svgtiny_code code = svgtiny_parse(diagram, data, size, url, 0, 0);
 	// Restore locale
-	std::locale::global( prev_locale );
+	std::locale::global(prev_locale);
 
-	if(code != svgtiny_OK){
+	if (code != svgtiny_OK) {
 		string msg;
-		switch(code){
-		 case svgtiny_OUT_OF_MEMORY:
-			 msg = "svgtiny_OUT_OF_MEMORY";
-			 break;
+		switch (code) {
+		case svgtiny_OUT_OF_MEMORY:
+			msg = "svgtiny_OUT_OF_MEMORY";
+			break;
 
-		 /*case svgtiny_LIBXML_ERROR:
+			/*case svgtiny_LIBXML_ERROR:
 			 msg = "svgtiny_LIBXML_ERROR";
 			 break;*/
 
-		 case svgtiny_NOT_SVG:
-			 msg = "svgtiny_NOT_SVG";
-			 break;
+		case svgtiny_NOT_SVG:
+			msg = "svgtiny_NOT_SVG";
+			break;
 
-		 case svgtiny_SVG_ERROR:
-			 msg = "svgtiny_SVG_ERROR: line " + ofToString(diagram->error_line) + ": " + diagram->error_message;
-			 break;
+		case svgtiny_SVG_ERROR:
+			msg = "svgtiny_SVG_ERROR: line " + ofToString(diagram->error_line) + ": " + diagram->error_message;
+			break;
 
-		 default:
-			 msg = "unknown svgtiny_code " + ofToString(code);
-			 break;
+		default:
+			msg = "unknown svgtiny_code " + ofToString(code);
+			break;
 		}
 		ofLogError("ofxSVG") << "load(): couldn't parse \"" << urlstring << "\": " << msg;
 	}
@@ -100,45 +99,45 @@ void ofxSvg::loadFromString(std::string stringdata, std::string urlstring){
 	svgtiny_free(diagram);
 }
 
-void ofxSvg::fixSvgString(std::string& xmlstring) {
-	
+void ofxSvg::fixSvgString(std::string & xmlstring) {
+
 	ofXml xml;
-	
+
 	xml.parse(xmlstring);
-	
+
 	// so it turns out that if the stroke width is <1 it rounds it down to 0,
 	// and makes it disappear because svgtiny stores strokewidth as an integer!
 	ofXml::Search strokeWidthElements = xml.find("//*[@stroke-width]");
-	if(!strokeWidthElements.empty()) {
-		for(ofXml & element: strokeWidthElements){
+	if (!strokeWidthElements.empty()) {
+		for (ofXml & element : strokeWidthElements) {
 			//cout << element.toString() << endl;
 			float strokewidth = element.getAttribute("stroke-width").getFloatValue();
-			strokewidth = MAX(1,round(strokewidth));
+			strokewidth = MAX(1, round(strokewidth));
 			element.getAttribute("stroke-width").set(strokewidth);
 		}
 	}
-	
+
 	// Affinity Designer does not set width/height as pixels but as a percentage
 	// and relies on the "viewBox" to convey the size of things. this applies the
 	// viewBox to the width and height.
-	
+
 	std::vector<std::string> rect;
-	for (ofXml & element: xml.find("//*[@viewBox]")){
+	for (ofXml & element : xml.find("//*[@viewBox]")) {
 		rect = ofSplitString(element.getAttribute("viewBox").getValue(), " ");
 	}
-	
+
 	if (rect.size() == 4) {
-		
-		for (ofXml & element: xml.find("//*[@width]")){
-			if (element.getAttribute("width").getValue()=="100%") {
+
+		for (ofXml & element : xml.find("//*[@width]")) {
+			if (element.getAttribute("width").getValue() == "100%") {
 				auto w = ofToFloat(rect.at(2));
 				ofLogWarning("ofxSvg::fixSvgString()") << "the SVG size is provided as percentage, which svgtiny translates to 0. The width is corrected from the viewBox width: " << w;
 				element.getAttribute("width").set(w);
 			}
 		}
-		
-		for (ofXml & element: xml.find("//*[@height]")){
-			if (element.getAttribute("height").getValue()=="100%") {
+
+		for (ofXml & element : xml.find("//*[@height]")) {
+			if (element.getAttribute("height").getValue() == "100%") {
 				auto w = ofToFloat(rect.at(3));
 				ofLogWarning("ofxSvg::fixSvgString()") << "the SVG size is provided as percentage, which svgtiny translates to 0. The height is corrected from the viewBox height: " << w;
 				element.getAttribute("height").set(w);
@@ -147,121 +146,114 @@ void ofxSvg::fixSvgString(std::string& xmlstring) {
 	}
 
 	//lib svgtiny doesn't remove elements with display = none, so this code fixes that
-	
+
 	bool finished = false;
-	while(!finished) {
-		
-		ofXml::Search invisibleElements  = xml.find("//*[@display=\"none\"]");
-		
-		if(invisibleElements.empty()) {
+	while (!finished) {
+
+		ofXml::Search invisibleElements = xml.find("//*[@display=\"none\"]");
+
+		if (invisibleElements.empty()) {
 			finished = true;
 		} else {
-			const ofXml& element = invisibleElements[0];
+			const ofXml & element = invisibleElements[0];
 			ofXml parent = element.getParent();
-			if(parent && element) parent.removeChild(element);
+			if (parent && element) parent.removeChild(element);
 		}
-		
 	}
-	
+
 	// implement the SVG "use" element by expanding out those elements into
 	// XML that svgtiny will parse correctly.
 	ofXml::Search useElements = xml.find("//use");
-	if(!useElements.empty()) {
-		
-		for(ofXml & element: useElements){
-			
+	if (!useElements.empty()) {
+
+		for (ofXml & element : useElements) {
+
 			// get the id attribute
 			string id = element.getAttribute("xlink:href").getValue();
 			// remove the leading "#" from the id
 			id.erase(id.begin());
-			
+
 			// find the original definition of that element - TODO add defs into path?
-			string searchstring ="//*[@id='"+id+"']";
+			string searchstring = "//*[@id='" + id + "']";
 			ofXml idelement = xml.findFirst(searchstring);
-			
+
 			// if we found one then use it! (find first returns an empty xml on failure)
-			if(idelement.getAttribute("id").getValue()!="") {
-				
+			if (idelement.getAttribute("id").getValue() != "") {
+
 				// make a copy of that element
 				element.appendChild(idelement);
-				
+
 				// then turn the use element into a g element
 				element.setName("g");
-				
 			}
 		}
 	}
-	
+
 	xmlstring = xml.toString();
-	
 }
 
-void ofxSvg::draw(){
-	for(int i = 0; i < (int)paths.size(); i++){
+void ofxSvg::draw() {
+	for (int i = 0; i < (int)paths.size(); i++) {
 		paths[i].draw();
 	}
 }
 
-void ofxSvg::setupDiagram(struct svgtiny_diagram * diagram){
+void ofxSvg::setupDiagram(struct svgtiny_diagram * diagram) {
 
 	width = diagram->width;
 	height = diagram->height;
 
 	paths.clear();
 
-	for(int i = 0; i < (int)diagram->shape_count; i++){
-		if(diagram->shape[i].path){
+	for (int i = 0; i < (int)diagram->shape_count; i++) {
+		if (diagram->shape[i].path) {
 			paths.push_back(ofPath());
-			setupShape(&diagram->shape[i],paths.back());
-		}else if(diagram->shape[i].text){
+			setupShape(&diagram->shape[i], paths.back());
+		} else if (diagram->shape[i].text) {
 			ofLogWarning("ofxSVG") << "setupDiagram(): text: not implemented yet";
 		}
 	}
 }
 
-void ofxSvg::setupShape(struct svgtiny_shape * shape, ofPath & path){
+void ofxSvg::setupShape(struct svgtiny_shape * shape, ofPath & path) {
 	float * p = shape->path;
 
 	path.setFilled(false);
 
-	if(shape->fill != svgtiny_TRANSPARENT){
+	if (shape->fill != svgtiny_TRANSPARENT) {
 		path.setFilled(true);
 		path.setFillHexColor(shape->fill);
 		path.setPolyWindingMode(OF_POLY_WINDING_NONZERO);
-    }
+	}
 
-	if(shape->stroke != svgtiny_TRANSPARENT){
+	if (shape->stroke != svgtiny_TRANSPARENT) {
 		path.setStrokeWidth(shape->stroke_width);
 		path.setStrokeHexColor(shape->stroke);
 	}
 
-	for(int i = 0; i < (int)shape->path_length;){
-		if(p[i] == svgtiny_PATH_MOVE){
+	for (int i = 0; i < (int)shape->path_length;) {
+		if (p[i] == svgtiny_PATH_MOVE) {
 			path.moveTo(p[i + 1], p[i + 2]);
 			i += 3;
-		}
-		else if(p[i] == svgtiny_PATH_CLOSE){
+		} else if (p[i] == svgtiny_PATH_CLOSE) {
 			path.close();
 
 			i += 1;
-		}
-		else if(p[i] == svgtiny_PATH_LINE){
+		} else if (p[i] == svgtiny_PATH_LINE) {
 			path.lineTo(p[i + 1], p[i + 2]);
 			i += 3;
-		}
-		else if(p[i] == svgtiny_PATH_BEZIER){
+		} else if (p[i] == svgtiny_PATH_BEZIER) {
 			path.bezierTo(p[i + 1], p[i + 2],
-						   p[i + 3], p[i + 4],
-						   p[i + 5], p[i + 6]);
+				p[i + 3], p[i + 4],
+				p[i + 5], p[i + 6]);
 			i += 7;
-		}
-		else{
+		} else {
 			ofLogError("ofxSVG") << "setupShape(): SVG parse error";
 			i += 1;
 		}
 	}
 }
 
-const vector <ofPath> & ofxSvg::getPaths() const{
-    return paths;
+const vector<ofPath> & ofxSvg::getPaths() const {
+	return paths;
 }

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -5,7 +5,6 @@
 #include "ofTypes.h"
 #include "ofXml.h"
 
-
 /// \file
 /// ofxSVG is used for loading and rendering SVG files. It's a wrapper
 /// for the open source C library [Libsvgtiny](https://www.netsurf-browser.org/projects/libsvgtiny/ "Libsvgtiny website"),
@@ -17,43 +16,41 @@
 /// SVG "use" element).
 
 class ofxSvg {
-	public: ~ofxSvg();
+public:
+	~ofxSvg();
 
-		float getWidth() const ;
-		float getHeight() const;
-	
-		/// \brief Loads an SVG file from the provided filename.
-		///
-		/// ~~~~
-		void load(of::filesystem::path fileName);
-	
-		/// \brief Loads an SVG from a text string.
-		///
-		/// Useful for parsing SVG text from sources other than a file. As the
-		/// underlying SVG parsing library requires a url, this method gives
-		/// you the option of providing one.
-		///
-		/// ~~~~
-		void loadFromString(std::string data, std::string url="local");
-	
-		void draw();
+	float getWidth() const;
+	float getHeight() const;
 
-		int getNumPath();
-		ofPath & getPathAt(int n);
-	
-		const std::vector <ofPath> & getPaths() const;
-		static void fixSvgString(std::string& xmlstring);
+	/// \brief Loads an SVG file from the provided filename.
+	///
+	/// ~~~~
+	void load(of::filesystem::path fileName);
 
-	private:
+	/// \brief Loads an SVG from a text string.
+	///
+	/// Useful for parsing SVG text from sources other than a file. As the
+	/// underlying SVG parsing library requires a url, this method gives
+	/// you the option of providing one.
+	///
+	/// ~~~~
+	void loadFromString(std::string data, std::string url = "local");
 
-	
-		float width, height;
+	void draw();
 
-		std::vector <ofPath> paths;
+	int getNumPath();
+	ofPath & getPathAt(int n);
 
-		void setupDiagram(struct svgtiny_diagram * diagram);
-		void setupShape(struct svgtiny_shape * shape, ofPath & path);
+	const std::vector<ofPath> & getPaths() const;
+	static void fixSvgString(std::string & xmlstring);
 
+private:
+	float width, height;
+
+	std::vector<ofPath> paths;
+
+	void setupDiagram(struct svgtiny_diagram * diagram);
+	void setupShape(struct svgtiny_shape * shape, ofPath & path);
 };
 
 typedef ofxSvg ofxSVG;

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -42,10 +42,10 @@ class ofxSvg {
 		ofPath & getPathAt(int n);
 	
 		const std::vector <ofPath> & getPaths() const;
+		static void fixSvgString(std::string& xmlstring);
 
 	private:
 
-		void fixSvgString(std::string& xmlstring);
 	
 		float width, height;
 


### PR DESCRIPTION
Affinity designer exports "flattened" SVG like this:
```xml
<svg width="100%" height="100%" viewBox="0 0 1920 1080" 
version="1.1" xmlns="http://www.w3.org/2000/svg" 
xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
```
this % approach throws of svgtiny and it generates all vertices at (0, 0).

as a reference, the tiger.svg:
```xml
<svg version="1.2" baseProfile="tiny" id="svg2" xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
    x="0px" y="0px" width="900px" height="900px"
    viewBox="0 0 900 900" overflow="inherit" xml:space="preserve">
```

the proposed addition "fixes" this by: (1) checking if a viewBox is defined and (2) checking if width and height are set to 100%. if so, it replaces the 100%'s with the viewBox corresponding values. 

(in other words, it should not be a breaking change as an SVG that has width/height defined as values with not be affected, and an SVG without them (or as %) would not work).

It emits warning when operating.

it also makes fixSvgString() static and public, this is to allow it's use outside of an instance, making it possible to slip into a preprocessing step in ofxSvgLoader(). (note that the method was already processing an inout string reference without accessing any member variables, so was not and instance method per se).
