### PR TITLE
RandomDistributions: explicit parameters for of::random::uniform

### DIFF
--- a/libs/openFrameworks/utils/ofRandomDistributions.h
+++ b/libs/openFrameworks/utils/ofRandomDistributions.h
@@ -18,15 +18,29 @@ namespace of::random {
 
 template <typename T = float, typename... Args>
 std::enable_if_t<std::is_floating_point_v<T>, T>
-uniform(Args &&... args) {
-	std::uniform_real_distribution<T> distr(std::forward<Args>(args)...);
+uniform(T max = 1.0) {
+	std::uniform_real_distribution<T> distr(0, max);
 	return distr(of::random::gen());
 }
 
 template <typename T, typename... Args>
 std::enable_if_t<std::is_integral_v<T>, T>
-uniform(Args &&... args) {
-	std::uniform_int_distribution<T> distr(std::forward<Args>(args)...);
+uniform(T max) {
+	std::uniform_int_distribution<T> distr(0, max);
+	return distr(of::random::gen());
+}
+
+template <typename T = float, typename... Args>
+std::enable_if_t<std::is_floating_point_v<T>, T>
+uniform(T min, T max) {
+	std::uniform_real_distribution<T> distr(min, max);
+	return distr(of::random::gen());
+}
+
+template <typename T, typename... Args>
+std::enable_if_t<std::is_integral_v<T>, T>
+uniform(T min, T max) {
+	std::uniform_int_distribution<T> distr(min, max);
 	return distr(of::random::gen());
 }
 


### PR DESCRIPTION
`of::random::uniform` was exercising perfect forwarding to move arguments into the actual distributions, however this created some ambiguities with zero or one parameters — technically the underlying distribution requires min and max and somehow forwarding nothing satisfied the criteria.

so reverted to explicit T min T max params, with the option of having a single (max) param, which defaults to 1.0 in the case of float — so no implicit "range" for int versions. so:

```c++
of::random::uniform(); // returns float (0,1]
of::random::uniform(5.0); // returns float (0,5]
of::random::uniform<int>(5); // returns int (0,5)
of::random::unfiorm<int>(); // does not compile
```
[edit to add: this does not affect the backward-compatibility of ofRandom() which already wraps explicit parameters]