### PR TITLE
ofNode with function to set position, rotation and scale

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -283,6 +283,29 @@ glm::vec3 ofNode::getScale() const {
 }
 
 //----------------------------------------
+void ofNode::setPositionRotationScale( const glm::vec3& p, const glm::quat& q, const glm::vec3& s ) {
+	this->position = p;
+	this->orientation = q;
+	this->scale = s;
+	createMatrix();
+	onPositionChanged();
+	onOrientationChanged();
+	onScaleChanged();
+}
+
+//----------------------------------------
+void ofNode::setPositionRotationScale( const glm::vec3& p, const glm::vec3& eulerAngles, const glm::vec3& s ) {
+	this->position = p;
+	glm::quat q(glm::radians(eulerAngles));
+	this->orientation = q;
+	this->scale = s;
+	createMatrix();
+	onPositionChanged();
+	onOrientationChanged();
+	onScaleChanged();
+}
+
+//----------------------------------------
 void ofNode::move(float x, float y, float z) {
 	move({x, y, z});
 }

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -236,6 +236,21 @@ public:
 	/// \param s Desired local scale for all axes as ref to 3D vector where 1 = 100%.
 	void setScale(const glm::vec3& s);
 	
+	/// \brief Set the local position, rotation and scale of the node.
+	///
+	/// \param p Desired local xyz coordinates as ref to 3D vector.
+	/// \param q Desired local orientation as ref to an glm::quat.
+	/// \param s Desired local scale for all axes as ref to 3D vector where 1 = 100%.
+	void setPositionRotationScale( const glm::vec3& p, const glm::quat& q, const glm::vec3& s );
+	
+	/// \brief Set the local position, rotation and scale of the node.
+	///
+	/// \param p Desired local xyz coordinates as ref to 3D vector.
+	/// \param eulerAngles Desired local xyz angles in degrees, as ref to 3D vector.
+	/// \param s Desired local scale for all axes as ref to 3D vector where 1 = 100%.
+	/// \note Using euler angles can cause gimbal lock.
+	void setPositionRotationScale( const glm::vec3& p, const glm::vec3& eulerAngles, const glm::vec3& s );
+	
 	/// \}
 	/// \name Modifiers
 	/// \{


### PR DESCRIPTION
The new functions will reduce the number of matrix multiplications when needing to set the position, rotation and scale. 
Previously each call to position, rotation or scale called createMatrix() internally, which resulted in 3 mat4 multiplications.

```
node.setPosition(pos);
node.setRotation(quat);
node.setScale(scale);
```
Would be 9 mat4 matrix multiplications.

With the proposed methods, 
`node.setPositionRotationScale(pos,quat,scale);`
Only performs 3 mat4 matrix multiplications.