### PR TITLE
OfTrueTypeFont  constructor+misc

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -341,7 +341,7 @@ public:
 	/// \param x X position of returned rectangle.
 	/// \param y Y position of returned rectangle.
 	/// \returns the bounding box of a string as a rectangle.
-	ofRectangle getStringBoundingBox(const std::string & s, float x, float y, bool vflip = true) const;
+	ofRectangle getStringBoundingBox(const std::string & s, float x = 0, float y = 0, bool vflip = true) const;
 
 	/// \}
 	/// \name Drawing

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -352,6 +352,9 @@ public:
 	/// \param x X position of string
 	/// \param y Y position of string
 	void drawString(const std::string & s, float x, float y) const;
+	void drawString(const std::string & s, glm::vec2 pos) const {
+		drawString(s, pos.x, pos.y);
+	}
 
 	/// \brief Draws the string as if it was geometrical shapes.
 	///
@@ -360,6 +363,9 @@ public:
 	/// \param x X position of shapes
 	/// \param y Y position of shapes
 	void drawStringAsShapes(const std::string & s, float x, float y) const;
+	void drawStringAsShapes(const std::string & s, glm::vec2 pos) const {
+		drawStringAsShapes(s, pos.x, pos.y);
+	}
 
 	ofPath getCharacterAsPoints(uint32_t character, bool vflip = true, bool filled = true) const;
 	std::vector<ofPath> getStringAsPoints(const std::string & str, bool vflip = true, bool filled = true) const;

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -174,6 +174,12 @@ public:
 	ofTrueTypeFont(ofTrueTypeFont && mom);
 	ofTrueTypeFont & operator=(ofTrueTypeFont && mom);
 
+	ofTrueTypeFont(const of::filesystem::path & filename, int fontsize, bool antiAliased = true,
+				   bool fullCharacterSet = true, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0)
+	: ofTrueTypeFont() {
+		load(filename, fontsize, antiAliased, fullCharacterSet, makeContours, simplifyAmt, dpi);
+	}
+
 	/// \name Load Font
 	/// \{
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -175,8 +175,8 @@ public:
 	ofTrueTypeFont & operator=(ofTrueTypeFont && mom);
 
 	ofTrueTypeFont(const of::filesystem::path & filename, int fontsize, bool antiAliased = true,
-				   bool fullCharacterSet = true, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0)
-	: ofTrueTypeFont() {
+		bool fullCharacterSet = true, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0)
+		: ofTrueTypeFont() {
 		load(filename, fontsize, antiAliased, fullCharacterSet, makeContours, simplifyAmt, dpi);
 	}
 


### PR DESCRIPTION
the constructor allows .h use like this:

```c++
ofTrueTypeFont font_titre_ {"fonts/Univers LT Std/UniversLTStd-BoldCn.otf", 20, true, true, true};
```

other tweaks allow positioning from glm::vec2, and additional (0) default values for getStringBoundingBox.