### PR TITLE
filesystem path removing double quotes

### DIFF
--- a/addons/ofxSvg/src/ofxSvg.cpp
+++ b/addons/ofxSvg/src/ofxSvg.cpp
@@ -30,7 +30,7 @@ ofPath & ofxSvg::getPathAt(int n) {
 void ofxSvg::load(const of::filesystem::path & fileName) {
 	of::filesystem::path file = ofToDataPath(fileName);
 	if (!of::filesystem::exists(file)) {
-		ofLogError("ofxSVG") << "load(): path does not exist: \"" << file << "\"";
+		ofLogError("ofxSVG") << "load(): path does not exist: " << file ;
 		return;
 	}
 

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1219,7 +1219,7 @@ void ofMesh_<V,N,C,T>::load(const of::filesystem::path& path){
 				goto clean;
 			}
 			if(!data.hasVertices()){
-				ofLogWarning("ofMesh") << "load(): mesh loaded from \"" << path << "\" has no vertices";
+				ofLogWarning("ofMesh") << "load(): mesh loaded from " << path << " has no vertices";
 			}
 			if(orderVertices==-1) orderVertices=9999;
 			if(orderIndices==-1) orderIndices=9999;

--- a/libs/openFrameworks/graphics/ofCairoRenderer.cpp
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.cpp
@@ -90,10 +90,10 @@ void ofCairoRenderer::setup(const of::filesystem::path & _filename, Type _type, 
 		surface = cairo_image_surface_create_for_data(imageBuffer.getData(), CAIRO_FORMAT_ARGB32, outputsize.width, outputsize.height, outputsize.width * 4);
 		break;
 	case FROM_FILE_EXTENSION:
-		ofLogFatalError("ofCairoRenderer") << "setup(): couldn't determine type from extension for filename: \"" << _filename << "\"!";
+		ofLogFatalError("ofCairoRenderer") << "setup(): couldn't determine type from extension for filename: " << _filename << "!";
 		break;
 	default:
-		ofLogError("ofCairoRenderer") << "setup(): encountered unknown type for filename \"" << _filename << "\"";
+		ofLogError("ofCairoRenderer") << "setup(): encountered unknown type for filename " << _filename;
 		break;
 	}
 

--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -369,7 +369,7 @@ template<typename PixelType>
 static bool saveImage(const ofPixels_<PixelType> & _pix, const of::filesystem::path& _fileName, ofImageQualityType qualityLevel) {
 	ofInitFreeImage();
 	if (_pix.isAllocated() == false){
-		ofLogError("ofImage") << "saveImage(): couldn't save \"" << _fileName << "\", pixels are not allocated";
+		ofLogError("ofImage") << "saveImage(): couldn't save " << _fileName << ", pixels are not allocated";
 		return false;
 	}
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -404,10 +404,10 @@ static bool loadFontFace(const of::filesystem::path& _fontname, FT_Face & face, 
 		filename = winFontPathByName(fontname.string());
 #endif
 		if(filename == "" ){
-			ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't find font \"" << fontname << "\"";
+			ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't find font " << fontname;
 			return false;
 		}
-		ofLogVerbose("ofTrueTypeFont") << "loadFontFace(): \"" << fontname << "\" not a file in data loading system font from \"" << filename << "\"";
+		ofLogVerbose("ofTrueTypeFont") << "loadFontFace(): " << fontname << " not a file in data loading system font from \"" << filename << "\"";
 	}
 	FT_Error err;
 	err = FT_New_Face( library, filename.string().c_str(), fontID, &face );
@@ -415,7 +415,7 @@ static bool loadFontFace(const of::filesystem::path& _fontname, FT_Face & face, 
 		// simple error table in lieu of full table (see fterrors.h)
 		string errorString = "unknown freetype";
 		if(err == 1) errorString = "INVALID FILENAME";
-		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for \"" << fontname << "\": FT_Error " << err << " " << errorString;
+		ofLogError("ofTrueTypeFont") << "loadFontFace(): couldn't create new face for " << fontname << ": FT_Error " << err << " " << errorString;
 		return false;
 	}
 

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.cpp
@@ -234,7 +234,7 @@ bool ofOpenALSoundPlayer::sfReadFile(const of::filesystem::path& path, std::vect
 	SF_INFO sfInfo;
 	SNDFILE* f = sf_open(path.string().c_str(),SFM_READ,&sfInfo);
 	if(!f){
-		ofLogError("ofOpenALSoundPlayer") << "sfReadFile(): couldn't read \"" << path << "\"";
+		ofLogError("ofOpenALSoundPlayer") << "sfReadFile(): couldn't read " << path;
 		return false;
 	}
 	duration = 0.0f;
@@ -253,7 +253,7 @@ bool ofOpenALSoundPlayer::sfReadFile(const of::filesystem::path& path, std::vect
 		sf_count_t samples_read = sf_read_float (f, &fftAuxBuffer[0], fftAuxBuffer.size());
 		if(samples_read<(int)fftAuxBuffer.size()){
 			ofLogWarning("ofOpenALSoundPlayer") << "sfReadFile(): read " << samples_read << " float samples, expected "
-			<< fftAuxBuffer.size() << " for \"" << path << "\"";
+			<< fftAuxBuffer.size() << " for " << path;
 		}
 		for (int i = 0 ; i < int(fftAuxBuffer.size()) ; i++){
 			fftAuxBuffer[i] *= scale ;
@@ -263,14 +263,14 @@ bool ofOpenALSoundPlayer::sfReadFile(const of::filesystem::path& path, std::vect
 		sf_count_t frames_read = sf_readf_short(f,&buffer[0],sfInfo.frames);
 		if(frames_read<sfInfo.frames){
 			ofLogError("ofOpenALSoundPlayer") << "sfReadFile(): read " << frames_read << " frames from buffer, expected "
-			<< sfInfo.frames << " for \"" << path << "\"";
+			<< sfInfo.frames << " for " << path ;
 			return false;
 		}
 		sf_seek(f,0,SEEK_SET);
 		frames_read = sf_readf_float(f,&fftAuxBuffer[0],sfInfo.frames);
 		if(frames_read<sfInfo.frames){
 			ofLogError("ofOpenALSoundPlayer") << "sfReadFile(): read " << frames_read << " frames from fft buffer, expected "
-			<< sfInfo.frames << " for \"" << path << "\"";
+			<< sfInfo.frames << " for " << path ;
 			return false;
 		}
 	}
@@ -289,7 +289,7 @@ bool ofOpenALSoundPlayer::mpg123ReadFile(const of::filesystem::path& path,std::v
 	duration = 0.0f;
 	mpg123_handle * f = mpg123_new(nullptr,&err);
 	if(mpg123_open(f,path.string().c_str())!=MPG123_OK){
-		ofLogError("ofOpenALSoundPlayer") << "mpg123ReadFile(): couldn't read \"" << path << "\"";
+		ofLogError("ofOpenALSoundPlayer") << "mpg123ReadFile(): couldn't read " << path ;
 		return false;
 	}
 
@@ -298,7 +298,7 @@ bool ofOpenALSoundPlayer::mpg123ReadFile(const of::filesystem::path& path,std::v
 	mpg123_getformat(f,&rate,&channels,(int*)&encoding);
 	if(encoding!=MPG123_ENC_SIGNED_16){
 		ofLogError("ofOpenALSoundPlayer") << "mpg123ReadFile(): " << getMpg123EncodingString(encoding)
-			<< " encoding for \"" << path << "\"" << " unsupported, expecting MPG123_ENC_SIGNED_16";
+			<< " encoding for " << path << " unsupported, expecting MPG123_ENC_SIGNED_16";
 		return false;
 	}
 	samplerate = rate;
@@ -328,7 +328,7 @@ bool ofOpenALSoundPlayer::sfStream(const of::filesystem::path& path,std::vector<
 		SF_INFO sfInfo;
 		streamf = sf_open(path.string().c_str(),SFM_READ,&sfInfo);
 		if(!streamf){
-			ofLogError("ofOpenALSoundPlayer") << "sfStream(): couldn't read \"" << path << "\"";
+			ofLogError("ofOpenALSoundPlayer") << "sfStream(): couldn't read " << path ;
 			return false;
 		}
 
@@ -393,7 +393,7 @@ bool ofOpenALSoundPlayer::mpg123Stream(const of::filesystem::path& path,std::vec
 		if(mpg123_open(mp3streamf,path.string().c_str())!=MPG123_OK){
 			mpg123_close(mp3streamf);
 			mpg123_delete(mp3streamf);
-			ofLogError("ofOpenALSoundPlayer") << "mpg123Stream(): couldn't read \"" << path << "\"";
+			ofLogError("ofOpenALSoundPlayer") << "mpg123Stream(): couldn't read " << path ;
 			return false;
 		}
 
@@ -401,7 +401,7 @@ bool ofOpenALSoundPlayer::mpg123Stream(const of::filesystem::path& path,std::vec
 		mpg123_getformat(mp3streamf,&rate,&channels,(int*)&stream_encoding);
 		if(stream_encoding!=MPG123_ENC_SIGNED_16){
 			ofLogError("ofOpenALSoundPlayer") << "mpg123Stream(): " << getMpg123EncodingString(stream_encoding)
-			<< " encoding for \"" << path << "\"" << " unsupported, expecting MPG123_ENC_SIGNED_16";
+			<< " encoding for " << path << " unsupported, expecting MPG123_ENC_SIGNED_16";
 			return false;
 		}
 		samplerate = rate;

--- a/libs/openFrameworks/utils/ofFileUtils.cpp
+++ b/libs/openFrameworks/utils/ofFileUtils.cpp
@@ -629,7 +629,7 @@ bool ofFile::writeFromBuffer(const ofBuffer & buffer){
 		return false;
 	}
 	if(!isWriteMode()){
-		ofLogError("ofFile") << "writeFromBuffer(): trying to write to read only file \"" << myFile.string() << "\"";
+		ofLogError("ofFile") << "writeFromBuffer(): trying to write to read only file " << myFile ;
 	}
 	return buffer.writeTo(*this);
 }
@@ -946,7 +946,7 @@ bool ofFile::copyTo(const of::filesystem::path& _path, bool bRelativeToData, boo
 			if(overwrite){
 				ofFile::removeFile(path, false);
 			}else{
-				ofLogWarning("ofFile") << "copyTo(): destination file \"" << path << "\" already exists, set bool overwrite to true if you want to overwrite it";
+				ofLogWarning("ofFile") << "copyTo(): destination file " << path << " already exists, set bool overwrite to true if you want to overwrite it";
 			}
 		}
 	}
@@ -960,7 +960,7 @@ bool ofFile::copyTo(const of::filesystem::path& _path, bool bRelativeToData, boo
 		}
 		of::filesystem::copy_file(myFile,path);
 	}catch(std::exception & except){
-		ofLogError("ofFile") <<  "copyTo(): unable to copy \"" << path << "\": " << except.what();
+		ofLogError("ofFile") <<  "copyTo(): unable to copy " << path << ": " << except.what();
 		return false;
 	}
 
@@ -996,7 +996,7 @@ bool ofFile::moveTo(const of::filesystem::path& _path, bool bRelativeToData, boo
 			if(overwrite){
 				ofFile::removeFile(path, false);
 			}else{
-				ofLogWarning("ofFile") << "copyTo(): destination file \"" << path << "\" already exists, set bool overwrite to true if you want to overwrite it";
+				ofLogWarning("ofFile") << "copyTo(): destination file " << path << " already exists, set bool overwrite to true if you want to overwrite it";
 			}
 		}
 	}
@@ -1018,7 +1018,7 @@ bool ofFile::moveTo(const of::filesystem::path& _path, bool bRelativeToData, boo
 		}
 	}
 	catch(std::exception & except){
-		ofLogError("ofFile") << "moveTo(): unable to move \"" << path << "\": " << except.what();
+		ofLogError("ofFile") << "moveTo(): unable to move " << path << ": " << except.what();
 		return false;
 	}
 
@@ -1051,7 +1051,7 @@ bool ofFile::remove(bool recursive){
 			of::filesystem::remove(myFile);
 		}
 	}catch(std::exception & except){
-		ofLogError("ofFile") << "remove(): unable to remove \"" << myFile << "\": " << except.what();
+		ofLogError("ofFile") << "remove(): unable to remove " << myFile << ": " << except.what();
 		return false;
 	}
 
@@ -1063,7 +1063,7 @@ uint64_t ofFile::getSize() const {
 	try{
 		return of::filesystem::file_size(myFile);
 	}catch(std::exception & except){
-		ofLogError("ofFile") << "getSize(): unable to get size of \"" << myFile << "\": " << except.what();
+		ofLogError("ofFile") << "getSize(): unable to get size of " << myFile << ": " << except.what();
 		return 0;
 	}
 }
@@ -1309,7 +1309,7 @@ bool ofDirectory::copyTo(const of::filesystem::path& _path, bool bRelativeToData
 		if(overwrite){
 			ofDirectory::removeDirectory(path, true, false);
 		}else{
-			ofLogWarning("ofDirectory") << "copyTo(): dest \"" << path << "\" already exists, set bool overwrite to true to overwrite it";
+			ofLogWarning("ofDirectory") << "copyTo(): dest " << path << " already exists, set bool overwrite to true to overwrite it";
 			return false;
 		}
 	}
@@ -1395,7 +1395,7 @@ std::size_t ofDirectory::listDir(){
 		return 0;
 	}
 	if(!of::filesystem::exists(myDir)){
-		ofLogError("ofDirectory") << "listDir:() source directory does not exist: \"" << myDir << "\"";
+		ofLogError("ofDirectory") << "listDir:() source directory does not exist: " << myDir ;
 		return 0;
 	}
 
@@ -1405,7 +1405,7 @@ std::size_t ofDirectory::listDir(){
 			files.emplace_back(dir_iter->path().string(), ofFile::Reference);
 		}
 	}else{
-		ofLogError("ofDirectory") << "listDir:() source directory does not exist: \"" << myDir << "\"";
+		ofLogError("ofDirectory") << "listDir:() source directory does not exist: " << myDir ;
 		return 0;
 	}
 
@@ -1626,7 +1626,7 @@ bool ofDirectory::createDirectory(const of::filesystem::path& _dirPath, bool bRe
 				success = of::filesystem::create_directories(dirPath);
 			}
 		} catch(std::exception & except){
-			ofLogError("ofDirectory") << "createDirectory(): couldn't create directory \"" << dirPath << "\": " << except.what();
+			ofLogError("ofDirectory") << "createDirectory(): couldn't create directory " << dirPath << ": " << except.what();
 			return false;
 		}
 		return success;
@@ -1646,7 +1646,7 @@ bool ofDirectory::doesDirectoryExist(const of::filesystem::path& _dirPath, bool 
 		return of::filesystem::exists(dirPath) && of::filesystem::is_directory(dirPath);
 	}
 	catch (std::exception & except) {
-		ofLogError("ofDirectory") << "doesDirectoryExist(): couldn't find directory \"" << dirPath << "\": " << except.what() << std::endl;
+		ofLogError("ofDirectory") << "doesDirectoryExist(): couldn't find directory " << dirPath << ": " << except.what() << std::endl;
 		return false;
 	}
 }


### PR DESCRIPTION
filesystem object already encloses path with double quotes, 
so I'm removing some manual double quotes from objects that were string previously.