### PR TITLE
[WIP] Window geometry constraints

### DIFF
--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -39,7 +39,15 @@ public:
 	virtual void showCursor(){}
 
 	virtual void setWindowPosition(int x, int y){}
+	virtual void setWindowSize(int w, int h){}
+	virtual void setWindowMinimumSize(int w, int h){}
+	virtual void setWindowMaximumSize(int w, int h){}
+	virtual void setWindowAspectRatio(int horizontal, int vertical){}
 	virtual void setWindowShape(int w, int h){}
+
+	std::optional<glm::vec2> minimumWindowSize;
+	std::optional<glm::vec2> maximumWindowSize;
+	std::optional<glm::vec2> windowAspectRatio;
 
 	virtual glm::vec2 getWindowPosition(){ return glm::vec2(); }
 	virtual glm::vec2 getWindowSize(){ return glm::vec2(); }

--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ofWindowSettings.h"
 #include "ofConstants.h"
+#include "ofWindowSettings.h"
 
 class ofBaseApp;
 class ofBaseRenderer;
@@ -18,119 +18,118 @@ struct _XDisplay;
 typedef struct _XDisplay Display;
 #endif
 
-class ofAppBaseWindow{
+class ofAppBaseWindow {
 public:
+	ofAppBaseWindow() { }
+	virtual ~ofAppBaseWindow() { }
 
-	ofAppBaseWindow(){}
-	virtual ~ofAppBaseWindow(){}
-
-	virtual void setup(const ofWindowSettings & settings)=0;
-	virtual void update()=0;
-	virtual void draw()=0;
-	virtual bool getWindowShouldClose(){
+	virtual void setup(const ofWindowSettings & settings) = 0;
+	virtual void update() = 0;
+	virtual void draw() = 0;
+	virtual bool getWindowShouldClose() {
 		return false;
 	}
-	virtual void setWindowShouldClose(){}
-	virtual void close(){}
+	virtual void setWindowShouldClose() { }
+	virtual void close() { }
 	virtual ofCoreEvents & events() = 0;
 	virtual std::shared_ptr<ofBaseRenderer> & renderer() = 0;
 
-	virtual void hideCursor(){}
-	virtual void showCursor(){}
+	virtual void hideCursor() { }
+	virtual void showCursor() { }
 
-	virtual void setWindowPosition(int x, int y){}
-	virtual void setWindowSize(int w, int h){}
-	virtual void setWindowMinimumSize(int w, int h){}
-	virtual void setWindowMaximumSize(int w, int h){}
-	virtual void setWindowAspectRatio(int horizontal, int vertical){}
-	virtual void setWindowShape(int w, int h){}
+	virtual void setWindowPosition(int x, int y) { }
+	virtual void setWindowSize(int w, int h) { }
+	virtual void setWindowMinimumSize(int w, int h) { }
+	virtual void setWindowMaximumSize(int w, int h) { }
+	virtual void setWindowAspectRatio(int horizontal, int vertical) { }
+	virtual void setWindowShape(int w, int h) { }
 
 	std::optional<glm::vec2> minimumWindowSize;
 	std::optional<glm::vec2> maximumWindowSize;
 	std::optional<glm::vec2> windowAspectRatio;
 
-	virtual glm::vec2 getWindowPosition(){ return glm::vec2(); }
-	virtual glm::vec2 getWindowSize(){ return glm::vec2(); }
-	virtual glm::vec2 getScreenSize(){ return glm::vec2(); }
+	virtual glm::vec2 getWindowPosition() { return glm::vec2(); }
+	virtual glm::vec2 getWindowSize() { return glm::vec2(); }
+	virtual glm::vec2 getScreenSize() { return glm::vec2(); }
 
-	virtual void setOrientation(ofOrientation orientation){ }
-	virtual ofOrientation getOrientation(){ return OF_ORIENTATION_DEFAULT; }
-	virtual bool doesHWOrientation(){ return false; }
+	virtual void setOrientation(ofOrientation orientation) { }
+	virtual ofOrientation getOrientation() { return OF_ORIENTATION_DEFAULT; }
+	virtual bool doesHWOrientation() { return false; }
 
 	//this is used by ofGetWidth and now determines the window width based on orientation
-	virtual int getWidth(){ return 0; }
-	virtual int getHeight(){ return 0; }
+	virtual int getWidth() { return 0; }
+	virtual int getHeight() { return 0; }
 
-	virtual void setWindowTitle(std::string title){}
+	virtual void setWindowTitle(std::string title) { }
 
-	virtual ofWindowMode getWindowMode(){ return OF_WINDOW; }
+	virtual ofWindowMode getWindowMode() { return OF_WINDOW; }
 
-	virtual void setFullscreen(bool fullscreen){}
-	virtual void toggleFullscreen(){}
+	virtual void setFullscreen(bool fullscreen) { }
+	virtual void toggleFullscreen() { }
 
-	virtual void enableSetupScreen(){}
-	virtual void disableSetupScreen(){}
+	virtual void enableSetupScreen() { }
+	virtual void disableSetupScreen() { }
 
-	virtual void setVerticalSync(bool enabled){}
-	virtual void setClipboardString(const std::string& text){}
-	virtual std::string getClipboardString(){ return ""; }
+	virtual void setVerticalSync(bool enabled) { }
+	virtual void setClipboardString(const std::string & text) { }
+	virtual std::string getClipboardString() { return ""; }
 
-	virtual void makeCurrent(){}
-	virtual void swapBuffers(){}
-	virtual void startRender(){}
-	virtual void finishRender(){}
+	virtual void makeCurrent() { }
+	virtual void swapBuffers() { }
+	virtual void startRender() { }
+	virtual void finishRender() { }
 
-	virtual void * getWindowContext(){ return nullptr; }
+	virtual void * getWindowContext() { return nullptr; }
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)
-	virtual Display* getX11Display(){ return nullptr; }
-	virtual Window  getX11Window(){ return 0; }
+	virtual Display * getX11Display() { return nullptr; }
+	virtual Window getX11Window() { return 0; }
 #endif
 
 #if defined(TARGET_LINUX) && !defined(TARGET_OPENGLES)
-	virtual GLXContext getGLXContext(){ return 0; }
+	virtual GLXContext getGLXContext() { return 0; }
 #endif
 
 #if defined(TARGET_LINUX) && defined(TARGET_OPENGLES)
-	virtual EGLDisplay getEGLDisplay(){ return 0; }
-	virtual EGLContext getEGLContext(){ return 0; }
-	virtual EGLSurface getEGLSurface(){ return 0; }
+	virtual EGLDisplay getEGLDisplay() { return 0; }
+	virtual EGLContext getEGLContext() { return 0; }
+	virtual EGLSurface getEGLSurface() { return 0; }
 #endif
 
 #if defined(TARGET_OSX)
-	virtual void * getNSGLContext(){ return nullptr; }
-	virtual void * getCocoaWindow(){ return nullptr; }
+	virtual void * getNSGLContext() { return nullptr; }
+	virtual void * getCocoaWindow() { return nullptr; }
 #endif
 
 #if defined(TARGET_WIN32)
-	virtual HGLRC getWGLContext(){ return 0; }
-	virtual HWND getWin32Window(){ return 0; }
+	virtual HGLRC getWGLContext() { return 0; }
+	virtual HWND getWin32Window() { return 0; }
 #endif
 };
 
-class ofAppBaseGLWindow: public ofAppBaseWindow{
+class ofAppBaseGLWindow : public ofAppBaseWindow {
 public:
-	virtual ~ofAppBaseGLWindow(){}
-	virtual void setup(const ofGLWindowSettings & settings)=0;
-	void setup(const ofWindowSettings & settings){
-		const ofGLWindowSettings * glSettings = dynamic_cast<const ofGLWindowSettings*>(&settings);
-		if(glSettings){
+	virtual ~ofAppBaseGLWindow() { }
+	virtual void setup(const ofGLWindowSettings & settings) = 0;
+	void setup(const ofWindowSettings & settings) {
+		const ofGLWindowSettings * glSettings = dynamic_cast<const ofGLWindowSettings *>(&settings);
+		if (glSettings) {
 			setup(*glSettings);
-		}else{
+		} else {
 			setup(ofGLWindowSettings(settings));
 		}
 	}
 };
 
-class ofAppBaseGLESWindow: public ofAppBaseWindow{
+class ofAppBaseGLESWindow : public ofAppBaseWindow {
 public:
-	virtual ~ofAppBaseGLESWindow(){}
-	virtual void setup(const ofGLESWindowSettings & settings)=0;
-	void setup(const ofWindowSettings & settings){
-		const ofGLESWindowSettings * glSettings = dynamic_cast<const ofGLESWindowSettings*>(&settings);
-		if(glSettings){
+	virtual ~ofAppBaseGLESWindow() { }
+	virtual void setup(const ofGLESWindowSettings & settings) = 0;
+	void setup(const ofWindowSettings & settings) {
+		const ofGLESWindowSettings * glSettings = dynamic_cast<const ofGLESWindowSettings *>(&settings);
+		if (glSettings) {
 			setup(*glSettings);
-		}else{
+		} else {
 			setup(ofGLESWindowSettings(settings));
 		}
 	}

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -1220,6 +1220,11 @@ nonFullscreenWindowRect = currentWindowRect;
 }
 
 //------------------------------------------------------------
+
+void ofAppEGLWindow::setWindowSize(int w, int h){
+	setWindowShape(w, h);
+}
+
 void ofAppEGLWindow::setWindowShape(int w, int h){
 	if(!isWindowInited) {
 		ofLogError("ofAppEGLWindow") << "setWindowPosition(): window not inited";

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -1,36 +1,36 @@
 #include "ofAppEGLWindow.h"
 
-#include "ofGraphics.h" // used in runAppViaInfiniteLoop()
 #include "ofAppRunner.h"
-#include "ofUtils.h"
 #include "ofFileUtils.h"
 #include "ofGLProgrammableRenderer.h"
 #include "ofGLRenderer.h"
+#include "ofGraphics.h" // used in runAppViaInfiniteLoop()
+#include "ofUtils.h"
 #include "ofVectorMath.h"
 #include <assert.h>
 // x11
-#include <X11/Xutil.h>
 #include <EGL/egl.h>
+#include <X11/Xutil.h>
 
 // include includes for both native and X11 possibilities
+#include <fcntl.h> // open fcntl
 #include <libudev.h>
+#include <linux/joystick.h>
+#include <math.h>
 #include <stdbool.h>
 #include <stdio.h> // sprintf
-#include <stdlib.h>  // malloc
-#include <math.h>
-#include <fcntl.h>  // open fcntl
+#include <stdlib.h> // malloc
 #include <unistd.h> // read close
-#include <linux/joystick.h>
 
-#include "linux/kd.h"	// keyboard stuff...
-#include "termios.h"
+#include "linux/kd.h" // keyboard stuff...
 #include "sys/ioctl.h"
+#include "termios.h"
 
 #include <string.h> // strlen
 
 // native events
-struct udev* udev;
-struct udev_monitor* mon;
+struct udev * udev;
+struct udev_monitor * mon;
 static int udev_fd = -1;
 
 typedef map<string, int> device;
@@ -38,27 +38,27 @@ static device inputDevices;
 
 // minimal map
 const int lowercase_map[] = {
-		0,  0,  '1',  '2',  '3',  '4',  '5', '6',  '7', '8', '9', '0',
-		'-', '=', '\b', '\t', 'q',  'w',  'e', 'r',  't', 'y', 'u', 'i',
-		'o', 'p', '[',  ']',  '\n', 0,   'a', 's',  'd', 'f', 'g', 'h',
-		'j', 'k', 'l',  ';',  '\'',  '\n', 0,  '\\', 'z', 'x', 'c', 'v',
-		'b', 'n', 'm',  ',',  '.',  '/',  0,  '*',  0,  ' ', 0,  0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  0, 0,  0, 0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  0, 0,  0, 0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  '\r'
+	0, 0, '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',
+	'-', '=', '\b', '\t', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i',
+	'o', 'p', '[', ']', '\n', 0, 'a', 's', 'd', 'f', 'g', 'h',
+	'j', 'k', 'l', ';', '\'', '\n', 0, '\\', 'z', 'x', 'c', 'v',
+	'b', 'n', 'm', ',', '.', '/', 0, '*', 0, ' ', 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '\r'
 
 };
 
 // minimal keyboard map
 const int uppercase_map[] = {
-		0,  0,  '!',  '@',  '#',  '$',  '%', '^',  '&', '*', '(', ')',
-		'_', '+', '\b', '\t', 'Q',  'W',  'E', 'R',  'T', 'Y', 'U', 'I',
-		'O', 'P', '{',  '}',  '\n', 0,   'A', 'S',  'D', 'F', 'G', 'H',
-		'J', 'K', 'L',  ':',  '"', '\n', 0,  '\\', 'Z', 'X', 'C', 'V',
-		'B', 'N', 'M',  '<',  '>',  '?',  0,  '*',  0,  ' ', 0,  0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  0, 0,  0, 0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  0, 0,  0, 0,
-		0,  0,  0,   0,   0,   0,   0,  0,   0,  0,  0,  '\r'
+	0, 0, '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+	'_', '+', '\b', '\t', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I',
+	'O', 'P', '{', '}', '\n', 0, 'A', 'S', 'D', 'F', 'G', 'H',
+	'J', 'K', 'L', ':', '"', '\n', 0, '\\', 'Z', 'X', 'C', 'V',
+	'B', 'N', 'M', '<', '>', '?', 0, '*', 0, ' ', 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '\r'
 };
 
 // keep track of a few things ...
@@ -80,16 +80,16 @@ typedef map<int, int> TouchState;
 typedef map<int, ofVec2f> TouchPosition;
 
 // TODO, make this match the upcoming additions to ofWindow
-#define MOUSE_BUTTON_LEFT_MASK		1
+#define MOUSE_BUTTON_LEFT_MASK 1
 #define MOUSE_BUTTON_MIDDLE_MASK 1 << 1
-#define MOUSE_BUTTON_RIGHT_MASK  2 << 1
+#define MOUSE_BUTTON_RIGHT_MASK 2 << 1
 
 static MouseState mb;
 static TouchState mt;
 static TouchPosition mtp;
-ofAppEGLWindow* ofAppEGLWindow::instance = NULL;
+ofAppEGLWindow * ofAppEGLWindow::instance = NULL;
 
-static int string_ends_with(const char *str, const char *suffix) {
+static int string_ends_with(const char * str, const char * suffix) {
 	if (!str || !suffix)
 		return 0;
 	size_t lenstr = strlen(str);
@@ -99,7 +99,7 @@ static int string_ends_with(const char *str, const char *suffix) {
 	return strncmp(str + lenstr - lensuffix, suffix, lensuffix) == 0;
 }
 
-static int string_begins_with(const char *str, const char *prefix) {
+static int string_begins_with(const char * str, const char * prefix) {
 	if (!str || !prefix)
 		return 0;
 	size_t lenstr = strlen(str);
@@ -110,112 +110,132 @@ static int string_begins_with(const char *str, const char *prefix) {
 }
 
 // native
-#define MOUSE_CURSOR_RUN_LENGTH_DECODE(image_buf, rle_data, size, bpp) do \
-		{ unsigned int __bpp; unsigned char *__ip; const unsigned char *__il, *__rd; \
-		__bpp = (bpp); __ip = (image_buf); __il = __ip + (size) * __bpp; \
-		__rd = (rle_data); \
-		while (__ip < __il) { unsigned int __l = *(__rd++); \
-		if (__l & 128) { __l = __l - 128; \
-		do { memcpy (__ip, __rd, 4); __ip += 4; } while (--__l); __rd += 4; \
-		} else { __l *= 4; memcpy (__ip, __rd, __l); \
-		__ip += __l; __rd += __l; } } \
-		} while (0)
+#define MOUSE_CURSOR_RUN_LENGTH_DECODE(image_buf, rle_data, size, bpp) \
+	do {                                                               \
+		unsigned int __bpp;                                            \
+		unsigned char * __ip;                                          \
+		const unsigned char *__il, *__rd;                              \
+		__bpp = (bpp);                                                 \
+		__ip = (image_buf);                                            \
+		__il = __ip + (size)*__bpp;                                    \
+		__rd = (rle_data);                                             \
+		while (__ip < __il) {                                          \
+			unsigned int __l = *(__rd++);                              \
+			if (__l & 128) {                                           \
+				__l = __l - 128;                                       \
+				do {                                                   \
+					memcpy(__ip, __rd, 4);                             \
+					__ip += 4;                                         \
+				} while (--__l);                                       \
+				__rd += 4;                                             \
+			} else {                                                   \
+				__l *= 4;                                              \
+				memcpy(__ip, __rd, __l);                               \
+				__ip += __l;                                           \
+				__rd += __l;                                           \
+			}                                                          \
+		}                                                              \
+	} while (0)
 static const struct {
 	unsigned int width;
 	unsigned int height;
 	unsigned int bpp; /* 2:RGB16, 3:RGB, 4:RGBA */
 	unsigned char rle_pixel_data[382 + 1];
 } mouse_cursor_data = {
-		12, 19, 4,
-		"\1\0\0\0\377\213\377\377\377\0\202\0\0\0\377\212\377\377\377\0\3\0\0\0\377"
-		"\377\377\377\377\0\0\0\377\211\377\377\377\0\1\0\0\0\377\202\377\377\377"
-		"\377\1\0\0\0\377\210\377\377\377\0\1\0\0\0\377\203\377\377\377\377\1\0\0"
-		"\0\377\207\377\377\377\0\1\0\0\0\377\204\377\377\377\377\1\0\0\0\377\206"
-		"\377\377\377\0\1\0\0\0\377\205\377\377\377\377\1\0\0\0\377\205\377\377\377"
-		"\0\1\0\0\0\377\206\377\377\377\377\1\0\0\0\377\204\377\377\377\0\1\0\0\0"
-		"\377\207\377\377\377\377\1\0\0\0\377\203\377\377\377\0\1\0\0\0\377\210\377"
-		"\377\377\377\1\0\0\0\377\202\377\377\377\0\1\0\0\0\377\211\377\377\377\377"
-		"\3\0\0\0\377\377\377\377\0\0\0\0\377\212\377\377\377\377\202\0\0\0\377\206"
-		"\377\377\377\377\206\0\0\0\377\203\377\377\377\377\1\0\0\0\377\202\377\377"
-		"\377\377\1\0\0\0\377\204\377\377\377\0\1\0\0\0\377\202\377\377\377\377\3"
-		"\0\0\0\377\377\377\377\0\0\0\0\377\202\377\377\377\377\1\0\0\0\377\203\377"
-		"\377\377\0\3\0\0\0\377\377\377\377\377\0\0\0\377\202\377\377\377\0\1\0\0"
-		"\0\377\202\377\377\377\377\1\0\0\0\377\203\377\377\377\0\202\0\0\0\377\204"
-		"\377\377\377\0\1\0\0\0\377\202\377\377\377\377\1\0\0\0\377\210\377\377\377"
-		"\0\1\0\0\0\377\202\377\377\377\377\1\0\0\0\377\211\377\377\377\0\202\0\0"
-		"\0\377\203\377\377\377\0",
+	12,
+	19,
+	4,
+	"\1\0\0\0\377\213\377\377\377\0\202\0\0\0\377\212\377\377\377\0\3\0\0\0\377"
+	"\377\377\377\377\0\0\0\377\211\377\377\377\0\1\0\0\0\377\202\377\377\377"
+	"\377\1\0\0\0\377\210\377\377\377\0\1\0\0\0\377\203\377\377\377\377\1\0\0"
+	"\0\377\207\377\377\377\0\1\0\0\0\377\204\377\377\377\377\1\0\0\0\377\206"
+	"\377\377\377\0\1\0\0\0\377\205\377\377\377\377\1\0\0\0\377\205\377\377\377"
+	"\0\1\0\0\0\377\206\377\377\377\377\1\0\0\0\377\204\377\377\377\0\1\0\0\0"
+	"\377\207\377\377\377\377\1\0\0\0\377\203\377\377\377\0\1\0\0\0\377\210\377"
+	"\377\377\377\1\0\0\0\377\202\377\377\377\0\1\0\0\0\377\211\377\377\377\377"
+	"\3\0\0\0\377\377\377\377\0\0\0\0\377\212\377\377\377\377\202\0\0\0\377\206"
+	"\377\377\377\377\206\0\0\0\377\203\377\377\377\377\1\0\0\0\377\202\377\377"
+	"\377\377\1\0\0\0\377\204\377\377\377\0\1\0\0\0\377\202\377\377\377\377\3"
+	"\0\0\0\377\377\377\377\0\0\0\0\377\202\377\377\377\377\1\0\0\0\377\203\377"
+	"\377\377\0\3\0\0\0\377\377\377\377\377\0\0\0\377\202\377\377\377\0\1\0\0"
+	"\0\377\202\377\377\377\377\1\0\0\0\377\203\377\377\377\0\202\0\0\0\377\204"
+	"\377\377\377\0\1\0\0\0\377\202\377\377\377\377\1\0\0\0\377\210\377\377\377"
+	"\0\1\0\0\0\377\202\377\377\377\377\1\0\0\0\377\211\377\377\377\0\202\0\0"
+	"\0\377\203\377\377\377\0",
 };
 
 // from http://cantuna.googlecode.com/svn-history/r16/trunk/src/screen.cpp
-#define CASE_STR(x,y) case x: str = y; break
+#define CASE_STR(x, y) \
+	case x:            \
+		str = y;       \
+		break
 
-static const char* eglErrorString(EGLint err) {
+static const char * eglErrorString(EGLint err) {
 	string str;
 	switch (err) {
-	CASE_STR(EGL_SUCCESS, "no error");
-	CASE_STR(EGL_NOT_INITIALIZED, "EGL not, or could not be, initialized");
-	CASE_STR(EGL_BAD_ACCESS, "access violation");
-	CASE_STR(EGL_BAD_ALLOC, "could not allocate resources");
-	CASE_STR(EGL_BAD_ATTRIBUTE, "invalid attribute");
-	CASE_STR(EGL_BAD_CONTEXT, "invalid context specified");
-	CASE_STR(EGL_BAD_CONFIG, "invald frame buffer configuration specified");
-	CASE_STR(EGL_BAD_CURRENT_SURFACE, "current window, pbuffer or pixmap surface is no longer valid");
-	CASE_STR(EGL_BAD_DISPLAY, "invalid display specified");
-	CASE_STR(EGL_BAD_SURFACE, "invalid surface specified");
-	CASE_STR(EGL_BAD_MATCH, "bad argument match");
-	CASE_STR(EGL_BAD_PARAMETER, "invalid paramater");
-	CASE_STR(EGL_BAD_NATIVE_PIXMAP, "invalid NativePixmap");
-	CASE_STR(EGL_BAD_NATIVE_WINDOW, "invalid NativeWindow");
-	CASE_STR(EGL_CONTEXT_LOST, "APM event caused context loss");
-	default: str = "unknown error " + err; break;
+		CASE_STR(EGL_SUCCESS, "no error");
+		CASE_STR(EGL_NOT_INITIALIZED, "EGL not, or could not be, initialized");
+		CASE_STR(EGL_BAD_ACCESS, "access violation");
+		CASE_STR(EGL_BAD_ALLOC, "could not allocate resources");
+		CASE_STR(EGL_BAD_ATTRIBUTE, "invalid attribute");
+		CASE_STR(EGL_BAD_CONTEXT, "invalid context specified");
+		CASE_STR(EGL_BAD_CONFIG, "invald frame buffer configuration specified");
+		CASE_STR(EGL_BAD_CURRENT_SURFACE, "current window, pbuffer or pixmap surface is no longer valid");
+		CASE_STR(EGL_BAD_DISPLAY, "invalid display specified");
+		CASE_STR(EGL_BAD_SURFACE, "invalid surface specified");
+		CASE_STR(EGL_BAD_MATCH, "bad argument match");
+		CASE_STR(EGL_BAD_PARAMETER, "invalid paramater");
+		CASE_STR(EGL_BAD_NATIVE_PIXMAP, "invalid NativePixmap");
+		CASE_STR(EGL_BAD_NATIVE_WINDOW, "invalid NativeWindow");
+		CASE_STR(EGL_CONTEXT_LOST, "APM event caused context loss");
+	default:
+		str = "unknown error " + err;
+		break;
 	}
 	return str.c_str();
 }
 
-
 // X11 events
 #include <X11/XKBlib.h>
 
-
 #ifdef TARGET_RASPBERRY_PI
-// TODO: remove these when they enter system headers
-// From : https://github.com/raspberrypi/userland/blob/master/interface/vmcs_host/vc_vchi_dispmanx.h
-#ifndef ELEMENT_CHANGE_LAYER
-#define ELEMENT_CHANGE_LAYER		  (1<<0)
+	// TODO: remove these when they enter system headers
+	// From : https://github.com/raspberrypi/userland/blob/master/interface/vmcs_host/vc_vchi_dispmanx.h
+	#ifndef ELEMENT_CHANGE_LAYER
+		#define ELEMENT_CHANGE_LAYER (1 << 0)
+	#endif
+	#ifndef ELEMENT_CHANGE_OPACITY
+		#define ELEMENT_CHANGE_OPACITY (1 << 1)
+	#endif
+	#ifndef ELEMENT_CHANGE_DEST_RECT
+		#define ELEMENT_CHANGE_DEST_RECT (1 << 2)
+	#endif
+	#ifndef ELEMENT_CHANGE_SRC_RECT
+		#define ELEMENT_CHANGE_SRC_RECT (1 << 3)
+	#endif
+	#ifndef ELEMENT_CHANGE_MASK_RESOURCE
+		#define ELEMENT_CHANGE_MASK_RESOURCE (1 << 4)
+	#endif
+	#ifndef ELEMENT_CHANGE_TRANSFORM
+		#define ELEMENT_CHANGE_TRANSFORM (1 << 5)
+	#endif
 #endif
-#ifndef ELEMENT_CHANGE_OPACITY
-#define ELEMENT_CHANGE_OPACITY		(1<<1)
-#endif
-#ifndef ELEMENT_CHANGE_DEST_RECT
-#define ELEMENT_CHANGE_DEST_RECT	  (1<<2)
-#endif
-#ifndef ELEMENT_CHANGE_SRC_RECT
-#define ELEMENT_CHANGE_SRC_RECT	   (1<<3)
-#endif
-#ifndef ELEMENT_CHANGE_MASK_RESOURCE
-#define ELEMENT_CHANGE_MASK_RESOURCE  (1<<4)
-#endif
-#ifndef ELEMENT_CHANGE_TRANSFORM
-#define ELEMENT_CHANGE_TRANSFORM	  (1<<5)
-#endif
-#endif
-
 
 //-------------------------------------------------------------------------------------
 ofAppEGLWindowSettings::ofAppEGLWindowSettings()
-:ofGLESWindowSettings(){
+	: ofGLESWindowSettings() {
 	eglWindowPreference = OF_APP_WINDOW_AUTO;
 	eglWindowOpacity = 255;
 
 	// these are usually set as default, but set them here just to be sure
-	frameBufferAttributes[EGL_RED_SIZE]	 = 8; // 8 bits for red
-	frameBufferAttributes[EGL_GREEN_SIZE]   = 8; // 8 bits for green
-	frameBufferAttributes[EGL_BLUE_SIZE]	= 8; // 8 bits for blue
-	frameBufferAttributes[EGL_ALPHA_SIZE]   = 8; // 8 bits for alpha
+	frameBufferAttributes[EGL_RED_SIZE] = 8; // 8 bits for red
+	frameBufferAttributes[EGL_GREEN_SIZE] = 8; // 8 bits for green
+	frameBufferAttributes[EGL_BLUE_SIZE] = 8; // 8 bits for blue
+	frameBufferAttributes[EGL_ALPHA_SIZE] = 8; // 8 bits for alpha
 	frameBufferAttributes[EGL_LUMINANCE_SIZE] = EGL_DONT_CARE; // 8 bits for alpha
-	frameBufferAttributes[EGL_DEPTH_SIZE]   = 24; // 24 bits for depth
+	frameBufferAttributes[EGL_DEPTH_SIZE] = 24; // 24 bits for depth
 	frameBufferAttributes[EGL_STENCIL_SIZE] = 8; // 8 bits for stencil
-	frameBufferAttributes[EGL_SAMPLES]	  = 1;
+	frameBufferAttributes[EGL_SAMPLES] = 1;
 
 	initialClearColor = ofColor(0.15 * 255, 0.15 * 255, 0.15 * 255, 255);
 
@@ -224,19 +244,19 @@ ofAppEGLWindowSettings::ofAppEGLWindowSettings()
 }
 
 ofAppEGLWindowSettings::ofAppEGLWindowSettings(const ofGLESWindowSettings & settings)
-:ofGLESWindowSettings(settings){
+	: ofGLESWindowSettings(settings) {
 	eglWindowPreference = OF_APP_WINDOW_AUTO;
 	eglWindowOpacity = 255;
 
 	// these are usually set as default, but set them here just to be sure
-	frameBufferAttributes[EGL_RED_SIZE]	 = 8; // 8 bits for red
-	frameBufferAttributes[EGL_GREEN_SIZE]   = 8; // 8 bits for green
-	frameBufferAttributes[EGL_BLUE_SIZE]	= 8; // 8 bits for blue
-	frameBufferAttributes[EGL_ALPHA_SIZE]   = 8; // 8 bits for alpha
+	frameBufferAttributes[EGL_RED_SIZE] = 8; // 8 bits for red
+	frameBufferAttributes[EGL_GREEN_SIZE] = 8; // 8 bits for green
+	frameBufferAttributes[EGL_BLUE_SIZE] = 8; // 8 bits for blue
+	frameBufferAttributes[EGL_ALPHA_SIZE] = 8; // 8 bits for alpha
 	frameBufferAttributes[EGL_LUMINANCE_SIZE] = EGL_DONT_CARE; // 8 bits for alpha
-	frameBufferAttributes[EGL_DEPTH_SIZE]   = 24; // 24 bits for depth
+	frameBufferAttributes[EGL_DEPTH_SIZE] = 24; // 24 bits for depth
 	frameBufferAttributes[EGL_STENCIL_SIZE] = 8; // 8 bits for stencil
-	frameBufferAttributes[EGL_SAMPLES]	  = 1;
+	frameBufferAttributes[EGL_SAMPLES] = 1;
 
 	initialClearColor = ofColor(0.15 * 255, 0.15 * 255, 0.15 * 255, 255);
 
@@ -264,7 +284,7 @@ ofAppEGLWindow::ofAppEGLWindow() {
 	x11ScreenNum = 0l;
 	glesVersion = 1;
 
-	if(instance!=NULL){
+	if (instance != NULL) {
 		ofLogError("ofAppEGLWindow") << "trying to create more than one instance";
 	}
 	instance = this;
@@ -292,12 +312,12 @@ EGLContext ofAppEGLWindow::getEglContext() const {
 
 #ifndef TARGET_RASPBERRY_PI_LEGACY
 //------------------------------------------------------------
-Display* ofAppEGLWindow::getX11Display(){
+Display * ofAppEGLWindow::getX11Display() {
 	return x11Display;
 }
 
 //------------------------------------------------------------
-Window ofAppEGLWindow::getX11Window(){
+Window ofAppEGLWindow::getX11Window() {
 	return x11Window;
 }
 #endif
@@ -307,7 +327,7 @@ EGLConfig ofAppEGLWindow::getEglConfig() const {
 }
 
 //------------------------------------------------------------
-EGLint ofAppEGLWindow::getEglVersionMajor () const {
+EGLint ofAppEGLWindow::getEglVersionMajor() const {
 	return eglVersionMajor;
 }
 
@@ -331,13 +351,13 @@ void ofAppEGLWindow::exitNative() {
 }
 
 //------------------------------------------------------------
-EGLNativeWindowType ofAppEGLWindow::getNativeWindow()  {
-	if(!isWindowInited) {
+EGLNativeWindowType ofAppEGLWindow::getNativeWindow() {
+	if (!isWindowInited) {
 		ofLogWarning("ofAppEGLWindow") << "getNativeDisplay(): window not initialized, returning NULL";
 		return NULL;
 	}
 
-	if(isUsingX11) {
+	if (isUsingX11) {
 		return (EGLNativeWindowType)x11Window;
 	} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
@@ -351,12 +371,12 @@ EGLNativeWindowType ofAppEGLWindow::getNativeWindow()  {
 
 //------------------------------------------------------------
 EGLNativeDisplayType ofAppEGLWindow::getNativeDisplay() {
-	if(!isWindowInited) {
+	if (!isWindowInited) {
 		ofLogWarning("ofAppEGLWindow") << "getNativeDisplay(): window not initialized, returning NULL";
 		return 0;
 	}
 
-	if(isUsingX11) {
+	if (isUsingX11) {
 		return (EGLNativeDisplayType)x11Display;
 	} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
@@ -369,11 +389,11 @@ EGLNativeDisplayType ofAppEGLWindow::getNativeDisplay() {
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setup(const ofGLESWindowSettings & settings){
-	const Settings * glSettings = dynamic_cast<const Settings*>(&settings);
-	if(glSettings){
+void ofAppEGLWindow::setup(const ofGLESWindowSettings & settings) {
+	const Settings * glSettings = dynamic_cast<const Settings *>(&settings);
+	if (glSettings) {
 		setup(*glSettings);
-	}else{
+	} else {
 		setup(Settings(settings));
 	}
 }
@@ -384,7 +404,7 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 	windowMode = OF_WINDOW;
 	bNewScreenMode = true;
 	nFramesSinceWindowResized = 0;
-	buttonInUse	= 0;
+	buttonInUse = 0;
 	bEnableSetupScreen = true;
 	eglDisplayString = "";
 	orientation = OF_ORIENTATION_DEFAULT;
@@ -396,13 +416,13 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 	mouseScaleY = 2.0f;
 
 	isUsingX11 = false;
-	isWindowInited  = false;
+	isWindowInited = false;
 	isSurfaceInited = false;
 
 	eglDisplay = NULL;
 	eglSurface = NULL;
 	eglContext = NULL;
-	eglConfig  = NULL;
+	eglConfig = NULL;
 	eglVersionMajor = -1;
 	eglVersionMinor = -1;
 	glesVersion = 1;
@@ -414,17 +434,17 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 
 	bool bIsX11Available = getenv("DISPLAY") != NULL;
 
-	if(settings.eglWindowPreference == OF_APP_WINDOW_AUTO) {
-		if(bIsX11Available) {
+	if (settings.eglWindowPreference == OF_APP_WINDOW_AUTO) {
+		if (bIsX11Available) {
 			isUsingX11 = true;
 		} else {
 			isUsingX11 = false;
 		}
-	} else if(settings.eglWindowPreference == OF_APP_WINDOW_NATIVE) {
+	} else if (settings.eglWindowPreference == OF_APP_WINDOW_NATIVE) {
 		isUsingX11 = false;
-	} else if(settings.eglWindowPreference == OF_APP_WINDOW_X11) {
+	} else if (settings.eglWindowPreference == OF_APP_WINDOW_X11) {
 		isUsingX11 = true;
-		if(!bIsX11Available) {
+		if (!bIsX11Available) {
 			isUsingX11 = false;
 			ofLogError("ofAppEGLWindow") << "init(): X11 window requested, but X11 is not available";
 		}
@@ -433,7 +453,7 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 	////////////////
 	// TODO remove the following ifdef once x11 is accelerated on RPI
 #ifdef TARGET_RASPBERRY_PI_LEGACY
-	if(isUsingX11) {
+	if (isUsingX11) {
 		isUsingX11 = false;
 		ofLogWarning("ofAppEGLWindow") << "init(): X11 not availble on RPI yet, using a native window instead";
 	}
@@ -448,50 +468,50 @@ void ofAppEGLWindow::setup(const ofAppEGLWindowSettings & _settings) {
 	windowMode = settings.windowMode;
 	bShowCursor = true;
 
-	nonFullscreenWindowRect.set(0,0,settings.getWidth(),settings.getHeight());
+	nonFullscreenWindowRect.set(0, 0, settings.getWidth(), settings.getHeight());
 	nonFullscreenWindowRect.standardize();
 
 	ofRectangle startRect = nonFullscreenWindowRect;
 	bNewScreenMode = false;
 
-	if(windowMode == OF_GAME_MODE) {
+	if (windowMode == OF_GAME_MODE) {
 		ofLogWarning("ofAppEGLWindow") << "setupOpenGL(): OF_GAME_MODE not supported, using OF_WINDOW";
 		startRect = nonFullscreenWindowRect;
-	} else if(windowMode == OF_FULLSCREEN) {
+	} else if (windowMode == OF_FULLSCREEN) {
 		startRect = getScreenRect();
 	}
 
 	isWindowInited = createWindow(startRect);
 	isSurfaceInited = createSurface();
 
-	if(!isWindowInited) {
-		ofLogError("ofAppEGLWindow")  << "setupOpenGL(): screen creation failed, window not inited";
+	if (!isWindowInited) {
+		ofLogError("ofAppEGLWindow") << "setupOpenGL(): screen creation failed, window not inited";
 	}
 
 	setupPeripherals();
 
 	nFramesSinceWindowResized = 0;
 
-	if(settings.glesVersion>1){
+	if (settings.glesVersion > 1) {
 		currentRenderer = std::make_shared<ofGLProgrammableRenderer>(this);
-	}else{
+	} else {
 		currentRenderer = std::make_shared<ofGLRenderer>(this);
 	}
 
 	makeCurrent();
-	if(currentRenderer->getType()==ofGLProgrammableRenderer::TYPE){
-		static_cast<ofGLProgrammableRenderer*>(currentRenderer.get())->setup(settings.glesVersion,0);
-	}else{
-		static_cast<ofGLRenderer*>(currentRenderer.get())->setup();
+	if (currentRenderer->getType() == ofGLProgrammableRenderer::TYPE) {
+		static_cast<ofGLProgrammableRenderer *>(currentRenderer.get())->setup(settings.glesVersion, 0);
+	} else {
+		static_cast<ofGLRenderer *>(currentRenderer.get())->setup();
 	}
 }
 
 //------------------------------------------------------------
 void ofAppEGLWindow::setupPeripherals() {
-	if(!isUsingX11) {
+	if (!isUsingX11) {
 		// roll our own cursor!
-		mouseCursor.allocate(mouse_cursor_data.width,mouse_cursor_data.height,OF_IMAGE_COLOR_ALPHA);
-		MOUSE_CURSOR_RUN_LENGTH_DECODE(mouseCursor.getPixels().getData(),mouse_cursor_data.rle_pixel_data,mouse_cursor_data.width*mouse_cursor_data.height,mouse_cursor_data.bpp);
+		mouseCursor.allocate(mouse_cursor_data.width, mouse_cursor_data.height, OF_IMAGE_COLOR_ALPHA);
+		MOUSE_CURSOR_RUN_LENGTH_DECODE(mouseCursor.getPixels().getData(), mouse_cursor_data.rle_pixel_data, mouse_cursor_data.width * mouse_cursor_data.height, mouse_cursor_data.bpp);
 		mouseCursor.update();
 		ofLogNotice("ofAppEGLWindow") << "setupPeripherals(): peripheral setup complete";
 		setupNativeEvents();
@@ -515,33 +535,33 @@ bool ofAppEGLWindow::createSurface() {
 
 	EGLint result;
 
-	if(display==0){
+	if (display == 0) {
 		eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-	}else{
+	} else {
 		eglDisplay = eglGetDisplay(display);
 	}
 
-	if(eglDisplay == EGL_NO_DISPLAY) {
+	if (eglDisplay == EGL_NO_DISPLAY) {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): eglGetDisplay returned: " << eglDisplay;
 		return false;
-	}else{
+	} else {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL Display correctly set " << eglDisplay;
 	}
 
 	// initialize the EGL eglDisplay connection
 	result = eglInitialize(eglDisplay,
-			&eglVersionMajor,
-			&eglVersionMinor);
+		&eglVersionMajor,
+		&eglVersionMinor);
 
-	if(result == EGL_BAD_DISPLAY) {
+	if (result == EGL_BAD_DISPLAY) {
 		//  eglDisplay is not an EGL connection
 		ofLogError("ofAppEGLWindow") << "createSurface(): eglInitialize returned EGL_BAD_DISPLAY";
 		return false;
-	} else if(result == EGL_NOT_INITIALIZED) {
+	} else if (result == EGL_NOT_INITIALIZED) {
 		// eglDisplay cannot be intitialized
 		ofLogError("ofAppEGLWindow") << "createSurface(): eglInitialize returned EGL_NOT_INITIALIZED";
 		return false;
-	} else if(result == EGL_FALSE) {
+	} else if (result == EGL_FALSE) {
 		// eglinitialize was not initialiezd
 		ofLogError("ofAppEGLWindow") << "createSurface(): eglInitialize returned EGL_FALSE";
 		return false;
@@ -553,17 +573,17 @@ bool ofAppEGLWindow::createSurface() {
 	EGLint glesVersion;
 	int glesVersionForContext;
 
-	if(ofGetCurrentRenderer()) {
+	if (ofGetCurrentRenderer()) {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): current renderer type: " << ofGetCurrentRenderer()->getType();
 	} else {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): no current renderer selected";
 	}
 
-	if(this->glesVersion==2){
+	if (this->glesVersion == 2) {
 		glesVersion = EGL_OPENGL_ES2_BIT;
 		glesVersionForContext = 2;
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): GLES2 renderer detected";
-	}else{
+	} else {
 		glesVersion = EGL_OPENGL_ES_BIT;
 		glesVersionForContext = 1;
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): default renderer detected";
@@ -578,7 +598,7 @@ bool ofAppEGLWindow::createSurface() {
 	iter = settings.frameBufferAttributes.begin();
 	iterEnd = settings.frameBufferAttributes.end();
 	i = 0;
-	for(; iter != iterEnd; iter++) {
+	for (; iter != iterEnd; iter++) {
 		attribute_list_framebuffer_config[i++] = iter->first;
 		attribute_list_framebuffer_config[i++] = iter->second;
 	}
@@ -591,25 +611,24 @@ bool ofAppEGLWindow::createSurface() {
 	// get an appropriate EGL frame buffer configuration
 	// http://www.khronos.org/registry/egl/sdk/docs/man/xhtml/eglChooseConfig.html
 	result = eglChooseConfig(eglDisplay,
-			attribute_list_framebuffer_config,
-			&eglConfig,
-			1, // we only want the first one.  if we want more,
-			// we need to pass in an array.
-			// we are optimistic and don't give it more chances
-			// to find a good configuration
-			&num_configs);
+		attribute_list_framebuffer_config,
+		&eglConfig,
+		1, // we only want the first one.  if we want more,
+		// we need to pass in an array.
+		// we are optimistic and don't give it more chances
+		// to find a good configuration
+		&num_configs);
 
-	if(result == EGL_FALSE) {
+	if (result == EGL_FALSE) {
 		EGLint error = eglGetError();
 		ofLogError("ofAppEGLWindow") << "createSurface(): error finding valid configuration based on settings: " << eglErrorString(error);
 		return false;
 	}
 
-	if(num_configs <= 0 || eglConfig == NULL) {
+	if (num_configs <= 0 || eglConfig == NULL) {
 		ofLogError("ofAppEGLWindow") << "createSurface(): no matching configs were found, num_configs: " << num_configs;
 		return false;
 	}
-
 
 	// each attribute has 2 values, and we need one extra for the EGL_NONE terminator
 	EGLint attribute_list_window_surface[settings.windowSurfaceAttributes.size() * 2 + 1];
@@ -618,21 +637,21 @@ bool ofAppEGLWindow::createSurface() {
 	iterEnd = settings.windowSurfaceAttributes.end();
 
 	i = 0;
-	for(; iter != iterEnd; iter++) {
+	for (; iter != iterEnd; iter++) {
 		attribute_list_window_surface[i++] = iter->first;
 		attribute_list_window_surface[i++] = iter->second;
 	}
 	attribute_list_window_surface[i] = EGL_NONE; // add the terminator
 
 	// create a surface
-	eglSurface = eglCreateWindowSurface( eglDisplay, // our display handle
-			eglConfig,	// our first config
-			nativeWindow, // our native window
-			attribute_list_window_surface); // surface attribute list
+	eglSurface = eglCreateWindowSurface(eglDisplay, // our display handle
+		eglConfig, // our first config
+		nativeWindow, // our native window
+		attribute_list_window_surface); // surface attribute list
 
-	if(eglSurface == EGL_NO_SURFACE) {
+	if (eglSurface == EGL_NO_SURFACE) {
 		EGLint error = eglGetError();
-		switch(error) {
+		switch (error) {
 		case EGL_BAD_MATCH:
 			ofLogError("ofAppEGLWindow") << "createSurface(): error creating surface: EGL_BAD_MATCH " << eglErrorString(error);
 			ofLogError("ofAppEGLWindow") << "createSurface(): check window and EGLConfig attributes to determine compatibility, ";
@@ -655,34 +674,34 @@ bool ofAppEGLWindow::createSurface() {
 		}
 
 		return false;
-	}else{
+	} else {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): surface created correctly";
 	}
 
 	// get an appropriate EGL frame buffer configuration
 	result = eglBindAPI(EGL_OPENGL_ES_API);
 
-	if(result == EGL_FALSE) {
+	if (result == EGL_FALSE) {
 		ofLogError("ofAppEGLWindow") << "createSurface(): error binding API: " << eglErrorString(eglGetError());
 		return false;
-	}else{
+	} else {
 		ofLogNotice("ofAppEGLWindow") << "createSurface(): API bound correctly";
 	}
 
 	// create an EGL rendering eglContext
 	EGLint attribute_list_surface_context[] = {
-			EGL_CONTEXT_CLIENT_VERSION, glesVersionForContext,
-			EGL_NONE
+		EGL_CONTEXT_CLIENT_VERSION, glesVersionForContext,
+		EGL_NONE
 	};
 
 	eglContext = eglCreateContext(eglDisplay,
-			eglConfig,
-			EGL_NO_CONTEXT,
-			attribute_list_surface_context);
+		eglConfig,
+		EGL_NO_CONTEXT,
+		attribute_list_surface_context);
 
-	if(eglContext == EGL_NO_CONTEXT) {
+	if (eglContext == EGL_NO_CONTEXT) {
 		EGLint error = eglGetError();
-		if(error == EGL_BAD_CONFIG) {
+		if (error == EGL_BAD_CONFIG) {
 			ofLogError("ofAppEGLWindow") << "createSurface(): error creating context: EGL_BAD_CONFIG " << eglErrorString(error);
 			return false;
 		} else {
@@ -693,11 +712,11 @@ bool ofAppEGLWindow::createSurface() {
 
 	// connect the eglContext to the eglSurface
 	result = eglMakeCurrent(eglDisplay,
-			eglSurface, // draw surface
-			eglSurface, // read surface
-			eglContext);
+		eglSurface, // draw surface
+		eglSurface, // read surface
+		eglContext);
 
-	if(eglContext == nullptr) {
+	if (eglContext == nullptr) {
 		EGLint error = eglGetError();
 		ofLogError("ofAppEGLWindow") << "createSurface(): couldn't making current surface: " << eglErrorString(error);
 		return false;
@@ -705,17 +724,17 @@ bool ofAppEGLWindow::createSurface() {
 
 	// Set background color and clear buffers
 	glClearColor(settings.initialClearColor.r / 255.0f,
-			settings.initialClearColor.g / 255.0f,
-			settings.initialClearColor.b / 255.0f,
-			settings.initialClearColor.a / 255.0f);
-	glClear( GL_COLOR_BUFFER_BIT );
-	glClear( GL_DEPTH_BUFFER_BIT );
+		settings.initialClearColor.g / 255.0f,
+		settings.initialClearColor.b / 255.0f,
+		settings.initialClearColor.a / 255.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	glClear(GL_DEPTH_BUFFER_BIT);
 
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): -----EGL-----";
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_VERSION_MAJOR = " << eglVersionMajor;
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_VERSION_MINOR = " << eglVersionMinor;
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_CLIENT_APIS = " << eglQueryString(eglDisplay, EGL_CLIENT_APIS);
-	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_VENDOR = "  << eglQueryString(eglDisplay, EGL_VENDOR);
+	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_VENDOR = " << eglQueryString(eglDisplay, EGL_VENDOR);
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_VERSION = " << eglQueryString(eglDisplay, EGL_VERSION);
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): EGL_EXTENSIONS = " << eglQueryString(eglDisplay, EGL_EXTENSIONS);
 	ofLogNotice("ofAppEGLWindow") << "createSurface(): GL_RENDERER = " << glGetString(GL_RENDERER);
@@ -730,7 +749,7 @@ bool ofAppEGLWindow::createSurface() {
 
 //------------------------------------------------------------
 bool ofAppEGLWindow::destroySurface() {
-	if(isSurfaceInited) {
+	if (isSurfaceInited) {
 		ofLogNotice("ofAppEGLWindow") << "destroySurface(): destroying EGL surface";
 		eglSwapBuffers(eglDisplay, eglSurface);
 		eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
@@ -742,7 +761,7 @@ bool ofAppEGLWindow::destroySurface() {
 		eglDisplay = NULL;
 		eglSurface = NULL;
 		eglContext = NULL;
-		eglConfig  = NULL;
+		eglConfig = NULL;
 		eglVersionMinor = -1;
 		eglVersionMinor = -1;
 
@@ -755,10 +774,10 @@ bool ofAppEGLWindow::destroySurface() {
 
 //------------------------------------------------------------
 bool ofAppEGLWindow::destroyWindow() {
-	if(isWindowInited) {
-		if(isUsingX11) {
+	if (isWindowInited) {
+		if (isUsingX11) {
 			// TODO: double check
-			XDestroyWindow(x11Display,x11Window); // or XCloseWindow?
+			XDestroyWindow(x11Display, x11Window); // or XCloseWindow?
 			XFree(x11Screen);
 		} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
@@ -775,7 +794,7 @@ bool ofAppEGLWindow::destroyWindow() {
 				dispman_display = DISPMANX_NO_HANDLE;
 			}
 #else
-	ofLogNotice("ofAppEGLWindow") << "destroyWindow(): no native window type for this system, perhaps try X11?";
+			ofLogNotice("ofAppEGLWindow") << "destroyWindow(): no native window type for this system, perhaps try X11?";
 #endif
 		}
 
@@ -786,9 +805,8 @@ bool ofAppEGLWindow::destroyWindow() {
 	return true;
 }
 
-
-void ofAppEGLWindow::close(){
-	if(!isUsingX11) {
+void ofAppEGLWindow::close() {
+	if (!isUsingX11) {
 		destroyNativeEvents();
 	}
 
@@ -802,17 +820,17 @@ void ofAppEGLWindow::close(){
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::makeCurrent(){
+void ofAppEGLWindow::makeCurrent() {
 	eglMakeCurrent(eglDisplay,
-			eglSurface, // draw surface
-			eglSurface, // read surface
-			eglContext);
+		eglSurface, // draw surface
+		eglSurface, // read surface
+		eglContext);
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::swapBuffers(){
+void ofAppEGLWindow::swapBuffers() {
 	EGLBoolean success = eglSwapBuffers(eglDisplay, eglSurface);
-	if(!success) {
+	if (!success) {
 		GLint error = eglGetError();
 		ofLogNotice("ofAppEGLWindow") << "display(): eglSwapBuffers failed: " << eglErrorString(error);
 	}
@@ -833,50 +851,49 @@ void ofAppEGLWindow::update() {
 	coreEvents.notifyUpdate();
 }
 
-
 //------------------------------------------------------------
 void ofAppEGLWindow::draw() {
 	// take care of any requests for a new screen mode
-	if (windowMode != OF_GAME_MODE && bNewScreenMode){
-		if( windowMode == OF_FULLSCREEN){
+	if (windowMode != OF_GAME_MODE && bNewScreenMode) {
+		if (windowMode == OF_FULLSCREEN) {
 			setWindowRect(getScreenRect());
-		} else if( windowMode == OF_WINDOW ){
+		} else if (windowMode == OF_WINDOW) {
 			setWindowRect(nonFullscreenWindowRect);
 		}
 		bNewScreenMode = false;
 	}
 
 	currentRenderer->startRender();
-	if( bEnableSetupScreen ) currentRenderer->setupScreen();
+	if (bEnableSetupScreen) currentRenderer->setupScreen();
 
 	coreEvents.notifyDraw();
 
-	if(!isUsingX11) {
-		if(bShowCursor){
+	if (!isUsingX11) {
+		if (bShowCursor) {
 			GLboolean bIsDepthTestEnabled = GL_FALSE;
 			glGetBooleanv(GL_DEPTH_TEST, &bIsDepthTestEnabled);
 
-			if(bIsDepthTestEnabled == GL_TRUE) {
+			if (bIsDepthTestEnabled == GL_TRUE) {
 				glDisable(GL_DEPTH_TEST);
 			}
 
 			bool isUsingNormalizedTexCoords = ofGetUsingNormalizedTexCoords();
-			if(isUsingNormalizedTexCoords) {
+			if (isUsingNormalizedTexCoords) {
 				ofDisableNormalizedTexCoords();
 			}
 
 			currentRenderer->pushStyle();
 			currentRenderer->setBlendMode(OF_BLENDMODE_ADD);
 			currentRenderer->setColor(255);
-			mouseCursor.draw(ofGetMouseX(),ofGetMouseY());
+			mouseCursor.draw(ofGetMouseX(), ofGetMouseY());
 
 			currentRenderer->popStyle();
 
-			if(bIsDepthTestEnabled == GL_TRUE) {
+			if (bIsDepthTestEnabled == GL_TRUE) {
 				glEnable(GL_DEPTH_TEST);
 			}
 
-			if(isUsingNormalizedTexCoords) {
+			if (isUsingNormalizedTexCoords) {
 				ofEnableNormalizedTexCoords();
 			}
 		}
@@ -884,22 +901,21 @@ void ofAppEGLWindow::draw() {
 	currentRenderer->finishRender();
 
 	EGLBoolean success = eglSwapBuffers(eglDisplay, eglSurface);
-	if(!success) {
+	if (!success) {
 		GLint error = eglGetError();
 		ofLogNotice("ofAppEGLWindow") << "display(): eglSwapBuffers failed: " << eglErrorString(error);
 	}
 
 	nFramesSinceWindowResized++;
-
 }
 
 //------------------------------------------------------------
-ofCoreEvents & ofAppEGLWindow::events(){
+ofCoreEvents & ofAppEGLWindow::events() {
 	return coreEvents;
 }
 
 //------------------------------------------------------------
-shared_ptr<ofBaseRenderer> & ofAppEGLWindow::renderer(){
+shared_ptr<ofBaseRenderer> & ofAppEGLWindow::renderer() {
 	return currentRenderer;
 }
 
@@ -918,27 +934,27 @@ void ofAppEGLWindow::destroyNativeEvents() {
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setWindowRect(const ofRectangle& requestedWindowRect) {
-	if(!isWindowInited) {
+void ofAppEGLWindow::setWindowRect(const ofRectangle & requestedWindowRect) {
+	if (!isWindowInited) {
 		ofLogError("ofAppEGLWindow") << "setWindowRect(): window not inited";
 		return;
 	}
 
 	ofRectangle newRect = requestedWindowRect.getStandardized();
 
-	if(newRect != currentWindowRect) {
+	if (newRect != currentWindowRect) {
 		ofRectangle oldWindowRect = currentWindowRect;
 
-		if(isUsingX11) {
+		if (isUsingX11) {
 			int ret = XMoveResizeWindow(x11Display,
-					x11Window,
-					(int)newRect.x,
-					(int)newRect.y,
-					(unsigned int)newRect.width,
-					(unsigned int)newRect.height);
-			if(ret == BadValue) {
+				x11Window,
+				(int)newRect.x,
+				(int)newRect.y,
+				(unsigned int)newRect.width,
+				(unsigned int)newRect.height);
+			if (ret == BadValue) {
 				ofLogError("ofAppEGLWindow") << "setWindowRect(): XMoveResizeWindow returned BadValue";
-			} else if(ret == BadWindow) {
+			} else if (ret == BadWindow) {
 				ofLogError("ofAppEGLWindow") << "setWindowRect(): XMoveResizeWindow returned BadWindow";
 			} else {
 				// all is good
@@ -962,15 +978,14 @@ void ofAppEGLWindow::setWindowRect(const ofRectangle& requestedWindowRect) {
 			DISPMANX_UPDATE_HANDLE_T dispman_update = vc_dispmanx_update_start(0);
 
 			vc_dispmanx_element_change_attributes(dispman_update,
-					dispman_element,
-					ELEMENT_CHANGE_SRC_RECT|ELEMENT_CHANGE_DEST_RECT, // we do both when resizing
-					0, // layer (we aren't changing it here)
-					0, // opactiy (we aren't changing it here)
-					&dst_rect,
-					&src_rect,
-					0, // mask (we aren't changing it here)
-					(DISPMANX_TRANSFORM_T)0);
-
+				dispman_element,
+				ELEMENT_CHANGE_SRC_RECT | ELEMENT_CHANGE_DEST_RECT, // we do both when resizing
+				0, // layer (we aren't changing it here)
+				0, // opactiy (we aren't changing it here)
+				&dst_rect,
+				&src_rect,
+				0, // mask (we aren't changing it here)
+				(DISPMANX_TRANSFORM_T)0);
 
 			vc_dispmanx_update_submit_sync(dispman_update);
 
@@ -986,17 +1001,16 @@ void ofAppEGLWindow::setWindowRect(const ofRectangle& requestedWindowRect) {
 #endif
 		}
 
-		if(oldWindowRect.width  != currentWindowRect.width || oldWindowRect.height != currentWindowRect.height) {
-			coreEvents.notifyWindowResized(currentWindowRect.width,	currentWindowRect.height);
+		if (oldWindowRect.width != currentWindowRect.width || oldWindowRect.height != currentWindowRect.height) {
+			coreEvents.notifyWindowResized(currentWindowRect.width, currentWindowRect.height);
 			nFramesSinceWindowResized = 0;
 		}
 	}
 }
 
-
 //------------------------------------------------------------
-bool ofAppEGLWindow::createWindow(const ofRectangle& requestedWindowRect) {
-	if(isUsingX11) {
+bool ofAppEGLWindow::createWindow(const ofRectangle & requestedWindowRect) {
+	if (isUsingX11) {
 		return createX11NativeWindow(requestedWindowRect);
 	} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
@@ -1019,16 +1033,16 @@ int ofAppEGLWindow::getWindowHeight() {
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::pollEvents(){
-	if(!instance) return;
-	if(instance->isUsingX11) {
-		while(1){
+void ofAppEGLWindow::pollEvents() {
+	if (!instance) return;
+	if (instance->isUsingX11) {
+		while (1) {
 			XEvent event;
-			if (::XCheckWindowEvent(instance->x11Display, instance->x11Window, -1, &event)){
+			if (::XCheckWindowEvent(instance->x11Display, instance->x11Window, -1, &event)) {
 				handleX11Event(event);
-			}else if (::XCheckTypedEvent(instance->x11Display, ClientMessage, &event)){
+			} else if (::XCheckTypedEvent(instance->x11Display, ClientMessage, &event)) {
 				handleX11Event(event);
-			}else{
+			} else {
 				break;
 			}
 		}
@@ -1036,11 +1050,11 @@ void ofAppEGLWindow::pollEvents(){
 		queue<ofMouseEventArgs> mouseEventsCopy;
 		instance->lock();
 		mouseEventsCopy = instance->mouseEvents;
-		while(!instance->mouseEvents.empty()){
+		while (!instance->mouseEvents.empty()) {
 			instance->mouseEvents.pop();
 		}
 		instance->unlock();
-		while(!mouseEventsCopy.empty()){
+		while (!mouseEventsCopy.empty()) {
 			instance->coreEvents.notifyMouseEvent(mouseEventsCopy.front());
 			mouseEventsCopy.pop();
 		}
@@ -1049,11 +1063,11 @@ void ofAppEGLWindow::pollEvents(){
 		queue<ofKeyEventArgs> keyEventsCopy;
 		instance->lock();
 		keyEventsCopy = instance->keyEvents;
-		while(!instance->keyEvents.empty()){
+		while (!instance->keyEvents.empty()) {
 			instance->keyEvents.pop();
 		}
 		instance->unlock();
-		while(!keyEventsCopy.empty()){
+		while (!keyEventsCopy.empty()) {
 			instance->coreEvents.notifyKeyEvent(keyEventsCopy.front());
 			keyEventsCopy.pop();
 		}
@@ -1061,11 +1075,11 @@ void ofAppEGLWindow::pollEvents(){
 		queue<ofTouchEventArgs> touchEventsCopy;
 		instance->lock();
 		touchEventsCopy = instance->touchEvents;
-		while(!instance->touchEvents.empty()){
+		while (!instance->touchEvents.empty()) {
 			instance->touchEvents.pop();
 		}
 		instance->unlock();
-		while(!touchEventsCopy.empty()){
+		while (!touchEventsCopy.empty()) {
 			instance->coreEvents.notifyTouchEvent(touchEventsCopy.front());
 			touchEventsCopy.pop();
 		}
@@ -1073,12 +1087,12 @@ void ofAppEGLWindow::pollEvents(){
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::hideCursor(){
+void ofAppEGLWindow::hideCursor() {
 	bShowCursor = false;
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::showCursor(){
+void ofAppEGLWindow::showCursor() {
 	bShowCursor = true;
 }
 
@@ -1088,24 +1102,24 @@ void ofAppEGLWindow::setWindowTitle(string title) {
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppEGLWindow::getWindowSize(){
-	return {currentWindowRect.width, currentWindowRect.height};
+glm::vec2 ofAppEGLWindow::getWindowSize() {
+	return { currentWindowRect.width, currentWindowRect.height };
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppEGLWindow::getWindowPosition(){
+glm::vec2 ofAppEGLWindow::getWindowPosition() {
 	return glm::vec2(currentWindowRect.getPosition());
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppEGLWindow::getScreenSize(){
+glm::vec2 ofAppEGLWindow::getScreenSize() {
 	unsigned int screenWidth = 0;
 	unsigned int screenHeight = 0;
 
-	if(isUsingX11) {
+	if (isUsingX11) {
 		// TODO, there must be a way to get screensize if the window is not inited
-		if(isWindowInited && x11Screen) {
-			screenWidth  = XWidthOfScreen(x11Screen);
+		if (isWindowInited && x11Screen) {
+			screenWidth = XWidthOfScreen(x11Screen);
 			screenHeight = XHeightOfScreen(x11Screen);
 		} else {
 			ofLogError("ofAppEGLWindow") << "getScreenSize(): tried to get display size but failed, x11Screen is not inited";
@@ -1114,42 +1128,41 @@ glm::vec2 ofAppEGLWindow::getScreenSize(){
 	} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
 		int success = graphics_get_display_size(settings.screenNum, &screenWidth, &screenHeight);
-		if(success < 0) {
+		if (success < 0) {
 			ofLogError("ofAppEGLWindow") << "getScreenSize(): tried to get display size but failed";
 		}
 
 #else
 		ofLogError("ofAppEGLWindow") << "getScreenSize(): no native window type for this system, perhaps try X11?";
 #endif
-
 	}
 
-	return {screenWidth, screenHeight};
+	return { screenWidth, screenHeight };
 }
 
 //------------------------------------------------------------
-int ofAppEGLWindow::getWidth(){
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
+int ofAppEGLWindow::getWidth() {
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
 		return currentWindowRect.width;
 	}
 	return currentWindowRect.height;
 }
 
 //------------------------------------------------------------
-int ofAppEGLWindow::getHeight(){
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
+int ofAppEGLWindow::getHeight() {
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
 		return currentWindowRect.height;
 	}
 	return currentWindowRect.width;
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setOrientation(ofOrientation orientationIn){
+void ofAppEGLWindow::setOrientation(ofOrientation orientationIn) {
 	orientation = orientationIn;
 }
 
 //------------------------------------------------------------
-ofOrientation ofAppEGLWindow::getOrientation(){
+ofOrientation ofAppEGLWindow::getOrientation() {
 	return orientation;
 }
 
@@ -1159,20 +1172,20 @@ bool ofAppEGLWindow::doesHWOrientation() {
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setWindowPosition(int x, int y){
-	if(!isWindowInited) {
+void ofAppEGLWindow::setWindowPosition(int x, int y) {
+	if (!isWindowInited) {
 		ofLogError("ofAppEGLWindow") << "setWindowPosition(): window not inited";
 		return;
 	}
 
-	if(isUsingX11) {
+	if (isUsingX11) {
 		int ret = XMoveWindow(x11Display,
-				x11Window,
-				x,
-				y);
-		if(ret == BadValue) {
+			x11Window,
+			x,
+			y);
+		if (ret == BadValue) {
 			ofLogError("ofAppEGLWindow") << "setWindowPosition(): XMoveWindow returned BadValue";
-		} else if(ret == BadWindow) {
+		} else if (ret == BadWindow) {
 			ofLogError("ofAppEGLWindow") << "setWindowPosition(): XMoveWindow returned BadWindow";
 		} else {
 			currentWindowRect.x = x;
@@ -1196,49 +1209,47 @@ void ofAppEGLWindow::setWindowPosition(int x, int y){
 		dispman_update = vc_dispmanx_update_start(0);
 
 		vc_dispmanx_element_change_attributes(dispman_update,
-				dispman_native_window.element,
-				ELEMENT_CHANGE_DEST_RECT,
-				0,
-				0,
-				&dst_rect,
-				NULL,
-				0,
-				(DISPMANX_TRANSFORM_T)0);
+			dispman_native_window.element,
+			ELEMENT_CHANGE_DEST_RECT,
+			0,
+			0,
+			&dst_rect,
+			NULL,
+			0,
+			(DISPMANX_TRANSFORM_T)0);
 
+		vc_dispmanx_update_submit_sync(dispman_update);
 
-vc_dispmanx_update_submit_sync(dispman_update);
-
-currentWindowRect.x = x;
-currentWindowRect.y = y;
-nonFullscreenWindowRect = currentWindowRect;
+		currentWindowRect.x = x;
+		currentWindowRect.y = y;
+		nonFullscreenWindowRect = currentWindowRect;
 
 #else
-	ofLogError("ofAppEGLWindow") << "setWindowPosition(): no native window type for this system, perhaps try X11?";
+		ofLogError("ofAppEGLWindow") << "setWindowPosition(): no native window type for this system, perhaps try X11?";
 #endif
 	}
-
 }
 
 //------------------------------------------------------------
 
-void ofAppEGLWindow::setWindowSize(int w, int h){
+void ofAppEGLWindow::setWindowSize(int w, int h) {
 	setWindowShape(w, h);
 }
 
-void ofAppEGLWindow::setWindowShape(int w, int h){
-	if(!isWindowInited) {
+void ofAppEGLWindow::setWindowShape(int w, int h) {
+	if (!isWindowInited) {
 		ofLogError("ofAppEGLWindow") << "setWindowPosition(): window not inited";
 		return;
 	}
 
-	if(isUsingX11) {
+	if (isUsingX11) {
 		int ret = XResizeWindow(x11Display,
-				x11Window,
-				(unsigned int)w,
-				(unsigned int)h);
-		if(ret == BadValue) {
+			x11Window,
+			(unsigned int)w,
+			(unsigned int)h);
+		if (ret == BadValue) {
 			ofLogError("ofAppEGLWindow") << "setWindowPosition(): XMoveWindow returned BadValue";
-		} else if(ret == BadWindow) {
+		} else if (ret == BadWindow) {
 			ofLogError("ofAppEGLWindow") << "setWindowPosition(): XMoveWindow returned BadWindow";
 		} else {
 			currentWindowRect.width = w;
@@ -1247,7 +1258,7 @@ void ofAppEGLWindow::setWindowShape(int w, int h){
 		}
 	} else {
 #ifdef TARGET_RASPBERRY_PI_LEGACY
-		setWindowRect(ofRectangle(currentWindowRect.x,currentWindowRect.y,w,h));
+		setWindowRect(ofRectangle(currentWindowRect.x, currentWindowRect.y, w, h));
 		nonFullscreenWindowRect = currentWindowRect;
 #else
 		ofLogError("ofAppEGLWindow") << "setWindowPosition(): no native window type for this system, perhaps try X11?";
@@ -1256,63 +1267,62 @@ void ofAppEGLWindow::setWindowShape(int w, int h){
 }
 
 //------------------------------------------------------------
-ofWindowMode ofAppEGLWindow::getWindowMode(){
+ofWindowMode ofAppEGLWindow::getWindowMode() {
 	return windowMode;
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::toggleFullscreen(){
-	if( windowMode == OF_GAME_MODE) return;
+void ofAppEGLWindow::toggleFullscreen() {
+	if (windowMode == OF_GAME_MODE) return;
 
-	if( windowMode == OF_WINDOW ){
+	if (windowMode == OF_WINDOW) {
 		setFullscreen(true);
-	}else{
+	} else {
 		setFullscreen(false);
 	}
-
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setFullscreen(bool fullscreen){
-	if( windowMode == OF_GAME_MODE) return;
+void ofAppEGLWindow::setFullscreen(bool fullscreen) {
+	if (windowMode == OF_GAME_MODE) return;
 
-	if(fullscreen && windowMode != OF_FULLSCREEN){
+	if (fullscreen && windowMode != OF_FULLSCREEN) {
 		bNewScreenMode = true;
 		windowMode = OF_FULLSCREEN;
-	}else if(!fullscreen && windowMode != OF_WINDOW) {
+	} else if (!fullscreen && windowMode != OF_WINDOW) {
 		bNewScreenMode = true;
 		windowMode = OF_WINDOW;
 	}
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::enableSetupScreen(){
+void ofAppEGLWindow::enableSetupScreen() {
 	bEnableSetupScreen = true;
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::disableSetupScreen(){
+void ofAppEGLWindow::disableSetupScreen() {
 	bEnableSetupScreen = false;
 }
 
 //------------------------------------------------------------
-ofRectangle ofAppEGLWindow::getScreenRect(){
+ofRectangle ofAppEGLWindow::getScreenRect() {
 	auto screenSize = getScreenSize();
-	return ofRectangle(0,0,screenSize.x,screenSize.y);
+	return ofRectangle(0, 0, screenSize.x, screenSize.y);
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::setVerticalSync(bool enabled){
+void ofAppEGLWindow::setVerticalSync(bool enabled) {
 	eglSwapInterval(eglDisplay, enabled ? 1 : 0);
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::threadedFunction(){
+void ofAppEGLWindow::threadedFunction() {
 	// TODO: a way to setup mouse and keyboard if
 	// they are not plugged in upon start
 	// This can be done with our udev device callbacks
 
-	while(isThreadRunning()) {
+	while (isThreadRunning()) {
 		readNativeUDevEvents();
 		readNativeInputEvents();
 		// sleep briefly
@@ -1328,7 +1338,7 @@ void ofAppEGLWindow::threadedFunction(){
 void ofAppEGLWindow::setupNativeUDev() {
 
 	udev = udev_new(); // create new udev object
-	if(!udev) {
+	if (!udev) {
 		ofLogError("ofAppEGLWindow") << "setupNativeUDev(): couldn't create udev object";
 	} else {
 		ofLogNotice("ofAppEGLWindow") << "setupNativeUDev(): created udev object";
@@ -1341,10 +1351,9 @@ void ofAppEGLWindow::setupNativeUDev() {
 		udev_fd = udev_monitor_get_fd(mon);
 	}
 
-	if(udev_fd < 0) {
+	if (udev_fd < 0) {
 		ofLogError("ofAppEGLWindow") << "setupNativeUDev(): did not create udev object, udev_fd < 0";
 	}
-
 }
 
 //------------------------------------------------------------
@@ -1352,10 +1361,10 @@ void ofAppEGLWindow::destroyNativeUDev() {
 	udev_unref(udev); // clean up
 }
 
-void ofAppEGLWindow::setupNativeInput(){
-	struct udev_enumerate *enumerate;
+void ofAppEGLWindow::setupNativeInput() {
+	struct udev_enumerate * enumerate;
 	struct udev_list_entry *devices, *entry;
-	struct udev_device *dev;
+	struct udev_device * dev;
 	bool isMouse;
 
 	ofLogNotice("ofAppEGLWindow") << "setupNativeInput()";
@@ -1368,8 +1377,7 @@ void ofAppEGLWindow::setupNativeInput(){
 
 	devices = udev_enumerate_get_list_entry(enumerate);
 
-	udev_list_entry_foreach(entry, devices)
-	{
+	udev_list_entry_foreach(entry, devices) {
 		/* Get the filename of the /sys entry for the device
 			and create a udev_device object (dev) representing it */
 		const char * name = udev_list_entry_get_name(entry);
@@ -1397,42 +1405,42 @@ void ofAppEGLWindow::setupNativeInput(){
 		ofLogNotice() << " - ID_INPUT_MOUSE: " << prop_mouse;
 		ofLogNotice() << " - ID_INPUT_TOUCHSCREEN: " << prop_touch;
 
-		if(prop_mouse || prop_touch){
+		if (prop_mouse || prop_touch) {
 			isMouse = true;
-		}else{
+		} else {
 			isMouse = false;
 		}
 
-		if(devnode && (prop_keyboard || prop_mouse || prop_touch) && string_begins_with(sysname, "event")){
+		if (devnode && (prop_keyboard || prop_mouse || prop_touch) && string_begins_with(sysname, "event")) {
 			addInput(devnode, isMouse);
 		}
-		if(prop_keyboard){
+		if (prop_keyboard) {
 			keyboardDetected = true;
 		}
-		if(prop_mouse || prop_touch){
+		if (prop_mouse || prop_touch) {
 			mouseDetected = true;
 		}
 
 		udev_device_unref(dev);
-    }
+	}
 	/* Free the enumerator object */
 	udev_enumerate_unref(enumerate);
 
-	if(!mouseDetected){
+	if (!mouseDetected) {
 		ofLogError("ofAppEGLWindow") << "setupNativeInput(): did not open mouse";
 	}
-	if(!keyboardDetected){
+	if (!keyboardDetected) {
 		ofLogError("ofAppEGLWindow") << "setupKeyboard(): did not open keyboard";
 	}
 
 	// save current terminal settings
-	tcgetattr (STDIN_FILENO, &tc);
+	tcgetattr(STDIN_FILENO, &tc);
 	ots = tc;
 	// disable echo on our temporary settings
 	tc.c_lflag &= ~ECHO;
 	tc.c_lflag |= ECHONL;
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &tc);
-	
+
 	mb.mouseButtonState = 0;
 
 	kb.shiftPressed = false;
@@ -1441,22 +1449,22 @@ void ofAppEGLWindow::setupNativeInput(){
 	printInput();
 }
 
-void ofAppEGLWindow::addInput(const char * node, bool isMouse){
-	if(node == NULL){
+void ofAppEGLWindow::addInput(const char * node, bool isMouse) {
+	if (node == NULL) {
 		return;
 	}
 
 	removeInput(node);
 
 	int fd = open(node, O_RDONLY | O_NONBLOCK);
-	if(fd >= 0){
+	if (fd >= 0) {
 		char deviceNameBuffer[256] = "Unknown Device";
 		ioctl(fd, EVIOCGNAME(sizeof(deviceNameBuffer)), deviceNameBuffer);
 		ofLogNotice("ofAppEGLWindow") << "addInput(): input device name = " << deviceNameBuffer;
 
-		if(isMouse){
+		if (isMouse) {
 			struct input_absinfo mabsx;
-			if(ioctl(fd, EVIOCGABS(0), &mabsx) < 0){
+			if (ioctl(fd, EVIOCGABS(0), &mabsx) < 0) {
 				ofLogError("ofAppEGLWindow") << "ioctl GABS failed";
 			} else {
 				mouseAbsXMin = mabsx.minimum;
@@ -1466,9 +1474,9 @@ void ofAppEGLWindow::addInput(const char * node, bool isMouse){
 
 			// Do that for the y axis. EVIOCGABS(1): 1 stands for y axis.
 			struct input_absinfo mabsy;
-			if(ioctl(fd, EVIOCGABS(1), &mabsy) < 0){
+			if (ioctl(fd, EVIOCGABS(1), &mabsy) < 0) {
 				ofLogError("ofAppEGLWindow") << "ioctl GABS failed";
-			}else{
+			} else {
 				mouseAbsYMin = mabsy.minimum;
 				mouseAbsYMax = mabsy.maximum;
 				ofLogNotice("ofAppEGLWindow") << "mouse y axis min, max: " << mouseAbsYMin << ", " << mouseAbsYMax;
@@ -1476,44 +1484,44 @@ void ofAppEGLWindow::addInput(const char * node, bool isMouse){
 		}
 
 		inputDevices[node] = fd;
-    }
+	}
 }
 
-void ofAppEGLWindow::removeInput(const char * node){
-	if(node == NULL)
-        return;
+void ofAppEGLWindow::removeInput(const char * node) {
+	if (node == NULL)
+		return;
 
 	device::iterator iter = inputDevices.find(node);
-	if(iter != inputDevices.end()){
+	if (iter != inputDevices.end()) {
 		::close(iter->second);
 		inputDevices.erase(iter);
 	}
 }
 
-void ofAppEGLWindow::printInput(){
+void ofAppEGLWindow::printInput() {
 	ofLogNotice("--- Input Device List ---");
-	for(device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++){
+	for (device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++) {
 		ofLogNotice() << " - " << iter->first;
 	}
 	ofLogNotice("-------------------------");
 }
 
-void ofAppEGLWindow::destroyNativeInput(){
+void ofAppEGLWindow::destroyNativeInput() {
 	ofLogNotice("ofAppEGLWindow") << "destroyNativeInput()";
-	
-	for(device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++){
-		if(iter->second >= 0){
-            ::close(iter->second);
-        }
+
+	for (device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++) {
+		if (iter->second >= 0) {
+			::close(iter->second);
+		}
 	}
 
 	inputDevices.clear();
 
-	tcsetattr (STDIN_FILENO, TCSAFLUSH, &ots);
+	tcsetattr(STDIN_FILENO, TCSAFLUSH, &ots);
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::processInput(int fd, const char * node){
+void ofAppEGLWindow::processInput(int fd, const char * node) {
 	// http://www.diegm.uniud.it/loghi/CE2/kbd.pdf
 	// http://cgit.freedesktop.org/~whot/evtest/plain/evtest.c
 	// https://strcpy.net/b/archives/2010/11/17/abusing_the_linux_input_subsystem/index.html
@@ -1522,7 +1530,7 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 	static ofMouseEventArgs mouseEvent;
 	struct input_event ev;
 	char key = 0;
-	
+
 	bool pushKeyEvent = false;
 	bool pushMouseEvent = false;
 	bool pushTouchEvent = false;
@@ -1530,215 +1538,214 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 	bool touchAxisValuePending = false;
 
 	int nBytesRead = read(fd, &ev, sizeof(struct input_event));
-	while(nBytesRead >= 0){
-		if(ev.type == EV_KEY){
-			if(ev.code == BTN_LEFT){
+	while (nBytesRead >= 0) {
+		if (ev.type == EV_KEY) {
+			if (ev.code == BTN_LEFT) {
 				ofLogNotice("ofAppEGLWindow") << "BTN_LEFT" << endl;
-				if(ev.value == 0){ // release
+				if (ev.value == 0) { // release
 					mouseEvent.button = OF_MOUSE_BUTTON_LEFT;
 					mouseEvent.type = ofMouseEventArgs::Released;
 					mb.mouseButtonState &= ~MOUSE_BUTTON_LEFT_MASK;
 					pushMouseEvent = true;
-				}else if(ev.value == 1){ // press
+				} else if (ev.value == 1) { // press
 					mb.mouseButtonState |= MOUSE_BUTTON_LEFT_MASK;
 					mouseEvent.type = ofMouseEventArgs::Pressed;
 					mouseEvent.button = OF_MOUSE_BUTTON_LEFT;
 					pushMouseEvent = true;
 				}
-			}else if(ev.code == BTN_MIDDLE){
+			} else if (ev.code == BTN_MIDDLE) {
 				ofLogNotice("ofAppEGLWindow") << "BTN_MIDDLE" << endl;
-				if(ev.value == 0){ // release
+				if (ev.value == 0) { // release
 					mouseEvent.button = OF_MOUSE_BUTTON_MIDDLE;
 					mouseEvent.type = ofMouseEventArgs::Released;
 					mb.mouseButtonState &= ~MOUSE_BUTTON_MIDDLE_MASK;
 					pushMouseEvent = true;
-				}else if(ev.value == 1){ // press
+				} else if (ev.value == 1) { // press
 					mb.mouseButtonState |= MOUSE_BUTTON_MIDDLE_MASK;
 					mouseEvent.type = ofMouseEventArgs::Pressed;
 					mouseEvent.button = OF_MOUSE_BUTTON_MIDDLE;
 					pushMouseEvent = true;
 				}
-			}else if(ev.code == BTN_RIGHT){
+			} else if (ev.code == BTN_RIGHT) {
 				ofLogNotice("ofAppEGLWindow") << "BTN_RIGHT" << endl;
-				if(ev.value == 0){ // release
+				if (ev.value == 0) { // release
 					mouseEvent.button = OF_MOUSE_BUTTON_RIGHT;
 					mouseEvent.type = ofMouseEventArgs::Released;
 					mb.mouseButtonState &= ~MOUSE_BUTTON_RIGHT_MASK;
 					pushMouseEvent = true;
-				}else if(ev.value == 1){ // press
+				} else if (ev.value == 1) { // press
 					mb.mouseButtonState |= MOUSE_BUTTON_RIGHT_MASK;
 					mouseEvent.type = ofMouseEventArgs::Pressed;
 					mouseEvent.button = OF_MOUSE_BUTTON_RIGHT;
 					pushMouseEvent = true;
 				}
-			}else if(ev.code == BTN_TOUCH){
-				if(ev.value == 0){ // release	
+			} else if (ev.code == BTN_TOUCH) {
+				if (ev.value == 0) { // release
 					touchEvent.type = ofTouchEventArgs::up;
 					touchEvent.id = 0;
 					mt[touchEvent.id] = 0;
 					pushTouchEvent = true;
 
-				}else if(ev.value == 1){ // press
+				} else if (ev.value == 1) { // press
 					touchEvent.type = ofTouchEventArgs::down;
 					touchEvent.id = 0;
 					mt[touchEvent.id] = 1;
 					pushTouchEvent = true;
 				}
-			}else{
-				if(ev.value == 0){
+			} else {
+				if (ev.value == 0) {
 					// key released
 					keyEvent.type = ofKeyEventArgs::Released;
-				}else if(ev.value == 1){
+				} else if (ev.value == 1) {
 					// key pressed
 					keyEvent.type = ofKeyEventArgs::Pressed;
-				}else if(ev.value == 2){
+				} else if (ev.value == 2) {
 					// key repeated
 					keyEvent.type = ofKeyEventArgs::Pressed;
-				}else{
+				} else {
 					// unknown ev.value
 				}
 				switch (ev.code) {
-					case KEY_RIGHTSHIFT:
-					case KEY_LEFTSHIFT:
-						kb.shiftPressed = ev.value;
-						break;
-					case KEY_RIGHTCTRL:
-					case KEY_LEFTCTRL:
-						break;
-					case KEY_CAPSLOCK:
-						if (ev.value == 1) {
-							if (kb.capsLocked) {
-								kb.capsLocked = 0;
-							} else {
-								kb.capsLocked = 1;
-							}
+				case KEY_RIGHTSHIFT:
+				case KEY_LEFTSHIFT:
+					kb.shiftPressed = ev.value;
+					break;
+				case KEY_RIGHTCTRL:
+				case KEY_LEFTCTRL:
+					break;
+				case KEY_CAPSLOCK:
+					if (ev.value == 1) {
+						if (kb.capsLocked) {
+							kb.capsLocked = 0;
+						} else {
+							kb.capsLocked = 1;
 						}
-						break;
-					case KEY_ESC:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_ESC;
-						break;
-					case KEY_BACKSPACE:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_BACKSPACE;
-						break;
-					case KEY_DELETE:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_DEL;
-						break;
-					case KEY_F1:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F1;
-						break;
-					case KEY_F2:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F2;
-						break;
-					case KEY_F3:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F3;
-						break;
-					case KEY_F4:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F4;
-						break;
-					case KEY_F5:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F5;
-						break;
-					case KEY_F6:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F6;
-						break;
-					case KEY_F7:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F7;
-						break;
-					case KEY_F8:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F8;
-						break;
-					case KEY_F9:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F9;
-						break;
-					case KEY_F10:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F10;
-						break;
-					case KEY_F11:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F11;
-						break;
-					case KEY_F12:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_F12;
-						break;
-					case KEY_LEFT:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_LEFT;
-						break;
-					case KEY_UP:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_UP;
-						break;
-					case KEY_RIGHT:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_RIGHT;
-						break;
-					case KEY_DOWN:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_DOWN;
-						break;
-					case KEY_PAGEUP:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_PAGE_UP;
-						break;
-					case KEY_PAGEDOWN:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_PAGE_DOWN;
-						break;
-					case KEY_HOME:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_HOME;
-						break;
-					case KEY_END:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_END;
-						break;
-					case KEY_INSERT:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_INSERT;
-						break;
-					case KEY_ENTER:
-					case KEY_KPENTER:
-						pushKeyEvent = true;
-						keyEvent.key = OF_KEY_RETURN;
-						break;
-					default:
-						// VERY RUDIMENTARY KEY MAPPING WITH MAPS ABOVE
-						if(ev.code < sizeof(lowercase_map)){
-							if(kb.shiftPressed){
-								key = uppercase_map[ev.code];
-								if(kb.capsLocked) keyEvent.key = tolower(key);
-								keyEvent.key = key;
-								pushKeyEvent = true;
-							}else{
-								key = lowercase_map[ev.code];
-								if(kb.capsLocked) key = toupper(key);
-								keyEvent.key = key;
-								pushKeyEvent = true;
-							}
-						}else{
-							ofLogNotice("ofAppEGLWindow") << "readKeyboardEvents(): input_event.code is outside of our small range";
+					}
+					break;
+				case KEY_ESC:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_ESC;
+					break;
+				case KEY_BACKSPACE:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_BACKSPACE;
+					break;
+				case KEY_DELETE:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_DEL;
+					break;
+				case KEY_F1:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F1;
+					break;
+				case KEY_F2:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F2;
+					break;
+				case KEY_F3:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F3;
+					break;
+				case KEY_F4:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F4;
+					break;
+				case KEY_F5:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F5;
+					break;
+				case KEY_F6:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F6;
+					break;
+				case KEY_F7:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F7;
+					break;
+				case KEY_F8:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F8;
+					break;
+				case KEY_F9:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F9;
+					break;
+				case KEY_F10:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F10;
+					break;
+				case KEY_F11:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F11;
+					break;
+				case KEY_F12:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_F12;
+					break;
+				case KEY_LEFT:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_LEFT;
+					break;
+				case KEY_UP:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_UP;
+					break;
+				case KEY_RIGHT:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_RIGHT;
+					break;
+				case KEY_DOWN:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_DOWN;
+					break;
+				case KEY_PAGEUP:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_PAGE_UP;
+					break;
+				case KEY_PAGEDOWN:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_PAGE_DOWN;
+					break;
+				case KEY_HOME:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_HOME;
+					break;
+				case KEY_END:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_END;
+					break;
+				case KEY_INSERT:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_INSERT;
+					break;
+				case KEY_ENTER:
+				case KEY_KPENTER:
+					pushKeyEvent = true;
+					keyEvent.key = OF_KEY_RETURN;
+					break;
+				default:
+					// VERY RUDIMENTARY KEY MAPPING WITH MAPS ABOVE
+					if (ev.code < sizeof(lowercase_map)) {
+						if (kb.shiftPressed) {
+							key = uppercase_map[ev.code];
+							if (kb.capsLocked) keyEvent.key = tolower(key);
+							keyEvent.key = key;
+							pushKeyEvent = true;
+						} else {
+							key = lowercase_map[ev.code];
+							if (kb.capsLocked) key = toupper(key);
+							keyEvent.key = key;
+							pushKeyEvent = true;
 						}
-				}	
+					} else {
+						ofLogNotice("ofAppEGLWindow") << "readKeyboardEvents(): input_event.code is outside of our small range";
+					}
+				}
 			}
-		}else if (ev.type == EV_REL){
+		} else if (ev.type == EV_REL) {
 			int axis = ev.code;
 			int amount = ev.value;
-			switch (axis)
-			{
+			switch (axis) {
 			case REL_X:
 				mouseEvent.x += amount * mouseScaleX;
 				mouseEvent.x = ofClamp(mouseEvent.x, 0, currentWindowRect.width);
@@ -1753,75 +1760,71 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 				ofLogNotice("ofAppEGLWindow") << "readMouseEvents(): unknown mouse axis (perhaps it's the scroll wheel?): axis " << axis << " amount " << amount << endl;
 				break;
 			}
-		}else if (ev.type == EV_ABS){
+		} else if (ev.type == EV_ABS) {
 			int axis = ev.code;
 			int amount = ev.value;
-			switch (axis)
-			{
-				// do not need this mouse returns REL_X/REL_Y
-				case ABS_X:
-					// mouseEvent.x = amount * (float)currentWindowRect.width / (float)mouseAbsXMax;
-					// mouseEvent.x = ofClamp(mouseEvent.x, 0, currentWindowRect.width);
-					// axisValuePending = true;
-					break;
-				case ABS_Y:
-					// mouseEvent.y = amount * (float)currentWindowRect.height / (float)mouseAbsYMax;
-					// mouseEvent.y = ofClamp(mouseEvent.y, 0, currentWindowRect.height);
-					// axisValuePending = true;
-					break;
-				case ABS_MT_TOOL_TYPE:
-					break;
-				case ABS_MT_SLOT:
-					touchEvent.id = amount;
-					break;
-				case ABS_MT_TRACKING_ID:
-					if (amount == -1)
-					{
-						if( mt[touchEvent.id] == 1){
-							touchEvent.type = ofTouchEventArgs::up;
-							mt[touchEvent.id] = 0;
-							pushTouchEvent = true;
-						}
+			switch (axis) {
+			// do not need this mouse returns REL_X/REL_Y
+			case ABS_X:
+				// mouseEvent.x = amount * (float)currentWindowRect.width / (float)mouseAbsXMax;
+				// mouseEvent.x = ofClamp(mouseEvent.x, 0, currentWindowRect.width);
+				// axisValuePending = true;
+				break;
+			case ABS_Y:
+				// mouseEvent.y = amount * (float)currentWindowRect.height / (float)mouseAbsYMax;
+				// mouseEvent.y = ofClamp(mouseEvent.y, 0, currentWindowRect.height);
+				// axisValuePending = true;
+				break;
+			case ABS_MT_TOOL_TYPE:
+				break;
+			case ABS_MT_SLOT:
+				touchEvent.id = amount;
+				break;
+			case ABS_MT_TRACKING_ID:
+				if (amount == -1) {
+					if (mt[touchEvent.id] == 1) {
+						touchEvent.type = ofTouchEventArgs::up;
+						mt[touchEvent.id] = 0;
+						pushTouchEvent = true;
 					}
-					else 
-					{
-						if (mt[touchEvent.id] == 0){
-							touchEvent.type = ofTouchEventArgs::down;
-							mt[touchEvent.id] = 1;
-							pushTouchEvent = true;
-						}
-						touchAxisValuePending = true;
-					}
-					break;
-				case ABS_MT_POSITION_X:
-					mtp[touchEvent.id].x = amount * (float)currentWindowRect.width / (float)mouseAbsXMax;
-					mtp[touchEvent.id].x = ofClamp(mtp[touchEvent.id].x, 0, currentWindowRect.width);
-					touchAxisValuePending = true;
-					break;
-				case ABS_MT_POSITION_Y:
-					mtp[touchEvent.id].y = amount * (float)currentWindowRect.height / (float)mouseAbsYMax;
-					mtp[touchEvent.id].y = ofClamp(mtp[touchEvent.id].y, 0, currentWindowRect.height);
-					if(!pushTouchEvent){
-						touchEvent.type = ofTouchEventArgs::move;
+				} else {
+					if (mt[touchEvent.id] == 0) {
+						touchEvent.type = ofTouchEventArgs::down;
+						mt[touchEvent.id] = 1;
 						pushTouchEvent = true;
 					}
 					touchAxisValuePending = true;
-					break;
-				default:
-					ofLogNotice("ofAppEGLWindow") << "EV_ABS unknown axis: axis " << axis << " amount " << amount << endl;
-					break;
+				}
+				break;
+			case ABS_MT_POSITION_X:
+				mtp[touchEvent.id].x = amount * (float)currentWindowRect.width / (float)mouseAbsXMax;
+				mtp[touchEvent.id].x = ofClamp(mtp[touchEvent.id].x, 0, currentWindowRect.width);
+				touchAxisValuePending = true;
+				break;
+			case ABS_MT_POSITION_Y:
+				mtp[touchEvent.id].y = amount * (float)currentWindowRect.height / (float)mouseAbsYMax;
+				mtp[touchEvent.id].y = ofClamp(mtp[touchEvent.id].y, 0, currentWindowRect.height);
+				if (!pushTouchEvent) {
+					touchEvent.type = ofTouchEventArgs::move;
+					pushTouchEvent = true;
+				}
+				touchAxisValuePending = true;
+				break;
+			default:
+				ofLogNotice("ofAppEGLWindow") << "EV_ABS unknown axis: axis " << axis << " amount " << amount << endl;
+				break;
 			}
-		}else if(ev.type == EV_MSC){
-		}else if(ev.type == EV_SYN){
+		} else if (ev.type == EV_MSC) {
+		} else if (ev.type == EV_SYN) {
 			// EV_SYN Used as markers to separate events. Events may be
 			// separated in time or in space, suc8h as with the multitouch protocol.
 			// EV_SYN events are sent when axis value (one or a pair) are changed
-			if(axisValuePending){
+			if (axisValuePending) {
 				// TODO, this state doesn't make as much sense when the mouse is not dragging
-				if(mb.mouseButtonState > 0){
+				if (mb.mouseButtonState > 0) {
 					// dragging (what if dragging w/ more than one button?)
 					mouseEvent.type = ofMouseEventArgs::Dragged;
-				}else{
+				} else {
 					// just moving
 					mouseEvent.type = ofMouseEventArgs::Moved;
 				}
@@ -1832,8 +1835,8 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 				axisValuePending = false;
 			}
 
-			if(touchAxisValuePending){
-				if(!pushTouchEvent){
+			if (touchAxisValuePending) {
+				if (!pushTouchEvent) {
 					touchEvent.type = ofTouchEventArgs::move;
 					pushTouchEvent = true;
 				}
@@ -1841,17 +1844,14 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 			}
 		}
 
-		
-		
-
-		if(pushKeyEvent){
+		if (pushKeyEvent) {
 			lock();
 			keyEvents.push(keyEvent);
 			unlock();
 			pushKeyEvent = false;
 		}
-		
-		if(pushMouseEvent){
+
+		if (pushMouseEvent) {
 			// lock the thread for a moment while we copy the data
 			lock();
 			mouseEvents.push(mouseEvent);
@@ -1859,7 +1859,7 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 			pushMouseEvent = false;
 		}
 
-		if(pushTouchEvent){
+		if (pushTouchEvent) {
 			touchEvent.x = mtp[touchEvent.id].x;
 			touchEvent.y = mtp[touchEvent.id].y;
 			lock();
@@ -1867,7 +1867,7 @@ void ofAppEGLWindow::processInput(int fd, const char * node){
 			unlock();
 			pushTouchEvent = false;
 		}
-		nBytesRead = read(fd, &ev,sizeof(struct input_event));
+		nBytesRead = read(fd, &ev, sizeof(struct input_event));
 	}
 }
 
@@ -1877,7 +1877,7 @@ void ofAppEGLWindow::readNativeUDevEvents() {
 	fd_set fds;
 	struct timeval tv;
 	int ret;
-	struct udev_device *dev;
+	struct udev_device * dev;
 	bool is_mouse = false;
 
 	FD_ZERO(&fds);
@@ -1885,14 +1885,14 @@ void ofAppEGLWindow::readNativeUDevEvents() {
 	tv.tv_sec = 0;
 	tv.tv_usec = 0;
 
-	ret = select(udev_fd+1, &fds, NULL, NULL, &tv);
+	ret = select(udev_fd + 1, &fds, NULL, NULL, &tv);
 
 	/* Check if our file descriptor has received data. */
-	if(ret > 0 && FD_ISSET(udev_fd, &fds)){
+	if (ret > 0 && FD_ISSET(udev_fd, &fds)) {
 		/* Make the call to receive the device.
 		   select() ensured that this will not block. */
 		dev = udev_monitor_receive_device(mon);
-		if(dev){
+		if (dev) {
 			const char * devnode = udev_device_get_devnode(dev);
 			const char * devpath = udev_device_get_devpath(dev);
 			const char * sysname = udev_device_get_sysname(dev);
@@ -1916,26 +1916,26 @@ void ofAppEGLWindow::readNativeUDevEvents() {
 			ofLogNotice() << " - ID_INPUT_KEYBOARD: " << prop_keyboard;
 			ofLogNotice() << " - ID_INPUT_MOUSE: " << prop_mouse;
 
-			if(prop_mouse){
+			if (prop_mouse) {
 				is_mouse = true;
 			}
-            if(devnode && (prop_keyboard || prop_mouse) && string_begins_with(sysname, "event")){
-                if(strcmp(action, "add") == 0){
+			if (devnode && (prop_keyboard || prop_mouse) && string_begins_with(sysname, "event")) {
+				if (strcmp(action, "add") == 0) {
 					addInput(devnode, is_mouse);
-                }else if(strcmp(action, "remove") == 0){
+				} else if (strcmp(action, "remove") == 0) {
 					removeInput(devnode);
-                }
-            }
-			
+				}
+			}
+
 			udev_device_unref(dev);
-		}else{
+		} else {
 			ofLogNotice("ofAppEGLWindow") << "readNativeUDevEvents(): device returned by receive_device() is NULL";
 		}
 	}
 }
 
-void ofAppEGLWindow::readNativeInputEvents(){
-	for(device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++){
+void ofAppEGLWindow::readNativeInputEvents() {
+	for (device::iterator iter = inputDevices.begin(); iter != inputDevices.end(); iter++) {
 		processInput(iter->second, iter->first.c_str());
 	}
 }
@@ -1948,11 +1948,10 @@ void ofAppEGLWindow::initRPiNative() {
 	memset(&dispman_native_window, 0x0, sizeof(EGL_DISPMANX_WINDOW_T));
 	dispman_element = DISPMANX_NO_HANDLE;
 	dispman_display = DISPMANX_NO_HANDLE;
-	dispman_update  = DISPMANX_NO_HANDLE;
+	dispman_update = DISPMANX_NO_HANDLE;
 	memset(&dispman_clamp, 0x0, sizeof(DISPMANX_CLAMP_T));
 	dispman_transform = DISPMANX_NO_ROTATE;
 	memset(&dispman_alpha, 0x0, sizeof(VC_DISPMANX_ALPHA_T)); // zero dispman_alpha
-
 }
 
 //------------------------------------------------------------
@@ -1961,7 +1960,7 @@ void ofAppEGLWindow::exitRPiNative() {
 }
 
 //------------------------------------------------------------
-bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle& requestedWindowRect){
+bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle & requestedWindowRect) {
 
 	ofRectangle screenRect = getScreenRect();
 
@@ -1984,12 +1983,12 @@ bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle& requestedWindowRec
 
 	src_rect.x = 0;
 	src_rect.y = 0;
-	src_rect.width  = dst_rect.width << 16;
+	src_rect.width = dst_rect.width << 16;
 	src_rect.height = dst_rect.height << 16;
 
 	memset(&dispman_alpha, 0x0, sizeof(VC_DISPMANX_ALPHA_T)); // zero dispman_alpha
 	dispman_alpha.flags = DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS;
-	dispman_alpha.opacity = ofClamp(settings.eglWindowOpacity,0,255);
+	dispman_alpha.opacity = ofClamp(settings.eglWindowOpacity, 0, 255);
 	dispman_alpha.mask = 0;
 
 	memset(&dispman_clamp, 0x0, sizeof(DISPMANX_CLAMP_T));
@@ -2001,28 +2000,28 @@ bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle& requestedWindowRec
 	dispman_display = vc_dispmanx_display_open(settings.screenNum);
 
 	// begin the display manager interaction
-	dispman_update  = vc_dispmanx_update_start( 0 );
+	dispman_update = vc_dispmanx_update_start(0);
 
 	// add a "display manager element" with our parameters so
 	// that it can fill in the structures.  we will pass this
 	// filled dispman_element to our native window, which will
 	// be used to construct the EGL surface, etc.
-	dispman_element = vc_dispmanx_element_add ( dispman_update,
-			dispman_display,
-			settings.layer, // layer
-			&dst_rect, // dst rect
-			(DISPMANX_RESOURCE_HANDLE_T)0, // src
-			&src_rect, // src rect
-			DISPMANX_PROTECTION_NONE, // ?
-			&dispman_alpha, // alpha
-			&dispman_clamp, // clamp
-			dispman_transform // transform
+	dispman_element = vc_dispmanx_element_add(dispman_update,
+		dispman_display,
+		settings.layer, // layer
+		&dst_rect, // dst rect
+		(DISPMANX_RESOURCE_HANDLE_T)0, // src
+		&src_rect, // src rect
+		DISPMANX_PROTECTION_NONE, // ?
+		&dispman_alpha, // alpha
+		&dispman_clamp, // clamp
+		dispman_transform // transform
 	);
 
-	if(dispman_element == DISPMANX_NO_HANDLE) {
+	if (dispman_element == DISPMANX_NO_HANDLE) {
 		ofLogError("ofAppEGLWindow") << "setupRPiNativeWindow(): dispman_element == DISPMANX_NO_HANDLE";
 		return false;
-	} else if(dispman_element == (unsigned)DISPMANX_INVALID) {
+	} else if (dispman_element == (unsigned)DISPMANX_INVALID) {
 		ofLogError("ofAppEGLWindow") << "setupRPiNativeWindow(): dispman_element == DISPMANX_INVALID";
 		return false;
 	}
@@ -2037,7 +2036,7 @@ bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle& requestedWindowRec
 	vc_dispmanx_display_set_background(dispman_update, dispman_display, 0x00, 0x00, 0x00);
 
 	// finished with display manager update, so sync
-	vc_dispmanx_update_submit_sync( dispman_update );
+	vc_dispmanx_update_submit_sync(dispman_update);
 
 	currentWindowRect = windowRect;
 
@@ -2048,14 +2047,14 @@ bool ofAppEGLWindow::createRPiNativeWindow(const ofRectangle& requestedWindowRec
 //------------------------------------------------------------
 // X11 BELOW
 //------------------------------------------------------------
-bool ofAppEGLWindow::createX11NativeWindow(const ofRectangle& requestedWindowRect){
+bool ofAppEGLWindow::createX11NativeWindow(const ofRectangle & requestedWindowRect) {
 
 	// X11 variables
 	x11Window = 0;
 	x11Display = 0;
 	x11ScreenNum = 0; // TODO: settings.screenNum?
 	x11Screen = 0;
-	XVisualInfo* x11Visual = 0; // TODO does this need to be deleted?
+	XVisualInfo * x11Visual = 0; // TODO does this need to be deleted?
 	Colormap x11Colormap = 0;
 
 	/*
@@ -2070,16 +2069,16 @@ bool ofAppEGLWindow::createX11NativeWindow(const ofRectangle& requestedWindowRec
 
 	// make sure our requested window rectangle does not exceed the native
 	// screen size, or start outside of it.
-	ofRectangle windowRect = requestedWindowRect.getStandardized();//screenRect.getIntersection(requestedWindowRect);
+	ofRectangle windowRect = requestedWindowRect.getStandardized(); //screenRect.getIntersection(requestedWindowRect);
 
 	// Initializes the display and screen
-	x11Display = XOpenDisplay( 0 );
+	x11Display = XOpenDisplay(0);
 	if (!x11Display) {
 		ofLogError("ofAppEGLWindow") << "unable to open X display";
 		return false;
 	}
 
-	x11ScreenNum = XDefaultScreen( x11Display );
+	x11ScreenNum = XDefaultScreen(x11Display);
 
 	x11Screen = XDefaultScreenOfDisplay(x11Display);
 
@@ -2088,18 +2087,18 @@ bool ofAppEGLWindow::createX11NativeWindow(const ofRectangle& requestedWindowRec
 	i32Depth = DefaultDepth(x11Display, x11ScreenNum);
 	x11Visual = new XVisualInfo();
 
-	XMatchVisualInfo( x11Display,
-			x11ScreenNum,
-			i32Depth,
-			TrueColor,
-			x11Visual);
+	XMatchVisualInfo(x11Display,
+		x11ScreenNum,
+		i32Depth,
+		TrueColor,
+		x11Visual);
 
 	if (!x11Visual) {
 		ofLogError("ofAppEGLWindow") << "unable to acquire XVisualInfo";
 		return false;
 	}
 
-	x11Colormap = XCreateColormap( x11Display, sRootWindow, x11Visual->visual, AllocNone );
+	x11Colormap = XCreateColormap(x11Display, sRootWindow, x11Visual->visual, AllocNone);
 
 	delete x11Visual;
 
@@ -2125,32 +2124,32 @@ bool ofAppEGLWindow::createX11NativeWindow(const ofRectangle& requestedWindowRec
 
 	// Creates the X11 window
 	x11Window = XCreateWindow(x11Display, // Specifies the connection to the X server.
-			sRootWindow, // Specifies the parent window.
-			(int)windowRect.x, (int)windowRect.y, // Specify the x and y coordinates,
-			// which are the top-left outside corner
-			// of the window's borders and are relative
-			// to the inside of the parent window's borders.
-			(unsigned int)windowRect.width, (unsigned int)windowRect.height, // Specify the width and height, which are the
-			// created window's inside dimensions and do
-			// not include the created window's borders.
-			0, // Specifies the width of the created
-			// window's border in pixels.
-			CopyFromParent, // Specifies the window's depth.
-			// A depth of CopyFromParent means
-			// the depth is taken from the parent.
-			InputOutput, // Specifies the created window's class.
-			// You can pass InputOutput, InputOnly,
-			// or CopyFromParent. A class of CopyFromParent
-			// means the class is taken from the parent.
-			CopyFromParent, // Specifies the visual type.
-			// A visual of CopyFromParent means the visual type
-			// is taken from the parent.
-			ui32Mask, // Specifies which window attributes are
-			// defined in the attributes argument. This mask is
-			// the bitwise inclusive OR of the valid attribute
-			// mask bits. If valuemask is zero, the attributes
-			// are ignored and are not referenced.
-			&sWA //Specifies the background pixel value of the window.
+		sRootWindow, // Specifies the parent window.
+		(int)windowRect.x, (int)windowRect.y, // Specify the x and y coordinates,
+		// which are the top-left outside corner
+		// of the window's borders and are relative
+		// to the inside of the parent window's borders.
+		(unsigned int)windowRect.width, (unsigned int)windowRect.height, // Specify the width and height, which are the
+		// created window's inside dimensions and do
+		// not include the created window's borders.
+		0, // Specifies the width of the created
+		// window's border in pixels.
+		CopyFromParent, // Specifies the window's depth.
+		// A depth of CopyFromParent means
+		// the depth is taken from the parent.
+		InputOutput, // Specifies the created window's class.
+		// You can pass InputOutput, InputOnly,
+		// or CopyFromParent. A class of CopyFromParent
+		// means the class is taken from the parent.
+		CopyFromParent, // Specifies the visual type.
+		// A visual of CopyFromParent means the visual type
+		// is taken from the parent.
+		ui32Mask, // Specifies which window attributes are
+		// defined in the attributes argument. This mask is
+		// the bitwise inclusive OR of the valid attribute
+		// mask bits. If valuemask is zero, the attributes
+		// are ignored and are not referenced.
+		&sWA //Specifies the background pixel value of the window.
 	);
 
 	XMapWindow(x11Display, x11Window);
@@ -2230,34 +2229,32 @@ static KeySym KeyCodeToKeySym(Display * display, KeyCode keycode, unsigned int e
 }
 
 //------------------------------------------------------------
-void ofAppEGLWindow::handleX11Event(const XEvent& event){
+void ofAppEGLWindow::handleX11Event(const XEvent & event) {
 	ofMouseEventArgs mouseEvent;
 	ofKeyEventArgs keyEvent;
 
-	switch (event.type){
+	switch (event.type) {
 	case KeyPress:
-	case KeyRelease:
-	{
-		KeySym key = KeyCodeToKeySym(instance->x11Display,event.xkey.keycode,event.xkey.state);
+	case KeyRelease: {
+		KeySym key = KeyCodeToKeySym(instance->x11Display, event.xkey.keycode, event.xkey.state);
 		keyEvent.key = key;
 		if (event.type == KeyPress) {
 			keyEvent.type = ofKeyEventArgs::Pressed;
-			if(key == 65307){
+			if (key == 65307) {
 				keyEvent.key = OF_KEY_ESC;
 			}
-		} else if (event.type == KeyRelease){
+		} else if (event.type == KeyRelease) {
 			keyEvent.type = ofKeyEventArgs::Released;
 		}
 
 		instance->coreEvents.notifyKeyEvent(keyEvent);
-	}
-	break;
+	} break;
 	case ButtonPress:
 	case ButtonRelease:
 		mouseEvent.x = static_cast<float>(event.xbutton.x);
 		mouseEvent.y = static_cast<float>(event.xbutton.y);
 		mouseEvent.button = event.xbutton.button;
-		if (event.type == ButtonPress){
+		if (event.type == ButtonPress) {
 			mouseEvent.type = ofMouseEventArgs::Pressed;
 		} else {
 			mouseEvent.type = ofMouseEventArgs::Released;
@@ -2270,7 +2267,7 @@ void ofAppEGLWindow::handleX11Event(const XEvent& event){
 		mouseEvent.x = static_cast<float>(event.xmotion.x);
 		mouseEvent.y = static_cast<float>(event.xmotion.y);
 		mouseEvent.button = event.xbutton.button;
-		if(ofGetMousePressed()) {
+		if (ofGetMousePressed()) {
 			mouseEvent.type = ofMouseEventArgs::Dragged;
 		} else {
 			mouseEvent.type = ofMouseEventArgs::Moved;
@@ -2284,9 +2281,9 @@ void ofAppEGLWindow::handleX11Event(const XEvent& event){
 		instance->currentWindowRect.width = event.xconfigure.width;
 		instance->currentWindowRect.height = event.xconfigure.height;
 		instance->nonFullscreenWindowRect = instance->currentWindowRect;
-		instance->coreEvents.notifyWindowResized(event.xconfigure.width,event.xconfigure.height);
+		instance->coreEvents.notifyWindowResized(event.xconfigure.width, event.xconfigure.height);
 		break;
-	/*case ClientMessage:{
+		/*case ClientMessage:{
 		if (event.xclient.message_type == wmProtocols_ &&
 		event.xclient.format == 32 &&
 		event.xclient.data.l[0] == (long) wmDeleteWindow_)

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "ofAppBaseWindow.h"
-#include "ofThread.h"
-#include "ofImage.h"
-#include "ofEvents.h"
-#include "ofRectangle.h"
 #include "ofConstants.h"
-#include <queue>
-#include <map>
+#include "ofEvents.h"
+#include "ofImage.h"
+#include "ofRectangle.h"
+#include "ofThread.h"
 #include <X11/Xlib.h>
+#include <map>
+#include <queue>
 
 enum ofAppEGLWindowType {
 	OF_APP_WINDOW_AUTO,
@@ -24,15 +24,15 @@ typedef struct _XDisplay Display;
 
 typedef unsigned int EGLBoolean;
 typedef int32_t EGLint;
-typedef void *EGLDisplay;
-typedef void *EGLConfig;
-typedef void *EGLSurface;
-typedef void *EGLContext;
+typedef void * EGLDisplay;
+typedef void * EGLConfig;
+typedef void * EGLSurface;
+typedef void * EGLContext;
 
-typedef std::map<EGLint,EGLint> ofEGLAttributeList;
-typedef std::map<EGLint,EGLint>::iterator ofEGLAttributeListIterator;
+typedef std::map<EGLint, EGLint> ofEGLAttributeList;
+typedef std::map<EGLint, EGLint>::iterator ofEGLAttributeListIterator;
 
-struct ofAppEGLWindowSettings: public ofGLESWindowSettings {
+struct ofAppEGLWindowSettings : public ofGLESWindowSettings {
 public:
 	ofAppEGLWindowType eglWindowPreference; ///< what window type is preferred?
 	EGLint eglWindowOpacity; ///< 0-255 window alpha value
@@ -52,7 +52,6 @@ public:
 
 class ofAppEGLWindow : public ofAppBaseGLESWindow, public ofThread {
 public:
-
 	/// ofAppEGLWindow::Settings is currently deprecated in favor of
 	/// the ofAppEGLWindowSettings struct
 	typedef ofAppEGLWindowSettings Settings;
@@ -60,10 +59,10 @@ public:
 	ofAppEGLWindow();
 	virtual ~ofAppEGLWindow();
 
-	static void loop(){};
-	static bool doesLoop(){ return false; }
-	static bool allowsMultiWindow(){ return false; }
-	static bool needsPolling(){ return true; }
+	static void loop() {};
+	static bool doesLoop() { return false; }
+	static bool allowsMultiWindow() { return false; }
+	static bool needsPolling() { return true; }
 	static void pollEvents();
 
 	using ofAppBaseGLESWindow::setup;
@@ -81,16 +80,18 @@ public:
 	ofCoreEvents & events();
 	std::shared_ptr<ofBaseRenderer> & renderer();
 
-	void setThreadTimeout(long timeOut){ threadTimeout = timeOut; }
+	void setThreadTimeout(long timeOut) { threadTimeout = timeOut; }
 
 	virtual void hideCursor();
 	virtual void showCursor();
 
 	virtual void setWindowPosition(int x, int y);
 	virtual void setWindowSize(int w, int h);
-	virtual void setWindowMinimumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMinimumSize() not implemented"};
-	virtual void setWindowMaximumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMaximumSize() not implemented"};;
-	virtual void setWindowAspectRatio(int horizontal, int vertical) { ofLogWarning("ofAppEGLWindow::") << "setWindowAspectRatio() not implemented"};;
+	virtual void setWindowMinimumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMinimumSize() not implemented" };
+	virtual void setWindowMaximumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMaximumSize() not implemented" };
+	;
+	virtual void setWindowAspectRatio(int horizontal, int vertical) { ofLogWarning("ofAppEGLWindow::") << "setWindowAspectRatio() not implemented" };
+	;
 	virtual void setWindowShape(int w, int h);
 
 	virtual glm::vec2 getWindowPosition();
@@ -102,8 +103,8 @@ public:
 	virtual bool doesHWOrientation();
 
 	//this is used by ofGetWidth and now determines the window width based on orientation
-	virtual int	getWidth();
-	virtual int	getHeight();
+	virtual int getWidth();
+	virtual int getHeight();
 
 	virtual void setWindowTitle(std::string title); // TODO const correct
 
@@ -122,21 +123,19 @@ public:
 	EGLContext getEglContext() const;
 
 #ifndef TARGET_RASPBERRY_PI_LEGACY
-	Display* getX11Display();
+	Display * getX11Display();
 	Window getX11Window();
 #endif
 
 	EGLConfig getEglConfig() const;
 
-	EGLint getEglVersionMajor () const;
+	EGLint getEglVersionMajor() const;
 	EGLint getEglVersionMinor() const;
 
-
 protected:
-	void setWindowRect(const ofRectangle& requestedWindowRect);
+	void setWindowRect(const ofRectangle & requestedWindowRect);
 
-
-//	bool create
+	//	bool create
 
 	virtual void setupPeripherals();
 
@@ -146,28 +145,26 @@ protected:
 	int getWindowHeight();
 
 	ofWindowMode windowMode;
-	bool bNewScreenMode;  ///< \brief This indicates if a (new) window rectangle has to be adjusted.
-	int	buttonInUse;  ///< \brief Mouse button currently in use.
-	bool bEnableSetupScreen;  ///< \brief This indicates the need/intent to draw a setup screen.
-	bool bShowCursor;  ///< \brief Indicate the visibility of the (mouse) cursor.
+	bool bNewScreenMode; ///< \brief This indicates if a (new) window rectangle has to be adjusted.
+	int buttonInUse; ///< \brief Mouse button currently in use.
+	bool bEnableSetupScreen; ///< \brief This indicates the need/intent to draw a setup screen.
+	bool bShowCursor; ///< \brief Indicate the visibility of the (mouse) cursor.
 
 	std::string eglDisplayString;
-	int nFramesSinceWindowResized;  ///< \brief The number of frames passed/shown since the window got resized.
+	int nFramesSinceWindowResized; ///< \brief The number of frames passed/shown since the window got resized.
 	ofOrientation orientation;
-
 
 	void threadedFunction();
 	std::queue<ofMouseEventArgs> mouseEvents;
-	std::queue<ofKeyEventArgs>   keyEvents;
+	std::queue<ofKeyEventArgs> keyEvents;
 	std::queue<ofTouchEventArgs> touchEvents;
 	void checkEvents();
 	ofImage mouseCursor;
 
 	// TODO: getters and setters?  OR automatically set based on
 	// OS or screen size?  Should be changed when screen is resized?
-	float mouseScaleX;  ///< \brief Amount by which to mouse movements along the X axis.
-	float mouseScaleY;  ///< \brief Amount by which to mouse movements along the Y axis.
-
+	float mouseScaleX; ///< \brief Amount by which to mouse movements along the X axis.
+	float mouseScaleY; ///< \brief Amount by which to mouse movements along the Y axis.
 
 	// float getMouseScaleX() const;
 	// void setMouseScaleX(float x);
@@ -184,17 +181,16 @@ protected:
 	bool hasMouse() { return mouseDetected; }
 	bool hasKeyboard() { return keyboardDetected; }
 
-
-//------------------------------------------------------------
-// EGL
-//------------------------------------------------------------
+	//------------------------------------------------------------
+	// EGL
+	//------------------------------------------------------------
 
 	bool createSurface();
 	bool destroySurface();
 
 	// bool resizeSurface();
 
-	EGLDisplay eglDisplay;  // EGL display connection
+	EGLDisplay eglDisplay; // EGL display connection
 	EGLSurface eglSurface;
 	EGLContext eglContext;
 
@@ -203,24 +199,24 @@ protected:
 	EGLint eglVersionMajor;
 	EGLint eglVersionMinor;
 
-//------------------------------------------------------------
-// PLATFORM SPECIFIC WINDOWING
-//------------------------------------------------------------
+	//------------------------------------------------------------
+	// PLATFORM SPECIFIC WINDOWING
+	//------------------------------------------------------------
 
-//------------------------------------------------------------
-// WINDOWING
-//------------------------------------------------------------
+	//------------------------------------------------------------
+	// WINDOWING
+	//------------------------------------------------------------
 	// EGL window
 	ofRectangle nonFullscreenWindowRect; // the rectangle describing the non-fullscreen window
 	ofRectangle currentWindowRect; // the rectangle describing the current device
 
-	bool createWindow(const ofRectangle& requestedWindowRect);
+	bool createWindow(const ofRectangle & requestedWindowRect);
 	bool destroyWindow();
 
-	bool isUsingX11;  ///< \brief Indicate the use of the X Window System.
+	bool isUsingX11; ///< \brief Indicate the use of the X Window System.
 
-	bool isWindowInited;  ///< \brief Indicate that the window is (properly) initialized.
-	bool isSurfaceInited;  ///< \brief Indicate that the surface is (properly) initialized.
+	bool isWindowInited; ///< \brief Indicate that the window is (properly) initialized.
+	bool isSurfaceInited; ///< \brief Indicate that the surface is (properly) initialized.
 
 	void initNative();
 	void exitNative();
@@ -238,26 +234,26 @@ protected:
 	DISPMANX_ELEMENT_HANDLE_T dispman_element;
 	DISPMANX_DISPLAY_HANDLE_T dispman_display;
 
-	DISPMANX_CLAMP_T  dispman_clamp;
+	DISPMANX_CLAMP_T dispman_clamp;
 	DISPMANX_TRANSFORM_T dispman_transform;
-	VC_DISPMANX_ALPHA_T	dispman_alpha;
+	VC_DISPMANX_ALPHA_T dispman_alpha;
 
-	bool createRPiNativeWindow(const ofRectangle& requestedWindowRect);
+	bool createRPiNativeWindow(const ofRectangle & requestedWindowRect);
 
 #else
 	// if you are not raspberry pi, you will not be able to
 	// create a window without using x11.
 #endif
 
-	Display* x11Display;  ///< \brief Indicate which X11 display is in use (currently).
-	Screen* x11Screen;  ///< \brief Indicate which X11 screen is in use (currently).
+	Display * x11Display; ///< \brief Indicate which X11 display is in use (currently).
+	Screen * x11Screen; ///< \brief Indicate which X11 screen is in use (currently).
 	Window x11Window;
-	long x11ScreenNum;  ///< \brief The number of the X11 screen is in use (currently).
-	bool createX11NativeWindow(const ofRectangle& requestedWindowRect);
+	long x11ScreenNum; ///< \brief The number of the X11 screen is in use (currently).
+	bool createX11NativeWindow(const ofRectangle & requestedWindowRect);
 
-//------------------------------------------------------------
-// EVENTS
-//------------------------------------------------------------
+	//------------------------------------------------------------
+	// EVENTS
+	//------------------------------------------------------------
 	void setupNativeEvents();
 	void destroyNativeEvents();
 
@@ -270,16 +266,16 @@ protected:
 	void readNativeUDevEvents();
 	void readNativeInputEvents();
 
-	void processInput(int fd, const char * node);	
+	void processInput(int fd, const char * node);
 	void addInput(const char * node, bool isMouse);
 	void removeInput(const char * node);
 	void printInput();
 
-	static void handleX11Event(const XEvent& event);
+	static void handleX11Event(const XEvent & event);
 
 private:
 	ofAppEGLWindowSettings settings;
-	int glesVersion;  ///< \brief Indicate the version of OpenGL for Embedded Systems.
+	int glesVersion; ///< \brief Indicate the version of OpenGL for Embedded Systems.
 	bool keyboardDetected;
 	bool mouseDetected;
 	long threadTimeout;

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -87,6 +87,10 @@ public:
 	virtual void showCursor();
 
 	virtual void setWindowPosition(int x, int y);
+	virtual void setWindowSize(int w, int h);
+	virtual void setWindowMinimumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMinimumSize() not implemented"};
+	virtual void setWindowMaximumSize(int w, int h) { ofLogWarning("ofAppEGLWindow::") << "setWindowMaximumSize() not implemented"};;
+	virtual void setWindowAspectRatio(int horizontal, int vertical) { ofLogWarning("ofAppEGLWindow::") << "setWindowAspectRatio() not implemented"};;
 	virtual void setWindowShape(int w, int h);
 
 	virtual glm::vec2 getWindowPosition();

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -68,17 +68,17 @@ ofAppGLFWWindow::~ofAppGLFWWindow() {
 void ofAppGLFWWindow::close() {
 	if (windowP) {
 
-		glfwSetMouseButtonCallback( windowP, nullptr );
-		glfwSetCursorPosCallback( windowP, nullptr );
-		glfwSetCursorEnterCallback( windowP, nullptr );
-		glfwSetKeyCallback( windowP, nullptr );
-		glfwSetWindowSizeCallback( windowP, nullptr );
-    glfwSetWindowPosCallback(windowP, nullptr);
-		glfwSetFramebufferSizeCallback( windowP, nullptr);
-		glfwSetWindowCloseCallback( windowP, nullptr );
-		glfwSetScrollCallback( windowP, nullptr );
-		glfwSetDropCallback( windowP, nullptr );
-  	glfwSetWindowRefreshCallback(windowP, nullptr);
+		glfwSetMouseButtonCallback(windowP, nullptr);
+		glfwSetCursorPosCallback(windowP, nullptr);
+		glfwSetCursorEnterCallback(windowP, nullptr);
+		glfwSetKeyCallback(windowP, nullptr);
+		glfwSetWindowSizeCallback(windowP, nullptr);
+		glfwSetWindowPosCallback(windowP, nullptr);
+		glfwSetFramebufferSizeCallback(windowP, nullptr);
+		glfwSetWindowCloseCallback(windowP, nullptr);
+		glfwSetScrollCallback(windowP, nullptr);
+		glfwSetDropCallback(windowP, nullptr);
+		glfwSetWindowRefreshCallback(windowP, nullptr);
 
 		//hide the window before we destroy it stops a flicker on OS X on exit.
 		glfwHideWindow(windowP);
@@ -379,7 +379,7 @@ void ofAppGLFWWindow::setup(const ofGLFWWindowSettings & _settings) {
 	glfwSetKeyCallback(windowP, keyboard_cb);
 	glfwSetCharCallback(windowP, char_cb);
 	glfwSetWindowSizeCallback(windowP, resize_cb);
-  glfwSetWindowPosCallback(windowP,position_cb);
+	glfwSetWindowPosCallback(windowP, position_cb);
 	glfwSetFramebufferSizeCallback(windowP, framebuffer_size_cb);
 	glfwSetWindowCloseCallback(windowP, exit_cb);
 	glfwSetScrollCallback(windowP, scroll_cb);
@@ -662,6 +662,35 @@ void ofAppGLFWWindow::setWindowPosition(int x, int y) {
 }
 
 //------------------------------------------------------------
+void ofAppGLFWWindow::setWindowSize(int w, int h) {
+	setWindowShape(w,h);
+}
+	
+void ofAppGLFWWindow::setWindowMinimumSize(int w, int h) {
+	
+	if (maximumWindowSize) {
+		glfwSetWindowSizeLimits(windowP, w, h, maximumWindowSize.value().x, maximumWindowSize.value().y);
+	} else {
+		glfwSetWindowSizeLimits(windowP, w, h, GLFW_DONT_CARE, GLFW_DONT_CARE);
+	}
+	minimumWindowSize = { w, h };
+}
+
+void ofAppGLFWWindow::setWindowAspectRatio(int horizontal, int vertical) {
+	
+	glfwSetWindowAspectRatio(windowP, horizontal, vertical);
+	windowAspectRatio = { horizontal, vertical };
+}
+		
+void ofAppGLFWWindow::setWindowMaximumSize(int w, int h) {
+	if (minimumWindowSize) {
+		glfwSetWindowSizeLimits(windowP, minimumWindowSize.value().x, minimumWindowSize.value().y, w, h);
+	} else {
+		glfwSetWindowSizeLimits(windowP, GLFW_DONT_CARE, GLFW_DONT_CARE, w, h);
+	}
+	maximumWindowSize = { w, h };
+}
+
 void ofAppGLFWWindow::setWindowShape(int w, int h) {
 	if (settings.windowMode == OF_WINDOW) {
 		windowW = w;
@@ -1573,12 +1602,12 @@ void ofAppGLFWWindow::char_cb(GLFWwindow * windowP_, uint32_t key) {
 }
 
 //------------------------------------------------------------
-void ofAppGLFWWindow::position_cb(GLFWwindow* windowP_, int x, int y){
-    ofAppGLFWWindow * instance = setCurrent(windowP_);
-    
-    x *= instance->pixelScreenCoordScale;
-    y *= instance->pixelScreenCoordScale;
-    instance->events().notifyWindowMoved(x,y);
+void ofAppGLFWWindow::position_cb(GLFWwindow * windowP_, int x, int y) {
+	ofAppGLFWWindow * instance = setCurrent(windowP_);
+
+	x *= instance->pixelScreenCoordScale;
+	y *= instance->pixelScreenCoordScale;
+	instance->events().notifyWindowMoved(x, y);
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -663,11 +663,11 @@ void ofAppGLFWWindow::setWindowPosition(int x, int y) {
 
 //------------------------------------------------------------
 void ofAppGLFWWindow::setWindowSize(int w, int h) {
-	setWindowShape(w,h);
+	setWindowShape(w, h);
 }
-	
+
 void ofAppGLFWWindow::setWindowMinimumSize(int w, int h) {
-	
+
 	if (maximumWindowSize) {
 		glfwSetWindowSizeLimits(windowP, w, h, maximumWindowSize.value().x, maximumWindowSize.value().y);
 	} else {
@@ -677,11 +677,11 @@ void ofAppGLFWWindow::setWindowMinimumSize(int w, int h) {
 }
 
 void ofAppGLFWWindow::setWindowAspectRatio(int horizontal, int vertical) {
-	
+
 	glfwSetWindowAspectRatio(windowP, horizontal, vertical);
 	windowAspectRatio = { horizontal, vertical };
 }
-		
+
 void ofAppGLFWWindow::setWindowMaximumSize(int w, int h) {
 	if (minimumWindowSize) {
 		glfwSetWindowSizeLimits(windowP, minimumWindowSize.value().x, minimumWindowSize.value().y, w, h);

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -114,7 +114,6 @@ public:
 	void setWindowSize(int w, int h);
 	void setWindowShape(int w, int h);
 
-
 	void setOrientation(ofOrientation orientation);
 	ofOrientation getOrientation();
 
@@ -185,20 +184,20 @@ public:
 #endif
 
 private:
-	static ofAppGLFWWindow * setCurrent(GLFWwindow* windowP);
-	static void 	mouse_cb(GLFWwindow* windowP_, int button, int state, int mods);
-	static void 	motion_cb(GLFWwindow* windowP_, double x, double y);
-	static void 	entry_cb(GLFWwindow* windowP_, int entered);
-	static void 	keyboard_cb(GLFWwindow* windowP_, int key, int scancode, int action, int mods);
-	static void 	char_cb(GLFWwindow* windowP_, uint32_t key);
-	static void 	resize_cb(GLFWwindow* windowP_, int w, int h);
-  static void   position_cb(GLFWwindow* windowP_, int x, int y);
-	static void 	framebuffer_size_cb(GLFWwindow* windowP_, int w, int h);
-	static void 	exit_cb(GLFWwindow* windowP_);
-	static void		scroll_cb(GLFWwindow* windowP_, double x, double y);
-	static void 	drop_cb(GLFWwindow* windowP_, int numFiles, const char** dropString);
-	static void		error_cb(int errorCode, const char* errorDescription);
- 	static void   refresh_cb(GLFWwindow * windowP_);
+	static ofAppGLFWWindow * setCurrent(GLFWwindow * windowP);
+	static void mouse_cb(GLFWwindow * windowP_, int button, int state, int mods);
+	static void motion_cb(GLFWwindow * windowP_, double x, double y);
+	static void entry_cb(GLFWwindow * windowP_, int entered);
+	static void keyboard_cb(GLFWwindow * windowP_, int key, int scancode, int action, int mods);
+	static void char_cb(GLFWwindow * windowP_, uint32_t key);
+	static void resize_cb(GLFWwindow * windowP_, int w, int h);
+	static void position_cb(GLFWwindow * windowP_, int x, int y);
+	static void framebuffer_size_cb(GLFWwindow * windowP_, int w, int h);
+	static void exit_cb(GLFWwindow * windowP_);
+	static void scroll_cb(GLFWwindow * windowP_, double x, double y);
+	static void drop_cb(GLFWwindow * windowP_, int numFiles, const char ** dropString);
+	static void error_cb(int errorCode, const char * errorDescription);
+	static void refresh_cb(GLFWwindow * windowP_);
 
 	void close();
 

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -108,7 +108,12 @@ public:
 
 	void setWindowTitle(std::string title);
 	void setWindowPosition(int x, int y);
+	void setWindowMinimumSize(int w, int h);
+	void setWindowMaximumSize(int w, int h);
+	void setWindowAspectRatio(int w, int h);
+	void setWindowSize(int w, int h);
 	void setWindowShape(int w, int h);
+
 
 	void setOrientation(ofOrientation orientation);
 	ofOrientation getOrientation();

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -457,6 +457,22 @@ void ofAppGlutWindow::setWindowPosition(int x, int y){
 }
 
 //------------------------------------------------------------
+void ofAppGlutWindow::setWindowSize(int w, int h){
+	setWindowShape(w, h);
+}
+
+
+void ofAppGlutWindow::setWindowMinimumSize(int width, int height){
+	minimumWindowSize = {width, height};
+}
+
+void ofAppGlutWindow::setWindowMaximumSize(int width, int height){
+	maximumWindowSize = {width, height};
+}
+
+
+
+//------------------------------------------------------------
 void ofAppGlutWindow::setWindowShape(int w, int h){
 	glutReshapeWindow(w, h);
 	// this is useful, esp if we are in the first frame (setup):
@@ -886,6 +902,29 @@ int ofAppGlutWindow::special_key_to_of(int key) {
 
 //------------------------------------------------------------
 void ofAppGlutWindow::resize_cb(int w, int h) {
+
+	if (minimumWindowSize) {
+		if (w < minimumWindowSize.value().x) {
+			glutReshapeWindow(minimumWindowSize.value().x, windowH);
+			return;
+		}
+		if (h < minimumWindowSize.value().y) {
+			glutReshapeWindow(windowW, minimumWindowSize.value().y);
+			return;
+		}
+	}
+	
+	if (maximumWindowSize) {
+		if (w > maximumWindowSize.value().x) {
+			glutReshapeWindow(maximumWindowSize.value().x, windowH);
+			return;
+		}
+		if (h > maximumWindowSize.value().y) {
+			glutReshapeWindow(windowW, maximumWindowSize.value().y);
+			return;
+		}
+	}
+
 	windowW = w;
 	windowH = h;
 

--- a/libs/openFrameworks/app/ofAppGlutWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGlutWindow.cpp
@@ -1,6 +1,6 @@
 #include "ofAppGlutWindow.h"
+
 #include "ofBaseApp.h"
-#include "ofPixels.h"
 #include "ofGLRenderer.h"
 
 #ifdef TARGET_WIN32
@@ -14,9 +14,9 @@
 	#include <Shellapi.h>
 #endif
 #ifdef TARGET_OSX
-    #include <OpenGL/OpenGL.h>
+	#include <OpenGL/OpenGL.h>
 	#include "../../../libs/glut/lib/osx/GLUT.framework/Versions/A/Headers/glut.h"
-    #include <Cocoa/Cocoa.h>
+	#include <Cocoa/Cocoa.h>
 #endif
 #ifdef TARGET_LINUX
 	#include <GL/glut.h>
@@ -30,19 +30,19 @@
 // glut works with static callbacks UGH, so we need static variables here:
 
 static ofWindowMode windowMode;
-static bool			bNewScreenMode;
-static int			buttonInUse;
-static bool			bEnableSetupScreen;
-static bool			bDoubleBuffered;
+static bool bNewScreenMode;
+static int buttonInUse;
+static bool bEnableSetupScreen;
+static bool bDoubleBuffered;
 
-static int			requestedWidth;
-static int			requestedHeight;
-static int 			nonFullScreenX;
-static int 			nonFullScreenY;
-static int			windowW;
-static int			windowH;
-static int          nFramesSinceWindowResized;
-static ofOrientation	orientation;
+static int requestedWidth;
+static int requestedHeight;
+static int nonFullScreenX;
+static int nonFullScreenY;
+static int windowW;
+static int windowH;
+static int nFramesSinceWindowResized;
+static ofOrientation orientation;
 static ofAppGlutWindow * instance;
 
 #ifdef TARGET_WIN32
@@ -56,18 +56,17 @@ static ofAppGlutWindow * instance;
 //------------------------------------------------
 
 static WNDPROC currentWndProc;
-static HWND handle  = nullptr;
+static HWND handle = nullptr;
 
 // This function takes in a wParam from the WM_DROPFILES message and
 // prints all the files to a message box.
 
-void HandleFiles(WPARAM wParam)
-{
-    // DragQueryFile() takes a LPWSTR for the name so we need a TCHAR string
-    TCHAR szName[MAX_PATH];
+void HandleFiles(WPARAM wParam) {
+	// DragQueryFile() takes a LPWSTR for the name so we need a TCHAR string
+	TCHAR szName[MAX_PATH];
 
-    // Here we cast the wParam as a HDROP handle to pass into the next functions
-    HDROP hDrop = (HDROP)wParam;
+	// Here we cast the wParam as a HDROP handle to pass into the next functions
+	HDROP hDrop = (HDROP)wParam;
 
 	POINT pt;
 	DragQueryPoint(hDrop, &pt);
@@ -77,79 +76,75 @@ void HandleFiles(WPARAM wParam)
 	info.position.x = pt.x;
 	info.position.y = pt.y;
 
+	// This functions has a couple functionalities.  If you pass in 0xFFFFFFFF in
+	// the second parameter then it returns the count of how many filers were drag
+	// and dropped.  Otherwise, the function fills in the szName string array with
+	// the current file being queried.
+	int count = DragQueryFile(hDrop, 0xFFFFFFFF, szName, MAX_PATH);
 
-    // This functions has a couple functionalities.  If you pass in 0xFFFFFFFF in
-    // the second parameter then it returns the count of how many filers were drag
-    // and dropped.  Otherwise, the function fills in the szName string array with
-    // the current file being queried.
-    int count = DragQueryFile(hDrop, 0xFFFFFFFF, szName, MAX_PATH);
+	// Here we go through all the files that were drag and dropped then display them
+	for (int i = 0; i < count; i++) {
+		// Grab the name of the file associated with index "i" in the list of files dropped.
+		// Be sure you know that the name is attached to the FULL path of the file.
+		DragQueryFile(hDrop, i, szName, MAX_PATH);
 
-    // Here we go through all the files that were drag and dropped then display them
-    for(int i = 0; i < count; i++)
-    {
-        // Grab the name of the file associated with index "i" in the list of files dropped.
-        // Be sure you know that the name is attached to the FULL path of the file.
-        DragQueryFile(hDrop, i, szName, MAX_PATH);
-
-		wchar_t * s =  (wchar_t*)szName;
+		wchar_t * s = (wchar_t *)szName;
 		char dfault = '?';
-        const std::locale& loc = std::locale();
+		const std::locale & loc = std::locale();
 		std::ostringstream stm;
-		while( *s != L'\0' ) {
-			stm << std::use_facet< std::ctype<wchar_t> >( loc ).narrow( *s++, dfault );
+		while (*s != L'\0') {
+			stm << std::use_facet<std::ctype<wchar_t>>(loc).narrow(*s++, dfault);
 		}
 		info.files.push_back(std::string(stm.str()));
 
-			//toUTF8(udispName, dispName);
+		//toUTF8(udispName, dispName);
 
-        // Bring up a message box that displays the current file being processed
-        //MessageBox(GetForegroundWindow(), szName, L"Current file received", MB_OK);
-    }
+		// Bring up a message box that displays the current file being processed
+		//MessageBox(GetForegroundWindow(), szName, L"Current file received", MB_OK);
+	}
 
-    // Finally, we destroy the HDROP handle so the extra memory
-    // allocated by the application is released.
-    DragFinish(hDrop);
+	// Finally, we destroy the HDROP handle so the extra memory
+	// allocated by the application is released.
+	DragFinish(hDrop);
 
 	instance->events().notifyDragEvent(info);
-
 }
 
+static LRESULT CALLBACK winProc(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam) {
 
-static LRESULT CALLBACK winProc(HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam){
+	//we catch close and destroy messages
+	//and send them to OF
 
-   //we catch close and destroy messages
-   //and send them to OF
+	switch (Msg) {
 
-   switch(Msg){
+	case WM_CLOSE:
+		OF_EXIT_APP(0);
+		break;
+	case WM_DESTROY:
+		OF_EXIT_APP(0);
+		break;
+	case WM_DROPFILES:
 
-      case WM_CLOSE:
-         OF_EXIT_APP(0);
-      break;
-      case WM_DESTROY:
-         OF_EXIT_APP(0);
-         break;
-	  case WM_DROPFILES:
+		// Call our function we created to display all the files.
+		// We pass the wParam because it's the HDROP handle.
+		HandleFiles(wParam);
+		break;
+	default:
+		return CallWindowProc(currentWndProc, handle, Msg, wParam, lParam);
+		break;
+	}
 
-            // Call our function we created to display all the files.
-            // We pass the wParam because it's the HDROP handle.
-            HandleFiles(wParam);
-            break;
-      default:
-         return CallWindowProc(currentWndProc, handle, Msg, wParam, lParam);
-      break;
-    }
-
-    return 0;
+	return 0;
 }
 
 //--------------------------------------
-static void fixCloseWindowOnWin32(){
+static void fixCloseWindowOnWin32() {
 
 	//get the HWND
 	handle = WindowFromDC(wglGetCurrentDC());
 
 	// enable drag and drop of files.
-	DragAcceptFiles (handle, TRUE);
+	DragAcceptFiles(handle, TRUE);
 
 	//store the current message event handler for the window
 	currentWndProc = (WNDPROC)GetWindowLongPtr(handle, GWLP_WNDPROC);
@@ -160,22 +155,19 @@ static void fixCloseWindowOnWin32(){
 
 #endif
 
-
-
-
 //----------------------------------------------------------
-ofAppGlutWindow::ofAppGlutWindow(){
-	windowMode			= OF_WINDOW;
-	bNewScreenMode		= true;
+ofAppGlutWindow::ofAppGlutWindow() {
+	windowMode = OF_WINDOW;
+	bNewScreenMode = true;
 	nFramesSinceWindowResized = 0;
-	buttonInUse			= 0;
-	bEnableSetupScreen	= true;
-	requestedWidth		= 0;
-	requestedHeight		= 0;
-	nonFullScreenX		= -1;
-	nonFullScreenY		= -1;
-	displayString		= "";
-	orientation			= OF_ORIENTATION_DEFAULT;
+	buttonInUse = 0;
+	bEnableSetupScreen = true;
+	requestedWidth = 0;
+	requestedHeight = 0;
+	nonFullScreenX = -1;
+	nonFullScreenY = -1;
+	displayString = "";
+	orientation = OF_ORIENTATION_DEFAULT;
 	bDoubleBuffered = true; // LIA
 	iconSet = false;
 	instance = this;
@@ -186,43 +178,43 @@ ofAppGlutWindow::ofAppGlutWindow(){
 // "rgba double samples>=4 depth" ( mac )
 // "rgb double depth alpha samples>=4" ( some pcs )
 //------------------------------------------------------------
- void ofAppGlutWindow::setGlutDisplayString(std::string displayStr){
+void ofAppGlutWindow::setGlutDisplayString(std::string displayStr) {
 	displayString = displayStr;
- }
+}
 
- //------------------------------------------------------------
-void ofAppGlutWindow::setDoubleBuffering(bool _bDoubleBuffered){
+//------------------------------------------------------------
+void ofAppGlutWindow::setDoubleBuffering(bool _bDoubleBuffered) {
 	bDoubleBuffered = _bDoubleBuffered;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
+void ofAppGlutWindow::setup(const ofGLWindowSettings & settings) {
 
 	int argc = 1;
-	char *argv = (char*)"openframeworks";
-	char **vptr = &argv;
+	char * argv = (char *)"openframeworks";
+	char ** vptr = &argv;
 	glutInit(&argc, vptr);
 
-	if( displayString != ""){
-		glutInitDisplayString( displayString.c_str() );
-	}else{
-		if(bDoubleBuffered){
-			glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_ALPHA );
-		}else{
-			glutInitDisplayMode(GLUT_RGB | GLUT_SINGLE | GLUT_DEPTH | GLUT_ALPHA );
+	if (displayString != "") {
+		glutInitDisplayString(displayString.c_str());
+	} else {
+		if (bDoubleBuffered) {
+			glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_ALPHA);
+		} else {
+			glutInitDisplayMode(GLUT_RGB | GLUT_SINGLE | GLUT_DEPTH | GLUT_ALPHA);
 		}
 	}
 
 	windowMode = settings.windowMode;
 	bNewScreenMode = true;
 
-	if (windowMode == OF_FULLSCREEN){
+	if (windowMode == OF_FULLSCREEN) {
 		glutInitWindowSize(glutGet(GLUT_SCREEN_WIDTH), glutGet(GLUT_SCREEN_HEIGHT));
 		windowId = glutCreateWindow("");
 
-		requestedWidth  = settings.getWidth();
+		requestedWidth = settings.getWidth();
 		requestedHeight = settings.getHeight();
-	} else if (windowMode != OF_GAME_MODE){
+	} else if (windowMode != OF_GAME_MODE) {
 		glutInitWindowSize(settings.getWidth(), settings.getHeight());
 		glutCreateWindow("");
 
@@ -236,62 +228,59 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 		// as default works the best...
 		*/
 
-		requestedWidth  = glutGet(GLUT_WINDOW_WIDTH);
+		requestedWidth = glutGet(GLUT_WINDOW_WIDTH);
 		requestedHeight = glutGet(GLUT_WINDOW_HEIGHT);
 	} else {
-		if( displayString != ""){
-			glutInitDisplayString( displayString.c_str() );
-		}else{
-			glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_ALPHA );
+		if (displayString != "") {
+			glutInitDisplayString(displayString.c_str());
+		} else {
+			glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH | GLUT_ALPHA);
 		}
 
-    	// w x h, 32bit pixel depth, 60Hz refresh rate
+		// w x h, 32bit pixel depth, 60Hz refresh rate
 		char gameStr[64];
-		sprintf( gameStr, "%dx%d:%d@%d", settings.getWidth(), settings.getHeight(), 32, 60 );
+		sprintf(gameStr, "%dx%d:%d@%d", settings.getWidth(), settings.getHeight(), 32, 60);
 
-    	glutGameModeString(gameStr);
+		glutGameModeString(gameStr);
 
-    	if (!glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)){
-    		ofLogError("ofAppGlutWindow") << "setupOpenGL(): selected game mode format " << gameStr << " not available";
-    	}
-    	// start fullscreen game mode
-    	glutEnterGameMode();
+		if (!glutGameModeGet(GLUT_GAME_MODE_POSSIBLE)) {
+			ofLogError("ofAppGlutWindow") << "setupOpenGL(): selected game mode format " << gameStr << " not available";
+		}
+		// start fullscreen game mode
+		glutEnterGameMode();
 	}
 	windowW = glutGet(GLUT_WINDOW_WIDTH);
 	windowH = glutGet(GLUT_WINDOW_HEIGHT);
 
 	currentRenderer = std::shared_ptr<ofBaseRenderer>(new ofGLRenderer(this));
 
-
 #ifndef TARGET_OPENGLES
 	glewExperimental = GL_TRUE;
 	GLenum err = glewInit();
-	if (GLEW_OK != err)
-	{
+	if (GLEW_OK != err) {
 		/* Problem: glewInit failed, something is seriously wrong. */
 		ofLogError("ofAppRunner") << "couldn't init GLEW: " << glewGetErrorString(err);
 		return;
 	}
 #endif
-	static_cast<ofGLRenderer*>(currentRenderer.get())->setup();
+	static_cast<ofGLRenderer *>(currentRenderer.get())->setup();
 	setVerticalSync(true);
 
+	//----------------------
+	// setup the callbacks
 
-    //----------------------
-    // setup the callbacks
+	glutMouseFunc(mouse_cb);
+	glutMotionFunc(motion_cb);
+	glutPassiveMotionFunc(passive_motion_cb);
+	glutIdleFunc(idle_cb);
+	glutDisplayFunc(display);
 
-    glutMouseFunc(mouse_cb);
-    glutMotionFunc(motion_cb);
-    glutPassiveMotionFunc(passive_motion_cb);
-    glutIdleFunc(idle_cb);
-    glutDisplayFunc(display);
+	glutKeyboardFunc(keyboard_cb);
+	glutKeyboardUpFunc(keyboard_up_cb);
+	glutSpecialFunc(special_key_cb);
+	glutSpecialUpFunc(special_key_up_cb);
 
-    glutKeyboardFunc(keyboard_cb);
-    glutKeyboardUpFunc(keyboard_up_cb);
-    glutSpecialFunc(special_key_cb);
-    glutSpecialUpFunc(special_key_up_cb);
-
-    glutReshapeFunc(resize_cb);
+	glutReshapeFunc(resize_cb);
 	glutEntryFunc(entry_cb);
 #ifdef TARGET_LINUX
 	glutCloseFunc(exit_cb);
@@ -301,29 +290,29 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 	glutDragEventFunc(dragEvent);
 #endif
 
-    nFramesSinceWindowResized = 0;
+	nFramesSinceWindowResized = 0;
 
-    #ifdef TARGET_WIN32
-        //----------------------
-        // this is specific to windows (respond properly to close / destroy)
-        fixCloseWindowOnWin32();
-    #endif
+#ifdef TARGET_WIN32
+	//----------------------
+	// this is specific to windows (respond properly to close / destroy)
+	fixCloseWindowOnWin32();
+#endif
 
 #ifdef TARGET_LINUX
-    if(!iconSet){
+	if (!iconSet) {
 		ofPixels iconPixels;
-		#ifdef DEBUG
-			iconPixels.allocate(ofIconDebug.width,ofIconDebug.height,ofIconDebug.bytes_per_pixel);
-			GIMP_IMAGE_RUN_LENGTH_DECODE(iconPixels.getData(),ofIconDebug.rle_pixel_data,iconPixels.getWidth()*iconPixels.getHeight(),ofIconDebug.bytes_per_pixel);
-		#else
-			iconPixels.allocate(ofIcon.width,ofIcon.height,ofIcon.bytes_per_pixel);
-			GIMP_IMAGE_RUN_LENGTH_DECODE(iconPixels.getData(),ofIcon.rle_pixel_data,iconPixels.getWidth()*iconPixels.getHeight(),ofIcon.bytes_per_pixel);
-		#endif
+	#ifdef DEBUG
+		iconPixels.allocate(ofIconDebug.width, ofIconDebug.height, ofIconDebug.bytes_per_pixel);
+		GIMP_IMAGE_RUN_LENGTH_DECODE(iconPixels.getData(), ofIconDebug.rle_pixel_data, iconPixels.getWidth() * iconPixels.getHeight(), ofIconDebug.bytes_per_pixel);
+	#else
+		iconPixels.allocate(ofIcon.width, ofIcon.height, ofIcon.bytes_per_pixel);
+		GIMP_IMAGE_RUN_LENGTH_DECODE(iconPixels.getData(), ofIcon.rle_pixel_data, iconPixels.getWidth() * iconPixels.getHeight(), ofIcon.bytes_per_pixel);
+	#endif
 		setWindowIcon(iconPixels);
-    }
+	}
 #endif
 	if (settings.isPositionSet()) {
-		setWindowPosition(settings.getPosition().x,settings.getPosition().y);
+		setWindowPosition(settings.getPosition().x, settings.getPosition().y);
 	}
 
 #ifdef TARGET_OSX
@@ -335,48 +324,48 @@ void ofAppGlutWindow::setup(const ofGLWindowSettings & settings){
 
 #ifdef TARGET_LINUX
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowIcon(const std::string & path){
-    ofPixels iconPixels;
-	ofLoadImage(iconPixels,path);
+void ofAppGlutWindow::setWindowIcon(const std::string & path) {
+	ofPixels iconPixels;
+	ofLoadImage(iconPixels, path);
 	setWindowIcon(iconPixels);
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowIcon(const ofPixels & iconPixels){
+void ofAppGlutWindow::setWindowIcon(const ofPixels & iconPixels) {
 	iconSet = true;
-	Display *m_display = glXGetCurrentDisplay();
+	Display * m_display = glXGetCurrentDisplay();
 	GLXDrawable m_window = glXGetCurrentDrawable();
 	iconSet = true;
-	int length = 2+iconPixels.getWidth()*iconPixels.getHeight();
+	int length = 2 + iconPixels.getWidth() * iconPixels.getHeight();
 	unsigned long * buffer = new unsigned long[length];
-	buffer[0]=iconPixels.getWidth();
-	buffer[1]=iconPixels.getHeight();
-	for(size_t i=0;i<iconPixels.getWidth()*iconPixels.getHeight();i++){
-		buffer[i+2] = iconPixels[i*4+3]<<24;
-		buffer[i+2] += iconPixels[i*4]<<16;
-		buffer[i+2] += iconPixels[i*4+1]<<8;
-		buffer[i+2] += iconPixels[i*4];
+	buffer[0] = iconPixels.getWidth();
+	buffer[1] = iconPixels.getHeight();
+	for (size_t i = 0; i < iconPixels.getWidth() * iconPixels.getHeight(); i++) {
+		buffer[i + 2] = iconPixels[i * 4 + 3] << 24;
+		buffer[i + 2] += iconPixels[i * 4] << 16;
+		buffer[i + 2] += iconPixels[i * 4 + 1] << 8;
+		buffer[i + 2] += iconPixels[i * 4];
 	}
 
 	XChangeProperty(m_display, m_window, XInternAtom(m_display, "_NET_WM_ICON", False), XA_CARDINAL, 32,
-						 PropModeReplace,  (const unsigned char*)buffer,  length);
+		PropModeReplace, (const unsigned char *)buffer, length);
 	delete[] buffer;
 	XFlush(m_display);
 }
 #endif
 
 //------------------------------------------------------------
-void ofAppGlutWindow::update(){
+void ofAppGlutWindow::update() {
 	idle_cb();
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::draw(){
+void ofAppGlutWindow::draw() {
 	display();
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::close(){
+void ofAppGlutWindow::close() {
 	events().notifyExit();
 	events().disable();
 #ifdef TARGET_LINUX
@@ -387,129 +376,126 @@ void ofAppGlutWindow::close(){
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::loop(){
+void ofAppGlutWindow::loop() {
 	instance->events().notifySetup();
 	instance->events().notifyUpdate();
 	glutMainLoop();
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowTitle(std::string title){
+void ofAppGlutWindow::setWindowTitle(std::string title) {
 	glutSetWindowTitle(title.c_str());
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppGlutWindow::getWindowSize(){
-	return {windowW, windowH};
+glm::vec2 ofAppGlutWindow::getWindowSize() {
+	return { windowW, windowH };
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppGlutWindow::getWindowPosition(){
+glm::vec2 ofAppGlutWindow::getWindowPosition() {
 	int x = glutGet(GLUT_WINDOW_X);
 	int y = glutGet(GLUT_WINDOW_Y);
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
-		return {x,y};
-	}else{
-		return {y,x};
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
+		return { x, y };
+	} else {
+		return { y, x };
 	}
 }
 
 //------------------------------------------------------------
-glm::vec2 ofAppGlutWindow::getScreenSize(){
+glm::vec2 ofAppGlutWindow::getScreenSize() {
 	int width = glutGet(GLUT_SCREEN_WIDTH);
 	int height = glutGet(GLUT_SCREEN_HEIGHT);
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
-		return {width, height};
-	}else{
-		return {height, width};
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
+		return { width, height };
+	} else {
+		return { height, width };
 	}
 }
 
 //------------------------------------------------------------
-int ofAppGlutWindow::getWidth(){
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
+int ofAppGlutWindow::getWidth() {
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
 		return windowW;
 	}
 	return windowH;
 }
 
 //------------------------------------------------------------
-int ofAppGlutWindow::getHeight(){
-	if( orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180 ){
+int ofAppGlutWindow::getHeight() {
+	if (orientation == OF_ORIENTATION_DEFAULT || orientation == OF_ORIENTATION_180) {
 		return windowH;
 	}
 	return windowW;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setOrientation(ofOrientation orientationIn){
+void ofAppGlutWindow::setOrientation(ofOrientation orientationIn) {
 	orientation = orientationIn;
 }
 
 //------------------------------------------------------------
-ofOrientation ofAppGlutWindow::getOrientation(){
+ofOrientation ofAppGlutWindow::getOrientation() {
 	return orientation;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowPosition(int x, int y){
-	glutPositionWindow(x,y);
+void ofAppGlutWindow::setWindowPosition(int x, int y) {
+	glutPositionWindow(x, y);
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowSize(int w, int h){
+void ofAppGlutWindow::setWindowSize(int w, int h) {
 	setWindowShape(w, h);
 }
 
-
-void ofAppGlutWindow::setWindowMinimumSize(int width, int height){
-	minimumWindowSize = {width, height};
+void ofAppGlutWindow::setWindowMinimumSize(int width, int height) {
+	minimumWindowSize = { width, height };
 }
 
-void ofAppGlutWindow::setWindowMaximumSize(int width, int height){
-	maximumWindowSize = {width, height};
+void ofAppGlutWindow::setWindowMaximumSize(int width, int height) {
+	maximumWindowSize = { width, height };
 }
-
-
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setWindowShape(int w, int h){
+void ofAppGlutWindow::setWindowShape(int w, int h) {
 	glutReshapeWindow(w, h);
 	// this is useful, esp if we are in the first frame (setup):
-	requestedWidth  = w;
+	requestedWidth = w;
 	requestedHeight = h;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::hideCursor(){
-	#if defined(TARGET_OSX) && defined(MAC_OS_X_VERSION_10_7)
-		 CGDisplayHideCursor(0);
-	#else
-		glutSetCursor(GLUT_CURSOR_NONE);
-	#endif
+void ofAppGlutWindow::hideCursor() {
+#if defined(TARGET_OSX) && defined(MAC_OS_X_VERSION_10_7)
+	CGDisplayHideCursor(0);
+#else
+	glutSetCursor(GLUT_CURSOR_NONE);
+#endif
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::showCursor(){
-	#if defined(TARGET_OSX) && defined(MAC_OS_X_VERSION_10_7)
-		 CGDisplayShowCursor(0);
-	#else
-		glutSetCursor(GLUT_CURSOR_LEFT_ARROW);
-	#endif
+void ofAppGlutWindow::showCursor() {
+#if defined(TARGET_OSX) && defined(MAC_OS_X_VERSION_10_7)
+	CGDisplayShowCursor(0);
+#else
+	glutSetCursor(GLUT_CURSOR_LEFT_ARROW);
+#endif
 }
 
 //------------------------------------------------------------
-ofWindowMode ofAppGlutWindow::getWindowMode(){
+ofWindowMode ofAppGlutWindow::getWindowMode() {
 	return windowMode;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::toggleFullscreen(){
-	if( windowMode == OF_GAME_MODE)return;
+void ofAppGlutWindow::toggleFullscreen() {
+	if (windowMode == OF_GAME_MODE) return;
 
-	if( windowMode == OF_WINDOW ){
+	if (windowMode == OF_WINDOW) {
 		windowMode = OF_FULLSCREEN;
-	}else{
+	} else {
 		windowMode = OF_WINDOW;
 	}
 
@@ -517,91 +503,91 @@ void ofAppGlutWindow::toggleFullscreen(){
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setFullscreen(bool fullscreen){
-    if( windowMode == OF_GAME_MODE)return;
+void ofAppGlutWindow::setFullscreen(bool fullscreen) {
+	if (windowMode == OF_GAME_MODE) return;
 
-    if(fullscreen && windowMode != OF_FULLSCREEN){
-        bNewScreenMode  = true;
-        windowMode      = OF_FULLSCREEN;
-    }else if(!fullscreen && windowMode != OF_WINDOW) {
-        bNewScreenMode  = true;
-        windowMode      = OF_WINDOW;
-    }
+	if (fullscreen && windowMode != OF_FULLSCREEN) {
+		bNewScreenMode = true;
+		windowMode = OF_FULLSCREEN;
+	} else if (!fullscreen && windowMode != OF_WINDOW) {
+		bNewScreenMode = true;
+		windowMode = OF_WINDOW;
+	}
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::enableSetupScreen(){
+void ofAppGlutWindow::enableSetupScreen() {
 	bEnableSetupScreen = true;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::disableSetupScreen(){
+void ofAppGlutWindow::disableSetupScreen() {
 	bEnableSetupScreen = false;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::setVerticalSync(bool bSync){
+void ofAppGlutWindow::setVerticalSync(bool bSync) {
+//----------------------------
+#ifdef TARGET_WIN32
 	//----------------------------
-	#ifdef TARGET_WIN32
-	//----------------------------
-		if (bSync) {
-			if (WGL_EXT_swap_control) {
-				wglSwapIntervalEXT (1);
-			}
-		} else {
-			if (WGL_EXT_swap_control) {
-				wglSwapIntervalEXT (0);
-			}
+	if (bSync) {
+		if (WGL_EXT_swap_control) {
+			wglSwapIntervalEXT(1);
 		}
-	//----------------------------
-	#endif
-	//----------------------------
+	} else {
+		if (WGL_EXT_swap_control) {
+			wglSwapIntervalEXT(0);
+		}
+	}
+//----------------------------
+#endif
+//----------------------------
 
+//--------------------------------------
+#ifdef TARGET_OSX
 	//--------------------------------------
-	#ifdef TARGET_OSX
-	//--------------------------------------
-		GLint sync = bSync == true ? 1 : 0;
-		CGLSetParameter (CGLGetCurrentContext(), kCGLCPSwapInterval, &sync);
-	//--------------------------------------
-	#endif
-	//--------------------------------------
+	GLint sync = bSync == true ? 1 : 0;
+	CGLSetParameter(CGLGetCurrentContext(), kCGLCPSwapInterval, &sync);
+//--------------------------------------
+#endif
+//--------------------------------------
 
+//--------------------------------------
+#ifdef TARGET_LINUX
 	//--------------------------------------
-	#ifdef TARGET_LINUX
-	//--------------------------------------
-		void (*swapIntervalExt)(Display *,GLXDrawable, int)	 = (void (*)(Display *,GLXDrawable, int)) glXGetProcAddress((const GLubyte*) "glXSwapIntervalEXT");
-		if(swapIntervalExt){
-			Display *dpy = glXGetCurrentDisplay();
-			GLXDrawable drawable = glXGetCurrentDrawable();
-			if (drawable) {
-				swapIntervalExt(dpy, drawable, bSync ? 1 : 0);
-				return;
-			}
+	void (*swapIntervalExt)(Display *, GLXDrawable, int) = (void (*)(Display *, GLXDrawable, int))glXGetProcAddress((const GLubyte *)"glXSwapIntervalEXT");
+	if (swapIntervalExt) {
+		Display * dpy = glXGetCurrentDisplay();
+		GLXDrawable drawable = glXGetCurrentDrawable();
+		if (drawable) {
+			swapIntervalExt(dpy, drawable, bSync ? 1 : 0);
+			return;
 		}
-		void (*swapInterval)(int) = (void (*)(int)) glXGetProcAddress((const GLubyte*) "glXSwapIntervalSGI");
-		if(!swapInterval) {
-			swapInterval = (void (*)(int)) glXGetProcAddress((const GLubyte*) "glXSwapIntervalMESA");
-		}
-		if(swapInterval) {
-			swapInterval(bSync ? 1 : 0);
-		}
-	//--------------------------------------
-	#endif
+	}
+	void (*swapInterval)(int) = (void (*)(int))glXGetProcAddress((const GLubyte *)"glXSwapIntervalSGI");
+	if (!swapInterval) {
+		swapInterval = (void (*)(int))glXGetProcAddress((const GLubyte *)"glXSwapIntervalMESA");
+	}
+	if (swapInterval) {
+		swapInterval(bSync ? 1 : 0);
+	}
+//--------------------------------------
+#endif
 	//--------------------------------------
 }
 
 //------------------------------------------------------------
-ofCoreEvents & ofAppGlutWindow::events(){
+ofCoreEvents & ofAppGlutWindow::events() {
 	return coreEvents;
 }
 
 //------------------------------------------------------------
-std::shared_ptr<ofBaseRenderer> & ofAppGlutWindow::renderer(){
+std::shared_ptr<ofBaseRenderer> & ofAppGlutWindow::renderer() {
 	return currentRenderer;
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::display(void){
+void ofAppGlutWindow::display(void) {
 
 	//--------------------------------
 	// when I had "glutFullScreen()"
@@ -611,9 +597,9 @@ void ofAppGlutWindow::display(void){
 	// by removing something unrelated, but everything seems
 	// to work if I put fullscreen on the first frame of display.
 
-	if (windowMode != OF_GAME_MODE){
-		if ( bNewScreenMode ){
-			if( windowMode == OF_FULLSCREEN){
+	if (windowMode != OF_GAME_MODE) {
+		if (bNewScreenMode) {
+			if (windowMode == OF_FULLSCREEN) {
 
 				//----------------------------------------------------
 				// before we go fullscreen, take a snapshot of where we are:
@@ -623,30 +609,30 @@ void ofAppGlutWindow::display(void){
 
 				glutFullScreen();
 
-				#ifdef TARGET_OSX
-					[NSApp setPresentationOptions:NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock];
-					#ifdef MAC_OS_X_VERSION_10_7 //needed for Lion as when the machine reboots the app is not at front level
-						if( instance->events().getFrameNum() <= 10 ){  //is this long enough? too long?
-							[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
-						}
-					#endif
-				#endif
+#ifdef TARGET_OSX
+				[NSApp setPresentationOptions:NSApplicationPresentationHideMenuBar | NSApplicationPresentationHideDock];
+	#ifdef MAC_OS_X_VERSION_10_7 //needed for Lion as when the machine reboots the app is not at front level
+				if (instance->events().getFrameNum() <= 10) { //is this long enough? too long?
+					[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+				}
+	#endif
+#endif
 
-			}else if( windowMode == OF_WINDOW ){
+			} else if (windowMode == OF_WINDOW) {
 
 				glutReshapeWindow(requestedWidth, requestedHeight);
 
 				//----------------------------------------------------
 				// if we have recorded the screen posion, put it there
 				// if not, better to let the system do it (and put it where it wants)
-				if (instance->events().getFrameNum() > 0){
-					glutPositionWindow(nonFullScreenX,nonFullScreenY);
+				if (instance->events().getFrameNum() > 0) {
+					glutPositionWindow(nonFullScreenX, nonFullScreenY);
 				}
 				//----------------------------------------------------
 
-				#ifdef TARGET_OSX
-					[NSApp setPresentationOptions:NSApplicationPresentationDefault];
-				#endif
+#ifdef TARGET_OSX
+				[NSApp setPresentationOptions:NSApplicationPresentationDefault];
+#endif
 			}
 			bNewScreenMode = false;
 		}
@@ -654,45 +640,46 @@ void ofAppGlutWindow::display(void){
 
 	instance->currentRenderer->startRender();
 
-	if( bEnableSetupScreen ) instance->currentRenderer->setupScreen();
+	if (bEnableSetupScreen) instance->currentRenderer->setupScreen();
 
 	instance->events().notifyDraw();
 
-    #ifdef TARGET_WIN32
-    if (instance->currentRenderer->getBackgroundAuto() == false){
-        // on a PC resizing a window with this method of accumulation (essentially single buffering)
-        // is BAD, so we clear on resize events.
-        if (nFramesSinceWindowResized < 3){
-            instance->currentRenderer->clear();
-        } else {
-            if ( (instance->events().getFrameNum() < 3 || nFramesSinceWindowResized < 3) && bDoubleBuffered)    glutSwapBuffers();
-            else  glFlush();
-        }
-    } else {
-        if(bDoubleBuffered){
+#ifdef TARGET_WIN32
+	if (instance->currentRenderer->getBackgroundAuto() == false) {
+		// on a PC resizing a window with this method of accumulation (essentially single buffering)
+		// is BAD, so we clear on resize events.
+		if (nFramesSinceWindowResized < 3) {
+			instance->currentRenderer->clear();
+		} else {
+			if ((instance->events().getFrameNum() < 3 || nFramesSinceWindowResized < 3) && bDoubleBuffered)
+				glutSwapBuffers();
+			else
+				glFlush();
+		}
+	} else {
+		if (bDoubleBuffered) {
 			glutSwapBuffers();
-		} else{
+		} else {
 			glFlush();
 		}
-    }
-    #else
-		if (instance->currentRenderer->getBackgroundAuto() == false){
-			// in accum mode resizing a window is BAD, so we clear on resize events.
-			if (nFramesSinceWindowResized < 3){
-				instance->currentRenderer->clear();
-			}
+	}
+#else
+	if (instance->currentRenderer->getBackgroundAuto() == false) {
+		// in accum mode resizing a window is BAD, so we clear on resize events.
+		if (nFramesSinceWindowResized < 3) {
+			instance->currentRenderer->clear();
 		}
-		if(bDoubleBuffered){
-			glutSwapBuffers();
-		} else{
-			glFlush();
-		}
-    #endif
+	}
+	if (bDoubleBuffered) {
+		glutSwapBuffers();
+	} else {
+		glFlush();
+	}
+#endif
 
 	instance->currentRenderer->finishRender();
 
-    nFramesSinceWindowResized++;
-
+	nFramesSinceWindowResized++;
 }
 
 //------------------------------------------------------------
@@ -711,29 +698,29 @@ void ofAppGlutWindow::finishRender() {
 }
 
 //------------------------------------------------------------
-static void rotateMouseXY(ofOrientation orientation, int w, int h, int &x, int &y) {
+static void rotateMouseXY(ofOrientation orientation, int w, int h, int & x, int & y) {
 	int savedY;
-	switch(orientation) {
-		case OF_ORIENTATION_180:
-			x = w - x;
-			y = h - y;
-			break;
+	switch (orientation) {
+	case OF_ORIENTATION_180:
+		x = w - x;
+		y = h - y;
+		break;
 
-		case OF_ORIENTATION_90_RIGHT:
-			savedY = y;
-			y = x;
-			x = w-savedY;
-			break;
+	case OF_ORIENTATION_90_RIGHT:
+		savedY = y;
+		y = x;
+		x = w - savedY;
+		break;
 
-		case OF_ORIENTATION_90_LEFT:
-			savedY = y;
-			y = h - x;
-			x = savedY;
-			break;
+	case OF_ORIENTATION_90_LEFT:
+		savedY = y;
+		y = h - x;
+		x = savedY;
+		break;
 
-		case OF_ORIENTATION_DEFAULT:
-		default:
-			break;
+	case OF_ORIENTATION_DEFAULT:
+	default:
+		break;
 	}
 }
 
@@ -741,8 +728,7 @@ static void rotateMouseXY(ofOrientation orientation, int w, int h, int &x, int &
 void ofAppGlutWindow::mouse_cb(int button, int state, int x, int y) {
 	rotateMouseXY(orientation, instance->getWidth(), instance->getHeight(), x, y);
 
-
-	switch(button){
+	switch (button) {
 	case GLUT_LEFT_BUTTON:
 		button = OF_MOUSE_BUTTON_LEFT;
 		break;
@@ -754,7 +740,7 @@ void ofAppGlutWindow::mouse_cb(int button, int state, int x, int y) {
 		break;
 	}
 
-	if (instance->events().getFrameNum() > 0){
+	if (instance->events().getFrameNum() > 0) {
 		if (state == GLUT_DOWN) {
 			instance->events().notifyMousePressed(x, y, button);
 		} else if (state == GLUT_UP) {
@@ -769,37 +755,35 @@ void ofAppGlutWindow::mouse_cb(int button, int state, int x, int y) {
 void ofAppGlutWindow::motion_cb(int x, int y) {
 	rotateMouseXY(orientation, instance->getWidth(), instance->getHeight(), x, y);
 
-	if (instance->events().getFrameNum() > 0){
+	if (instance->events().getFrameNum() > 0) {
 		instance->events().notifyMouseDragged(x, y, buttonInUse);
 	}
-
 }
 
 //------------------------------------------------------------
 void ofAppGlutWindow::passive_motion_cb(int x, int y) {
 	rotateMouseXY(orientation, instance->getWidth(), instance->getHeight(), x, y);
 
-	if (instance->events().getFrameNum() > 0){
+	if (instance->events().getFrameNum() > 0) {
 		instance->events().notifyMouseMoved(x, y);
 	}
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::dragEvent(char ** names, int howManyFiles, int dragX, int dragY){
+void ofAppGlutWindow::dragEvent(char ** names, int howManyFiles, int dragX, int dragY) {
 
 	// TODO: we need position info on mac passed through
 	ofDragInfo info;
 	info.position.x = dragX;
-	info.position.y = instance->getHeight()-dragY;
+	info.position.y = instance->getHeight() - dragY;
 
-	for (int i = 0; i < howManyFiles; i++){
+	for (int i = 0; i < howManyFiles; i++) {
 		std::string temp = std::string(names[i]);
 		info.files.push_back(temp);
 	}
 
 	instance->events().notifyDragEvent(info);
 }
-
 
 //------------------------------------------------------------
 void ofAppGlutWindow::idle_cb(void) {
@@ -808,14 +792,13 @@ void ofAppGlutWindow::idle_cb(void) {
 	glutPostRedisplay();
 }
 
-
 //------------------------------------------------------------
 void ofAppGlutWindow::keyboard_cb(unsigned char key, int x, int y) {
 	instance->events().notifyKeyPressed(key);
 }
 
 //------------------------------------------------------------
-void ofAppGlutWindow::keyboard_up_cb(unsigned char key, int x, int y){
+void ofAppGlutWindow::keyboard_up_cb(unsigned char key, int x, int y) {
 	instance->events().notifyKeyReleased(key);
 }
 
@@ -913,7 +896,7 @@ void ofAppGlutWindow::resize_cb(int w, int h) {
 			return;
 		}
 	}
-	
+
 	if (maximumWindowSize) {
 		if (w > maximumWindowSize.value().x) {
 			glutReshapeWindow(maximumWindowSize.value().x, windowH);
@@ -935,9 +918,9 @@ void ofAppGlutWindow::resize_cb(int w, int h) {
 
 //------------------------------------------------------------
 void ofAppGlutWindow::entry_cb(int state) {
-	if (state == GLUT_ENTERED){
+	if (state == GLUT_ENTERED) {
 		instance->events().notifyMouseEntered(instance->events().getMouseX(), instance->events().getMouseY());
-	}else if (state == GLUT_LEFT){
+	} else if (state == GLUT_LEFT) {
 		instance->events().notifyMouseExited(instance->events().getMouseX(), instance->events().getMouseY());
 	}
 }

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "ofAppBaseWindow.h"
-#include "ofEvents.h"
-#include "ofTypes.h"
-#include "ofPixels.h"
 #include "ofConstants.h"
+#include "ofEvents.h"
+#include "ofPixels.h"
+#include "ofTypes.h"
 
 class ofBaseApp;
 class ofBaseRenderer;
@@ -12,30 +12,29 @@ class ofBaseRenderer;
 class ofAppGlutWindow : public ofAppBaseGLWindow {
 
 public:
-
 	ofAppGlutWindow();
-	~ofAppGlutWindow(){}
+	~ofAppGlutWindow() { }
 
-	static bool doesLoop(){ return true; }
-	static bool allowsMultiWindow(){ return false; }
+	static bool doesLoop() { return true; }
+	static bool allowsMultiWindow() { return false; }
 	static void loop();
-	static bool needsPolling(){ return false; }
-	static void pollEvents(){  }
+	static bool needsPolling() { return false; }
+	static void pollEvents() { }
 
 	using ofAppBaseWindow::setup;
 	void setup(const ofGLWindowSettings & settings);
 	void update();
 	void draw();
 	void close();
-	
-	void setDoubleBuffering(bool _bDoubleBuffered); 
-	
+
+	void setDoubleBuffering(bool _bDoubleBuffered);
+
 	//note if you fail to set a compatible string the app will not launch
 	void setGlutDisplayString(std::string str);
 
 	void hideCursor();
 	void showCursor();
-	
+
 	void setFullscreen(bool fullScreen);
 	void toggleFullscreen();
 
@@ -46,22 +45,22 @@ public:
 	void setWindowMinimumSize(int w, int h);
 	void setWindowMaximumSize(int w, int h);
 
-	glm::vec2	getWindowPosition();
-	glm::vec2	getWindowSize();
-	glm::vec2	getScreenSize();
-	
-	void			setOrientation(ofOrientation orientation);
-	ofOrientation	getOrientation();
-	
-	int			getWidth();
-	int			getHeight();	
-	
-	ofWindowMode	getWindowMode();
+	glm::vec2 getWindowPosition();
+	glm::vec2 getWindowSize();
+	glm::vec2 getScreenSize();
 
-	void		enableSetupScreen();
-	void		disableSetupScreen();
+	void setOrientation(ofOrientation orientation);
+	ofOrientation getOrientation();
 
-	void		setVerticalSync(bool enabled);
+	int getWidth();
+	int getHeight();
+
+	ofWindowMode getWindowMode();
+
+	void enableSetupScreen();
+	void disableSetupScreen();
+
+	void setVerticalSync(bool enabled);
 	void swapBuffers();
 	void startRender();
 	void finishRender();
@@ -79,7 +78,7 @@ private:
 	static void keyboard_up_cb(unsigned char key, int x, int y);
 	static void special_key_cb(int key, int x, int y);
 	static void special_key_up_cb(int key, int x, int y);
-	static int  special_key_to_of(int key);
+	static int special_key_to_of(int key);
 	static void resize_cb(int w, int h);
 	static void entry_cb(int state);
 	static void exit_cb();
@@ -91,9 +90,8 @@ private:
 	void setWindowIcon(const std::string & path);
 	void setWindowIcon(const ofPixels & iconPixels);
 #endif
-	
+
 	ofCoreEvents coreEvents;
 	std::shared_ptr<ofBaseRenderer> currentRenderer;
 	int windowId;
 };
-

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -42,6 +42,9 @@ public:
 	void setWindowTitle(std::string title);
 	void setWindowPosition(int x, int y);
 	void setWindowShape(int w, int h);
+	void setWindowSize(int w, int h);
+	void setWindowMinimumSize(int w, int h);
+	void setWindowMaximumSize(int w, int h);
 
 	glm::vec2	getWindowPosition();
 	glm::vec2	getWindowSize();

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -377,8 +377,28 @@ void ofSetWindowPosition(int x, int y){
 }
 
 //--------------------------------------
+void ofSetWindowSize(int width, int height){
+	ofSetWindowShape(width, height);
+}
+
+//--------------------------------------
 void ofSetWindowShape(int width, int height){
 	mainLoop()->getCurrentWindow()->setWindowShape(width, height);
+}
+
+//--------------------------------------
+void ofSetWindowAspectRatio(int horizontal, int vertical){
+	mainLoop()->getCurrentWindow()->setWindowAspectRatio(horizontal, vertical);
+}
+
+//--------------------------------------
+void ofSetWindowMinimumSize(int width, int height){
+	mainLoop()->getCurrentWindow()->setWindowMinimumSize(width, height);
+}
+
+//--------------------------------------
+void ofSetWindowMaximumSize(int width, int height){
+	mainLoop()->getCurrentWindow()->setWindowMaximumSize(width, height);
 }
 
 //--------------------------------------

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -1,12 +1,12 @@
 #include "ofAppRunner.h"
 
-#include "ofBaseApp.h"
 #include "ofAppBaseWindow.h"
+#include "ofBaseApp.h"
 
 // IDEA BRANCH - remove this comment
+#include "ofGraphicsBaseTypes.h"
 #include "ofLog.h"
 #include "ofMath.h"
-#include "ofGraphicsBaseTypes.h"
 #include "ofRectangle.h"
 
 // MASTER - TODO: Remove commented out code
@@ -17,30 +17,29 @@
 // #include "ofImage.h"
 // #include "ofTrueTypeFont.h"
 
-
 #include "ofMainLoop.h"
 
 using std::shared_ptr;
 
 #if !defined(TARGET_NODISPLAY)
-	#if !defined( TARGET_OF_IOS ) & !defined(TARGET_ANDROID) & !defined(TARGET_EMSCRIPTEN) & !defined(TARGET_RASPBERRY_PI_LEGACY)
-	#include "ofAppGLFWWindow.h"
-	//special case so we preserve supplied settngs
-	//TODO: remove me when we remove the ofAppGLFWWindow setters.
-	//--------------------------------------
-	void ofSetupOpenGL(const shared_ptr<ofAppGLFWWindow> & windowPtr, int w, int h, ofWindowMode screenMode){
-		ofInit();
-		auto settings = windowPtr->getSettings();
-		settings.setSize(w,h);
-		settings.windowMode = screenMode;
-		ofGetMainLoop()->addWindow(windowPtr);
-		windowPtr->setup(settings);
-	}
+	#if !defined(TARGET_OF_IOS) & !defined(TARGET_ANDROID) & !defined(TARGET_EMSCRIPTEN) & !defined(TARGET_RASPBERRY_PI_LEGACY)
+		#include "ofAppGLFWWindow.h"
+//special case so we preserve supplied settngs
+//TODO: remove me when we remove the ofAppGLFWWindow setters.
+//--------------------------------------
+void ofSetupOpenGL(const shared_ptr<ofAppGLFWWindow> & windowPtr, int w, int h, ofWindowMode screenMode) {
+	ofInit();
+	auto settings = windowPtr->getSettings();
+	settings.setSize(w, h);
+	settings.windowMode = screenMode;
+	ofGetMainLoop()->addWindow(windowPtr);
+	windowPtr->setup(settings);
+}
 	#endif
 #endif
 
 #ifdef TARGET_LINUX
-#include "ofGstUtils.h"
+	#include "ofGstUtils.h"
 #endif
 
 // adding this for vc2010 compile: error C3861: 'closeQuicktime': identifier not found
@@ -48,79 +47,76 @@ using std::shared_ptr;
 	#include "ofQtUtils.h"
 #endif
 
-#if defined (TARGET_WIN32)
-#include <mmsystem.h>
+#if defined(TARGET_WIN32)
+	#include <mmsystem.h>
 #endif
 
-
 //--------------------------------------
-namespace{
+namespace {
 
-    shared_ptr<ofMainLoop> & mainLoop(){
-        static shared_ptr<ofMainLoop> * mainLoop(new shared_ptr<ofMainLoop>(new ofMainLoop));
-        return *mainLoop;
-    }
-
-    bool & initialized(){
-        static bool * initialized = new bool(false);
-        return *initialized;
-    }
-
-	bool & exiting(){
-		static bool * exiting = new bool(false);
-		return *exiting;
-	}
-
-	ofCoreEvents & noopEvents(){
-		static auto * noopEvents = new ofCoreEvents();
-		return *noopEvents;
-	}
-
-    #if defined(TARGET_LINUX) || defined(TARGET_OSX)
-        #include <signal.h>
-        #include <string.h>
-        void ofSignalHandler(int signum){
-            char* pSignalString = strsignal(signum);
-
-            if(pSignalString){
-                ofLogVerbose("ofSignalHandler") << pSignalString;
-            }else{
-                ofLogVerbose("ofSignalHandler") << "Unknown: " << signum;
-            }
-
-            signal(SIGTERM, nullptr);
-            signal(SIGQUIT, nullptr);
-            signal(SIGINT,  nullptr);
-            signal(SIGHUP,  nullptr);
-            signal(SIGABRT, nullptr);
-
-            if(mainLoop()){
-                mainLoop()->shouldClose(signum);
-            }
-        }
-    #endif
+shared_ptr<ofMainLoop> & mainLoop() {
+	static shared_ptr<ofMainLoop> * mainLoop(new shared_ptr<ofMainLoop>(new ofMainLoop));
+	return *mainLoop;
 }
 
+bool & initialized() {
+	static bool * initialized = new bool(false);
+	return *initialized;
+}
+
+bool & exiting() {
+	static bool * exiting = new bool(false);
+	return *exiting;
+}
+
+ofCoreEvents & noopEvents() {
+	static auto * noopEvents = new ofCoreEvents();
+	return *noopEvents;
+}
+
+#if defined(TARGET_LINUX) || defined(TARGET_OSX)
+	#include <signal.h>
+	#include <string.h>
+void ofSignalHandler(int signum) {
+	char * pSignalString = strsignal(signum);
+
+	if (pSignalString) {
+		ofLogVerbose("ofSignalHandler") << pSignalString;
+	} else {
+		ofLogVerbose("ofSignalHandler") << "Unknown: " << signum;
+	}
+
+	signal(SIGTERM, nullptr);
+	signal(SIGQUIT, nullptr);
+	signal(SIGINT, nullptr);
+	signal(SIGHUP, nullptr);
+	signal(SIGABRT, nullptr);
+
+	if (mainLoop()) {
+		mainLoop()->shouldClose(signum);
+	}
+}
+#endif
+}
 
 void ofExitCallback();
 void ofURLFileLoaderShutdown();
 void ofTrueTypeShutdown();
 void ofCloseFreeImage();
 
-#if defined(TARGET_ANDROID) || defined (TARGET_LINUX_ARM)
-	inline void ofSoundShutdown(){}
+#if defined(TARGET_ANDROID) || defined(TARGET_LINUX_ARM)
+inline void ofSoundShutdown() { }
 #else
-	void ofSoundShutdown();
+void ofSoundShutdown();
 #endif
 
-
-void ofInit(){
-	if(initialized()) return;
+void ofInit() {
+	if (initialized()) return;
 	initialized() = true;
 	exiting() = false;
 
 #if defined(TARGET_ANDROID) || defined(TARGET_OF_IOS)
-    // manage own exit
+	// manage own exit
 #else
 	atexit(ofExitCallback);
 #endif
@@ -129,51 +125,51 @@ void ofInit(){
 	// see http://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html#Termination-Signals
 	signal(SIGTERM, &ofSignalHandler);
 	signal(SIGQUIT, &ofSignalHandler);
-	signal(SIGINT,  &ofSignalHandler);
+	signal(SIGINT, &ofSignalHandler);
 
-	signal(SIGHUP,  &ofSignalHandler); // not much to be done here
+	signal(SIGHUP, &ofSignalHandler); // not much to be done here
 
 	// http://www.gnu.org/software/libc/manual/html_node/Program-Error-Signals.html#Program-Error-Signals
-	signal(SIGABRT, &ofSignalHandler);  // abort signal
+	signal(SIGABRT, &ofSignalHandler); // abort signal
 #endif
 
-    of::priv::initutils();
-    of::priv::initfileutils();
+	of::priv::initutils();
+	of::priv::initfileutils();
 
 #ifdef WIN32_HIGH_RES_TIMING
-    timeBeginPeriod(1);		// ! experimental, sets high res time
-                            // you need to call timeEndPeriod.
-                            // if you quit the app other than "esc"
-                            // (ie, close the console, kill the process, etc)
-                            // at exit wont get called, and the time will
-                            // remain high res, that could mess things
-                            // up on your system.
-                            // info here:http://www.geisswerks.com/ryan/FAQS/timing.html
+	timeBeginPeriod(1); // ! experimental, sets high res time
+		// you need to call timeEndPeriod.
+		// if you quit the app other than "esc"
+		// (ie, close the console, kill the process, etc)
+		// at exit wont get called, and the time will
+		// remain high res, that could mess things
+		// up on your system.
+		// info here:http://www.geisswerks.com/ryan/FAQS/timing.html
 #endif
 
 #ifdef TARGET_LINUX
-	if(std::locale().name() == "C"){
-		try{
-            std::locale::global(std::locale("C.UTF-8"));
-		}catch(...){
-			if(ofToLower(std::locale("").name()).find("utf-8")==std::string::npos){
+	if (std::locale().name() == "C") {
+		try {
+			std::locale::global(std::locale("C.UTF-8"));
+		} catch (...) {
+			if (ofToLower(std::locale("").name()).find("utf-8") == std::string::npos) {
 				ofLogWarning("ofInit") << "Couldn't set UTF-8 locale, string manipulation functions\n"
-						"won't work correctly for non ansi characters unless you specify a UTF-8 locale\n"
-						"manually using std::locale::global(std::locale(\"locale\"))\n"
-						"available locales can be queried with 'locale -a' in a terminal.";
+										  "won't work correctly for non ansi characters unless you specify a UTF-8 locale\n"
+										  "manually using std::locale::global(std::locale(\"locale\"))\n"
+										  "available locales can be queried with 'locale -a' in a terminal.";
 			}
 		}
 	}
 #endif
 
 #if defined(TARGET_WIN32) && !_MSC_VER //MSYS2 UTF-8 limited support
-    setlocale(LC_ALL,"");
-    ofLogWarning("ofInit") << "MSYS2 has limited support for UTF-8. using "<< std::string( setlocale(LC_ALL,NULL) );
+	setlocale(LC_ALL, "");
+	ofLogWarning("ofInit") << "MSYS2 has limited support for UTF-8. using " << std::string(setlocale(LC_ALL, NULL));
 #endif
 }
 
 //--------------------------------------
-shared_ptr<ofMainLoop> ofGetMainLoop(){
+shared_ptr<ofMainLoop> ofGetMainLoop() {
 	return mainLoop();
 }
 
@@ -183,7 +179,7 @@ void ofSetMainLoop(const shared_ptr<ofMainLoop> & newMainLoop) {
 }
 
 //--------------------------------------
-int ofRunApp(ofBaseApp * OFSA){
+int ofRunApp(ofBaseApp * OFSA) {
 	mainLoop()->run(shared_ptr<ofBaseApp>(OFSA));
 	auto ret = ofRunMainLoop();
 #if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
@@ -193,7 +189,7 @@ int ofRunApp(ofBaseApp * OFSA){
 }
 
 //--------------------------------------
-int ofRunApp(shared_ptr<ofBaseApp> && app){
+int ofRunApp(shared_ptr<ofBaseApp> && app) {
 	mainLoop()->run(std::move(app));
 	auto ret = ofRunMainLoop();
 #if !defined(TARGET_ANDROID) && !defined(TARGET_OF_IOS)
@@ -203,17 +199,17 @@ int ofRunApp(shared_ptr<ofBaseApp> && app){
 }
 
 //--------------------------------------
-void ofRunApp(const shared_ptr<ofAppBaseWindow> & window, shared_ptr<ofBaseApp> && app){
+void ofRunApp(const shared_ptr<ofAppBaseWindow> & window, shared_ptr<ofBaseApp> && app) {
 	mainLoop()->run(window, std::move(app));
 }
 
-int ofRunMainLoop(){
+int ofRunMainLoop() {
 	auto ret = mainLoop()->loop();
 	return ret;
 }
 
 //--------------------------------------
-void ofSetupOpenGL(int w, int h, ofWindowMode screenMode){
+void ofSetupOpenGL(int w, int h, ofWindowMode screenMode) {
 #ifdef TARGET_OPENGLES
 	ofGLESWindowSettings settings;
 	settings.glesVersion = 1;
@@ -228,7 +224,7 @@ void ofSetupOpenGL(int w, int h, ofWindowMode screenMode){
 	ofCreateWindow(settings);
 }
 
-shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings){
+shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings) {
 	ofInit();
 	return mainLoop()->createWindow(settings);
 }
@@ -237,8 +233,8 @@ shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings){
 //							currently looking at who to turn off
 //							at the end of the application
 
-void ofExitCallback(){
-	if(!initialized()) return;
+void ofExitCallback() {
+	if (!initialized()) return;
 
 	// controlled destruction of the mainLoop before
 	// any other deinitialization
@@ -247,37 +243,34 @@ void ofExitCallback(){
 	// everything should be destroyed here, except for
 	// static objects
 
-
 	// finish every library and subsystem
 	ofURLFileLoaderShutdown();
 
-	#ifndef TARGET_NO_SOUND
-		//------------------------
-		// try to close engine if needed:
-		ofSoundShutdown();
-		//------------------------
-	#endif
+#ifndef TARGET_NO_SOUND
+	//------------------------
+	// try to close engine if needed:
+	ofSoundShutdown();
+	//------------------------
+#endif
 
-	// try to close quicktime, for non-linux systems:
-	#if defined(OF_VIDEO_CAPTURE_QUICKTIME) || defined(OF_VIDEO_PLAYER_QUICKTIME)
+// try to close quicktime, for non-linux systems:
+#if defined(OF_VIDEO_CAPTURE_QUICKTIME) || defined(OF_VIDEO_PLAYER_QUICKTIME)
 	closeQuicktime();
-	#endif
-
+#endif
 
 	//------------------------
 	// try to close freeImage:
 	ofCloseFreeImage();
 
+#ifdef WIN32_HIGH_RES_TIMING
+	timeEndPeriod(1);
+#endif
 
-	#ifdef WIN32_HIGH_RES_TIMING
-		timeEndPeriod(1);
-	#endif
-
-	//------------------------
-	// try to close gstreamer
-	#ifdef TARGET_LINUX
-		ofGstUtils::quitGstMainLoop();
-	#endif
+//------------------------
+// try to close gstreamer
+#ifdef TARGET_LINUX
+	ofGstUtils::quitGstMainLoop();
+#endif
 
 	//------------------------
 	// try to close font libraries
@@ -294,12 +287,12 @@ void ofExitCallback(){
 
 //--------------------------------------
 // core events instance & arguments
-ofCoreEvents & ofEvents(){
+ofCoreEvents & ofEvents() {
 	auto window = mainLoop()->getCurrentWindow();
-	if(window){
+	if (window) {
 		return window->events();
-	}else{
-		if(!exiting()){
+	} else {
+		if (!exiting()) {
 			ofLogError("ofEvents") << "Trying to call ofEvents() before a window has been setup";
 			ofLogError("ofEvents") << "We'll return a void events instance to avoid crashes but somethings might not work";
 			ofLogError("ofEvents") << "Set a breakpoint in " << __FILE__ << " line " << __LINE__ << " to check where is the wrong call";
@@ -309,23 +302,23 @@ ofCoreEvents & ofEvents(){
 }
 
 //--------------------------------------
-void ofSetEscapeQuitsApp(bool bQuitOnEsc){
+void ofSetEscapeQuitsApp(bool bQuitOnEsc) {
 	mainLoop()->setEscapeQuitsLoop(bQuitOnEsc);
 }
 
 //--------------------------------------
-shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer(){
+shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer() {
 	return mainLoop()->getCurrentWindow()->renderer();
 }
 
 //--------------------------------------
-ofBaseApp * ofGetAppPtr(){
+ofBaseApp * ofGetAppPtr() {
 	return mainLoop()->getCurrentApp().get();
 }
 
 //--------------------------------------
 std::thread::id ofGetMainThreadId() {
-	return ofGetMainLoop()->get_thread_id() ;
+	return ofGetMainLoop()->get_thread_id();
 }
 
 bool ofIsCurrentThreadTheMainThread() {
@@ -333,7 +326,7 @@ bool ofIsCurrentThreadTheMainThread() {
 }
 
 //--------------------------------------
-ofAppBaseWindow * ofGetWindowPtr(){
+ofAppBaseWindow * ofGetWindowPtr() {
 	return mainLoop()->getCurrentWindow().get();
 }
 
@@ -343,114 +336,114 @@ std::shared_ptr<ofAppBaseWindow> ofGetCurrentWindow() {
 }
 
 //--------------------------------------
-void ofExit(int status){
+void ofExit(int status) {
 	mainLoop()->shouldClose(status);
 }
 
 //--------------------------------------
-void ofHideCursor(){
+void ofHideCursor() {
 	mainLoop()->getCurrentWindow()->hideCursor();
 }
 
 //--------------------------------------
-void ofShowCursor(){
+void ofShowCursor() {
 	mainLoop()->getCurrentWindow()->showCursor();
 }
 
 //--------------------------------------
-void ofSetOrientation(ofOrientation orientation, bool vFlip){
+void ofSetOrientation(ofOrientation orientation, bool vFlip) {
 	mainLoop()->getCurrentWindow()->setOrientation(orientation);
 	// TODO: every window should set orientation on it's renderer
-	if(ofGetCurrentRenderer()){
-		ofGetCurrentRenderer()->setOrientation(orientation,vFlip);
+	if (ofGetCurrentRenderer()) {
+		ofGetCurrentRenderer()->setOrientation(orientation, vFlip);
 	}
 }
 
 //--------------------------------------
-ofOrientation ofGetOrientation(){
+ofOrientation ofGetOrientation() {
 	return mainLoop()->getCurrentWindow()->getOrientation();
 }
 
 //--------------------------------------
-void ofSetWindowPosition(int x, int y){
-	mainLoop()->getCurrentWindow()->setWindowPosition(x,y);
+void ofSetWindowPosition(int x, int y) {
+	mainLoop()->getCurrentWindow()->setWindowPosition(x, y);
 }
 
 //--------------------------------------
-void ofSetWindowSize(int width, int height){
+void ofSetWindowSize(int width, int height) {
 	ofSetWindowShape(width, height);
 }
 
 //--------------------------------------
-void ofSetWindowShape(int width, int height){
+void ofSetWindowShape(int width, int height) {
 	mainLoop()->getCurrentWindow()->setWindowShape(width, height);
 }
 
 //--------------------------------------
-void ofSetWindowAspectRatio(int horizontal, int vertical){
+void ofSetWindowAspectRatio(int horizontal, int vertical) {
 	mainLoop()->getCurrentWindow()->setWindowAspectRatio(horizontal, vertical);
 }
 
 //--------------------------------------
-void ofSetWindowMinimumSize(int width, int height){
+void ofSetWindowMinimumSize(int width, int height) {
 	mainLoop()->getCurrentWindow()->setWindowMinimumSize(width, height);
 }
 
 //--------------------------------------
-void ofSetWindowMaximumSize(int width, int height){
+void ofSetWindowMaximumSize(int width, int height) {
 	mainLoop()->getCurrentWindow()->setWindowMaximumSize(width, height);
 }
 
 //--------------------------------------
-int ofGetWindowPositionX(){
+int ofGetWindowPositionX() {
 	return (int)mainLoop()->getCurrentWindow()->getWindowPosition().x;
 }
 
 //--------------------------------------
-int ofGetWindowPositionY(){
+int ofGetWindowPositionY() {
 	return (int)mainLoop()->getCurrentWindow()->getWindowPosition().y;
 }
 
 //--------------------------------------
-int ofGetScreenWidth(){
+int ofGetScreenWidth() {
 	return (int)mainLoop()->getCurrentWindow()->getScreenSize().x;
 }
 
 //--------------------------------------
-int ofGetScreenHeight(){
+int ofGetScreenHeight() {
 	return (int)mainLoop()->getCurrentWindow()->getScreenSize().y;
 }
 
 //--------------------------------------------------
-int ofGetWidth(){
+int ofGetWidth() {
 	return (int)mainLoop()->getCurrentWindow()->getWidth();
 }
 //--------------------------------------------------
-int ofGetHeight(){
+int ofGetHeight() {
 	return (int)mainLoop()->getCurrentWindow()->getHeight();
 }
 
 //--------------------------------------------------
-int ofGetWindowWidth(){
+int ofGetWindowWidth() {
 	return (int)mainLoop()->getCurrentWindow()->getWindowSize().x;
 }
 //--------------------------------------------------
-int ofGetWindowHeight(){
+int ofGetWindowHeight() {
 	return (int)mainLoop()->getCurrentWindow()->getWindowSize().y;
 }
 
 //--------------------------------------------------
-std::string ofGetClipboardString(){
+std::string ofGetClipboardString() {
 	return mainLoop()->getCurrentWindow()->getClipboardString();
 }
 
 //--------------------------------------------------
-void ofSetClipboardString(const std::string & str){
+void ofSetClipboardString(const std::string & str) {
 	mainLoop()->getCurrentWindow()->setClipboardString(str);
 }
 
 //--------------------------------------------------
-bool ofDoesHWOrientation(){
+bool ofDoesHWOrientation() {
 	return mainLoop()->getCurrentWindow()->doesHWOrientation();
 }
 
@@ -471,91 +464,91 @@ float ofRandomHeight() {
 }
 
 //--------------------------------------------------
-ofRectangle	ofGetWindowRect() {
+ofRectangle ofGetWindowRect() {
 	return ofRectangle(0, 0, ofGetWindowWidth(), ofGetWindowHeight());
 }
 
 //--------------------------------------
-void ofSetWindowTitle(std::string title){
+void ofSetWindowTitle(std::string title) {
 	mainLoop()->getCurrentWindow()->setWindowTitle(title);
 }
 
 //----------------------------------------------------------
-void ofEnableSetupScreen(){
+void ofEnableSetupScreen() {
 	mainLoop()->getCurrentWindow()->enableSetupScreen();
 }
 
 //----------------------------------------------------------
-void ofDisableSetupScreen(){
+void ofDisableSetupScreen() {
 	mainLoop()->getCurrentWindow()->disableSetupScreen();
 }
 
 //--------------------------------------
-void ofToggleFullscreen(){
+void ofToggleFullscreen() {
 	mainLoop()->getCurrentWindow()->toggleFullscreen();
 }
 
 //--------------------------------------
-void ofSetFullscreen(bool fullscreen){
+void ofSetFullscreen(bool fullscreen) {
 	mainLoop()->getCurrentWindow()->setFullscreen(fullscreen);
 }
 
 //--------------------------------------
-int ofGetWindowMode(){
+int ofGetWindowMode() {
 	return mainLoop()->getCurrentWindow()->getWindowMode();
 }
 
 //--------------------------------------
-void ofSetVerticalSync(bool bSync){
+void ofSetVerticalSync(bool bSync) {
 	mainLoop()->getCurrentWindow()->setVerticalSync(bSync);
 }
 
 //-------------------------- native window handles
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)
-Display* ofGetX11Display(){
+Display * ofGetX11Display() {
 	return mainLoop()->getCurrentWindow()->getX11Display();
 }
 
-Window  ofGetX11Window(){
+Window ofGetX11Window() {
 	return mainLoop()->getCurrentWindow()->getX11Window();
 }
 #endif
 
 #if defined(TARGET_LINUX) && !defined(TARGET_OPENGLES)
-GLXContext ofGetGLXContext(){
+GLXContext ofGetGLXContext() {
 	return mainLoop()->getCurrentWindow()->getGLXContext();
 }
 #endif
 
 #if defined(TARGET_LINUX) && defined(TARGET_OPENGLES)
-EGLDisplay ofGetEGLDisplay(){
+EGLDisplay ofGetEGLDisplay() {
 	return mainLoop()->getCurrentWindow()->getEGLDisplay();
 }
 
-EGLContext ofGetEGLContext(){
+EGLContext ofGetEGLContext() {
 	return mainLoop()->getCurrentWindow()->getEGLContext();
 }
-EGLSurface ofGetEGLSurface(){
+EGLSurface ofGetEGLSurface() {
 	return mainLoop()->getCurrentWindow()->getEGLSurface();
 }
 #endif
 
 #if defined(TARGET_OSX)
-void * ofGetNSGLContext(){
+void * ofGetNSGLContext() {
 	return mainLoop()->getCurrentWindow()->getNSGLContext();
 }
 
-void * ofGetCocoaWindow(){
+void * ofGetCocoaWindow() {
 	return mainLoop()->getCurrentWindow()->getCocoaWindow();
 }
 #endif
 
 #if defined(TARGET_WIN32)
-HGLRC ofGetWGLContext(){
+HGLRC ofGetWGLContext() {
 	return mainLoop()->getCurrentWindow()->getWGLContext();
 }
 
-HWND ofGetWin32Window(){
+HWND ofGetWin32Window() {
 	return mainLoop()->getCurrentWindow()->getWin32Window();
 }
 #endif

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -98,6 +98,10 @@ ofAppBaseWindow * ofGetWindowPtr();
 std::shared_ptr<ofAppBaseWindow> ofGetCurrentWindow();
 
 void 		ofSetWindowPosition(int x, int y);
+void 		ofSetWindowSize(int width, int height);
+void 		ofSetWindowMinimumSize(int width, int height);
+void 		ofSetWindowMaxmimumSize(int width, int height);
+void 		ofSetWindowAspectRatio(int horizontal, int vertical);
 void 		ofSetWindowShape(int width, int height);
 void 		ofSetWindowTitle(std::string title);
 void		ofEnableSetupScreen();

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "ofWindowSettings.h"
 #include "ofConstants.h"
 #include "ofMainLoop.h"
+#include "ofWindowSettings.h"
 
 class ofRectangle;
 class ofAppBaseWindow;
@@ -11,15 +11,14 @@ class ofBaseApp;
 class ofBaseRenderer;
 class ofCoreEvents;
 
-
 void ofInit();
-void ofSetupOpenGL(int w, int h, ofWindowMode screenMode);	// sets up the opengl context!
-std::shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings);	// sets up the opengl context!
+void ofSetupOpenGL(int w, int h, ofWindowMode screenMode); // sets up the opengl context!
+std::shared_ptr<ofAppBaseWindow> ofCreateWindow(const ofWindowSettings & settings); // sets up the opengl context!
 std::shared_ptr<ofMainLoop> ofGetMainLoop();
 void ofSetMainLoop(const std::shared_ptr<ofMainLoop> & mainLoop);
 
-template<typename Window>
-void ofSetupOpenGL(const std::shared_ptr<Window> & windowPtr, int w, int h, ofWindowMode screenMode){
+template <typename Window>
+void ofSetupOpenGL(const std::shared_ptr<Window> & windowPtr, int w, int h, ofWindowMode screenMode) {
 	ofInit();
 	ofWindowSettings settings;
 	settings.setSize(w, h);
@@ -32,87 +31,85 @@ void ofSetupOpenGL(const std::shared_ptr<Window> & windowPtr, int w, int h, ofWi
 //TODO: remove me when we remove the ofSetupOpenGL legacy approach.
 void ofSetupOpenGL(const std::shared_ptr<ofAppGLFWWindow> & windowPtr, int w, int h, ofWindowMode screenMode);
 
-template<typename Window>
-static void noopDeleter(Window*){}
+template <typename Window>
+static void noopDeleter(Window *) { }
 
-template<typename Window>
-void ofSetupOpenGL(Window * windowPtr, int w, int h, ofWindowMode screenMode){
+template <typename Window>
+void ofSetupOpenGL(Window * windowPtr, int w, int h, ofWindowMode screenMode) {
 	std::shared_ptr<Window> window = std::shared_ptr<Window>(windowPtr, std::function<void(Window *)>(noopDeleter<Window>));
-	ofSetupOpenGL(window,w,h,screenMode);
+	ofSetupOpenGL(window, w, h, screenMode);
 }
-
 
 int ofRunApp(std::shared_ptr<ofBaseApp> && OFSA);
 int ofRunApp(ofBaseApp * OFSA = nullptr); // will be deprecated
 void ofRunApp(const std::shared_ptr<ofAppBaseWindow> & window, std::shared_ptr<ofBaseApp> && app);
 int ofRunMainLoop();
 
-
 ofBaseApp * ofGetAppPtr();
 
-void		ofExit(int status=0);
+void ofExit(int status = 0);
 
-bool 		ofIsCurrentThreadTheMainThread();
+bool ofIsCurrentThreadTheMainThread();
 std::thread::id ofGetMainThreadId();
 
 //-------------------------- time
-float 		ofGetFrameRate();
-float 		ofGetTargetFrameRate();
-uint64_t	ofGetFrameNum();
-void 		ofSetFrameRate(int targetRate);
-double		ofGetLastFrameTime();
-void		ofSetTimeModeSystem();
-uint64_t	ofGetFixedStepForFps(double fps);
-void		ofSetTimeModeFixedRate(uint64_t stepNanos = ofGetFixedStepForFps(60)); //default nanos for 1 frame at 60fps
-void		ofSetTimeModeFiltered(float alpha = 0.9);
+float ofGetFrameRate();
+float ofGetTargetFrameRate();
+uint64_t ofGetFrameNum();
+void ofSetFrameRate(int targetRate);
+double ofGetLastFrameTime();
+void ofSetTimeModeSystem();
+uint64_t ofGetFixedStepForFps(double fps);
+void ofSetTimeModeFixedRate(uint64_t stepNanos = ofGetFixedStepForFps(60)); //default nanos for 1 frame at 60fps
+void ofSetTimeModeFiltered(float alpha = 0.9);
 
-void		ofSetOrientation(ofOrientation orientation, bool vFlip=true);
-ofOrientation			ofGetOrientation();
+void ofSetOrientation(ofOrientation orientation, bool vFlip = true);
+ofOrientation ofGetOrientation();
 
 //-------------------------- cursor
-void 		ofHideCursor();
-void 		ofShowCursor();
+void ofHideCursor();
+void ofShowCursor();
 //-------------------------- window / screen
-int 		ofGetWindowPositionX();
-int 		ofGetWindowPositionY();
-int 		ofGetScreenWidth();
-int 		ofGetScreenHeight();
-int			ofGetWindowMode();
-int 		ofGetWidth();			// ofGetWidth is correct for orientation
-int 		ofGetHeight();
-int 		ofGetWindowWidth();			// ofGetWindowWidth is correct for actual window coordinates - so doesn't change with orientation.
-int 		ofGetWindowHeight();
+int ofGetWindowPositionX();
+int ofGetWindowPositionY();
+int ofGetScreenWidth();
+int ofGetScreenHeight();
+int ofGetWindowMode();
+int ofGetWidth(); // ofGetWidth is correct for orientation
+int ofGetHeight();
+int ofGetWindowWidth(); // ofGetWindowWidth is correct for actual window coordinates - so doesn't change with orientation.
+int ofGetWindowHeight();
 
 std::string ofGetClipboardString();
-void		ofSetClipboardString(const std::string & str);
+void ofSetClipboardString(const std::string & str);
 
 /// \returns a random number between 0 and the width of the window.
 float ofRandomWidth();
 
 /// \returns a random number between 0 and the height of the window.
 float ofRandomHeight();
-bool		ofDoesHWOrientation();
-glm::vec2	ofGetWindowSize();
-ofRectangle	ofGetWindowRect();
+bool ofDoesHWOrientation();
+glm::vec2 ofGetWindowSize();
+ofRectangle ofGetWindowRect();
 ofAppBaseWindow * ofGetWindowPtr();
 std::shared_ptr<ofAppBaseWindow> ofGetCurrentWindow();
 
-void 		ofSetWindowPosition(int x, int y);
-void 		ofSetWindowSize(int width, int height);
-void 		ofSetWindowMinimumSize(int width, int height);
-void 		ofSetWindowMaxmimumSize(int width, int height);
-void 		ofSetWindowAspectRatio(int horizontal, int vertical);
-void 		ofSetWindowShape(int width, int height);
-void 		ofSetWindowTitle(std::string title);
-void		ofEnableSetupScreen();
-void		ofDisableSetupScreen();
-void		ofSetFullscreen(bool fullscreen);
-void		ofToggleFullscreen();
+void ofSetWindowPosition(int x, int y);
+void ofSetWindowSize(int width, int height);
+void ofSetWindowMinimumSize(int width, int height);
+void ofSetWindowMaxmimumSize(int width, int height);
+void ofSetWindowAspectRatio(int horizontal, int vertical);
+void ofSetWindowShape(int width, int height);
+void ofSetWindowTitle(std::string title);
+void ofEnableSetupScreen();
+void ofDisableSetupScreen();
+void ofSetFullscreen(bool fullscreen);
+void ofToggleFullscreen();
 //-------------------------- sync
-void 		ofSetVerticalSync(bool bSync);
+void ofSetVerticalSync(bool bSync);
 
 ofCoreEvents & ofEvents();
-void ofSetCurrentRenderer(std::shared_ptr<ofBaseRenderer> renderer,bool setDefaults=false);
+void ofSetCurrentRenderer(std::shared_ptr<ofBaseRenderer> renderer, bool setDefaults = false);
 std::shared_ptr<ofBaseRenderer> & ofGetCurrentRenderer();
 void ofSetEscapeQuitsApp(bool bQuitOnEsc);
 
@@ -121,8 +118,8 @@ void ofSetEscapeQuitsApp(bool bQuitOnEsc);
 typedef unsigned long Window;
 struct _XDisplay;
 typedef struct _XDisplay Display;
-Display* ofGetX11Display();
-Window  ofGetX11Window();
+Display * ofGetX11Display();
+Window ofGetX11Window();
 #endif
 
 #if defined(TARGET_LINUX) && !defined(TARGET_OPENGLES)
@@ -138,11 +135,11 @@ EGLSurface ofGetEGLSurface();
 #endif
 
 #if defined(TARGET_OSX)
-	void * ofGetNSGLContext();
-	void * ofGetCocoaWindow();
+void * ofGetNSGLContext();
+void * ofGetCocoaWindow();
 #endif
 
 #if defined(TARGET_WIN32)
-	HGLRC ofGetWGLContext();
-	HWND ofGetWin32Window();
+HGLRC ofGetWGLContext();
+HWND ofGetWin32Window();
 #endif


### PR DESCRIPTION
add support for windows contraints (size and/or aspect ratio). tested in GLFW; GLUT should work (they say to [enforce yourself it in the resize callback](https://community.khronos.org/t/how-to-limit-the-glut-window-resize-to-a-minimum-size/43516)).

not sure how to handle/test other windows? (e.g. in EAGL ofLogWarning() to mention the operation is unimplemented?)

behaves like this with some "adaptive" content: minimum size only:

![c1](https://github.com/openframeworks/openFrameworks/assets/2172370/188cf96e-c5ad-4ee0-98f3-f6d3818d1f73)

aspect ratio locked to 4:3 + minimum size:

![c2](https://github.com/openframeworks/openFrameworks/assets/2172370/0702ae08-2968-46ba-82c8-bc6caf46e1a2)

