### PR TITLE
New Emscripten audioWorklet draft

### DIFF
--- a/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
+++ b/addons/ofxEmscripten/libs/html5audio/include/html5audio.h
@@ -28,7 +28,7 @@ extern "C"{
 	extern void html5audio_sound_set_pan(int sound, double pan);
 	extern void html5audio_sound_free(int sound);
 
-	extern void html5audio_stream_create(int bufferSize, int inputChannels, int outputChannels, float * inbuffer, float * outbuffer, html5audio_stream_callback callback, void * userData);
+	extern void html5audio_stream_create(int audioWorkletNode, int numInputChannels);
 	extern void html5audio_stream_free();
 	extern bool html5audio_sound_is_loaded(int sound);
 }

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -210,12 +210,13 @@ var LibraryHTML5Audio = {
             navigator.mediaDevices.getUserMedia({ audio: true })
             .then(function (audioIn) {
                 var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
-                mediaElement.connect(audioWorkletNode).connect(AUDIO.fft);
+                mediaElement.connect(audioWorkletNode);
             })
             .catch(function (error) {
                 console.log("Error creating audio in", error);
             });
         }
+        audioWorkletNode.connect(AUDIO.fft);
     },
 
     html5audio_stream_free: function () {

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -207,28 +207,14 @@ var LibraryHTML5Audio = {
     html5audio_stream_create: function(audioWorkletNode, numInputChannels){
         var audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
         if(numInputChannels>0){
-            navigator.getUserMedia = navigator.getUserMedia ||
-            navigator.webkitGetUserMedia ||
-            navigator.mozGetUserMedia ||
-            navigator.msGetUserMedia;
-            if(navigator.getUserMedia){
-                navigator.getUserMedia({
-                    audio: {
-                        autoGainControl: false,
-                        echoCancellation: false,
-                        noiseSuppression: false
-                        }
-                    },
-                    function(audioIn) {
-                        var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
-                        mediaElement.connect(audioWorkletNode);
-                        AUDIO.mediaElement = mediaElement;
-                    },
-                    function(error){
-                        console.log("error creating audio in",error);
-                    }
-                );
-            }
+            navigator.mediaDevices.getUserMedia({ audio: true })
+                .then(function (audioIn) {
+                    var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
+                    mediaElement.connect(audioWorkletNode);
+                })
+                .catch(function (error) {
+                    console.log("Error creating audio in", error);
+                });
         }
         audioWorkletNode.connect(AUDIO.fft);
     },

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -208,15 +208,14 @@ var LibraryHTML5Audio = {
         var audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
         if(numInputChannels > 0){
             navigator.mediaDevices.getUserMedia({ audio: true })
-                .then(function (audioIn) {
-                    var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
-                    mediaElement.connect(audioWorkletNode);
-                })
-                .catch(function (error) {
-                    console.log("Error creating audio in", error);
-                });
+            .then(function (audioIn) {
+                var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
+                mediaElement.connect(audioWorkletNode).connect(AUDIO.fft);
+            })
+            .catch(function (error) {
+                console.log("Error creating audio in", error);
+            });
         }
-        audioWorkletNode.connect(AUDIO.fft);
     },
 
     html5audio_stream_free: function () {

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -29,7 +29,7 @@ var LibraryHTML5Audio = {
        try {
             // Fix up for prefixing
             window.AudioContext = window.AudioContext || window.webkitAudioContext;
-            var context = new AudioContext({});
+            var context = new AudioContext({ sampleRate: 44100 });
             var id = emscriptenRegisterAudioObject(context);
 
             // Fix issue with chrome autoplay policy

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -64,7 +64,11 @@ var LibraryHTML5Audio = {
     html5audio_context_spectrum: function (bands, spectrum) {
         AUDIO.fft.fftSize = bands * 2;
         var spectrumArray = Module.HEAPF32.subarray(spectrum >> 2, (spectrum >> 2) + bands);
-        AUDIO.fft.getFloatFrequencyData(spectrumArray);
+        var spectrumArrayCopy = new Float32Array (spectrumArray);
+        AUDIO.fft.getFloatFrequencyData(spectrumArrayCopy);
+        for (let i = 0; i < spectrumArrayCopy.length; i++) {
+            spectrumArray[i] = spectrumArrayCopy[i];
+        }
     },
 
     html5audio_context_samplerate: function () {
@@ -99,7 +103,7 @@ var LibraryHTML5Audio = {
                 var fileSizeInBytes = stats.size;
                     
                 var tag = ext; //this covers most types
-                if( ext == mp3 ){
+                if( ext == 'mp3'){
                     tag = 'mpeg';
                 }else if( ext == 'oga'){
                     tag = 'ogg';

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -206,7 +206,7 @@ var LibraryHTML5Audio = {
     html5audio_stream_create__deps: ['$emscriptenGetAudioObject'],
     html5audio_stream_create: function(audioWorkletNode, numInputChannels){
         var audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
-        if(numInputChannels>0){
+        if(numInputChannels > 0){
             navigator.mediaDevices.getUserMedia({ audio: true })
                 .then(function (audioIn) {
                     var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -24,6 +24,7 @@ var LibraryHTML5Audio = {
         }
     },
 
+    html5audio_context_create__deps: ['$emscriptenRegisterAudioObject'],
     html5audio_context_create: function () {
        try {
             // Fix up for prefixing

--- a/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
+++ b/addons/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
@@ -29,6 +29,7 @@ var LibraryHTML5Audio = {
             // Fix up for prefixing
             window.AudioContext = window.AudioContext || window.webkitAudioContext;
             var context = new AudioContext({});
+            var id = emscriptenRegisterAudioObject(context);
 
             // Fix issue with chrome autoplay policy
             document.addEventListener('mousedown', function cb(event) {
@@ -44,7 +45,7 @@ var LibraryHTML5Audio = {
             fft.maxDecibels = 0;
             fft.minDecibels = -100;
             AUDIO.fft = fft;
-            return 0;
+            return id;
         } catch (e) {
             console.log('Web Audio API is not supported in this browser', e);
             return -1;
@@ -201,48 +202,35 @@ var LibraryHTML5Audio = {
 	}
     },
 
-    html5audio_stream_create: function(bufferSize, inputChannels, outputChannels, inbuffer, outbuffer, callback, userData) {
-            var stream = AUDIO.context.createScriptProcessor(bufferSize, inputChannels, outputChannels);
-            var inbufferArray = Module.HEAPF32.subarray(inbuffer >> 2, (inbuffer >> 2) + bufferSize * inputChannels);
-            var outbufferArray = Module.HEAPF32.subarray(outbuffer >> 2, (outbuffer >> 2) + bufferSize * outputChannels);
-
-            stream.onaudioprocess = function(event) {
-                var i, j, c;
-                if (inputChannels > 0) {
-                    for (c = 0; c < inputChannels; ++c) {
-                        var inChannel = event.inputBuffer.getChannelData(c);
-                        for (i = 0, j = c; i < bufferSize; ++i, j += inputChannels) {
-                            inbufferArray[j] = inChannel[i];
+    html5audio_stream_create__deps: ['$emscriptenGetAudioObject'],
+    html5audio_stream_create: function(audioWorkletNode, numInputChannels){
+        var audioWorkletNode = emscriptenGetAudioObject(audioWorkletNode);
+        if(numInputChannels>0){
+            navigator.getUserMedia = navigator.getUserMedia ||
+            navigator.webkitGetUserMedia ||
+            navigator.mozGetUserMedia ||
+            navigator.msGetUserMedia;
+            if(navigator.getUserMedia){
+                navigator.getUserMedia({
+                    audio: {
+                        autoGainControl: false,
+                        echoCancellation: false,
+                        noiseSuppression: false
                         }
-                    }
-                }
-
-                {{{ makeDynCall('viiii', 'callback') }}}(bufferSize, inputChannels, outputChannels, userData);
-
-                if (outputChannels > 0) {
-                    for (c = 0; c < outputChannels; ++c) {
-                        var outChannel = event.outputBuffer.getChannelData(c);
-                        for (i = 0, j = c; i < bufferSize; ++i, j += outputChannels) {
-                            outChannel[i] = outbufferArray[j];
-                        }
-                    }
-                }
-            };
-
-            if (inputChannels > 0) {
-                navigator.mediaDevices.getUserMedia({ audio: true })
-                    .then(function (audioIn) {
+                    },
+                    function(audioIn) {
                         var mediaElement = AUDIO.context.createMediaStreamSource(audioIn);
-                        mediaElement.connect(stream);
+                        mediaElement.connect(audioWorkletNode);
                         AUDIO.mediaElement = mediaElement;
-                    })
-                    .catch(function (error) {
-                        console.log("Error creating audio in", error);
-                    });
+                    },
+                    function(error){
+                        console.log("error creating audio in",error);
+                    }
+                );
             }
-
-            stream.connect(AUDIO.fft);
-        },
+        }
+        audioWorkletNode.connect(AUDIO.fft);
+    },
 
     html5audio_stream_free: function () {
 

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -6,9 +6,11 @@
  */
 
 #include "ofxEmscriptenSoundStream.h"
-#include "html5audio.h"
+#include "ofSoundBuffer.h"
 #include "ofBaseApp.h"
 #include "ofLog.h"
+#include "html5audio.h"
+#include "emscripten/webaudio.h"
 
 using namespace std;
 

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -14,17 +14,13 @@
 
 using namespace std;
 
-int stream_callback;
-ofSoundBuffer inbuffer;
-ofSoundBuffer outbuffer;
-
 ofxEmscriptenSoundStream * stream;
 ofSoundBuffer inbuffer;
 ofSoundBuffer outbuffer;
 
 EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData) {
+	stream->ofxEmscriptenSoundStream::audioCB(stream->settings.bufferSize, stream->settings.numInputChannels, stream->settings.numOutputChannels);
 	if (stream->settings.numInputChannels > 0) {
-		stream->settings.inCallback(inbuffer);
 		for (int o = 0; o < numInputs; ++o) {
 			for (int i = 0; i < 128; ++i) {
 				for (int ch = 0; ch < inputs[o].numberOfChannels; ++ch) {
@@ -34,7 +30,6 @@ EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutpu
 		}
 	}
 	if (stream->settings.numOutputChannels > 0) {
-		stream->settings.outCallback(outbuffer);
 		for (int o = 0; o < numOutputs; ++o) {
 			for (int i = 0; i < 128; ++i) {
 				for (int ch = 0; ch < stream->settings.numOutputChannels; ++ch) {
@@ -139,4 +134,10 @@ int ofxEmscriptenSoundStream::getSampleRate() const{
 
 int ofxEmscriptenSoundStream::getBufferSize() const{
 	return settings.bufferSize;
+}
+
+void ofxEmscriptenSoundStream::audioCB(int bufferSize, int inputChannels, int outputChannels) {
+	if (inputChannels > 0 && settings.inCallback) settings.inCallback(inbuffer);
+	if (outputChannels > 0 && settings.outCallback) settings.outCallback(outbuffer);
+	tickCount++;
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -86,7 +86,6 @@ bool ofxEmscriptenSoundStream::setup(const ofSoundStreamSettings & settings) {
 	outbuffer.allocate(settings.bufferSize, settings.numOutputChannels);
 	this->settings = settings;
 	stream_callback = reinterpret_cast<std::uintptr_t>(this);
-	uint8_t wasmAudioWorkletStack[4096];
 	emscripten_start_wasm_audio_worklet_thread_async(context, wasmAudioWorkletStack, sizeof(wasmAudioWorkletStack), WebAudioWorkletThreadInitialized, 0);
 	return true;
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -80,6 +80,7 @@ std::vector<ofSoundDevice> ofxEmscriptenSoundStream::getDeviceList(ofSoundDevice
 bool ofxEmscriptenSoundStream::setup(const ofSoundStreamSettings & settings) {
 	inbuffer.allocate(settings.bufferSize, settings.numInputChannels);
 	outbuffer.allocate(settings.bufferSize, settings.numOutputChannels);
+	audioProcessedCount = 0;
 	this->settings = settings;
 	stream = this;
 	emscripten_start_wasm_audio_worklet_thread_async(context, wasmAudioWorkletStack, sizeof(wasmAudioWorkletStack), WebAudioWorkletThreadInitialized, 0);

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -31,7 +31,7 @@ EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutpu
 		stream->settings.outCallback(stream->outbuffer);
 		for (int o = 0; o < numOutputs; ++o) {
 			for (int i = 0; i < 128; ++i) {
-				for (int ch = 0; ch < stream->settings.numOutputChannels; ++ch) {
+				for (int ch = 0; ch < outputs[o].numberOfChannels; ++ch) {
 					outputs[o].data[ch * 128 + i] = stream->outbuffer[i * outputs[o].numberOfChannels + ch];
 				}
 			}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "ofxEmscriptenSoundStream.h"
-#include "ofSoundBuffer.h"
 #include "ofBaseApp.h"
 #include "ofLog.h"
 #include "html5audio.h"
@@ -15,28 +14,25 @@
 using namespace std;
 
 ofxEmscriptenSoundStream * stream;
-ofSoundBuffer inbuffer;
-ofSoundBuffer outbuffer;
-int audioProcessedCount = 0;
 
 EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData) {
-	++audioProcessedCount;
+	++stream->audioProcessedCount;
 	if (stream->settings.numInputChannels > 0 && stream->settings.inCallback) {
-		stream->settings.inCallback(inbuffer);
+		stream->settings.inCallback(stream->inbuffer);
 		for (int o = 0; o < numInputs; ++o) {
 			for (int i = 0; i < 128; ++i) {
 				for (int ch = 0; ch < inputs[o].numberOfChannels; ++ch) {
-					inbuffer[i * inputs[o].numberOfChannels + ch] = inputs[o].data[ch * 128 + i];
+					stream->inbuffer[i * inputs[o].numberOfChannels + ch] = inputs[o].data[ch * 128 + i];
 				}
 			}
 		}
 	}
 	if (stream->settings.numOutputChannels > 0 && stream->settings.outCallback) {
-		stream->settings.outCallback(outbuffer);
+		stream->settings.outCallback(stream->outbuffer);
 		for (int o = 0; o < numOutputs; ++o) {
 			for (int i = 0; i < 128; ++i) {
 				for (int ch = 0; ch < stream->settings.numOutputChannels; ++ch) {
-					outputs[o].data[ch * 128 + i] = outbuffer[i * outputs[o].numberOfChannels + ch];
+					outputs[o].data[ch * 128 + i] = stream->outbuffer[i * outputs[o].numberOfChannels + ch];
 				}
 			}
 		}

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -9,7 +9,6 @@
 #include "html5audio.h"
 #include "ofBaseApp.h"
 #include "ofLog.h"
-#include "ofSoundBuffer.h"
 
 using namespace std;
 
@@ -52,7 +51,7 @@ void AudioWorkletProcessorCreated(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL su
 		.outputChannelCounts = outputChannelCounts
 	};
 	EMSCRIPTEN_AUDIO_WORKLET_NODE_T audioWorklet = emscripten_create_wasm_audio_worklet_node(audioContext, "audio-processor", &options, &ProcessAudio, 0);
-	html5audio_stream_create(audioWorklet, static_cast<int>(stream->settings.numInputChannels));
+	html5audio_stream_create(audioWorklet, stream->settings.numInputChannels);
 }
 
 void WebAudioWorkletThreadInitialized(EMSCRIPTEN_WEBAUDIO_T audioContext, EM_BOOL success, void *userData) {

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp
@@ -17,7 +17,6 @@ using namespace std;
 int stream_callback;
 ofSoundBuffer inbuffer;
 ofSoundBuffer outbuffer;
-uint8_t wasmAudioWorkletStack[4096];
 
 EM_BOOL ProcessAudio(int numInputs, const AudioSampleFrame *inputs, int numOutputs, AudioSampleFrame *outputs, int numParams, const AudioParamFrame *params, void *userData) {
 	ofxEmscriptenSoundStream* stream = (ofxEmscriptenSoundStream*)stream_callback;
@@ -87,6 +86,7 @@ bool ofxEmscriptenSoundStream::setup(const ofSoundStreamSettings & settings) {
 	outbuffer.allocate(settings.bufferSize, settings.numOutputChannels);
 	this->settings = settings;
 	stream_callback = reinterpret_cast<std::uintptr_t>(this);
+	uint8_t wasmAudioWorkletStack[4096];
 	emscripten_start_wasm_audio_worklet_thread_async(context, wasmAudioWorkletStack, sizeof(wasmAudioWorkletStack), WebAudioWorkletThreadInitialized, 0);
 	return true;
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -32,8 +32,8 @@ public:
 	int getSampleRate() const;
 	int getBufferSize() const;
 	ofSoundStreamSettings settings;
-	uint8_t wasmAudioWorkletStack[4096];
 
 private:
 	int context;
+	uint8_t wasmAudioWorkletStack[4096];
 };

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
+#include "ofSoundBuffer.h"
 #include "emscripten/webaudio.h"
 
 class ofxEmscriptenSoundStream: public ofBaseSoundStream {

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -8,8 +8,6 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
-#include "ofSoundBuffer.h"
-#include "emscripten/webaudio.h"
 
 class ofxEmscriptenSoundStream: public ofBaseSoundStream {
 public:

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
+#include "ofSoundBuffer.h"
 
 class ofxEmscriptenSoundStream: public ofBaseSoundStream {
 public:
@@ -32,8 +33,11 @@ public:
 	int getSampleRate() const;
 	int getBufferSize() const;
 	ofSoundStreamSettings settings;
+	ofSoundBuffer inbuffer;
+	ofSoundBuffer outbuffer;
 
 private:
 	int context;
+	int audioProcessedCount;
 	uint8_t wasmAudioWorkletStack[4096];
 };

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -35,9 +35,9 @@ public:
 	ofSoundStreamSettings settings;
 	ofSoundBuffer inbuffer;
 	ofSoundBuffer outbuffer;
+	int audioProcessedCount;
 
 private:
 	int context;
-	int audioProcessedCount;
 	uint8_t wasmAudioWorkletStack[4096];
 };

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -32,7 +32,6 @@ public:
 	int getSampleRate() const;
 	int getBufferSize() const;
 	ofSoundStreamSettings settings;
-	void audioCB(int bufferSize, int inputChannels, int outputChannels);
 	uint8_t wasmAudioWorkletStack[4096];
 
 private:

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -33,6 +33,7 @@ public:
 	int getBufferSize() const;
 	ofSoundStreamSettings settings;
 	void audioCB(int bufferSize, int inputChannels, int outputChannels);
+	uint8_t wasmAudioWorkletStack[4096];
 
 private:
 	int context;

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -36,5 +36,4 @@ public:
 
 private:
 	int context;
-	unsigned long long tickCount;
 };

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
-#include "ofSoundBuffer.h"
+#include "emscripten/webaudio.h"
 
 class ofxEmscriptenSoundStream: public ofBaseSoundStream {
 public:

--- a/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.h
@@ -32,13 +32,10 @@ public:
 	int getNumOutputChannels() const;
 	int getSampleRate() const;
 	int getBufferSize() const;
+	ofSoundStreamSettings settings;
+	void audioCB(int bufferSize, int inputChannels, int outputChannels);
 
 private:
-	static void audio_cb(int bufferSize, int inputChannels, int outputChannels, void * userData);
-	void audioCB(int bufferSize, int inputChannels, int outputChannels);
 	int context;
 	unsigned long long tickCount;
-	ofSoundStreamSettings settings;
-	ofSoundBuffer inbuffer;
-	ofSoundBuffer outbuffer;
 };

--- a/examples/sound/audioInputExample/src/ofApp.cpp
+++ b/examples/sound/audioInputExample/src/ofApp.cpp
@@ -9,7 +9,7 @@ void ofApp::setup(){
 	
 	soundStream.printDeviceList();
 	
-	int bufferSize = 256;
+	int bufferSize = 128;
 
 	left.assign(bufferSize, 0.0);
 	right.assign(bufferSize, 0.0);
@@ -44,10 +44,11 @@ void ofApp::setup(){
 	settings.sampleRate = 44100;
 	#ifdef TARGET_EMSCRIPTEN
 		settings.numOutputChannels = 2;
+		settings.numInputChannels = 2;
 	#else
 		settings.numOutputChannels = 0;
+		settings.numInputChannels = 1;
 	#endif
-	settings.numInputChannels = 1;
 	settings.bufferSize = bufferSize;
 	soundStream.setup(settings);
 
@@ -92,7 +93,7 @@ void ofApp::draw(){
 					
 			ofBeginShape();
 			for (unsigned int i = 0; i < left.size(); i++){
-				ofVertex(i*2, 100 -left[i]*180.0f);
+				ofVertex(i*4, 100 -left[i]*180.0f);
 			}
 			ofEndShape(false);
 			
@@ -115,7 +116,7 @@ void ofApp::draw(){
 					
 			ofBeginShape();
 			for (unsigned int i = 0; i < right.size(); i++){
-				ofVertex(i*2, 100 -right[i]*180.0f);
+				ofVertex(i*4, 100 -right[i]*180.0f);
 			}
 			ofEndShape(false);
 			

--- a/examples/sound/audioOutputExample/src/ofApp.cpp
+++ b/examples/sound/audioOutputExample/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup(){
 
 	ofBackground(34, 34, 34);
 	
-	int bufferSize		= 512;
+	int bufferSize		= 128;
 	sampleRate 			= 44100;
 	phase 				= 0;
 	phaseAdder 			= 0.0f;

--- a/examples/sound/soundBufferExample/src/ofApp.cpp
+++ b/examples/sound/soundBufferExample/src/ofApp.cpp
@@ -24,7 +24,7 @@ void ofApp::update(){
 	// "lastBuffer" is shared between update() and audioOut(), which are called
 	// on two different threads. This lock makes sure we don't use lastBuffer
 	// from both threads simultaneously (see the corresponding lock in audioOut())
-	unique_lock<mutex> lock(audioMutex);
+	std::unique_lock<std::mutex> lock(audioMutex);
 
 	// this loop is building up a polyline representing the audio contained in
 	// the left channel of the buffer
@@ -92,7 +92,7 @@ void ofApp::audioOut(ofSoundBuffer &outBuffer) {
 		pulsePhase += pulsePhaseStep;
 	}
 	
-	unique_lock<mutex> lock(audioMutex);
+	std::unique_lock<std::mutex> lock(audioMutex);
 	lastBuffer = outBuffer;
 }
 

--- a/examples/sound/soundBufferExample/src/ofApp.cpp
+++ b/examples/sound/soundBufferExample/src/ofApp.cpp
@@ -12,7 +12,7 @@ void ofApp::setup(){
 	ofSoundStreamSettings settings;
 	settings.numOutputChannels = 2;
 	settings.sampleRate = 44100;
-	settings.bufferSize = 512;
+	settings.bufferSize = 128;
 	settings.numBuffers = 4;
 	settings.setOutListener(this);
 	soundStream.setup(settings);

--- a/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+++ b/libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
@@ -64,8 +64,8 @@ PLATFORM_REQUIRED_ADDONS = ofxEmscripten
 ################################################################################
 
 # Code Generation Option Flags (http://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html)
-PLATFORM_CFLAGS =
-PLATFORM_CXXFLAGS = -Wall -std=c++17 -Wno-warn-absolute-paths
+PLATFORM_CFLAGS = -s USE_PTHREADS=1
+PLATFORM_CXXFLAGS = -Wall -std=c++17 -Wno-warn-absolute-paths -s USE_PTHREADS=1
 
 ################################################################################
 # PLATFORM LDFLAGS
@@ -93,7 +93,7 @@ ifdef USE_CCACHE
 	endif
 endif
 
-PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 -s FULL_ES2 -sFULL_ES3=1
+PLATFORM_LDFLAGS = -Wl --gc-sections --preload-file bin/data@data --emrun --bind --profiling-funcs -s USE_FREETYPE=1 -s ALLOW_MEMORY_GROWTH=1 -s MAX_WEBGL_VERSION=2 -s WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1 -s FULL_ES2 -sFULL_ES3=1  -s USE_PTHREADS=1 -s AUDIO_WORKLET=1 -s WASM_WORKERS=1 -sENVIRONMENT="web,worker" -s WEBAUDIO_DEBUG=1
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5video/lib/emscripten/library_html5video.js
 PLATFORM_LDFLAGS += --js-library $(OF_ADDONS_PATH)/ofxEmscripten/libs/html5audio/lib/emscripten/library_html5audio.js
 


### PR DESCRIPTION
This draft should work as it is (without any additional changes). It works well, but maybe its not implemented nicely.
Besides that: The main downside is, that `sharedArrayBuffer` needs to be enabled with `-S USE_PTHREADS` and because of that CORS header need to be set, if uploaded to a server: https://github.com/emscripten-core/emscripten/issues/20454
The `sharedArrayBuffer` and the other `audioWorklet` related `Emscripten` flags are also only needed, if `ofSoundStream` is used.
But what speaks for `audioWorklets` is, that it performs much better, and the old `ScriptProcessorNode` method https://developer.mozilla.org/en-US/docs/Web/API/ScriptProcessorNode is deprecated and will be removed at some point.

Here is the main part of the implementation: https://github.com/Jonathhhan/openFrameworks/blob/audioWorklet-3/addons/ofxEmscripten/src/ofxEmscriptenSoundStream.cpp

Maybe this PR is good for testing and thinking about a proper implementation?