### PR TITLE
ofxSvg initialize with filename

### DIFF
--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -35,7 +35,7 @@ void ofxSvg::load(const of::filesystem::path & fileName) {
 	}
 
 	ofBuffer buffer = ofBufferFromFile(fileName);
-	loadFromString(buffer.getText(), file);
+	loadFromString(buffer.getText(), file.string());
 }
 
 void ofxSvg::loadFromString(std::string stringdata, std::string urlstring) {

--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -3,11 +3,15 @@
 #include <locale>
 
 using std::string;
-using std::vector;
 
 extern "C" {
 #include "svgtiny.h"
 }
+
+ofxSvg::ofxSvg(const of::filesystem::path & fileName) {
+	load(fileName);
+}
+
 ofxSvg::~ofxSvg() {
 	paths.clear();
 }
@@ -27,7 +31,7 @@ ofPath & ofxSvg::getPathAt(int n) {
 	return paths[n];
 }
 
-void ofxSvg::load(of::filesystem::path fileName) {
+void ofxSvg::load(const of::filesystem::path & fileName) {
 	// fileName = ofToDataPath(fileName);
 	std::string file = ofToDataPath(fileName);
 
@@ -48,7 +52,6 @@ void ofxSvg::load(of::filesystem::path fileName) {
 	}
 
 	ofBuffer buffer = ofBufferFromFile(file);
-
 	loadFromString(buffer.getText(), file);
 }
 
@@ -69,7 +72,7 @@ void ofxSvg::loadFromString(std::string stringdata, std::string urlstring) {
 	std::locale::global(prev_locale);
 
 	if (code != svgtiny_OK) {
-		string msg;
+		std::string msg;
 		switch (code) {
 		case svgtiny_OUT_OF_MEMORY:
 			msg = "svgtiny_OUT_OF_MEMORY";
@@ -254,6 +257,6 @@ void ofxSvg::setupShape(struct svgtiny_shape * shape, ofPath & path) {
 	}
 }
 
-const vector<ofPath> & ofxSvg::getPaths() const {
+const std::vector<ofPath> & ofxSvg::getPaths() const {
 	return paths;
 }

--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -8,8 +8,6 @@ extern "C" {
 #include "svgtiny.h"
 }
 
-ofxSvg::ofxSvg() {}
-
 ofxSvg::ofxSvg(const of::filesystem::path & fileName) {
 	load(fileName);
 }

--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -14,10 +14,6 @@ ofxSvg::ofxSvg(const of::filesystem::path & fileName) {
 	load(fileName);
 }
 
-ofxSvg::~ofxSvg() {
-	paths.clear();
-}
-
 float ofxSvg::getWidth() const {
 	return width;
 }
@@ -34,26 +30,13 @@ ofPath & ofxSvg::getPathAt(int n) {
 }
 
 void ofxSvg::load(const of::filesystem::path & fileName) {
-	// fileName = ofToDataPath(fileName);
-	std::string file = ofToDataPath(fileName);
-
-	// FIXME: I think this is the equivalent of .empty() which is simpler.
-	// maybe use file exists to check instead?
-	// if(fileName.compare("") == 0){
-	// 	ofLogError("ofxSVG") << "load(): path does not exist: \"" << fileName << "\"";
-	// 	return;
-	// }
-
-	// ofBuffer buffer = ofBufferFromFile(fileName);
-
-	// loadFromString(buffer.getText(), fileName);
-
-	if (file.compare("") == 0) {
+	of::filesystem::path file = ofToDataPath(fileName);
+	if (!of::filesystem::exists(file)) {
 		ofLogError("ofxSVG") << "load(): path does not exist: \"" << file << "\"";
 		return;
 	}
 
-	ofBuffer buffer = ofBufferFromFile(file);
+	ofBuffer buffer = ofBufferFromFile(fileName);
 	loadFromString(buffer.getText(), file);
 }
 

--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -8,6 +8,8 @@ extern "C" {
 #include "svgtiny.h"
 }
 
+ofxSvg::ofxSvg() {}
+
 ofxSvg::ofxSvg(const of::filesystem::path & fileName) {
 	load(fileName);
 }

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -17,11 +17,10 @@
 
 class ofxSvg {
 public:
-	~ofxSvg();
-	
 	ofxSvg();
 	ofxSvg(const of::filesystem::path & fileName);
-
+	~ofxSvg();
+	
 	float getWidth() const;
 	float getHeight() const;
 

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -17,7 +17,11 @@
 
 class ofxSvg {
 public:
-	ofxSvg();
+
+	ofxSvg() = default;
+	~ofxSvg() = default;
+	ofxSvg(const ofxSvg & a) = default;
+
 	ofxSvg(const of::filesystem::path & fileName);
 	
 	float getWidth() const;

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -18,6 +18,9 @@
 class ofxSvg {
 public:
 	~ofxSvg();
+	
+	ofxSvg();
+	ofxSvg(const of::filesystem::path & fileName);
 
 	float getWidth() const;
 	float getHeight() const;
@@ -25,7 +28,7 @@ public:
 	/// \brief Loads an SVG file from the provided filename.
 	///
 	/// ~~~~
-	void load(of::filesystem::path fileName);
+	void load(const of::filesystem::path & fileName);
 
 	/// \brief Loads an SVG from a text string.
 	///

--- a/addons/ofxSvg/src/ofxSvg.h
+++ b/addons/ofxSvg/src/ofxSvg.h
@@ -19,7 +19,6 @@ class ofxSvg {
 public:
 	ofxSvg();
 	ofxSvg(const of::filesystem::path & fileName);
-	~ofxSvg();
 	
 	float getWidth() const;
 	float getHeight() const;


### PR DESCRIPTION
This allows for direct initialization and file loading in the likes of ofImage.
Yes I didn't know about this ofImage until recently
```c++
ofxSvg logoSvg { "_material/logo.svg" };
ofImage logo { "_material/logo2.png" };

```