### PR TITLE
ofLoadImage for ofTexture will detect HDR and EXR 

### DIFF
--- a/libs/openFrameworks/graphics/ofImage.cpp
+++ b/libs/openFrameworks/graphics/ofImage.cpp
@@ -343,12 +343,42 @@ bool ofLoadImage(ofFloatPixels & pix, const ofBuffer & buffer, const ofImageLoad
 }
 
 //----------------------------------------------------------------
-bool ofLoadImage(ofTexture & tex, const of::filesystem::path& path, const ofImageLoadSettings &settings){
-	ofPixels pixels;
-	bool loaded = ofLoadImage(pixels, path, settings);
-	if(loaded){
-		tex.allocate(pixels.getWidth(), pixels.getHeight(), ofGetGLInternalFormat(pixels));
-		tex.loadData(pixels);
+bool ofLoadImage(ofTexture & tex, const of::filesystem::path& path, const ofImageLoadSettings &settings ) {
+	return ofLoadImage( tex, path, false, settings );
+}
+
+//----------------------------------------------------------------
+bool ofLoadImage(ofTexture & tex, const of::filesystem::path& path, bool bFlipInY, const ofImageLoadSettings &settings){
+	bool loaded = false;
+	std::string ext = ofToLower(path.extension().string());
+	bool hdr = (ext == ".hdr" || ext == ".exr");
+	if( hdr ) {
+		ofFloatPixels pixels;
+		loaded = ofLoadImage(pixels, path, settings);
+		if(loaded){
+			#if defined(TARGET_OPENGLES)
+			// GL_RGB32F, GL_RGBA32F and GL_RGB16F is not supported in Emscripten opengl es, so we need to set to GL_RGBA16F or GL_RGBA32F. But GL_RGBA32F is not supported via opengl es on most mobile devices as of right now.
+			if(pixels.getNumChannels() != 4 ) {
+				// set alpha to 1.
+				ofLogVerbose("ofLoadImage") << "changing number of loaded pixel channels from " << pixels.getNumChannels() << " to 4 for more broad support on OpenGL ES.";
+				pixels.setImageType( OF_IMAGE_COLOR_ALPHA );
+			}
+			#endif
+			if(bFlipInY) {
+				pixels.mirror(true, false);
+			}
+			tex.loadData(pixels);
+		}
+	} else {
+		ofPixels pixels;
+		loaded = ofLoadImage(pixels, path, settings);
+		if(loaded){
+			if(bFlipInY) {
+				pixels.mirror(true, false);
+			}
+			tex.allocate(pixels.getWidth(), pixels.getHeight(), ofGetGLInternalFormat(pixels));
+			tex.loadData(pixels);
+		}
 	}
 	return loaded;
 }

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -147,6 +147,7 @@ bool ofLoadImage(ofShortPixels & pix, const ofBuffer & buffer, const ofImageLoad
 
 /// \todo Needs documentation.
 bool ofLoadImage(ofTexture & tex, const of::filesystem::path& path, const ofImageLoadSettings &settings = ofImageLoadSettings());
+bool ofLoadImage(ofTexture & tex, const of::filesystem::path& path, bool bFlipInY, const ofImageLoadSettings &settings = ofImageLoadSettings());
 bool ofLoadImage(ofTexture & tex, const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings());
 
 /// \todo Needs documentation.


### PR DESCRIPTION
Detect and load HDR and EXR to ofTexture from file paths using either ofPixels or ofFloatPixels. Will also set the pixels to 4 channels for broader OpenGL ES support. There is also an added function for adding a flip in y argument.

`bool bLoadOk = ofLoadImage(*tex, "excellentHdrImage.hdr", mirrorY );`

Previously, something like below would be necessary.
```
std::string ext = ofFilePath::getFileExt( "excellentHdrImage.hdr" );
ext = ofToLower(ext);
bool hdr = (ext == "hdr" || ext == "exr");
if( hdr ) {
	ofFloatPixels fpix;
	bLoadOk = ofLoadImage(fpix, apath);
	if( bLoadOk) {
		#if defined(TARGET_OPENGLES)
		// GL_RGB32F, GL_RGBA32F and GL_RGB16F is not supported in Emscripten opengl es, so we need to set to GL_RGBA16F or GL_RGBA32F. But GL_RGBA32F is not supported via opengl es on most mobile devices as of right now.
			if(fpix.getNumChannels() != 4 ) {
				// set alpha to 1.
				fpix.setImageType( OF_IMAGE_COLOR_ALPHA );
			}
		#endif
		if( mirrorY ) {
			fpix.mirror(mirrorY, false);
		}
		tex->loadData(fpix);
	}
} else {
	ofPixels pixels;
	bLoadOk = ofLoadImage( pixels, apath );
	if( bLoadOk ) {
		if( mirrorY ) {
			pixels.mirror(mirrorY, false);
		}
		tex->loadData(pixels);
	}
}
```