### PR TITLE
update Nightly (auto and manual) actions

### DIFF
--- a/.github/workflows/build-linux-nightly.yml
+++ b/.github/workflows/build-linux-nightly.yml
@@ -25,7 +25,7 @@ jobs:
       run: scripts/ci/package_builds.sh;
       id: createpackage
     - name: Update Release
-      uses: IsaacShelton/update-existing-release@v1.3.2
+      uses: IsaacShelton/update-existing-release@v1.3.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: nightly

--- a/.github/workflows/manual-nightly.yml
+++ b/.github/workflows/manual-nightly.yml
@@ -28,7 +28,7 @@ jobs:
       run: scripts/ci/package_builds.sh ${{ github.event.inputs.release }};
       id: createpackage
     - name: Update Release
-      uses: IsaacShelton/update-existing-release@v1.3.2
+      uses: IsaacShelton/update-existing-release@v1.3.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.event.inputs.release }}


### PR DESCRIPTION
It is just a version bump so it starts using more recent github actions and avoid commands that will be disabled soon
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 
```
For more information see: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/