### PR TITLE
Material with Displacement Proper Shadows

### DIFF
--- a/examples/gl/materialPBRAdvanced/bin/data/shaders/main.vert
+++ b/examples/gl/materialPBRAdvanced/bin/data/shaders/main.vert
@@ -1,10 +1,11 @@
 // we set this define in the ofApp class
-#if defined(OF_SHADOW_DEPTH_PASS)
-uniform mat4 modelMatrix;
-in vec4 position;
-uniform float iElapsedTime;
-uniform float uWiggleVerts;
-#else
+//#if defined(OF_SHADOW_DEPTH_PASS)
+//uniform mat4 modelMatrix;
+//in vec4 position;
+//uniform float iElapsedTime;
+//uniform float uWiggleVerts;
+//#else
+#if !defined(OF_SHADOW_DEPTH_PASS)
 // the mesh we are using does not have texture coordinates
 // so we are going to send the local vertex positions to use for animation
 OUT vec3 v_localPos;

--- a/examples/gl/materialPBRAdvanced/bin/data/shaders/main.vert
+++ b/examples/gl/materialPBRAdvanced/bin/data/shaders/main.vert
@@ -1,10 +1,12 @@
 // we set this define in the ofApp class
-//#if defined(OF_SHADOW_DEPTH_PASS)
-//uniform mat4 modelMatrix;
-//in vec4 position;
-//uniform float iElapsedTime;
-//uniform float uWiggleVerts;
-//#else
+#if defined(NON_MATERIAL_DEPTH_PASS)
+uniform mat4 modelMatrix;
+in vec4 position;
+uniform float iElapsedTime;
+uniform float uWiggleVerts;
+#endif
+
+// this define is added via ofShadow.setupShadowDepthShader
 #if !defined(OF_SHADOW_DEPTH_PASS)
 // the mesh we are using does not have texture coordinates
 // so we are going to send the local vertex positions to use for animation
@@ -17,9 +19,11 @@ void main (void){
 	npos.xyz += uWiggleVerts * 0.25 * vec3( cos(iElapsedTime*1.3+(position.z*1.25)+position.y*1.25), 0.0, 0.0);
 #if defined(OF_SHADOW_DEPTH_PASS)
 	vec3 worldPosition = (modelMatrix * vec4(npos.xyz, 1.0)).xyz;
+	// this method is added via ofShadow.setupShadowDepthShader
 	sendShadowDepthWorldPosition(worldPosition);
 #else
 	v_localPos = position.xyz;
+	// this method is added via ofMaterial
 	sendVaryings(npos);
 	gl_Position = modelViewProjectionMatrix * npos;
 #endif

--- a/examples/gl/materialPBRAdvanced/src/ofApp.cpp
+++ b/examples/gl/materialPBRAdvanced/src/ofApp.cpp
@@ -108,6 +108,7 @@ void ofApp::draw(){
 	stringstream ss;
 	ss << "Reload shader(r): make changes to shader in data/shaders/main.frag and then press 'r' to see changes.";
 	ss << endl << "Wiggle verts(w): " << (bWiggleVerts ? "yes" : "no");
+	ss << endl << "Frame rate: " << ofGetFrameRate();
 	ofDrawBitmapStringHighlight(ss.str(), 40, 40);
 }
 
@@ -176,7 +177,9 @@ bool ofApp::reloadShader() {
 		matLogo.setDepthShaderMain(vbuffer.getText(), "main.glsl");
 		// configure the shader to include shadow functions for passing depth
 		// #define OF_SHADOW_DEPTH_PASS gets added by OF so we can use the same shader file and run different bits of code for the shadow pass
-//		light.getShadow().setupShadowDepthShader(mDepthShader, vbuffer.getText());
+		// we add #define NON_MATERIAL_DEPTH_PASS because ofMaterial adds variables that we need
+		// to add manually when not using a materil, see main.vert
+//		light.getShadow().setupShadowDepthShader(mDepthShader, "#define NON_MATERIAL_DEPTH_PASS\n"+vbuffer.getText());
 		return true;
 	}
 	return false;
@@ -184,6 +187,7 @@ bool ofApp::reloadShader() {
 
 //--------------------------------------------------------------
 void ofApp::keyPressed(int key){
+	cout << "key: " << key << endl;
 	if( key == 'r' ) {
 		reloadShader();
 	}
@@ -192,6 +196,12 @@ void ofApp::keyPressed(int key){
 	}
 	if( key == 'w') {
 		bWiggleVerts = !bWiggleVerts;
+	}
+	if( key == OF_KEY_DEL || key == 8 ) {
+		cout << "trying to remove texture from mat plywood" << endl;
+		matPlywood.removeTexture(OF_MATERIAL_TEXTURE_DIFFUSE);
+		matPlywood.removeTexture(OF_MATERIAL_TEXTURE_NORMAL );
+		matPlywood.removeTexture(OF_MATERIAL_TEXTURE_AO_ROUGHNESS_METALLIC );
 	}
 }
 

--- a/libs/openFrameworks/gl/shaders/pbr.vert
+++ b/libs/openFrameworks/gl/shaders/pbr.vert
@@ -1,10 +1,14 @@
 static const string shader_pbr_vert = R"(
+
+#if !defined(OF_SHADOW_DEPTH_PASS)
 OUT vec3 v_worldPosition;
 OUT vec3 v_worldNormal;
 OUT vec2 v_texcoord; // pass the texCoord just in case
 #if HAS_COLOR
 OUT vec4 v_color;
 #endif
+#endif
+
 
 %additional_includes%
 
@@ -55,6 +59,7 @@ vec4 getTransformedPosition() {
 #endif
 }
 
+#if !defined(OF_SHADOW_DEPTH_PASS)
 void sendVaryings(in vec4 apos) {
 	v_worldNormal = normalize(mat3(modelMatrix) * normal.xyz);
 //	v_texcoord = (textureMatrix*vec4(texcoord.x*mat_texcoord_scale.x,texcoord.y*mat_texcoord_scale.y,0,1)).xy;
@@ -65,6 +70,7 @@ void sendVaryings(in vec4 apos) {
 		v_color = color;
 	#endif
 }
+#endif
 
 %mainVertex%
 
@@ -76,5 +82,13 @@ void main (void){
 	vec4 npos = getTransformedPosition();
 	sendVaryings(npos);
 	gl_Position = modelViewProjectionMatrix * npos;
+}
+)";
+
+static const string shader_pbr_main_depth_vert = R"(
+void main (void){
+	vec4 npos = getTransformedPosition();
+	vec3 worldPosition = (modelMatrix * vec4(npos.xyz, 1.0)).xyz;
+	sendShadowDepthWorldPosition(worldPosition);
 }
 )";


### PR DESCRIPTION
Address #7712. When adding a displacement map to a material, the shadows are not calculated from modified vertices from the shader.
See a fixed example based on the forum [post](https://forum.openframeworks.cc/t/ofshadow-and-ofshader-issue-on-of-0-12/42600/5)
https://nickhardeman.com/temp/OFExamples/ofShaderAndShadowTest-main/