### PR TITLE
ofImage: loadImage error - removing double quotes

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -723,7 +723,7 @@ bool ofImage_<PixelType>::load(const of::filesystem::path& fileName, const ofIma
 	#endif
 	bool bLoadedOk = ofLoadImage(pixels, fileName, settings);
 	if (!bLoadedOk) {
-		ofLogError("ofImage") << "loadImage(): couldn't load image from \"" << fileName << "\"";
+		ofLogError("ofImage") << "loadImage(): couldn't load image from " << fileName << "";
 		clear();
 		return false;
 	}


### PR DESCRIPTION
as the file is now filesystem object instead of string, it is already enclosed in double quotes when printed, this PR changes this
```
[ error ] ofImage: loadImage(): couldn't load image from ""P8.png""
```
to
```
[ error ] ofImage: loadImage(): couldn't load image from "P8.png"
```
and updates PG submodule to latest