### PR TITLE
[[deprecated]] PR

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -47,14 +47,14 @@ class ofxAssimpModelLoader{
 		bool load(std::string modelName, int assimpOptimizeFlags=OPTIMIZE_DEFAULT);
 		bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
-		[[deprecated("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
 		bool load(std::string modelName, bool optimize);
-		[[deprecated("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
 		bool load(ofBuffer & buffer, bool optimize, const char * extension);
 
-		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
+		[[deprecated("use load() instead.")]]
 		bool loadModel(std::string modelName, bool optimize=false);
-		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
+		[[deprecated("use load() instead.")]]
 		bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
 
 		void createEmptyModel();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -47,11 +47,15 @@ class ofxAssimpModelLoader{
 		bool load(std::string modelName, int assimpOptimizeFlags=OPTIMIZE_DEFAULT);
 		bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
-		OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(std::string modelName, bool optimize));
-		OF_DEPRECATED_MSG("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.", bool load(ofBuffer & buffer, bool optimize, const char * extension));
+		[[deprecated("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+bool load(std::string modelName, bool optimize);
+		[[deprecated("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+bool load(ofBuffer & buffer, bool optimize, const char * extension);
 
-		OF_DEPRECATED_MSG("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.", bool loadModel(std::string modelName, bool optimize=false));
-		OF_DEPRECATED_MSG("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.", bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension=""));
+		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
+bool loadModel(std::string modelName, bool optimize=false);
+		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
+bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
 
 		void createEmptyModel();
 		void createLightsFromAiModel();
@@ -72,10 +76,14 @@ class ofxAssimpModelLoader{
 		void setPausedForAllAnimations(bool pause);
 		void setLoopStateForAllAnimations(ofLoopType state);
 		void setPositionForAllAnimations(float position);
-		OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setAnimation(int animationIndex));
-		OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setNormalizedTime(float time));
-		OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", void setTime(float time));
-		OF_DEPRECATED_MSG("Use ofxAssimpAnimation instead", float getDuration(int animationIndex));
+		[[deprecated("Use ofxAssimpAnimation instead")]]
+void setAnimation(int animationIndex);
+		[[deprecated("Use ofxAssimpAnimation instead")]]
+void setNormalizedTime(float time);
+		[[deprecated("Use ofxAssimpAnimation instead")]]
+void setTime(float time);
+		[[deprecated("Use ofxAssimpAnimation instead")]]
+float getDuration(int animationIndex);
 
 		bool hasMeshes();
 		unsigned int getMeshCount();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -48,14 +48,14 @@ class ofxAssimpModelLoader{
 		bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
 		[[deprecated("ofxAssimpModelLoader::load(std::string modelName, bool bOptimize) is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
-bool load(std::string modelName, bool optimize);
+		bool load(std::string modelName, bool optimize);
 		[[deprecated("ofxAssimpModelLoader::load(ofBuffer & buffer, bool optimize=false, const char * extension="") is deprecated, use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
-bool load(ofBuffer & buffer, bool optimize, const char * extension);
+		bool load(ofBuffer & buffer, bool optimize, const char * extension);
 
 		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
-bool loadModel(std::string modelName, bool optimize=false);
+		bool loadModel(std::string modelName, bool optimize=false);
 		[[deprecated("ofxAssimpModelLoader::loadModel() is deprecated, use load() instead.")]]
-bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
+		bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
 
 		void createEmptyModel();
 		void createLightsFromAiModel();
@@ -77,13 +77,13 @@ bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension=""
 		void setLoopStateForAllAnimations(ofLoopType state);
 		void setPositionForAllAnimations(float position);
 		[[deprecated("Use ofxAssimpAnimation instead")]]
-void setAnimation(int animationIndex);
+		void setAnimation(int animationIndex);
 		[[deprecated("Use ofxAssimpAnimation instead")]]
-void setNormalizedTime(float time);
+		void setNormalizedTime(float time);
 		[[deprecated("Use ofxAssimpAnimation instead")]]
-void setTime(float time);
+		void setTime(float time);
 		[[deprecated("Use ofxAssimpAnimation instead")]]
-float getDuration(int animationIndex);
+		float getDuration(int animationIndex);
 
 		bool hasMeshes();
 		unsigned int getMeshCount();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -76,13 +76,13 @@ class ofxAssimpModelLoader{
 		void setPausedForAllAnimations(bool pause);
 		void setLoopStateForAllAnimations(ofLoopType state);
 		void setPositionForAllAnimations(float position);
-		[[deprecated("Use ofxAssimpAnimation instead")]]
+		[[deprecated("Use ofxAssimpAnimation")]]
 		void setAnimation(int animationIndex);
-		[[deprecated("Use ofxAssimpAnimation instead")]]
+		[[deprecated("Use ofxAssimpAnimation")]]
 		void setNormalizedTime(float time);
-		[[deprecated("Use ofxAssimpAnimation instead")]]
+		[[deprecated("Use ofxAssimpAnimation")]]
 		void setTime(float time);
-		[[deprecated("Use ofxAssimpAnimation instead")]]
+		[[deprecated("Use ofxAssimpAnimation")]]
 		float getDuration(int animationIndex);
 
 		bool hasMeshes();

--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.h
@@ -47,14 +47,14 @@ class ofxAssimpModelLoader{
 		bool load(std::string modelName, int assimpOptimizeFlags=OPTIMIZE_DEFAULT);
 		bool load(ofBuffer & buffer, int assimpOptimizeFlags=OPTIMIZE_DEFAULT, const char * extension="");
 
-		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags)")]]
 		bool load(std::string modelName, bool optimize);
-		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags) instead.")]]
+		[[deprecated("use load(std::string modelName, int assimpOptimizeFlags)")]]
 		bool load(ofBuffer & buffer, bool optimize, const char * extension);
 
-		[[deprecated("use load() instead.")]]
+		[[deprecated("use load()")]]
 		bool loadModel(std::string modelName, bool optimize=false);
-		[[deprecated("use load() instead.")]]
+		[[deprecated("use load()")]]
 		bool loadModel(ofBuffer & buffer, bool optimize=false, const char * extension="");
 
 		void createEmptyModel();

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -177,14 +177,18 @@ public:
 	/// get the video (ir or rgb) texture
 	ofTexture& getTexture();
 	const ofTexture& getTexture() const;
-	OF_DEPRECATED_MSG("Use getTexture() instead", ofTexture& getTextureReference());
-	OF_DEPRECATED_MSG("Use getTexture() instead", const ofTexture& getTextureReference() const);
+	[[deprecated("Use getTexture() instead")]]
+ofTexture& getTextureReference();
+	[[deprecated("Use getTexture() instead")]]
+const ofTexture& getTextureReference() const;
 
 	/// get the grayscale depth texture
 	ofTexture& getDepthTexture();
 	const ofTexture& getDepthTexture() const;
-	OF_DEPRECATED_MSG("Use getDepthTexture() instead", ofTexture& getDepthTextureReference());
-	OF_DEPRECATED_MSG("Use getDepthTexture() instead", const ofTexture& getDepthTextureReference() const);
+	[[deprecated("Use getDepthTexture() instead")]]
+ofTexture& getDepthTextureReference();
+	[[deprecated("Use getDepthTexture() instead")]]
+const ofTexture& getDepthTextureReference() const;
 
 /// \section Grayscale Depth Value
 

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -177,17 +177,17 @@ public:
 	/// get the video (ir or rgb) texture
 	ofTexture & getTexture();
 	const ofTexture & getTexture() const;
-	[[deprecated("Use getTexture() instead")]]
+	[[deprecated("Use getTexture()")]]
 	ofTexture & getTextureReference();
-	[[deprecated("Use getTexture() instead")]]
+	[[deprecated("Use getTexture()")]]
 	const ofTexture & getTextureReference() const;
 
 	/// get the grayscale depth texture
 	ofTexture & getDepthTexture();
 	const ofTexture & getDepthTexture() const;
-	[[deprecated("Use getDepthTexture() instead")]]
+	[[deprecated("Use getDepthTexture()")]]
 	ofTexture & getDepthTextureReference();
-	[[deprecated("Use getDepthTexture() instead")]]
+	[[deprecated("Use getDepthTexture()")]]
 	const ofTexture & getDepthTextureReference() const;
 
 /// \section Grayscale Depth Value

--- a/addons/ofxKinect/src/ofxKinect.h
+++ b/addons/ofxKinect/src/ofxKinect.h
@@ -175,20 +175,20 @@ public:
 	const ofFloatPixels & getDistancePixels() const;
 
 	/// get the video (ir or rgb) texture
-	ofTexture& getTexture();
-	const ofTexture& getTexture() const;
+	ofTexture & getTexture();
+	const ofTexture & getTexture() const;
 	[[deprecated("Use getTexture() instead")]]
-ofTexture& getTextureReference();
+	ofTexture & getTextureReference();
 	[[deprecated("Use getTexture() instead")]]
-const ofTexture& getTextureReference() const;
+	const ofTexture & getTextureReference() const;
 
 	/// get the grayscale depth texture
-	ofTexture& getDepthTexture();
-	const ofTexture& getDepthTexture() const;
+	ofTexture & getDepthTexture();
+	const ofTexture & getDepthTexture() const;
 	[[deprecated("Use getDepthTexture() instead")]]
-ofTexture& getDepthTextureReference();
+	ofTexture & getDepthTextureReference();
 	[[deprecated("Use getDepthTexture() instead")]]
-const ofTexture& getDepthTextureReference() const;
+	const ofTexture & getDepthTextureReference() const;
 
 /// \section Grayscale Depth Value
 

--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -57,7 +57,7 @@ void ofxNetworkLogError(int err, const char* file=__FILE__, int line=__LINE__-1)
  * @param line the line where the error happened, generally __LINE__
  * @return int the last network error
  */
-[[deprecated("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead")]]
+[[deprecated("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line)")]]
 int ofxNetworkCheckErrno(const char* file, int line) ;
 
 

--- a/addons/ofxNetwork/src/ofxNetworkUtils.h
+++ b/addons/ofxNetwork/src/ofxNetworkUtils.h
@@ -57,6 +57,7 @@ void ofxNetworkLogError(int err, const char* file=__FILE__, int line=__LINE__-1)
  * @param line the line where the error happened, generally __LINE__
  * @return int the last network error
  */
-OF_DEPRECATED_MSG("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead", int ofxNetworkCheckErrno(const char* file, int line) );
+[[deprecated("use ofxNetworkLogError(ofxNetworkGetLastError(), file, line) instead")]]
+int ofxNetworkCheckErrno(const char* file, int line) ;
 
 

--- a/addons/ofxOpenCv/src/ofxCvImage.h
+++ b/addons/ofxOpenCv/src/ofxCvImage.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-
 #include "ofxCvConstants.h"
 
 class ofxCvGrayscaleImage;
@@ -20,179 +19,176 @@ class ofxCvFloatImage;
 class ofxCvShortImage;
 class ofxCvBlob;
 
-
-
 class ofxCvImage : public ofBaseImage {
-    
-  public:
+public:
 
-    int width;
-    int height;
+	int width;
+	int height;
 	bool bAllocated;
 
-    ofxCvImage();
-    virtual  ~ofxCvImage();
-    virtual void  allocate( int w, int h );
-    virtual void  clear();
+	ofxCvImage();
+	virtual  ~ofxCvImage();
+	virtual void  allocate( int w, int h );
+	virtual void  clear();
 	virtual float getWidth() const;        // get width of this image or its ROI width
 	virtual float getHeight() const;       // get height of this image or its ROI height
-    virtual void  setUseTexture( bool bUse );
-    virtual bool isUsingTexture() const;
-    virtual ofTexture&  getTexture();
+	virtual void  setUseTexture( bool bUse );
+	virtual bool isUsingTexture() const;
+	virtual ofTexture&  getTexture();
 	virtual const ofTexture & getTexture() const;
 	[[deprecated("Use getTexture")]]
-virtual ofTexture&  getTextureReference();
+	virtual ofTexture &  getTextureReference();
 	[[deprecated("Use getTexture")]]
-virtual const ofTexture & getTextureReference() const;
-    virtual void flagImageChanged();  //mostly used internally
+	virtual const ofTexture & getTextureReference() const;
+	virtual void flagImageChanged();  //mostly used internally
 
-    
-    // ROI - region of interest
-    //
-    virtual void  setROI( int x, int y, int w, int h );
-    virtual void  setROI( const ofRectangle& rect );
-    virtual ofRectangle  getROI() const;
-    virtual void  resetROI();
-    virtual ofRectangle  getIntersectionROI( const ofRectangle& rec1,
-                                             const ofRectangle& rec2 );
-    
-    
-    // Set Pixel Data
-    //
-    virtual void  set( float value ) = 0;
-    virtual void  operator -= ( float value );
-    virtual void  operator += ( float value );
-
-    virtual void  setFromPixels( const unsigned char* _pixels, int w, int h ) = 0;
-    virtual void  setFromPixels( const ofPixels & pixels );
-    virtual void  setRoiFromPixels( const unsigned char* _pixels, int w, int h ) = 0;
-    virtual void  setRoiFromPixels( const ofPixels & pixels );
-    virtual void  operator = ( const ofxCvGrayscaleImage& mom ) = 0;
-    virtual void  operator = ( const ofxCvColorImage& mom ) = 0;
-    virtual void  operator = ( const ofxCvFloatImage& mom ) = 0;
-    virtual void  operator = ( const ofxCvShortImage& mom ) = 0;
-    virtual void  operator = ( const IplImage* mom );
-    
-    virtual void  operator -= ( ofxCvImage& mom );
-    virtual void  operator += ( ofxCvImage& mom );
-    virtual void  operator *= ( ofxCvImage& mom );
-    virtual void  operator &= ( ofxCvImage& mom );
-    
-    virtual void  drawBlobIntoMe( ofxCvBlob& blob, int color );
-        
-
-    // Get Pixel Data
-    //
-    virtual ofPixels&		getPixels();
-    virtual ofPixels&		getRoiPixels();
-    virtual IplImage*  getCvImage() { return cvImage; };
-    virtual const ofPixels&		getPixels() const;
-    virtual const ofPixels&		getRoiPixels() const;
-    virtual const IplImage*  getCvImage() const { return cvImage; };
-
-    // Access the IplImage as the more modern cv::Mat
-    // Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
-    virtual cv::Mat getCvMat() { return  cv::cvarrToMat(getCvImage()); };
-    virtual const cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
 	
-    // Draw Image
-    //
-    virtual void updateTexture();
-    virtual void draw( float x, float y ) const;
-    virtual void draw( float x, float y, float w, float h ) const;
+	// ROI - region of interest
+	//
+	virtual void  setROI( int x, int y, int w, int h );
+	virtual void  setROI( const ofRectangle& rect );
+	virtual ofRectangle  getROI() const;
+	virtual void  resetROI();
+	virtual ofRectangle  getIntersectionROI( const ofRectangle& rec1,
+											 const ofRectangle& rec2 );
+	
+	
+	// Set Pixel Data
+	//
+	virtual void  set( float value ) = 0;
+	virtual void  operator -= ( float value );
+	virtual void  operator += ( float value );
+
+	virtual void  setFromPixels( const unsigned char* _pixels, int w, int h ) = 0;
+	virtual void  setFromPixels( const ofPixels & pixels );
+	virtual void  setRoiFromPixels( const unsigned char* _pixels, int w, int h ) = 0;
+	virtual void  setRoiFromPixels( const ofPixels & pixels );
+	virtual void  operator = ( const ofxCvGrayscaleImage& mom ) = 0;
+	virtual void  operator = ( const ofxCvColorImage& mom ) = 0;
+	virtual void  operator = ( const ofxCvFloatImage& mom ) = 0;
+	virtual void  operator = ( const ofxCvShortImage& mom ) = 0;
+	virtual void  operator = ( const IplImage* mom );
+	
+	virtual void  operator -= ( ofxCvImage& mom );
+	virtual void  operator += ( ofxCvImage& mom );
+	virtual void  operator *= ( ofxCvImage& mom );
+	virtual void  operator &= ( ofxCvImage& mom );
+	
+	virtual void  drawBlobIntoMe( ofxCvBlob& blob, int color );
+		
+
+	// Get Pixel Data
+	//
+	virtual ofPixels&		getPixels();
+	virtual ofPixels&		getRoiPixels();
+	virtual IplImage*  getCvImage() { return cvImage; };
+	virtual const ofPixels&		getPixels() const;
+	virtual const ofPixels&		getRoiPixels() const;
+	virtual const IplImage*  getCvImage() const { return cvImage; };
+
+	// Access the IplImage as the more modern cv::Mat
+	// Might need to call ofxCvImage::flagImageChanged() if you want extenral changes to show up in the ofxCvImage texture or pixels
+	virtual cv::Mat getCvMat() { return  cv::cvarrToMat(getCvImage()); };
+	virtual const cv::Mat getCvMat() const { return  cv::cvarrToMat(getCvImage()); };
+	
+	// Draw Image
+	//
+	virtual void updateTexture();
+	virtual void draw( float x, float y ) const;
+	virtual void draw( float x, float y, float w, float h ) const;
 	virtual void draw(const glm::vec2 & point) const;
 	virtual void draw(const ofRectangle & rect) const;
-    virtual void drawROI( float x, float y ) const;
-    virtual void drawROI( float x, float y, float w, float h ) const;
-    virtual void setAnchorPercent( float xPct, float yPct );
-    virtual void setAnchorPoint( float x, float y );
-    virtual void resetAnchor();
-    
-    
-    // Image Filter Operations
-    //
-    virtual void  erode( );                     // based on 3x3 shape
-    virtual void  dilate( );                    // based on 3x3 shape
-    virtual void  blur( int value=3 );          // value = x*2+1, where x is an integer
-    virtual void  blurGaussian( int value=3 );  // value = x*2+1, where x is an integer
-    virtual void  invert();
-    virtual void  contrastStretch() = 0;
-    virtual void  convertToRange(float min, float max) = 0;
+	virtual void drawROI( float x, float y ) const;
+	virtual void drawROI( float x, float y, float w, float h ) const;
+	virtual void setAnchorPercent( float xPct, float yPct );
+	virtual void setAnchorPoint( float x, float y );
+	virtual void resetAnchor();
+	
+	
+	// Image Filter Operations
+	//
+	virtual void  erode( );                     // based on 3x3 shape
+	virtual void  dilate( );                    // based on 3x3 shape
+	virtual void  blur( int value=3 );          // value = x*2+1, where x is an integer
+	virtual void  blurGaussian( int value=3 );  // value = x*2+1, where x is an integer
+	virtual void  invert();
+	virtual void  contrastStretch() = 0;
+	virtual void  convertToRange(float min, float max) = 0;
 
 
-    // Image Transformation Operations
-    //
-    virtual void  resize( int w, int h ) = 0;
-    virtual void  scaleIntoMe( ofxCvImage& mom, int interpolationMethod = CV_INTER_NN ) = 0;
-    virtual void  mirror( bool bFlipVertically, bool bFlipHorizontally );
+	// Image Transformation Operations
+	//
+	virtual void  resize( int w, int h ) = 0;
+	virtual void  scaleIntoMe( ofxCvImage& mom, int interpolationMethod = CV_INTER_NN ) = 0;
+	virtual void  mirror( bool bFlipVertically, bool bFlipHorizontally );
 
-    virtual void  translate( float x, float y );
-    virtual void  rotate( float angle, float centerX, float centerY );
-    virtual void  scale( float scaleX, float sclaeY );
-    virtual void  transform( float angle, float centerX, float centerY,
-                             float scaleX, float scaleY,
-                             float moveX, float moveY );
-    /**
-    * undistort Usage Example:
-    * undistort( 0, 1, 0, 0, 200, 200, cwidth/2, cheight/2 );
-    * creates kind of an old TV monitor distortion.
-    */
-    virtual void  undistort( float radialDistX, float radialDistY,
-                             float tangentDistX, float tangentDistY,
-                             float focalX, float focalY,
-                             float centerX, float centerY );
+	virtual void  translate( float x, float y );
+	virtual void  rotate( float angle, float centerX, float centerY );
+	virtual void  scale( float scaleX, float sclaeY );
+	virtual void  transform( float angle, float centerX, float centerY,
+							 float scaleX, float scaleY,
+							 float moveX, float moveY );
+	/**
+	* undistort Usage Example:
+	* undistort( 0, 1, 0, 0, 200, 200, cwidth/2, cheight/2 );
+	* creates kind of an old TV monitor distortion.
+	*/
+	virtual void  undistort( float radialDistX, float radialDistY,
+							 float tangentDistX, float tangentDistY,
+							 float focalX, float focalY,
+							 float centerX, float centerY );
 
-    virtual void  remap( IplImage* mapX, IplImage* mapY );
+	virtual void  remap( IplImage* mapX, IplImage* mapY );
 
-    virtual void  warpPerspective( const ofPoint& A, const ofPoint& B,
-                                   const ofPoint& C, const ofPoint& D );
-    virtual void  warpIntoMe( ofxCvImage& mom,
-                              const ofPoint src[4], const ofPoint dst[4] );
+	virtual void  warpPerspective( const ofPoint& A, const ofPoint& B,
+								   const ofPoint& C, const ofPoint& D );
+	virtual void  warpIntoMe( ofxCvImage& mom,
+							  const ofPoint src[4], const ofPoint dst[4] );
 
 
 
-    // Other Image Operations
-    //
-    virtual int  countNonZeroInRegion( int x, int y, int w, int h );
+	// Other Image Operations
+	//
+	virtual int  countNonZeroInRegion( int x, int y, int w, int h );
 
 
 
 
   protected:
 
-    virtual void allocateTexture() = 0;
-    virtual void allocatePixels(int w, int h) = 0;
-    bool matchingROI( const ofRectangle& rec1, const ofRectangle& rec2 );
-    virtual void  setImageROI( IplImage* img, const ofRectangle& rect );
-    virtual void  resetImageROI( IplImage* img );
+	virtual void allocateTexture() = 0;
+	virtual void allocatePixels(int w, int h) = 0;
+	bool matchingROI( const ofRectangle& rec1, const ofRectangle& rec2 );
+	virtual void  setImageROI( IplImage* img, const ofRectangle& rect );
+	virtual void  resetImageROI( IplImage* img );
 
-    virtual void  rangeMap( IplImage* img, float min1, float max1, float min2, float max2 );
-    virtual void  rangeMap( IplImage* mom, IplImage* kid, float min1, float max1, float min2, float max2 );
-                                     
-    virtual void swapTemp();  // swap cvImageTemp back
-                              // to cvImage after an image operation
-    virtual IplImage*  getCv8BitsImage() { return cvImage; }
-    virtual IplImage*  getCv8BitsRoiImage() { return cvImage; }
-                          
-    IplImage*  cvImage;
-    IplImage*  cvImageTemp;   // this is typically swapped back into cvImage
-                              // after an image operation with swapImage()
-                              
-    int ipldepth;             // IPL_DEPTH_8U, IPL_DEPTH_16U, IPL_DEPTH_32F, ...
-    int iplchannels;          // 1, 3, 4, ...
-    
-    ofPixels pixels;	  // not width stepped for getPixels(), allocated on demand
-    ofPixels roiPixels;
-    bool bPixelsDirty;        // pixels need to be reloaded
-    bool bRoiPixelsDirty;        // pixels need to be reloaded
-    
-    // the texture in this class is usually only update in draw
-    // to allow draw to be const we mark the texture as mutable
-    mutable ofTexture  tex;		      // internal tex
-    mutable bool bTextureDirty;       // texture needs to be reloaded before drawing
-    bool bUseTexture;
-    
-    ofPoint  anchor;
-    bool  bAnchorIsPct;    
+	virtual void  rangeMap( IplImage* img, float min1, float max1, float min2, float max2 );
+	virtual void  rangeMap( IplImage* mom, IplImage* kid, float min1, float max1, float min2, float max2 );
+									 
+	virtual void swapTemp();  // swap cvImageTemp back
+							  // to cvImage after an image operation
+	virtual IplImage*  getCv8BitsImage() { return cvImage; }
+	virtual IplImage*  getCv8BitsRoiImage() { return cvImage; }
+						  
+	IplImage*  cvImage;
+	IplImage*  cvImageTemp;   // this is typically swapped back into cvImage
+							  // after an image operation with swapImage()
+							  
+	int ipldepth;             // IPL_DEPTH_8U, IPL_DEPTH_16U, IPL_DEPTH_32F, ...
+	int iplchannels;          // 1, 3, 4, ...
+	
+	ofPixels pixels;	  // not width stepped for getPixels(), allocated on demand
+	ofPixels roiPixels;
+	bool bPixelsDirty;        // pixels need to be reloaded
+	bool bRoiPixelsDirty;        // pixels need to be reloaded
+	
+	// the texture in this class is usually only update in draw
+	// to allow draw to be const we mark the texture as mutable
+	mutable ofTexture  tex;		      // internal tex
+	mutable bool bTextureDirty;       // texture needs to be reloaded before drawing
+	bool bUseTexture;
+	
+	ofPoint  anchor;
+	bool  bAnchorIsPct;    
 
 };

--- a/addons/ofxOpenCv/src/ofxCvImage.h
+++ b/addons/ofxOpenCv/src/ofxCvImage.h
@@ -40,8 +40,10 @@ class ofxCvImage : public ofBaseImage {
     virtual bool isUsingTexture() const;
     virtual ofTexture&  getTexture();
 	virtual const ofTexture & getTexture() const;
-	OF_DEPRECATED_MSG("Use getTexture",virtual ofTexture&  getTextureReference());
-	OF_DEPRECATED_MSG("Use getTexture",virtual const ofTexture & getTextureReference() const);
+	[[deprecated("Use getTexture")]]
+virtual ofTexture&  getTextureReference();
+	[[deprecated("Use getTexture")]]
+virtual const ofTexture & getTextureReference() const;
     virtual void flagImageChanged();  //mostly used internally
 
     

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -29,7 +29,7 @@ public:
 	/// \return the OSC address
 	std::string getAddress() const;
 
-	[[deprecated("Use getRemoteHost() instead")]]
+	[[deprecated("Use getRemoteHost()")]]
 	std::string getRemoteIp() const;
 
 	/// \return the remote host name/ip or "" if not set

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -30,7 +30,8 @@ public:
 	std::string getAddress() const;
 
 	/// \return the remote host name/ip (deprecated)
-	OF_DEPRECATED_MSG("Use getRemoteHost() instead", std::string getRemoteIp() const);
+	[[deprecated("Use getRemoteHost() instead")]]
+std::string getRemoteIp() const;
 
 	/// \return the remote host name/ip or "" if not set
 	std::string getRemoteHost() const;

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -29,9 +29,8 @@ public:
 	/// \return the OSC address
 	std::string getAddress() const;
 
-	/// \return the remote host name/ip (deprecated)
 	[[deprecated("Use getRemoteHost() instead")]]
-std::string getRemoteIp() const;
+	std::string getRemoteIp() const;
 
 	/// \return the remote host name/ip or "" if not set
 	std::string getRemoteHost() const;

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -85,7 +85,8 @@ public:
 	/// remove a message from the queue and copy it's data into msg
 	/// \return false if there are no waiting messages, otherwise return true
 	bool getNextMessage(ofxOscMessage & msg);
-	OF_DEPRECATED_MSG("Pass a reference instead of a pointer", bool getNextMessage(ofxOscMessage * msg));
+	[[deprecated("Pass a reference instead of a pointer")]]
+bool getNextMessage(ofxOscMessage * msg);
 
 	/// if there is at tleast 1 message in the queue, pop and swap it into an optional message
 	/// \return the std::optional<ofxOscMessage> if there was a message; std::nullopt otherwise

--- a/addons/ofxOsc/src/ofxOscReceiver.h
+++ b/addons/ofxOsc/src/ofxOscReceiver.h
@@ -86,7 +86,7 @@ public:
 	/// \return false if there are no waiting messages, otherwise return true
 	bool getNextMessage(ofxOscMessage & msg);
 	[[deprecated("Pass a reference instead of a pointer")]]
-bool getNextMessage(ofxOscMessage * msg);
+	bool getNextMessage(ofxOscMessage * msg);
 
 	/// if there is at tleast 1 message in the queue, pop and swap it into an optional message
 	/// \return the std::optional<ofxOscMessage> if there was a message; std::nullopt otherwise

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -54,9 +54,12 @@ class ofxXmlSettings{
 
 		void setVerbose(bool _verbose);
 
-		OF_DEPRECATED_MSG("ofxXmlSettings::loadFile() is deprecated, use load() instead.", bool loadFile(const std::string& xmlFile));
-		OF_DEPRECATED_MSG("ofxXmlSettings::saveFile() is deprecated, use save() instead.", bool saveFile(const std::string& xmlFile));
-		OF_DEPRECATED_MSG("ofxXmlSettings::saveFile() is deprecated, use save() instead.", bool saveFile());
+		[[deprecated("ofxXmlSettings::loadFile() is deprecated, use load() instead.")]]
+bool loadFile(const std::string& xmlFile);
+		[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+bool saveFile(const std::string& xmlFile);
+		[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+bool saveFile();
 
 		bool load(const std::string & path);
 		bool save(const std::string & path);

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -54,11 +54,11 @@ public:
 
 	void setVerbose(bool _verbose);
 
-	[[deprecated("use load() instead.")]]
+	[[deprecated("use load()")]]
 	bool loadFile(const std::string& xmlFile);
-	[[deprecated("use save() instead.")]]
+	[[deprecated("use save()")]]
 	bool saveFile(const std::string& xmlFile);
-	[[deprecated("use save() instead.")]]
+	[[deprecated("use save()")]]
 	bool saveFile();
 
 	bool load(const std::string & path);

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -54,11 +54,11 @@ public:
 
 	void setVerbose(bool _verbose);
 
-	[[deprecated("ofxXmlSettings::loadFile() is deprecated, use load() instead.")]]
+	[[deprecated("use load() instead.")]]
 	bool loadFile(const std::string& xmlFile);
-	[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+	[[deprecated("use save() instead.")]]
 	bool saveFile(const std::string& xmlFile);
-	[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+	[[deprecated("use save() instead.")]]
 	bool saveFile();
 
 	bool load(const std::string & path);

--- a/addons/ofxXmlSettings/src/ofxXmlSettings.h
+++ b/addons/ofxXmlSettings/src/ofxXmlSettings.h
@@ -45,133 +45,133 @@
 #define MAX_TAG_VALUE_LENGTH_IN_CHARS		1024
 
 class ofxXmlSettings{
-	
-	public:
-        ofxXmlSettings();
-        ofxXmlSettings(const std::string& xmlFile);
+public:
 
-        ~ofxXmlSettings();
+	ofxXmlSettings();
+	ofxXmlSettings(const std::string& xmlFile);
 
-		void setVerbose(bool _verbose);
+	~ofxXmlSettings();
 
-		[[deprecated("ofxXmlSettings::loadFile() is deprecated, use load() instead.")]]
-bool loadFile(const std::string& xmlFile);
-		[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
-bool saveFile(const std::string& xmlFile);
-		[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
-bool saveFile();
+	void setVerbose(bool _verbose);
 
-		bool load(const std::string & path);
-		bool save(const std::string & path);
-		bool save();
+	[[deprecated("ofxXmlSettings::loadFile() is deprecated, use load() instead.")]]
+	bool loadFile(const std::string& xmlFile);
+	[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+	bool saveFile(const std::string& xmlFile);
+	[[deprecated("ofxXmlSettings::saveFile() is deprecated, use save() instead.")]]
+	bool saveFile();
 
-
-
-		void clearTagContents(const std::string& tag, int which = 0);
-		void removeTag(const std::string& tag, int which = 0);
-
-		bool tagExists(const std::string& tag, int which = 0) const;
-
-		// removes all tags from within either the whole document
-		// or the tag you are currently at using pushTag
-		void	clear();
-
-		int 	getValue(const std::string&  tag, int            defaultValue, int which = 0) const;
-		double 	getValue(const std::string&  tag, double         defaultValue, int which = 0) const;
-		std::string 	getValue(const std::string&  tag, const std::string& 	defaultValue, int which = 0) const;
-
-		int 	setValue(const std::string&  tag, int            value, int which = 0);
-		int 	setValue(const std::string&  tag, double         value, int which = 0);
-		int 	setValue(const std::string&  tag, const std::string& 	value, int which = 0);
-
-		//advanced
-
-		//-- pushTag/popTag
-		//pushing a tag moves you inside it which has the effect of
-		//temporarily treating the tag you are in as the document root
-		//all setValue, readValue and getValue commands are then be relative to the tag you pushed.
-		//this can be used with addValue to create multiple tags of the same name within
-		//the pushed tag - normally addValue only lets you create multiple tags of the same
-		//at the top most level.
-
-		bool	pushTag(const std::string&  tag, int which = 0);
-		int		popTag();
-		int		getPushLevel();
-
-		//-- numTags
-		//this only works for tags at the current root level
-		//use pushTag and popTag to get number of tags whithin other tags
-		// both getNumTags("PT"); and getNumTags("PT:X"); will just return the
-		//number of <PT> tags at the current root level.
-		int		getNumTags(const std::string& tag) const;
-
-		//-- addValue/addTag
-		//adds a tag to the document even if a tag with the same name
-		//already exists - returns an index which can then be used to
-		//modify the tag by passing it as the last argument to setValue
-
-		//-- important - this only works for top level tags
-		//   to put multiple tags inside other tags - use pushTag() and popTag()
-
-		int 	addValue(const std::string&  tag, int            value);
-		int 	addValue(const std::string&  tag, double         value);
-		int 	addValue(const std::string&  tag, const std::string& 	value);
-
-		int		addTag(const std::string& tag); //adds an empty tag at the current level
-
-        // Attribute-related methods
-		int		addAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
-		int		addAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
-		int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
-
-		int		addAttribute(const std::string& tag, const std::string& attribute, int value);
-		int		addAttribute(const std::string& tag, const std::string& attribute, double value);
-		int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
-
-		void	removeAttribute(const std::string& tag, const std::string& attribute, int which = 0);
-		void	clearTagAttributes(const std::string& tag, int which = 0);
-
-		int		getNumAttributes(const std::string& tag, int which = 0) const;
-
-		bool	attributeExists(const std::string& tag, const std::string& attribute, int which = 0) const;
-
-		bool    getAttributeNames(const std::string& tag, std::vector<std::string>& outNames, int which = 0) const;
-
-		int		getAttribute(const std::string& tag, const std::string& attribute, int defaultValue, int which = 0) const;
-		double	getAttribute(const std::string& tag, const std::string& attribute, double defaultValue, int which = 0) const;
-		std::string	getAttribute(const std::string& tag, const std::string& attribute, const std::string& defaultValue, int which = 0) const;
-
-		int		setAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
-		int		setAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
-		int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
-
-		int		setAttribute(const std::string& tag, const std::string& attribute, int value);
-		int		setAttribute(const std::string& tag, const std::string& attribute, double value);
-		int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
-
-		bool	loadFromBuffer(std::string buffer);
-		void	copyXmlToString(std::string & str) const;
-
-		TiXmlDocument 	doc;
-		bool 			bDocLoaded;
-
-	protected:
-
-		TiXmlHandle     storedHandle;
-		int             level;
+	bool load(const std::string & path);
+	bool save(const std::string & path);
+	bool save();
 
 
-		int 	writeTag(const std::string&  tag, const std::string& valueString, int which = 0);
-		bool 	readTag(const std::string&  tag, TiXmlHandle& valHandle, int which = 0) const;	// max 1024 chars...
+
+	void clearTagContents(const std::string& tag, int which = 0);
+	void removeTag(const std::string& tag, int which = 0);
+
+	bool tagExists(const std::string& tag, int which = 0) const;
+
+	// removes all tags from within either the whole document
+	// or the tag you are currently at using pushTag
+	void	clear();
+
+	int 	getValue(const std::string&  tag, int            defaultValue, int which = 0) const;
+	double 	getValue(const std::string&  tag, double         defaultValue, int which = 0) const;
+	std::string 	getValue(const std::string&  tag, const std::string& 	defaultValue, int which = 0) const;
+
+	int 	setValue(const std::string&  tag, int            value, int which = 0);
+	int 	setValue(const std::string&  tag, double         value, int which = 0);
+	int 	setValue(const std::string&  tag, const std::string& 	value, int which = 0);
+
+	//advanced
+
+	//-- pushTag/popTag
+	//pushing a tag moves you inside it which has the effect of
+	//temporarily treating the tag you are in as the document root
+	//all setValue, readValue and getValue commands are then be relative to the tag you pushed.
+	//this can be used with addValue to create multiple tags of the same name within
+	//the pushed tag - normally addValue only lets you create multiple tags of the same
+	//at the top most level.
+
+	bool	pushTag(const std::string&  tag, int which = 0);
+	int		popTag();
+	int		getPushLevel();
+
+	//-- numTags
+	//this only works for tags at the current root level
+	//use pushTag and popTag to get number of tags whithin other tags
+	// both getNumTags("PT"); and getNumTags("PT:X"); will just return the
+	//number of <PT> tags at the current root level.
+	int		getNumTags(const std::string& tag) const;
+
+	//-- addValue/addTag
+	//adds a tag to the document even if a tag with the same name
+	//already exists - returns an index which can then be used to
+	//modify the tag by passing it as the last argument to setValue
+
+	//-- important - this only works for top level tags
+	//   to put multiple tags inside other tags - use pushTag() and popTag()
+
+	int 	addValue(const std::string&  tag, int            value);
+	int 	addValue(const std::string&  tag, double         value);
+	int 	addValue(const std::string&  tag, const std::string& 	value);
+
+	int		addTag(const std::string& tag); //adds an empty tag at the current level
+
+	// Attribute-related methods
+	int		addAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
+	int		addAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
+	int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
+
+	int		addAttribute(const std::string& tag, const std::string& attribute, int value);
+	int		addAttribute(const std::string& tag, const std::string& attribute, double value);
+	int		addAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
+
+	void	removeAttribute(const std::string& tag, const std::string& attribute, int which = 0);
+	void	clearTagAttributes(const std::string& tag, int which = 0);
+
+	int		getNumAttributes(const std::string& tag, int which = 0) const;
+
+	bool	attributeExists(const std::string& tag, const std::string& attribute, int which = 0) const;
+
+	bool    getAttributeNames(const std::string& tag, std::vector<std::string>& outNames, int which = 0) const;
+
+	int		getAttribute(const std::string& tag, const std::string& attribute, int defaultValue, int which = 0) const;
+	double	getAttribute(const std::string& tag, const std::string& attribute, double defaultValue, int which = 0) const;
+	std::string	getAttribute(const std::string& tag, const std::string& attribute, const std::string& defaultValue, int which = 0) const;
+
+	int		setAttribute(const std::string& tag, const std::string& attribute, int value, int which = 0);
+	int		setAttribute(const std::string& tag, const std::string& attribute, double value, int which = 0);
+	int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value, int which = 0);
+
+	int		setAttribute(const std::string& tag, const std::string& attribute, int value);
+	int		setAttribute(const std::string& tag, const std::string& attribute, double value);
+	int		setAttribute(const std::string& tag, const std::string& attribute, const std::string& value);
+
+	bool	loadFromBuffer(std::string buffer);
+	void	copyXmlToString(std::string & str) const;
+
+	TiXmlDocument 	doc;
+	bool 			bDocLoaded;
+
+protected:
+
+	TiXmlHandle     storedHandle;
+	int             level;
 
 
-		int		writeAttribute(const std::string& tag, const std::string& attribute, const std::string& valueString, int which = 0);
+	int 	writeTag(const std::string&  tag, const std::string& valueString, int which = 0);
+	bool 	readTag(const std::string&  tag, TiXmlHandle& valHandle, int which = 0) const;	// max 1024 chars...
 
-		TiXmlElement* getElementForAttribute(const std::string& tag, int which) const;
-		bool readIntAttribute(const std::string& tag, const std::string& attribute, int& valueString, int which) const;
-		bool readDoubleAttribute(const std::string& tag, const std::string& attribute, double& outValue, int which) const;
-		bool readStringAttribute(const std::string& tag, const std::string& attribute, std::string& outValue, int which) const;
-};   
+
+	int		writeAttribute(const std::string& tag, const std::string& attribute, const std::string& valueString, int which = 0);
+
+	TiXmlElement* getElementForAttribute(const std::string& tag, int which) const;
+	bool readIntAttribute(const std::string& tag, const std::string& attribute, int& valueString, int which) const;
+	bool readDoubleAttribute(const std::string& tag, const std::string& attribute, double& outValue, int which) const;
+	bool readStringAttribute(const std::string& tag, const std::string& attribute, std::string& outValue, int which) const;
+};
 
 void ofSerialize(ofxXmlSettings & settings, const ofAbstractParameter & parameter);
 void ofDeserialize(const ofxXmlSettings & settings, ofAbstractParameter & parameter);

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -184,7 +184,7 @@ public:
 	void setup();
 	
 	void run(ofBaseApp * appPtr);
-	[[deprecated("Use setup(const ofiOSWindowSettings & settings); instead.")]]
+	[[deprecated("Use setup(const ofiOSWindowSettings & settings);")]]
 	virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) ;
 	static void startAppWithDelegate(std::string appDelegateClassName);
 	void update();
@@ -281,7 +281,7 @@ protected:
 	bool hasExited;
 };
 
-[[deprecated("use ofAppiOSWindow instead.")]]
+[[deprecated("use ofAppiOSWindow")]]
 typedef ofAppiOSWindow ofAppiPhoneWindow;
 
 

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -37,248 +37,248 @@
 
 class ofiOSWindowSettings: public ofGLESWindowSettings{
 public:
-    ofiOSWindowSettings()
-    :enableRetina(true)
-    ,retinaScale(0)
-    ,enableDepth(false)
-    ,enableAntiAliasing(false)
-    ,numOfAntiAliasingSamples(0)
-    ,enableHardwareOrientation(false)
-    ,enableHardwareOrientationAnimation(false)
-    ,enableSetupScreen(true)
-    ,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
-    ,colorType(ofxiOSRendererColorFormat::RGBA8888)
-    ,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
-    ,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
-    ,enableMultiTouch(false) {
-        windowMode = OF_FULLSCREEN;
-        setupOrientation = OF_ORIENTATION_DEFAULT;
-        glesVersion = 2;
-    }
-    
-    ofiOSWindowSettings(const ofWindowSettings & settings)
-    :ofGLESWindowSettings(settings)
-    ,enableRetina(true)
-    ,retinaScale(0)
-    ,enableDepth(false)
-    ,enableAntiAliasing(false)
-    ,numOfAntiAliasingSamples(0)
-    ,enableHardwareOrientation(false)
-    ,enableHardwareOrientationAnimation(false)
-    ,enableSetupScreen(true)
-    ,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
-    ,colorType(ofxiOSRendererColorFormat::RGBA8888)
-    ,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
-    ,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
-    ,enableMultiTouch(false) {
-        const ofGLESWindowSettings * glesSettings = dynamic_cast<const ofGLESWindowSettings*>(&settings);
-        if(glesSettings){
-            glesVersion = glesSettings->glesVersion;
-        } else {
-            glesVersion = 2;
-        }
-        const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&settings);
-        if(iosSettings){
-            enableRetina = iosSettings->enableRetina;
-            retinaScale = iosSettings->retinaScale;
-            enableDepth = iosSettings->enableDepth;
-            enableAntiAliasing = iosSettings->enableAntiAliasing;
-            numOfAntiAliasingSamples = iosSettings->numOfAntiAliasingSamples;
-            enableHardwareOrientation = iosSettings->enableHardwareOrientation;
-            enableHardwareOrientationAnimation = iosSettings->enableHardwareOrientationAnimation;
-            enableSetupScreen = iosSettings->enableSetupScreen;
-            setupOrientation = iosSettings->setupOrientation;
-            windowControllerType = iosSettings->windowControllerType;
-            colorType = iosSettings->colorType;
-            depthType = iosSettings->depthType;
-            stencilType = iosSettings->stencilType;
-            enableMultiTouch = iosSettings->enableMultiTouch;
-        } else {
-            enableRetina = true;
-            retinaScale = 0;
-            enableDepth = false;
-            enableAntiAliasing = false;
-            numOfAntiAliasingSamples = 0;
-            enableHardwareOrientation = false;
-            enableHardwareOrientationAnimation = false;
-            enableSetupScreen = true;
-            setupOrientation = OF_ORIENTATION_DEFAULT;
-            colorType = ofxiOSRendererColorFormat::RGBA8888;
-            depthType = ofxiOSRendererDepthFormat::DEPTH_NONE;
-            stencilType = ofxiOSRendererStencilFormat::STENCIL_NONE;
-            enableMultiTouch = false;
-        }
-    }
+	ofiOSWindowSettings()
+	:enableRetina(true)
+	,retinaScale(0)
+	,enableDepth(false)
+	,enableAntiAliasing(false)
+	,numOfAntiAliasingSamples(0)
+	,enableHardwareOrientation(false)
+	,enableHardwareOrientationAnimation(false)
+	,enableSetupScreen(true)
+	,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
+	,colorType(ofxiOSRendererColorFormat::RGBA8888)
+	,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
+	,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
+	,enableMultiTouch(false) {
+		windowMode = OF_FULLSCREEN;
+		setupOrientation = OF_ORIENTATION_DEFAULT;
+		glesVersion = 2;
+	}
+	
+	ofiOSWindowSettings(const ofWindowSettings & settings)
+	:ofGLESWindowSettings(settings)
+	,enableRetina(true)
+	,retinaScale(0)
+	,enableDepth(false)
+	,enableAntiAliasing(false)
+	,numOfAntiAliasingSamples(0)
+	,enableHardwareOrientation(false)
+	,enableHardwareOrientationAnimation(false)
+	,enableSetupScreen(true)
+	,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
+	,colorType(ofxiOSRendererColorFormat::RGBA8888)
+	,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
+	,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
+	,enableMultiTouch(false) {
+		const ofGLESWindowSettings * glesSettings = dynamic_cast<const ofGLESWindowSettings*>(&settings);
+		if(glesSettings){
+			glesVersion = glesSettings->glesVersion;
+		} else {
+			glesVersion = 2;
+		}
+		const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&settings);
+		if(iosSettings){
+			enableRetina = iosSettings->enableRetina;
+			retinaScale = iosSettings->retinaScale;
+			enableDepth = iosSettings->enableDepth;
+			enableAntiAliasing = iosSettings->enableAntiAliasing;
+			numOfAntiAliasingSamples = iosSettings->numOfAntiAliasingSamples;
+			enableHardwareOrientation = iosSettings->enableHardwareOrientation;
+			enableHardwareOrientationAnimation = iosSettings->enableHardwareOrientationAnimation;
+			enableSetupScreen = iosSettings->enableSetupScreen;
+			setupOrientation = iosSettings->setupOrientation;
+			windowControllerType = iosSettings->windowControllerType;
+			colorType = iosSettings->colorType;
+			depthType = iosSettings->depthType;
+			stencilType = iosSettings->stencilType;
+			enableMultiTouch = iosSettings->enableMultiTouch;
+		} else {
+			enableRetina = true;
+			retinaScale = 0;
+			enableDepth = false;
+			enableAntiAliasing = false;
+			numOfAntiAliasingSamples = 0;
+			enableHardwareOrientation = false;
+			enableHardwareOrientationAnimation = false;
+			enableSetupScreen = true;
+			setupOrientation = OF_ORIENTATION_DEFAULT;
+			colorType = ofxiOSRendererColorFormat::RGBA8888;
+			depthType = ofxiOSRendererDepthFormat::DEPTH_NONE;
+			stencilType = ofxiOSRendererStencilFormat::STENCIL_NONE;
+			enableMultiTouch = false;
+		}
+	}
 
-    ofiOSWindowSettings(const ofGLESWindowSettings & settings)
-    :ofGLESWindowSettings(settings)
-    ,enableRetina(true)
-    ,retinaScale(0)
-    ,enableDepth(false)
-    ,enableAntiAliasing(false)
-    ,numOfAntiAliasingSamples(0)
-    ,enableHardwareOrientation(false)
-    ,enableHardwareOrientationAnimation(false)
-    ,enableSetupScreen(true)
-    ,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
-    ,colorType(ofxiOSRendererColorFormat::RGBA8888)
-    ,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
-    ,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
-    ,enableMultiTouch(false){
-        const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&settings);
-        if(iosSettings){
-            enableRetina = iosSettings->enableRetina;
-            retinaScale = iosSettings->retinaScale;
-            enableDepth = iosSettings->enableDepth;
-            enableAntiAliasing = iosSettings->enableAntiAliasing;
-            numOfAntiAliasingSamples = iosSettings->numOfAntiAliasingSamples;
-            enableHardwareOrientation = iosSettings->enableHardwareOrientation;
-            enableHardwareOrientationAnimation = iosSettings->enableHardwareOrientationAnimation;
-            enableSetupScreen = iosSettings->enableSetupScreen;
-            setupOrientation = iosSettings->setupOrientation;
-            windowControllerType = iosSettings->windowControllerType;
-            colorType = iosSettings->colorType;
-            depthType = iosSettings->depthType;
-            stencilType = iosSettings->stencilType;
-            enableMultiTouch = iosSettings->enableMultiTouch;
-        }
-    }
+	ofiOSWindowSettings(const ofGLESWindowSettings & settings)
+	:ofGLESWindowSettings(settings)
+	,enableRetina(true)
+	,retinaScale(0)
+	,enableDepth(false)
+	,enableAntiAliasing(false)
+	,numOfAntiAliasingSamples(0)
+	,enableHardwareOrientation(false)
+	,enableHardwareOrientationAnimation(false)
+	,enableSetupScreen(true)
+	,windowControllerType(ofxiOSWindowControllerType::CORE_ANIMATION)
+	,colorType(ofxiOSRendererColorFormat::RGBA8888)
+	,depthType(ofxiOSRendererDepthFormat::DEPTH_NONE)
+	,stencilType(ofxiOSRendererStencilFormat::STENCIL_NONE)
+	,enableMultiTouch(false){
+		const ofiOSWindowSettings * iosSettings = dynamic_cast<const ofiOSWindowSettings*>(&settings);
+		if(iosSettings){
+			enableRetina = iosSettings->enableRetina;
+			retinaScale = iosSettings->retinaScale;
+			enableDepth = iosSettings->enableDepth;
+			enableAntiAliasing = iosSettings->enableAntiAliasing;
+			numOfAntiAliasingSamples = iosSettings->numOfAntiAliasingSamples;
+			enableHardwareOrientation = iosSettings->enableHardwareOrientation;
+			enableHardwareOrientationAnimation = iosSettings->enableHardwareOrientationAnimation;
+			enableSetupScreen = iosSettings->enableSetupScreen;
+			setupOrientation = iosSettings->setupOrientation;
+			windowControllerType = iosSettings->windowControllerType;
+			colorType = iosSettings->colorType;
+			depthType = iosSettings->depthType;
+			stencilType = iosSettings->stencilType;
+			enableMultiTouch = iosSettings->enableMultiTouch;
+		}
+	}
 
-    virtual ~ofiOSWindowSettings(){};
-    
-    bool enableRetina;
-    float retinaScale;
-    bool enableDepth;
-    bool enableAntiAliasing;
-    int numOfAntiAliasingSamples;
-    bool enableHardwareOrientation;
-    bool enableHardwareOrientationAnimation;
-    bool enableSetupScreen;
-    bool enableMultiTouch;
-    ofxiOSWindowControllerType windowControllerType;
-    ofxiOSRendererColorFormat colorType;
-    ofxiOSRendererDepthFormat depthType;
-    ofxiOSRendererStencilFormat stencilType;
-    ofOrientation setupOrientation;
-    
+	virtual ~ofiOSWindowSettings(){};
+	
+	bool enableRetina;
+	float retinaScale;
+	bool enableDepth;
+	bool enableAntiAliasing;
+	int numOfAntiAliasingSamples;
+	bool enableHardwareOrientation;
+	bool enableHardwareOrientationAnimation;
+	bool enableSetupScreen;
+	bool enableMultiTouch;
+	ofxiOSWindowControllerType windowControllerType;
+	ofxiOSRendererColorFormat colorType;
+	ofxiOSRendererDepthFormat depthType;
+	ofxiOSRendererStencilFormat stencilType;
+	ofOrientation setupOrientation;
+	
 };
 
 
 class ofAppiOSWindow : public ofAppBaseGLESWindow {
 public:
 
-    static ofAppiOSWindow * getInstance();
-    
-    ofAppiOSWindow();
-    ~ofAppiOSWindow();
-    
-    static void loop();
-    static bool doesLoop(){ return true; }
-    static bool allowsMultiWindow(){ return false; }
-    static bool needsPolling(){ return false; }
-    static void pollEvents(){ }
-    
-    void setup(const ofWindowSettings & _settings);
-    void setup(const ofGLESWindowSettings & _settings);
-    void setup(const ofiOSWindowSettings & _settings);
-    void setup();
-    
-    void run(ofBaseApp * appPtr);
-    [[deprecated("Use setup(const ofiOSWindowSettings & settings); instead.")]]
-virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) ;
-    static void startAppWithDelegate(std::string appDelegateClassName);
-    void update();
-    void draw();
+	static ofAppiOSWindow * getInstance();
+	
+	ofAppiOSWindow();
+	~ofAppiOSWindow();
+	
+	static void loop();
+	static bool doesLoop(){ return true; }
+	static bool allowsMultiWindow(){ return false; }
+	static bool needsPolling(){ return false; }
+	static void pollEvents(){ }
+	
+	void setup(const ofWindowSettings & _settings);
+	void setup(const ofGLESWindowSettings & _settings);
+	void setup(const ofiOSWindowSettings & _settings);
+	void setup();
+	
+	void run(ofBaseApp * appPtr);
+	[[deprecated("Use setup(const ofiOSWindowSettings & settings); instead.")]]
+	virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) ;
+	static void startAppWithDelegate(std::string appDelegateClassName);
+	void update();
+	void draw();
    
-    void close();
-    
-    virtual void hideCursor();
-    virtual void showCursor();
-    
-    virtual void setWindowPosition(int x, int y);
-    virtual void setWindowShape(int w, int h);
-        
-    virtual glm::vec2 getWindowPosition();
-    virtual glm::vec2 getWindowSize();
-    virtual glm::vec2 getScreenSize();
-    
+	void close();
+	
+	virtual void hideCursor();
+	virtual void showCursor();
+	
+	virtual void setWindowPosition(int x, int y);
+	virtual void setWindowShape(int w, int h);
+		
+	virtual glm::vec2 getWindowPosition();
+	virtual glm::vec2 getWindowSize();
+	virtual glm::vec2 getScreenSize();
+	
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
-    virtual void setOrientation(ofOrientation orientation);
-    virtual ofOrientation getOrientation();
-    virtual bool doesHWOrientation();
-    //-------------------------------------------- ios config.
-    bool enableHardwareOrientation();
-    bool disableHardwareOrientation();
-    
-    bool enableOrientationAnimation();
-    bool disableOrientationAnimation();
+	virtual void setOrientation(ofOrientation orientation);
+	virtual ofOrientation getOrientation();
+	virtual bool doesHWOrientation();
+	//-------------------------------------------- ios config.
+	bool enableHardwareOrientation();
+	bool disableHardwareOrientation();
+	
+	bool enableOrientationAnimation();
+	bool disableOrientationAnimation();
 #endif
-    
-    virtual int getWidth();
-    virtual int getHeight();
-    
-    ofiOSWindowSettings & getSettings();
-    ofCoreEvents & events();
-    std::shared_ptr<ofBaseRenderer> & renderer();
-    
-    virtual void setWindowTitle(std::string title);
-    
-    virtual ofWindowMode getWindowMode();
-    
-    virtual void setFullscreen(bool fullscreen);
-    virtual void toggleFullscreen();
-    
-    virtual void enableSetupScreen();
-    virtual void disableSetupScreen();
-    virtual bool isSetupScreenEnabled();
-    
-    virtual void setVerticalSync(bool enabled);
-        
-    bool isProgrammableRenderer();
-    ofxiOSRendererType getGLESVersion();
-    [[deprecated("Use ofiOSWindowSettings to setup programmable renderer by selecting glesVerison to >=2")]]
-bool enableRendererES2();
-    [[deprecated("Use ofiOSWindowSettings to setup  non-programmable renderer by selecting glesVersion Version to 1")]]
-bool enableRendererES1();
-    [[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
-bool isRendererES2();
-    [[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
-bool isRendererES1();
-    
-    bool enableRetina(float retinaScale=0);
-    bool disableRetina();
-    bool isRetinaEnabled();
-    bool isRetinaSupportedOnDevice();
-    float getRetinaScale();
-    
-    bool enableDepthBuffer();
-    bool disableDepthBuffer();
-    bool isDepthBufferEnabled();
-    
-    bool enableAntiAliasing(int samples);
-    bool disableAntiAliasing();
-    bool isAntiAliasingEnabled();
-    int getAntiAliasingSampleCount();
-    
-    void enableMultiTouch(bool isOn);
-    bool isMultiTouch();
-    ofxiOSWindowControllerType getWindowControllerType();
-    ofxiOSRendererColorFormat getRendererColorType();
-    ofxiOSRendererDepthFormat getRendererDepthType();
-    ofxiOSRendererStencilFormat getRendererStencilType();
-    
+	
+	virtual int getWidth();
+	virtual int getHeight();
+	
+	ofiOSWindowSettings & getSettings();
+	ofCoreEvents & events();
+	std::shared_ptr<ofBaseRenderer> & renderer();
+	
+	virtual void setWindowTitle(std::string title);
+	
+	virtual ofWindowMode getWindowMode();
+	
+	virtual void setFullscreen(bool fullscreen);
+	virtual void toggleFullscreen();
+	
+	virtual void enableSetupScreen();
+	virtual void disableSetupScreen();
+	virtual bool isSetupScreenEnabled();
+	
+	virtual void setVerticalSync(bool enabled);
+		
+	bool isProgrammableRenderer();
+	ofxiOSRendererType getGLESVersion();
+	[[deprecated("Use ofiOSWindowSettings to setup programmable renderer by selecting glesVerison to >=2")]]
+	bool enableRendererES2();
+	[[deprecated("Use ofiOSWindowSettings to setup  non-programmable renderer by selecting glesVersion Version to 1")]]
+	bool enableRendererES1();
+	[[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
+	bool isRendererES2();
+	[[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
+	bool isRendererES1();
+	
+	bool enableRetina(float retinaScale=0);
+	bool disableRetina();
+	bool isRetinaEnabled();
+	bool isRetinaSupportedOnDevice();
+	float getRetinaScale();
+	
+	bool enableDepthBuffer();
+	bool disableDepthBuffer();
+	bool isDepthBufferEnabled();
+	
+	bool enableAntiAliasing(int samples);
+	bool disableAntiAliasing();
+	bool isAntiAliasingEnabled();
+	int getAntiAliasingSampleCount();
+	
+	void enableMultiTouch(bool isOn);
+	bool isMultiTouch();
+	ofxiOSWindowControllerType getWindowControllerType();
+	ofxiOSRendererColorFormat getRendererColorType();
+	ofxiOSRendererDepthFormat getRendererDepthType();
+	ofxiOSRendererStencilFormat getRendererStencilType();
+	
 protected:
-    
-    ofCoreEvents coreEvents;
-    std::shared_ptr<ofBaseRenderer> currentRenderer;
-    ofiOSWindowSettings settings;
+	
+	ofCoreEvents coreEvents;
+	std::shared_ptr<ofBaseRenderer> currentRenderer;
+	ofiOSWindowSettings settings;
 
-    ofOrientation orientation;
-    
-    bool bRetinaSupportedOnDevice;
-    bool bRetinaSupportedOnDeviceChecked;
-    
-    bool hasExited;
+	ofOrientation orientation;
+	
+	bool bRetinaSupportedOnDevice;
+	bool bRetinaSupportedOnDeviceChecked;
+	
+	bool hasExited;
 };
 
 [[deprecated("ofAppiPhoneWindow is deprecated, use ofAppiOSWindow instead.")]]

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -281,7 +281,7 @@ protected:
 	bool hasExited;
 };
 
-[[deprecated("ofAppiPhoneWindow is deprecated, use ofAppiOSWindow instead.")]]
+[[deprecated("use ofAppiOSWindow instead.")]]
 typedef ofAppiOSWindow ofAppiPhoneWindow;
 
 

--- a/addons/ofxiOS/src/app/ofAppiOSWindow.h
+++ b/addons/ofxiOS/src/app/ofAppiOSWindow.h
@@ -184,7 +184,8 @@ public:
     void setup();
     
     void run(ofBaseApp * appPtr);
-    OF_DEPRECATED_MSG("Use setup(const ofiOSWindowSettings & settings); instead.", virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) );
+    [[deprecated("Use setup(const ofiOSWindowSettings & settings); instead.")]]
+virtual void setupOpenGL(int w, int h, ofWindowMode screenMode) ;
     static void startAppWithDelegate(std::string appDelegateClassName);
     void update();
     void draw();
@@ -235,10 +236,14 @@ public:
         
     bool isProgrammableRenderer();
     ofxiOSRendererType getGLESVersion();
-    OF_DEPRECATED_MSG("Use ofiOSWindowSettings to setup programmable renderer by selecting glesVerison to >=2", bool enableRendererES2());
-    OF_DEPRECATED_MSG("Use ofiOSWindowSettings to setup  non-programmable renderer by selecting glesVersion Version to 1", bool enableRendererES1());
-    OF_DEPRECATED_MSG("Use isProgrammableRenderer() or getGLESVersion()", bool isRendererES2());
-    OF_DEPRECATED_MSG("Use isProgrammableRenderer() or getGLESVersion()", bool isRendererES1());
+    [[deprecated("Use ofiOSWindowSettings to setup programmable renderer by selecting glesVerison to >=2")]]
+bool enableRendererES2();
+    [[deprecated("Use ofiOSWindowSettings to setup  non-programmable renderer by selecting glesVersion Version to 1")]]
+bool enableRendererES1();
+    [[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
+bool isRendererES2();
+    [[deprecated("Use isProgrammableRenderer() or getGLESVersion()")]]
+bool isRendererES1();
     
     bool enableRetina(float retinaScale=0);
     bool disableRetina();
@@ -276,7 +281,8 @@ protected:
     bool hasExited;
 };
 
-OF_DEPRECATED_MSG("ofAppiPhoneWindow is deprecated, use ofAppiOSWindow instead.", typedef ofAppiOSWindow ofAppiPhoneWindow);
+[[deprecated("ofAppiPhoneWindow is deprecated, use ofAppiOSWindow instead.")]]
+typedef ofAppiOSWindow ofAppiPhoneWindow;
 
 
 

--- a/addons/ofxiOS/src/app/ofxiOSApp.h
+++ b/addons/ofxiOS/src/app/ofxiOSApp.h
@@ -49,5 +49,5 @@ public:
 
 };
 
-[[deprecated("use ofxiOSApp instead.")]]
+[[deprecated("use ofxiOSApp")]]
 typedef ofxiOSApp ofxiPhoneApp;

--- a/addons/ofxiOS/src/app/ofxiOSApp.h
+++ b/addons/ofxiOS/src/app/ofxiOSApp.h
@@ -49,5 +49,5 @@ public:
 
 };
 
-[[deprecated("ofxiPhoneApp is deprecated, use ofxiOSApp instead.")]]
+[[deprecated("use ofxiOSApp instead.")]]
 typedef ofxiOSApp ofxiPhoneApp;

--- a/addons/ofxiOS/src/app/ofxiOSApp.h
+++ b/addons/ofxiOS/src/app/ofxiOSApp.h
@@ -49,5 +49,6 @@ public:
 
 };
 
-OF_DEPRECATED_MSG("ofxiPhoneApp is deprecated, use ofxiOSApp instead.", typedef ofxiOSApp ofxiPhoneApp);
+[[deprecated("ofxiPhoneApp is deprecated, use ofxiOSApp instead.")]]
+typedef ofxiOSApp ofxiPhoneApp;
 

--- a/addons/ofxiOS/src/app/ofxiOSApp.h
+++ b/addons/ofxiOS/src/app/ofxiOSApp.h
@@ -14,8 +14,8 @@
 #include "ofEvents.h"
 
 class ofxiOSApp : public ofBaseApp, public ofxiOSAlertsListener {
-	
 public:
+
 	virtual void setup() {};
 	virtual void update() {};
 	virtual void draw() {};
@@ -51,4 +51,3 @@ public:
 
 [[deprecated("ofxiPhoneApp is deprecated, use ofxiOSApp instead.")]]
 typedef ofxiOSApp ofxiPhoneApp;
-

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -163,9 +163,9 @@ void ofxiOSUnlockGLContext();
 void ofxiOSEnableLoopInThread();
 
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
-[[deprecated("ofxiOSSetOrientation is deprecated, use ofSetOrientation instead.")]]
+[[deprecated("use ofSetOrientation instead.")]]
 void ofxiOSSetOrientation(ofOrientation orientation);
-[[deprecated("ofxiOSGetOrientation is deprecated, use ofGetOrientation instead.")]]
+[[deprecated("use ofGetOrientation instead.")]]
 UIDeviceOrientation ofxiOSGetOrientation();
 #endif
 

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -163,8 +163,10 @@ void ofxiOSUnlockGLContext();
 void ofxiOSEnableLoopInThread();
 
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
-OF_DEPRECATED_MSG("ofxiOSSetOrientation is deprecated, use ofSetOrientation instead.", void ofxiOSSetOrientation(ofOrientation orientation));
-OF_DEPRECATED_MSG("ofxiOSGetOrientation is deprecated, use ofGetOrientation instead.", UIDeviceOrientation ofxiOSGetOrientation());
+[[deprecated("ofxiOSSetOrientation is deprecated, use ofSetOrientation instead.")]]
+void ofxiOSSetOrientation(ofOrientation orientation);
+[[deprecated("ofxiOSGetOrientation is deprecated, use ofGetOrientation instead.")]]
+UIDeviceOrientation ofxiOSGetOrientation();
 #endif
 
 // load an image from the app bundle into a texture

--- a/addons/ofxiOS/src/utils/ofxiOSExtras.h
+++ b/addons/ofxiOS/src/utils/ofxiOSExtras.h
@@ -163,9 +163,9 @@ void ofxiOSUnlockGLContext();
 void ofxiOSEnableLoopInThread();
 
 #if TARGET_OS_IOS || (TARGET_OS_IPHONE && !TARGET_OS_TV)
-[[deprecated("use ofSetOrientation instead.")]]
+[[deprecated("use ofSetOrientation")]]
 void ofxiOSSetOrientation(ofOrientation orientation);
-[[deprecated("use ofGetOrientation instead.")]]
+[[deprecated("use ofGetOrientation")]]
 UIDeviceOrientation ofxiOSGetOrientation();
 #endif
 

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -68,7 +68,7 @@ public:
 	void setMaxChars(int max);
 	
 	std::string getText();
-    [[deprecated("Use getText() instead.")]]
+    [[deprecated("Use getText()")]]
 	std::string getLabelText();
 	bool isKeyboardShowing();
 	

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -68,7 +68,8 @@ public:
 	void setMaxChars(int max);
 	
 	std::string getText();
-    OF_DEPRECATED_MSG("Use getText() instead.", std::string getLabelText());
+    [[deprecated("Use getText() instead.")]]
+std::string getLabelText();
 	bool isKeyboardShowing();
 	
     UITextField * getKeyboardTextField();

--- a/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
+++ b/addons/ofxiOS/src/utils/ofxiOSKeyboard.h
@@ -69,7 +69,7 @@ public:
 	
 	std::string getText();
     [[deprecated("Use getText() instead.")]]
-std::string getLabelText();
+	std::string getLabelText();
 	bool isKeyboardShowing();
 	
     UITextField * getKeyboardTextField();

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -59,10 +59,14 @@ public:
     // deprecated.
     //---------------------------------------
     
-    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.", bool initGrabber(int w, int h));
-    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.", void getDeviceList() const);
-    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels&	getPixelsRef());
-    OF_DEPRECATED_MSG("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels&  getPixelsRef() const);
+    [[deprecated("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.")]]
+bool initGrabber(int w, int h);
+    [[deprecated("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.")]]
+void getDeviceList() const;
+    [[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+ofPixels&	getPixelsRef();
+    [[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+const ofPixels&  getPixelsRef() const;
     
 protected:
     

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -14,66 +14,66 @@ public:
 	ofxiOSVideoGrabber();
 	~ofxiOSVideoGrabber();
 	
-    //---------------------------------------
-    // inherited from ofBaseVideoGrabber
-    //---------------------------------------
-    
+	//---------------------------------------
+	// inherited from ofBaseVideoGrabber
+	//---------------------------------------
+	
 	std::vector<ofVideoDevice> listDevices() const;
-    bool setup(int w, int h);
+	bool setup(int w, int h);
 
 	float getHeight() const;
 	float getWidth() const;
-    
-    ofTexture * getTexturePtr();
-    
-    void setVerbose(bool bTalkToMe);
-    void setDeviceID(int deviceID);
-    void setDesiredFrameRate(int framerate);
-    void videoSettings();
-    
-    //---------------------------------------
-    // inherited from ofBaseVideo
-    //---------------------------------------
-    
-    bool isFrameNew() const;
-    void close();
-    bool isInitialized() const;
-    
-    bool setPixelFormat(ofPixelFormat pixelFormat);
-    ofPixelFormat getPixelFormat() const;
-    
-    //---------------------------------------
-    // inherited from ofBaseHasPixels
-    //---------------------------------------
-    
+	
+	ofTexture * getTexturePtr();
+	
+	void setVerbose(bool bTalkToMe);
+	void setDeviceID(int deviceID);
+	void setDesiredFrameRate(int framerate);
+	void videoSettings();
+	
+	//---------------------------------------
+	// inherited from ofBaseVideo
+	//---------------------------------------
+	
+	bool isFrameNew() const;
+	void close();
+	bool isInitialized() const;
+	
+	bool setPixelFormat(ofPixelFormat pixelFormat);
+	ofPixelFormat getPixelFormat() const;
+	
+	//---------------------------------------
+	// inherited from ofBaseHasPixels
+	//---------------------------------------
+	
 	ofPixels & getPixels();
 	const ofPixels & getPixels() const;
-    
-    //---------------------------------------
-    // inherited from ofBaseUpdates
-    //---------------------------------------
-    
+	
+	//---------------------------------------
+	// inherited from ofBaseUpdates
+	//---------------------------------------
+	
 	void update();
-    
-    //---------------------------------------
-    // deprecated.
-    //---------------------------------------
-    
-    [[deprecated("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.")]]
-bool initGrabber(int w, int h);
-    [[deprecated("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.")]]
-void getDeviceList() const;
-    [[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
-ofPixels&	getPixelsRef();
-    [[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
-const ofPixels&  getPixelsRef() const;
-    
+	
+	//---------------------------------------
+	// deprecated.
+	//---------------------------------------
+	
+	[[deprecated("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.")]]
+	bool initGrabber(int w, int h);
+	[[deprecated("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.")]]
+	void getDeviceList() const;
+	[[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	ofPixels&	getPixelsRef();
+	[[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	const ofPixels&  getPixelsRef() const;
+	
 protected:
-    
-    std::shared_ptr<AVFoundationVideoGrabber> grabber;
-    
-    ofPixels pixels;
-    
+	
+	std::shared_ptr<AVFoundationVideoGrabber> grabber;
+	
+	ofPixels pixels;
+	
 };
 
 #define ofxiPhoneVideoGrabber ofxiOSVideoGrabber

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -59,13 +59,13 @@ public:
 	// deprecated.
 	//---------------------------------------
 	
-	[[deprecated("ofxiOSVideoGrabber::initGrabber(int w, int h) is deprecated, use setup(int w, int h) instead.")]]
+	[[deprecated("use setup(int w, int h) instead.")]]
 	bool initGrabber(int w, int h);
-	[[deprecated("ofxiOSVideoGrabber::getDeviceList() is deprecated, use listDevices() instead.")]]
+	[[deprecated("use listDevices() instead.")]]
 	void getDeviceList() const;
-	[[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	ofPixels&	getPixelsRef();
-	[[deprecated("ofxiOSVideoGrabber::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	const ofPixels&  getPixelsRef() const;
 	
 protected:

--- a/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoGrabber.h
@@ -59,13 +59,13 @@ public:
 	// deprecated.
 	//---------------------------------------
 	
-	[[deprecated("use setup(int w, int h) instead.")]]
+	[[deprecated("use setup(int w, int h)")]]
 	bool initGrabber(int w, int h);
-	[[deprecated("use listDevices() instead.")]]
+	[[deprecated("use listDevices()")]]
 	void getDeviceList() const;
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	ofPixels&	getPixelsRef();
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	const ofPixels&  getPixelsRef() const;
 	
 protected:

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -60,10 +60,14 @@ public:
     
 	void * getAVFoundationVideoPlayer();
     
-    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(std::string name));
-    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels & getPixelsRef());
-    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels & getPixelsRef() const);
-    OF_DEPRECATED_MSG("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.", ofTexture * getTexture());
+    [[deprecated("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.")]]
+bool loadMovie(std::string name);
+    [[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+ofPixels & getPixelsRef();
+    [[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+const ofPixels & getPixelsRef() const;
+    [[deprecated("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+ofTexture * getTexture();
     
 protected:
     

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -60,13 +60,13 @@ public:
 	
 	void * getAVFoundationVideoPlayer();
 	
-	[[deprecated("use load() instead.")]]
+	[[deprecated("use load()")]]
 	bool loadMovie(std::string name);
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	ofPixels & getPixelsRef();
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	const ofPixels & getPixelsRef() const;
-	[[deprecated("use getTexturePtr() instead.")]]
+	[[deprecated("use getTexturePtr()")]]
 	ofTexture * getTexture();
 	
 protected:

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -11,76 +11,76 @@ public:
 	ofxiOSVideoPlayer();
 	~ofxiOSVideoPlayer();
 	   
-    void enableTextureCache();
-    void disableTextureCache();
-    
-    bool load(std::string name);
-    void close();
-    void update();
+	void enableTextureCache();
+	void disableTextureCache();
+	
+	bool load(std::string name);
+	void close();
+	void update();
 	
 	bool setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat getPixelFormat() const;
 	
-    void play();
-    void stop();
+	void play();
+	void stop();
 	
-    bool isFrameNew() const;
-    ofPixels & getPixels();
-    const ofPixels & getPixels() const;
-    ofTexture * getTexturePtr();
-    void initTextureCache();
-    void killTextureCache();
+	bool isFrameNew() const;
+	ofPixels & getPixels();
+	const ofPixels & getPixels() const;
+	ofTexture * getTexturePtr();
+	void initTextureCache();
+	void killTextureCache();
 	
-    float getWidth() const;
-    float getHeight() const;
+	float getWidth() const;
+	float getHeight() const;
 	
-    bool isPaused() const;
-    bool isLoaded() const;
-    bool isPlaying() const;
+	bool isPaused() const;
+	bool isLoaded() const;
+	bool isPlaying() const;
 	
-    float getPosition() const;
-    float getSpeed() const;
-    float getDuration() const;
-    bool getIsMovieDone() const;
+	float getPosition() const;
+	float getSpeed() const;
+	float getDuration() const;
+	bool getIsMovieDone() const;
 	
-    void setPaused(bool bPause);
-    void setPosition(float pct);
-    void setVolume(float volume); // 0..1
-    void setLoopState(ofLoopType state);
-    void setSpeed(float speed);
-    void setFrame(int frame);  // frame 0 = first frame...
+	void setPaused(bool bPause);
+	void setPosition(float pct);
+	void setVolume(float volume); // 0..1
+	void setLoopState(ofLoopType state);
+	void setSpeed(float speed);
+	void setFrame(int frame);  // frame 0 = first frame...
 	
-    int	getCurrentFrame() const;
-    int	getTotalNumFrames() const;
-    ofLoopType	getLoopState() const;
+	int	getCurrentFrame() const;
+	int	getTotalNumFrames() const;
+	ofLoopType	getLoopState() const;
 	
-    void firstFrame();
-    void nextFrame();
-    void previousFrame();
-    
+	void firstFrame();
+	void nextFrame();
+	void previousFrame();
+	
 	void * getAVFoundationVideoPlayer();
-    
-    [[deprecated("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.")]]
-bool loadMovie(std::string name);
-    [[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
-ofPixels & getPixelsRef();
-    [[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
-const ofPixels & getPixelsRef() const;
-    [[deprecated("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
-ofTexture * getTexture();
-    
+	
+	[[deprecated("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.")]]
+	bool loadMovie(std::string name);
+	[[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	ofPixels & getPixelsRef();
+	[[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	const ofPixels & getPixelsRef() const;
+	[[deprecated("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+	ofTexture * getTexture();
+	
 protected:
-    
+	
 	void * videoPlayer; // super hack to forward declare an objective c class inside a header file that can only handle c classes.
 	
-    bool bFrameNew;
-    bool bResetPixels;
-    bool bUpdatePixels;
-    bool bUpdateTexture;
-    bool bTextureCacheSupported;
-    bool bTextureCacheEnabled;
+	bool bFrameNew;
+	bool bResetPixels;
+	bool bUpdatePixels;
+	bool bUpdateTexture;
+	bool bTextureCacheSupported;
+	bool bTextureCacheEnabled;
 	
-    ofPixels pixels;
+	ofPixels pixels;
 	ofPixelFormat pixelFormat;
 	ofTexture videoTexture;
 };

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -60,13 +60,13 @@ public:
 	
 	void * getAVFoundationVideoPlayer();
 	
-	[[deprecated("ofxiOSVideoPlayer::loadMovie() is deprecated, use load() instead.")]]
+	[[deprecated("use load() instead.")]]
 	bool loadMovie(std::string name);
-	[[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	ofPixels & getPixelsRef();
-	[[deprecated("ofxiOSVideoPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	const ofPixels & getPixelsRef() const;
-	[[deprecated("ofxiOSVideoPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+	[[deprecated("use getTexturePtr() instead.")]]
 	ofTexture * getTexture();
 	
 protected:

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -144,19 +144,19 @@ public:
 	// window settings, this functions can only be called from main before calling ofSetupOpenGL
 	// TODO: remove specialized version of ofSetupOpenGL when these go away
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setNumSamples(int samples);
+	void setNumSamples(int samples);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setDoubleBuffering(bool doubleBuff);
+	void setDoubleBuffering(bool doubleBuff);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setColorBits(int r, int g, int b);
+	void setColorBits(int r, int g, int b);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setAlphaBits(int a);
+	void setAlphaBits(int a);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setDepthBits(int depth);
+	void setDepthBits(int depth);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setStencilBits(int stencil);
+	void setStencilBits(int stencil);
 	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
-	 void setMultiDisplayFullscreen(bool bMultiFullscreen); //note this just enables the mode, you have to toggle fullscreen to activate it.
+	void setMultiDisplayFullscreen(bool bMultiFullscreen); //note this just enables the mode, you have to toggle fullscreen to activate it.
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)
 	Display * getX11Display();

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -143,13 +143,20 @@ public:
 
 	// window settings, this functions can only be called from main before calling ofSetupOpenGL
 	// TODO: remove specialized version of ofSetupOpenGL when these go away
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setNumSamples(int samples));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setDoubleBuffering(bool doubleBuff));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setColorBits(int r, int g, int b));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setAlphaBits(int a));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setDepthBits(int depth));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setStencilBits(int stencil));
-	OF_DEPRECATED_MSG("use ofGLFWWindowSettings to create the window instead", void setMultiDisplayFullscreen(bool bMultiFullscreen)); //note this just enables the mode, you have to toggle fullscreen to activate it.
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setNumSamples(int samples);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setDoubleBuffering(bool doubleBuff);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setColorBits(int r, int g, int b);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setAlphaBits(int a);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setDepthBits(int depth);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setStencilBits(int stencil);
+	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	 void setMultiDisplayFullscreen(bool bMultiFullscreen); //note this just enables the mode, you have to toggle fullscreen to activate it.
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)
 	Display * getX11Display();

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -143,19 +143,19 @@ public:
 
 	// window settings, this functions can only be called from main before calling ofSetupOpenGL
 	// TODO: remove specialized version of ofSetupOpenGL when these go away
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setNumSamples(int samples);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setDoubleBuffering(bool doubleBuff);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setColorBits(int r, int g, int b);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setAlphaBits(int a);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setDepthBits(int depth);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setStencilBits(int stencil);
-	[[deprecated("use ofGLFWWindowSettings to create the window instead")]]
+	[[deprecated("use ofGLFWWindowSettings to create the window")]]
 	void setMultiDisplayFullscreen(bool bMultiFullscreen); //note this just enables the mode, you have to toggle fullscreen to activate it.
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -150,7 +150,7 @@ public:
 	/// device 0 - COM2
 	/// device 1 - COM4
 	/// ~~~~
-	[[deprecated("Use listDevices() instead")]]
+	[[deprecated("Use listDevices()")]]
 	void enumerateDevices();
 
 	/// \brief Returns a vector of ofSerialDeviceInfo instances with the

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: deprecated / targets
+// FIXME: ofConstants targets
 #include "ofConstants.h"
 
 class ofBuffer;
@@ -151,7 +151,7 @@ public:
 	/// device 1 - COM4
 	/// ~~~~
 	[[deprecated("Use listDevices() instead")]]
-	 void enumerateDevices();
+	void enumerateDevices();
 
 	/// \brief Returns a vector of ofSerialDeviceInfo instances with the
 	/// devicePath, deviceName, deviceID set.

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -150,7 +150,8 @@ public:
 	/// device 0 - COM2
 	/// device 1 - COM4
 	/// ~~~~
-	OF_DEPRECATED_MSG("Use listDevices() instead", void enumerateDevices());
+	[[deprecated("Use listDevices() instead")]]
+	 void enumerateDevices();
 
 	/// \brief Returns a vector of ofSerialDeviceInfo instances with the
 	/// devicePath, deviceName, deviceID set.

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -61,7 +61,8 @@ public:
 	void allocate(ofFboSettings settings = ofFboSettings(nullptr));
 	bool isAllocated() const;
 
-	OF_DEPRECATED_MSG("Use clear() instead",void destroy());
+	[[deprecated("Use clear() instead")]]
+	void destroy();
 	void clear();
 
 #ifndef TARGET_OPENGLES
@@ -102,13 +103,17 @@ public:
 	void setDefaultTextureIndex(int defaultTexture);
 	int getDefaultTextureIndex() const;
 
-	OF_DEPRECATED_MSG("Use getTexture()",ofTexture & getTextureReference());
-	OF_DEPRECATED_MSG("Use getTexture()",ofTexture & getTextureReference(int attachmentPoint));
+	[[deprecated("Use getTexture()")]]
+	ofTexture & getTextureReference();
+	[[deprecated("Use getTexture()")]]
+	ofTexture & getTextureReference(int attachmentPoint);
 	ofTexture & getTexture();
 	ofTexture & getTexture(int attachmentPoint);
 	ofTexture & getDepthTexture();
-	OF_DEPRECATED_MSG("Use getTexture()",const ofTexture & getTextureReference() const);
-	OF_DEPRECATED_MSG("Use getTexture()",const ofTexture & getTextureReference(int attachmentPoint) const);
+	[[deprecated("Use getTexture()")]]
+	const ofTexture & getTextureReference() const;
+	[[deprecated("Use getTexture()")]]
+	const ofTexture & getTextureReference(int attachmentPoint) const;
 	const ofTexture & getTexture() const ;
 	const ofTexture & getTexture(int attachmentPoint) const;
 	const ofTexture & getDepthTexture() const;
@@ -123,7 +128,8 @@ public:
     ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
 	///           method instead.
     /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-    OF_DEPRECATED_MSG("Use begin(OF_FBOMODE_NODEFAULTS) instead", void begin(bool setupScreen) const);
+    [[deprecated("Use begin(OF_FBOMODE_NODEFAULTS) instead")]]
+	 void begin(bool setupScreen) const;
 
     /// Sets up the framebuffer and binds it for rendering.
     ///
@@ -211,7 +217,8 @@ public:
 	void setActiveDrawBuffers(const std::vector<int>& i);
 	void activateAllDrawBuffers();
 
-	OF_DEPRECATED_MSG("Use getId()", GLuint getFbo() const);
+	[[deprecated("Use getId()")]]
+	 GLuint getFbo() const;
 
 	/// returns id of the underlying GL object for advanced actions
 	GLuint getId() const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -218,7 +218,7 @@ public:
 	void activateAllDrawBuffers();
 
 	[[deprecated("Use getId()")]]
-	 GLuint getFbo() const;
+	GLuint getFbo() const;
 
 	/// returns id of the underlying GL object for advanced actions
 	GLuint getId() const;

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -6,41 +6,41 @@
 
 /// ofFbo mode(s) when binding
 enum ofFboMode : short {
-    OF_FBOMODE_NODEFAULTS  = 0, ///< base GL fbo, no OF defaults
-    OF_FBOMODE_PERSPECTIVE = 1, ///< set OF perspective and viewport
-    OF_FBOMODE_MATRIXFLIP  = 2  ///< flip vertically
+	OF_FBOMODE_NODEFAULTS  = 0, ///< base GL fbo, no OF defaults
+	OF_FBOMODE_PERSPECTIVE = 1, ///< set OF perspective and viewport
+	OF_FBOMODE_MATRIXFLIP  = 2  ///< flip vertically
 };
 
 inline ofFboMode operator | (ofFboMode m1, ofFboMode m2){
-    return static_cast<ofFboMode>(short(m1) | short(m2));
+	return static_cast<ofFboMode>(short(m1) | short(m2));
 }
 
 inline bool operator & (ofFboMode m1, ofFboMode m2){
-    return static_cast<bool>(short(m1) & short(m2));
+	return static_cast<bool>(short(m1) & short(m2));
 }
 
 /// ofFbo internal settings
 struct ofFboSettings {
-    int width;                        ///< width of images attached to fbo
-    int height;                       ///< height of images attached to fbo
-    int numColorbuffers;              ///< how many color buffers to create
-    std::vector<GLint> colorFormats;  ///< format of the color attachments for MRT.
-    bool useDepth;                    ///< whether to use depth buffer or not
-    bool useStencil;                  ///< whether to use stencil buffer or not
-    bool depthStencilAsTexture;       ///< use a texture instead of a renderbuffer for depth (useful to draw it or use it in a shader later)
-    GLenum textureTarget;             ///< GL_TEXTURE_2D or GL_TEXTURE_RECTANGLE_ARB
-    GLint internalformat;             ///< GL_RGBA, GL_RGBA16F_ARB, GL_RGBA32F_ARB, GL_LUMINANCE32F_ARB etc.
-    GLint depthStencilInternalFormat; ///< GL_DEPTH_COMPONENT(16/24/32)
-    int wrapModeHorizontal;           ///< GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
-    int wrapModeVertical;             ///< GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
-    int minFilter;                    ///< GL_NEAREST, GL_LINEAR etc.
-    int maxFilter;                    ///< GL_NEAREST, GL_LINEAR etc.
-    int numSamples;                   ///< number of samples for multisampling (set 0 to disable)
-    ofFboSettings(std::shared_ptr<ofBaseGLRenderer> renderer=nullptr);
-    bool operator!=(const ofFboSettings & other);
+	int width;                        ///< width of images attached to fbo
+	int height;                       ///< height of images attached to fbo
+	int numColorbuffers;              ///< how many color buffers to create
+	std::vector<GLint> colorFormats;  ///< format of the color attachments for MRT.
+	bool useDepth;                    ///< whether to use depth buffer or not
+	bool useStencil;                  ///< whether to use stencil buffer or not
+	bool depthStencilAsTexture;       ///< use a texture instead of a renderbuffer for depth (useful to draw it or use it in a shader later)
+	GLenum textureTarget;             ///< GL_TEXTURE_2D or GL_TEXTURE_RECTANGLE_ARB
+	GLint internalformat;             ///< GL_RGBA, GL_RGBA16F_ARB, GL_RGBA32F_ARB, GL_LUMINANCE32F_ARB etc.
+	GLint depthStencilInternalFormat; ///< GL_DEPTH_COMPONENT(16/24/32)
+	int wrapModeHorizontal;           ///< GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
+	int wrapModeVertical;             ///< GL_REPEAT, GL_MIRRORED_REPEAT, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_BORDER etc.
+	int minFilter;                    ///< GL_NEAREST, GL_LINEAR etc.
+	int maxFilter;                    ///< GL_NEAREST, GL_LINEAR etc.
+	int numSamples;                   ///< number of samples for multisampling (set 0 to disable)
+	ofFboSettings(std::shared_ptr<ofBaseGLRenderer> renderer=nullptr);
+	bool operator!=(const ofFboSettings & other);
 private:
-    std::weak_ptr<ofBaseGLRenderer> renderer;
-    friend class ofFbo;
+	std::weak_ptr<ofBaseGLRenderer> renderer;
+	friend class ofFbo;
 };
 
 class ofFbo : public ofBaseDraws, public ofBaseHasTexture {
@@ -49,8 +49,8 @@ public:
 	ofFbo();
 	ofFbo(const ofFbo & mom);
 	ofFbo & operator=(const ofFbo & fbo);
-    ofFbo(ofFbo && mom);
-    ofFbo & operator=(ofFbo && fbo);
+	ofFbo(ofFbo && mom);
+	ofFbo & operator=(ofFbo && fbo);
 	virtual ~ofFbo();
 
 	/// ofFbo::Settings is currently deprecated in favor of the ofFboSettings struct
@@ -97,7 +97,7 @@ public:
 	void draw(float x, float y, float width, float height) const;
 
 	void setAnchorPercent(float xPct, float yPct);
-    void setAnchorPoint(float x, float y);
+	void setAnchorPoint(float x, float y);
 	void resetAnchor();
 
 	void setDefaultTextureIndex(int defaultTexture);
@@ -120,43 +120,43 @@ public:
 	void setUseTexture(bool){ /*irrelevant*/ };
 	bool isUsingTexture() const {return true;}
 
-    /// Sets up the framebuffer and binds it for rendering.
-    ///
+	/// Sets up the framebuffer and binds it for rendering.
+	///
 	/// \warning  This is a convenience method, and is considered unsafe 
 	///           in multi-window and/or multi-renderer scenarios.
 	///           If you use more than one renderer, use each renderer's
-    ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
+	///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
 	///           method instead.
-    /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-    [[deprecated("Use begin(OF_FBOMODE_NODEFAULTS) instead")]]
-	 void begin(bool setupScreen) const;
+	/// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
+	[[deprecated("Use begin(OF_FBOMODE_NODEFAULTS) instead")]]
+	void begin(bool setupScreen) const;
 
-    /// Sets up the framebuffer and binds it for rendering.
-    ///
-    /// The mode parameter indicates which defaults are set when binding
-    /// the fbo.
-    ///
-    /// The default OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP
-    /// will set the screen perspective to the OF default for the fbo size, the
-    /// correct viewport to cover the full fbo and will flip the orientation
-    /// matrix in y so when drawing the fbo later or accesing it from a shader
-    /// it's correctly oriented
-    ///
-    /// Passing OF_FBOMODE_PERSPECTIVE will only set perspective and viewport
-    ///
-    /// Passing OF_FBOMODE_MATRIXFLIP won't set the perspective but will flip
-    /// the matrix.
-    ///
-    /// Passing OF_FBOMODE_NODEFAULTS won't change anything and just bind the fbo
-    /// and set it as current rendering surface in OF
-    ///
-    /// \warning  This is a convenience method, and is considered unsafe
-    ///           in multi-window and/or multi-renderer scenarios.
-    ///           If you use more than one renderer, use each renderer's
-    ///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-    ///           method instead.
-    /// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-    void begin(ofFboMode mode = OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP) const;
+	/// Sets up the framebuffer and binds it for rendering.
+	///
+	/// The mode parameter indicates which defaults are set when binding
+	/// the fbo.
+	///
+	/// The default OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP
+	/// will set the screen perspective to the OF default for the fbo size, the
+	/// correct viewport to cover the full fbo and will flip the orientation
+	/// matrix in y so when drawing the fbo later or accesing it from a shader
+	/// it's correctly oriented
+	///
+	/// Passing OF_FBOMODE_PERSPECTIVE will only set perspective and viewport
+	///
+	/// Passing OF_FBOMODE_MATRIXFLIP won't set the perspective but will flip
+	/// the matrix.
+	///
+	/// Passing OF_FBOMODE_NODEFAULTS won't change anything and just bind the fbo
+	/// and set it as current rendering surface in OF
+	///
+	/// \warning  This is a convenience method, and is considered unsafe
+	///           in multi-window and/or multi-renderer scenarios.
+	///           If you use more than one renderer, use each renderer's
+	///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
+	///           method instead.
+	/// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
+	void begin(ofFboMode mode = OF_FBOMODE_PERSPECTIVE | OF_FBOMODE_MATRIXFLIP) const;
 
 	/// \brief    Ends the current framebuffer render context.
 	/// \sa       void begin(bool setupScreen=true) const;
@@ -206,7 +206,7 @@ public:
 
 	bool checkStatus() const;
 	void createAndAttachTexture(GLenum internalFormat, GLenum attachmentPoint);
-    void attachTexture(ofTexture & texture, GLenum internalFormat, GLenum attachmentPoint);
+	void attachTexture(ofTexture & texture, GLenum internalFormat, GLenum attachmentPoint);
 	GLuint createAndAttachRenderbuffer(GLenum internalFormat, GLenum attachmentPoint);
 	void createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum attachment );
 	void createAndAttachDepthStencilTexture(GLenum target, GLint internalformat, GLenum attachment, GLenum transferFormat, GLenum transferType );
@@ -272,5 +272,3 @@ private:
 #endif
 
 };
-
-

--- a/libs/openFrameworks/gl/ofFbo.h
+++ b/libs/openFrameworks/gl/ofFbo.h
@@ -61,7 +61,7 @@ public:
 	void allocate(ofFboSettings settings = ofFboSettings(nullptr));
 	bool isAllocated() const;
 
-	[[deprecated("Use clear() instead")]]
+	[[deprecated("Use clear()")]]
 	void destroy();
 	void clear();
 
@@ -128,7 +128,7 @@ public:
 	///           explicit void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
 	///           method instead.
 	/// \sa       void ofBaseGLRenderer::begin(const ofFbo & fbo, ofFboMode mode)
-	[[deprecated("Use begin(OF_FBOMODE_NODEFAULTS) instead")]]
+	[[deprecated("Use begin(OF_FBOMODE_NODEFAULTS)")]]
 	void begin(bool setupScreen) const;
 
 	/// Sets up the framebuffer and binds it for rendering.

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -31,11 +31,11 @@ int ofGetGLInternalFormat(const ofShortPixels & pixels);
 int ofGetGLInternalFormat(const ofFloatPixels & pixels);
 
 [[deprecated("Use ofGetGLInternalFormat() instead")]]
-	 int ofGetGlInternalFormat(const ofPixels & pixels);
+int ofGetGlInternalFormat(const ofPixels & pixels);
 [[deprecated("Use ofGetGLInternalFormat() instead")]]
-	 int ofGetGlInternalFormat(const ofShortPixels & pixels);
+int ofGetGlInternalFormat(const ofShortPixels & pixels);
 [[deprecated("Use ofGetGLInternalFormat() instead")]]
-	 int ofGetGlInternalFormat(const ofFloatPixels & pixels);
+int ofGetGlInternalFormat(const ofFloatPixels & pixels);
 
 //---------------------------------
 // this is helpful for debugging ofTexture
@@ -45,9 +45,9 @@ int ofGetGLFormatFromInternal(int gInternalFormat);
 int ofGetGLTypeFromInternal(int glInternalFormat);
 
 [[deprecated("Use ofGetGLInternalFormatName() instead")]]
-	 std::string ofGetGlInternalFormatName(int glInternalFormat);
+std::string ofGetGlInternalFormatName(int glInternalFormat);
 [[deprecated("Use ofGetGLTypeFromInternal() instead")]]
-	 int ofGetGlTypeFromInternal(int glInternalFormat);
+int ofGetGlTypeFromInternal(int glInternalFormat);
 
 std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer();
 
@@ -56,11 +56,11 @@ int ofGetGLType(const ofShortPixels & pixels);
 int ofGetGLType(const ofFloatPixels & pixels);
 
 [[deprecated("Use ofGetGLType() instead")]]
-	 int ofGetGlType(const ofPixels & pixels);
+int ofGetGlType(const ofPixels & pixels);
 [[deprecated("Use ofGetGLType() instead")]]
-	 int ofGetGlType(const ofShortPixels & pixels);
+int ofGetGlType(const ofShortPixels & pixels);
 [[deprecated("Use ofGetGLType() instead")]]
-	 int ofGetGlType(const ofFloatPixels & pixels);
+int ofGetGlType(const ofFloatPixels & pixels);
 
 ofImageType ofGetImageTypeFromGLType(int glType);
 
@@ -85,7 +85,7 @@ bool ofIsGLProgrammableRenderer();
 
 template<class T>
 [[deprecated("Use ofGetGLFormat() instead")]]
-	 int ofGetGlFormat(const ofPixels_<T> & pixels);
+int ofGetGlFormat(const ofPixels_<T> & pixels);
 
 template<class T>
 int ofGetGlFormat(const ofPixels_<T> & pixels) {

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -30,9 +30,12 @@ int ofGetGLInternalFormat(const ofPixels & pixels);
 int ofGetGLInternalFormat(const ofShortPixels & pixels);
 int ofGetGLInternalFormat(const ofFloatPixels & pixels);
 
-OF_DEPRECATED_MSG("Use ofGetGLInternalFormat() instead", int ofGetGlInternalFormat(const ofPixels & pixels));
-OF_DEPRECATED_MSG("Use ofGetGLInternalFormat() instead", int ofGetGlInternalFormat(const ofShortPixels & pixels));
-OF_DEPRECATED_MSG("Use ofGetGLInternalFormat() instead", int ofGetGlInternalFormat(const ofFloatPixels & pixels));
+[[deprecated("Use ofGetGLInternalFormat() instead")]]
+	 int ofGetGlInternalFormat(const ofPixels & pixels);
+[[deprecated("Use ofGetGLInternalFormat() instead")]]
+	 int ofGetGlInternalFormat(const ofShortPixels & pixels);
+[[deprecated("Use ofGetGLInternalFormat() instead")]]
+	 int ofGetGlInternalFormat(const ofFloatPixels & pixels);
 
 //---------------------------------
 // this is helpful for debugging ofTexture
@@ -41,8 +44,10 @@ std::string ofGetGLInternalFormatName(int glInternalFormat);
 int ofGetGLFormatFromInternal(int gInternalFormat);
 int ofGetGLTypeFromInternal(int glInternalFormat);
 
-OF_DEPRECATED_MSG("Use ofGetGLInternalFormatName() instead", std::string ofGetGlInternalFormatName(int glInternalFormat));
-OF_DEPRECATED_MSG("Use ofGetGLTypeFromInternal() instead", int ofGetGlTypeFromInternal(int glInternalFormat));
+[[deprecated("Use ofGetGLInternalFormatName() instead")]]
+	 std::string ofGetGlInternalFormatName(int glInternalFormat);
+[[deprecated("Use ofGetGLTypeFromInternal() instead")]]
+	 int ofGetGlTypeFromInternal(int glInternalFormat);
 
 std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer();
 
@@ -50,9 +55,12 @@ int ofGetGLType(const ofPixels & pixels);
 int ofGetGLType(const ofShortPixels & pixels);
 int ofGetGLType(const ofFloatPixels & pixels);
 
-OF_DEPRECATED_MSG("Use ofGetGLType() instead", int ofGetGlType(const ofPixels & pixels));
-OF_DEPRECATED_MSG("Use ofGetGLType() instead", int ofGetGlType(const ofShortPixels & pixels));
-OF_DEPRECATED_MSG("Use ofGetGLType() instead", int ofGetGlType(const ofFloatPixels & pixels));
+[[deprecated("Use ofGetGLType() instead")]]
+	 int ofGetGlType(const ofPixels & pixels);
+[[deprecated("Use ofGetGLType() instead")]]
+	 int ofGetGlType(const ofShortPixels & pixels);
+[[deprecated("Use ofGetGLType() instead")]]
+	 int ofGetGlType(const ofFloatPixels & pixels);
 
 ofImageType ofGetImageTypeFromGLType(int glType);
 
@@ -76,7 +84,8 @@ bool ofGLSupportsNPOTTextures();
 bool ofIsGLProgrammableRenderer();
 
 template<class T>
-OF_DEPRECATED_MSG("Use ofGetGLFormat() instead", int ofGetGlFormat(const ofPixels_<T> & pixels));
+[[deprecated("Use ofGetGLFormat() instead")]]
+	 int ofGetGlFormat(const ofPixels_<T> & pixels);
 
 template<class T>
 int ofGetGlFormat(const ofPixels_<T> & pixels) {

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -30,11 +30,11 @@ int ofGetGLInternalFormat(const ofPixels & pixels);
 int ofGetGLInternalFormat(const ofShortPixels & pixels);
 int ofGetGLInternalFormat(const ofFloatPixels & pixels);
 
-[[deprecated("Use ofGetGLInternalFormat() instead")]]
+[[deprecated("Use ofGetGLInternalFormat()")]]
 int ofGetGlInternalFormat(const ofPixels & pixels);
-[[deprecated("Use ofGetGLInternalFormat() instead")]]
+[[deprecated("Use ofGetGLInternalFormat()")]]
 int ofGetGlInternalFormat(const ofShortPixels & pixels);
-[[deprecated("Use ofGetGLInternalFormat() instead")]]
+[[deprecated("Use ofGetGLInternalFormat()")]]
 int ofGetGlInternalFormat(const ofFloatPixels & pixels);
 
 //---------------------------------
@@ -44,9 +44,9 @@ std::string ofGetGLInternalFormatName(int glInternalFormat);
 int ofGetGLFormatFromInternal(int gInternalFormat);
 int ofGetGLTypeFromInternal(int glInternalFormat);
 
-[[deprecated("Use ofGetGLInternalFormatName() instead")]]
+[[deprecated("Use ofGetGLInternalFormatName()")]]
 std::string ofGetGlInternalFormatName(int glInternalFormat);
-[[deprecated("Use ofGetGLTypeFromInternal() instead")]]
+[[deprecated("Use ofGetGLTypeFromInternal()")]]
 int ofGetGlTypeFromInternal(int glInternalFormat);
 
 std::shared_ptr<ofBaseGLRenderer> ofGetGLRenderer();
@@ -55,11 +55,11 @@ int ofGetGLType(const ofPixels & pixels);
 int ofGetGLType(const ofShortPixels & pixels);
 int ofGetGLType(const ofFloatPixels & pixels);
 
-[[deprecated("Use ofGetGLType() instead")]]
+[[deprecated("Use ofGetGLType()")]]
 int ofGetGlType(const ofPixels & pixels);
-[[deprecated("Use ofGetGLType() instead")]]
+[[deprecated("Use ofGetGLType()")]]
 int ofGetGlType(const ofShortPixels & pixels);
-[[deprecated("Use ofGetGLType() instead")]]
+[[deprecated("Use ofGetGLType()")]]
 int ofGetGlType(const ofFloatPixels & pixels);
 
 ofImageType ofGetImageTypeFromGLType(int glType);
@@ -84,7 +84,7 @@ bool ofGLSupportsNPOTTextures();
 bool ofIsGLProgrammableRenderer();
 
 template<class T>
-[[deprecated("Use ofGetGLFormat() instead")]]
+[[deprecated("Use ofGetGLFormat()")]]
 int ofGetGlFormat(const ofPixels_<T> & pixels);
 
 template<class T>

--- a/libs/openFrameworks/gl/ofMaterial.h
+++ b/libs/openFrameworks/gl/ofMaterial.h
@@ -343,12 +343,12 @@ public:
 	float getNormalGeomToNormalMapMix() const;
 
 	typedef ofMaterialSettings Data;
-	[[deprecated("Use getSettings() instead")]]
+	[[deprecated("Use getSettings()")]]
 	Data getData() const;
 	ofMaterialSettings getSettings() const;
 
 	/// \brief set the material color properties data struct
-	[[deprecated("Use setup(settings) instead")]]
+	[[deprecated("Use setup(settings)")]]
 	void setData(const ofMaterial::Data & data);
 
 	// documented in ofBaseMaterial

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -7,8 +7,10 @@
  make sure to catch and report that error.
  */
 
-// FIXME: Targets CTOR
+// FIXME: ofConstants Targets
 #include "ofConstants.h"
+
+#define GLM_FORCE_CTOR_INIT
 #include "glm/fwd.hpp"
 #include <unordered_map>
 

--- a/libs/openFrameworks/gl/ofShadow.cpp
+++ b/libs/openFrameworks/gl/ofShadow.cpp
@@ -11,7 +11,7 @@
 #include "ofGLUtils.h"
 #include "ofLight.h"
 #include "ofGLProgrammableRenderer.h"
-// FIXME: Targets
+// FIXME: ofConstants Targets
 #include "ofConstants.h"
 
 #define GLM_FORCE_CTOR_INIT

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -99,7 +99,8 @@ void ofDisableNormalizedTexCoords();
 ///
 /// \param wrapS wrap parameter for texture coordinate s.
 /// \param wrapT wrap parameter for texture coordinate t.
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP_TO_EDGE));
+[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+	void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP_TO_EDGE);
 
 /// \brief Check whether OF is using custom global texture wrapping.
 ///
@@ -107,7 +108,8 @@ OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",void 
 ///
 /// \sa ofSetTextureWrap()
 /// \returns true if OF is currently using custom global texture wrapping. 
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",bool ofGetUsingCustomTextureWrap());
+[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+	bool ofGetUsingCustomTextureWrap();
 
 /// \brief Removes global custom texture wrapping.
 ///
@@ -116,7 +118,8 @@ OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",bool 
 /// \warning Deprecated. Use member methods instead.
 ///
 /// \sa ofSetTextureWrap()
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",void ofRestoreTextureWrap());
+[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+	void ofRestoreTextureWrap();
 
 /// \brief Set custom global texture minification/magnification scaling filters.
 ///
@@ -128,18 +131,21 @@ OF_DEPRECATED_MSG("Use member method ofTexture::setTextureWrap() instead.",void 
 /// \sa ofTexture::setTextureMinMagFilter()
 /// \param minFilter minifying filter for scaling a pixel to a smaller area.
 /// \param magFilter magnifying filter for scaling a pixel to a larger area.
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureMinMagFilter() instead.",void ofSetMinMagFilters(GLfloat minFilter = GL_LINEAR, GLfloat magFilter = GL_LINEAR));
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+	void ofSetMinMagFilters(GLfloat minFilter = GL_LINEAR, GLfloat magFilter = GL_LINEAR);
 
 /// \brief Check whether OF is using custom global texture scaling filters.
 /// \returns true if OF is currently using custom texture scaling filters.
 /// \warning Deprecated. Use member methods instead.
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureMinMagFilter() instead.",bool ofGetUsingCustomMinMagFilters());
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+	bool ofGetUsingCustomMinMagFilters();
 
 /// \brief Removes global custom texture wrapping.
 ///
 /// Restores individual ofTexture min mag filter settings.
 /// \warning Deprecated. Use member methods instead.
-OF_DEPRECATED_MSG("Use member method ofTexture::setTextureMinMagFilter() instead.",void ofRestoreMinMagFilters());
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+	void ofRestoreMinMagFilters();
 
 /// \brief Texture compression types.
 ///
@@ -423,7 +429,8 @@ class ofTexture : public ofBaseDraws {
 	/// Legacy function for backwards compatibility.
 	///
 	/// \returns true if the texture has been allocated.
-	OF_DEPRECATED_MSG("Use isAllocated instead",bool bAllocated() const);
+	[[deprecated("Use isAllocated instead")]]
+	bool bAllocated() const;
 
 	/// \brief Destroy an ofTexture instance.
 	///

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -100,7 +100,7 @@ void ofDisableNormalizedTexCoords();
 /// \param wrapS wrap parameter for texture coordinate s.
 /// \param wrapT wrap parameter for texture coordinate t.
 [[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
-	void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP_TO_EDGE);
+void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP_TO_EDGE);
 
 /// \brief Check whether OF is using custom global texture wrapping.
 ///
@@ -109,7 +109,7 @@ void ofDisableNormalizedTexCoords();
 /// \sa ofSetTextureWrap()
 /// \returns true if OF is currently using custom global texture wrapping. 
 [[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
-	bool ofGetUsingCustomTextureWrap();
+bool ofGetUsingCustomTextureWrap();
 
 /// \brief Removes global custom texture wrapping.
 ///
@@ -119,7 +119,7 @@ void ofDisableNormalizedTexCoords();
 ///
 /// \sa ofSetTextureWrap()
 [[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
-	void ofRestoreTextureWrap();
+void ofRestoreTextureWrap();
 
 /// \brief Set custom global texture minification/magnification scaling filters.
 ///
@@ -132,20 +132,20 @@ void ofDisableNormalizedTexCoords();
 /// \param minFilter minifying filter for scaling a pixel to a smaller area.
 /// \param magFilter magnifying filter for scaling a pixel to a larger area.
 [[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
-	void ofSetMinMagFilters(GLfloat minFilter = GL_LINEAR, GLfloat magFilter = GL_LINEAR);
+void ofSetMinMagFilters(GLfloat minFilter = GL_LINEAR, GLfloat magFilter = GL_LINEAR);
 
 /// \brief Check whether OF is using custom global texture scaling filters.
 /// \returns true if OF is currently using custom texture scaling filters.
 /// \warning Deprecated. Use member methods instead.
 [[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
-	bool ofGetUsingCustomMinMagFilters();
+bool ofGetUsingCustomMinMagFilters();
 
 /// \brief Removes global custom texture wrapping.
 ///
 /// Restores individual ofTexture min mag filter settings.
 /// \warning Deprecated. Use member methods instead.
 [[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
-	void ofRestoreMinMagFilters();
+void ofRestoreMinMagFilters();
 
 /// \brief Texture compression types.
 ///

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -99,7 +99,7 @@ void ofDisableNormalizedTexCoords();
 ///
 /// \param wrapS wrap parameter for texture coordinate s.
 /// \param wrapT wrap parameter for texture coordinate t.
-[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureWrap()")]]
 void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP_TO_EDGE);
 
 /// \brief Check whether OF is using custom global texture wrapping.
@@ -108,7 +108,7 @@ void ofSetTextureWrap(GLfloat wrapS = GL_CLAMP_TO_EDGE, GLfloat wrapT = GL_CLAMP
 ///
 /// \sa ofSetTextureWrap()
 /// \returns true if OF is currently using custom global texture wrapping. 
-[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureWrap()")]]
 bool ofGetUsingCustomTextureWrap();
 
 /// \brief Removes global custom texture wrapping.
@@ -118,7 +118,7 @@ bool ofGetUsingCustomTextureWrap();
 /// \warning Deprecated. Use member methods instead.
 ///
 /// \sa ofSetTextureWrap()
-[[deprecated("Use member method ofTexture::setTextureWrap() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureWrap()")]]
 void ofRestoreTextureWrap();
 
 /// \brief Set custom global texture minification/magnification scaling filters.
@@ -131,20 +131,20 @@ void ofRestoreTextureWrap();
 /// \sa ofTexture::setTextureMinMagFilter()
 /// \param minFilter minifying filter for scaling a pixel to a smaller area.
 /// \param magFilter magnifying filter for scaling a pixel to a larger area.
-[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter()")]]
 void ofSetMinMagFilters(GLfloat minFilter = GL_LINEAR, GLfloat magFilter = GL_LINEAR);
 
 /// \brief Check whether OF is using custom global texture scaling filters.
 /// \returns true if OF is currently using custom texture scaling filters.
 /// \warning Deprecated. Use member methods instead.
-[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter()")]]
 bool ofGetUsingCustomMinMagFilters();
 
 /// \brief Removes global custom texture wrapping.
 ///
 /// Restores individual ofTexture min mag filter settings.
 /// \warning Deprecated. Use member methods instead.
-[[deprecated("Use member method ofTexture::setTextureMinMagFilter() instead.")]]
+[[deprecated("Use member method ofTexture::setTextureMinMagFilter()")]]
 void ofRestoreMinMagFilters();
 
 /// \brief Texture compression types.

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -429,7 +429,7 @@ class ofTexture : public ofBaseDraws {
 	/// Legacy function for backwards compatibility.
 	///
 	/// \returns true if the texture has been allocated.
-	[[deprecated("Use isAllocated instead")]]
+	[[deprecated("Use isAllocated")]]
 	bool bAllocated() const;
 
 	/// \brief Destroy an ofTexture instance.

--- a/libs/openFrameworks/graphics/of3dGraphics.h
+++ b/libs/openFrameworks/graphics/of3dGraphics.h
@@ -122,13 +122,13 @@ void ofDrawSphere(const glm::vec3& position, float radius);
 void ofDrawSphere(float radius);
 
 [[deprecated("Use ofDrawSphere instead.")]]
-	 void ofSphere(float x, float y, float radius) ;
+void ofSphere(float x, float y, float radius) ;
 [[deprecated("Use ofDrawSphere instead.")]]
-	 void ofSphere(float x, float y, float z, float radius) ;
+void ofSphere(float x, float y, float z, float radius) ;
 [[deprecated("Use ofDrawSphere instead.")]]
-	 void ofSphere(const glm::vec3& position, float radius) ;
+void ofSphere(const glm::vec3& position, float radius) ;
 [[deprecated("Use ofDrawSphere instead.")]]
-	 void ofSphere(float radius) ;
+void ofSphere(float radius) ;
 
 /// \brief Set the icosphere resolution for the current renderer.
 ///
@@ -329,13 +329,13 @@ void ofDrawCone(const glm::vec3& position, float radius, float height);
 void ofDrawCone(float radius, float height);
 
 [[deprecated("Use ofDrawCone instead.")]]
-	 void ofCone(float x, float y, float z, float radius, float height) ;
+void ofCone(float x, float y, float z, float radius, float height) ;
 [[deprecated("Use ofDrawCone instead.")]]
-	 void ofCone(float x, float y, float radius, float height) ;
+void ofCone(float x, float y, float radius, float height) ;
 [[deprecated("Use ofDrawCone instead.")]]
-	 void ofCone(const glm::vec3& position, float radius, float height) ;
+void ofCone(const glm::vec3& position, float radius, float height) ;
 [[deprecated("Use ofDrawCone instead.")]]
-	 void ofCone(float radius, float height) ;
+void ofCone(float radius, float height) ;
 
 /// \section Boxes
 
@@ -444,17 +444,17 @@ void ofDrawBox( float width, float height, float depth );
 
 // deprecated methods //
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox( float x, float y, float z, float width, float height, float depth) ;
+void ofBox( float x, float y, float z, float width, float height, float depth) ;
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox(float x, float y, float z, float size) ;
+void ofBox(float x, float y, float z, float size) ;
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox(const glm::vec3& position, float width, float height, float depth) ;
+void ofBox(const glm::vec3& position, float width, float height, float depth) ;
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox(const glm::vec3& position, float size) ;
+void ofBox(const glm::vec3& position, float size) ;
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox(float size) ;
+void ofBox(float size) ;
 [[deprecated("Use ofDrawBox instead.")]]
-	 void ofBox( float width, float height, float depth ) ;
+void ofBox( float width, float height, float depth ) ;
 
 class of3dGraphics{
 public:

--- a/libs/openFrameworks/graphics/of3dGraphics.h
+++ b/libs/openFrameworks/graphics/of3dGraphics.h
@@ -121,13 +121,13 @@ void ofDrawSphere(const glm::vec3& position, float radius);
 /// \param radius The radius of the sphere.
 void ofDrawSphere(float radius);
 
-[[deprecated("Use ofDrawSphere instead.")]]
+[[deprecated("Use ofDrawSphere")]]
 void ofSphere(float x, float y, float radius) ;
-[[deprecated("Use ofDrawSphere instead.")]]
+[[deprecated("Use ofDrawSphere")]]
 void ofSphere(float x, float y, float z, float radius) ;
-[[deprecated("Use ofDrawSphere instead.")]]
+[[deprecated("Use ofDrawSphere")]]
 void ofSphere(const glm::vec3& position, float radius) ;
-[[deprecated("Use ofDrawSphere instead.")]]
+[[deprecated("Use ofDrawSphere")]]
 void ofSphere(float radius) ;
 
 /// \brief Set the icosphere resolution for the current renderer.
@@ -328,13 +328,13 @@ void ofDrawCone(const glm::vec3& position, float radius, float height);
 /// \param height The height to use when drawing this cone.
 void ofDrawCone(float radius, float height);
 
-[[deprecated("Use ofDrawCone instead.")]]
+[[deprecated("Use ofDrawCone")]]
 void ofCone(float x, float y, float z, float radius, float height) ;
-[[deprecated("Use ofDrawCone instead.")]]
+[[deprecated("Use ofDrawCone")]]
 void ofCone(float x, float y, float radius, float height) ;
-[[deprecated("Use ofDrawCone instead.")]]
+[[deprecated("Use ofDrawCone")]]
 void ofCone(const glm::vec3& position, float radius, float height) ;
-[[deprecated("Use ofDrawCone instead.")]]
+[[deprecated("Use ofDrawCone")]]
 void ofCone(float radius, float height) ;
 
 /// \section Boxes
@@ -443,17 +443,17 @@ void ofDrawBox(float size);
 void ofDrawBox( float width, float height, float depth );
 
 // deprecated methods //
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox( float x, float y, float z, float width, float height, float depth) ;
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox(float x, float y, float z, float size) ;
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox(const glm::vec3& position, float width, float height, float depth) ;
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox(const glm::vec3& position, float size) ;
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox(float size) ;
-[[deprecated("Use ofDrawBox instead.")]]
+[[deprecated("Use ofDrawBox")]]
 void ofBox( float width, float height, float depth ) ;
 
 class of3dGraphics{

--- a/libs/openFrameworks/graphics/of3dGraphics.h
+++ b/libs/openFrameworks/graphics/of3dGraphics.h
@@ -121,10 +121,14 @@ void ofDrawSphere(const glm::vec3& position, float radius);
 /// \param radius The radius of the sphere.
 void ofDrawSphere(float radius);
 
-OF_DEPRECATED_MSG("Use ofDrawSphere instead.", void ofSphere(float x, float y, float radius) );
-OF_DEPRECATED_MSG("Use ofDrawSphere instead.", void ofSphere(float x, float y, float z, float radius) );
-OF_DEPRECATED_MSG("Use ofDrawSphere instead.", void ofSphere(const glm::vec3& position, float radius) );
-OF_DEPRECATED_MSG("Use ofDrawSphere instead.", void ofSphere(float radius) );
+[[deprecated("Use ofDrawSphere instead.")]]
+	 void ofSphere(float x, float y, float radius) ;
+[[deprecated("Use ofDrawSphere instead.")]]
+	 void ofSphere(float x, float y, float z, float radius) ;
+[[deprecated("Use ofDrawSphere instead.")]]
+	 void ofSphere(const glm::vec3& position, float radius) ;
+[[deprecated("Use ofDrawSphere instead.")]]
+	 void ofSphere(float radius) ;
 
 /// \brief Set the icosphere resolution for the current renderer.
 ///
@@ -324,10 +328,14 @@ void ofDrawCone(const glm::vec3& position, float radius, float height);
 /// \param height The height to use when drawing this cone.
 void ofDrawCone(float radius, float height);
 
-OF_DEPRECATED_MSG("Use ofDrawCone instead.", void ofCone(float x, float y, float z, float radius, float height) );
-OF_DEPRECATED_MSG("Use ofDrawCone instead.", void ofCone(float x, float y, float radius, float height) );
-OF_DEPRECATED_MSG("Use ofDrawCone instead.", void ofCone(const glm::vec3& position, float radius, float height) );
-OF_DEPRECATED_MSG("Use ofDrawCone instead.", void ofCone(float radius, float height) );
+[[deprecated("Use ofDrawCone instead.")]]
+	 void ofCone(float x, float y, float z, float radius, float height) ;
+[[deprecated("Use ofDrawCone instead.")]]
+	 void ofCone(float x, float y, float radius, float height) ;
+[[deprecated("Use ofDrawCone instead.")]]
+	 void ofCone(const glm::vec3& position, float radius, float height) ;
+[[deprecated("Use ofDrawCone instead.")]]
+	 void ofCone(float radius, float height) ;
 
 /// \section Boxes
 
@@ -435,12 +443,18 @@ void ofDrawBox(float size);
 void ofDrawBox( float width, float height, float depth );
 
 // deprecated methods //
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox( float x, float y, float z, float width, float height, float depth) );
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox(float x, float y, float z, float size) );
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox(const glm::vec3& position, float width, float height, float depth) );
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox(const glm::vec3& position, float size) );
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox(float size) );
-OF_DEPRECATED_MSG("Use ofDrawBox instead.", void ofBox( float width, float height, float depth ) );
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox( float x, float y, float z, float width, float height, float depth) ;
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox(float x, float y, float z, float size) ;
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox(const glm::vec3& position, float width, float height, float depth) ;
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox(const glm::vec3& position, float size) ;
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox(float size) ;
+[[deprecated("Use ofDrawBox instead.")]]
+	 void ofBox( float width, float height, float depth ) ;
 
 class of3dGraphics{
 public:

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -105,7 +105,8 @@ ofFillFlag ofGetFill();
 
 /// \brief Returns the current background color as an ofColor.
 ofFloatColor ofGetBackgroundColor();
-OF_DEPRECATED_MSG("Use ofGetBackgroundColor instead", ofFloatColor ofGetBackground());
+[[deprecated("Use ofGetBackgroundColor instead")]]
+	 ofFloatColor ofGetBackground();
 
 /// \brief Sets the background color.
 ///
@@ -271,7 +272,8 @@ void ofClear(float r, float g, float b);
 /// }
 /// ~~~~
 void ofClear(float brightness, float a);
-OF_DEPRECATED_MSG("Use ofClear(brightness, alpha) instead", void ofClear(float brightness));
+[[deprecated("Use ofClear(brightness, alpha) instead")]]
+	 void ofClear(float brightness);
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with
 /// an ofColor.
@@ -293,7 +295,8 @@ void ofClearFloat(float brightness, float a);
 void ofClearFloat(const ofFloatColor & c);
 
 // OF's access to settings (bgAuto, origin, corner mode):
-OF_DEPRECATED_MSG("Use ofGetBackgroundAuto instead", bool ofbClearBg());
+[[deprecated("Use ofGetBackgroundAuto instead")]]
+	 bool ofbClearBg();
 
 /// \}
 /// \name 2D Primitives Drawing
@@ -499,43 +502,70 @@ void ofDrawCurve(float x0, float y0, float z0, float x1, float y1, float z1, flo
 void ofDrawBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 void ofDrawBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
-OF_DEPRECATED_MSG("Use ofDrawTriangle instead", void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3));
-OF_DEPRECATED_MSG("Use ofDrawTriangle instead", void ofTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3));
-OF_DEPRECATED_MSG("Use ofDrawTriangle instead", void ofTriangle(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3 & p3));
+[[deprecated("Use ofDrawTriangle instead")]]
+	 void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
+[[deprecated("Use ofDrawTriangle instead")]]
+	 void ofTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
+[[deprecated("Use ofDrawTriangle instead")]]
+	 void ofTriangle(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3 & p3);
 
-OF_DEPRECATED_MSG("Use ofDrawCircle instead", void ofCircle(float x, float y, float radius));
-OF_DEPRECATED_MSG("Use ofDrawCircle instead", void ofCircle(float x, float y, float z, float radius));
-OF_DEPRECATED_MSG("Use ofDrawCircle instead", void ofCircle(const glm::vec3 & p, float radius));
+[[deprecated("Use ofDrawCircle instead")]]
+	 void ofCircle(float x, float y, float radius);
+[[deprecated("Use ofDrawCircle instead")]]
+	 void ofCircle(float x, float y, float z, float radius);
+[[deprecated("Use ofDrawCircle instead")]]
+	 void ofCircle(const glm::vec3 & p, float radius);
 
-OF_DEPRECATED_MSG("Use ofDrawEllipse instead", void ofEllipse(float x, float y, float width, float height));
-OF_DEPRECATED_MSG("Use ofDrawEllipse instead", void ofEllipse(float x, float y, float z, float width, float height));
-OF_DEPRECATED_MSG("Use ofDrawEllipse instead", void ofEllipse(const glm::vec3 & p, float width, float height));
+[[deprecated("Use ofDrawEllipse instead")]]
+	 void ofEllipse(float x, float y, float width, float height);
+[[deprecated("Use ofDrawEllipse instead")]]
+	 void ofEllipse(float x, float y, float z, float width, float height);
+[[deprecated("Use ofDrawEllipse instead")]]
+	 void ofEllipse(const glm::vec3 & p, float width, float height);
 
-OF_DEPRECATED_MSG("Use ofDrawLine instead", void ofLine(float x1, float y1, float x2, float y2));
-OF_DEPRECATED_MSG("Use ofDrawLine instead", void ofLine(float x1, float y1, float z1, float x2, float y2, float z2));
-OF_DEPRECATED_MSG("Use ofDrawLine instead", void ofLine(const glm::vec3 & p1, const glm::vec3 & p2));
+[[deprecated("Use ofDrawLine instead")]]
+	 void ofLine(float x1, float y1, float x2, float y2);
+[[deprecated("Use ofDrawLine instead")]]
+	 void ofLine(float x1, float y1, float z1, float x2, float y2, float z2);
+[[deprecated("Use ofDrawLine instead")]]
+	 void ofLine(const glm::vec3 & p1, const glm::vec3 & p2);
 
-OF_DEPRECATED_MSG("Use ofDrawRectangle instead", void ofRect(float x1, float y1, float w, float h));
-OF_DEPRECATED_MSG("Use ofDrawRectangle instead", void ofRect(const ofRectangle & r));
-OF_DEPRECATED_MSG("Use ofDrawRectangle instead", void ofRect(const glm::vec3 & p, float w, float h));
-OF_DEPRECATED_MSG("Use ofDrawRectangle instead", void ofRect(float x, float y, float z, float w, float h));
+[[deprecated("Use ofDrawRectangle instead")]]
+	 void ofRect(float x1, float y1, float w, float h);
+[[deprecated("Use ofDrawRectangle instead")]]
+	 void ofRect(const ofRectangle & r);
+[[deprecated("Use ofDrawRectangle instead")]]
+	 void ofRect(const glm::vec3 & p, float w, float h);
+[[deprecated("Use ofDrawRectangle instead")]]
+	 void ofRect(float x, float y, float z, float w, float h);
 
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(const ofRectangle & b, float r));
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(const glm::vec3 & p, float w, float h, float r));
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(float x, float y, float w, float h, float r));
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(float x, float y, float z, float w, float h, float r));
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(const ofRectangle & b, float r);
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(const glm::vec3 & p, float w, float h, float r);
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(float x, float y, float w, float h, float r);
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(float x, float y, float z, float w, float h, float r);
 
 //----------------------------------------------------------
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(const glm::vec3 & p, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius));
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(const glm::vec3 & p, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(const ofRectangle & b, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius));
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(const ofRectangle & b, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-OF_DEPRECATED_MSG("Use ofDrawRectRounded instead", void ofRectRounded(float x, float y, float z, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius));
+[[deprecated("Use ofDrawRectRounded instead")]]
+	 void ofRectRounded(float x, float y, float z, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-OF_DEPRECATED_MSG("Use ofDrawCurve instead", void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3));
-OF_DEPRECATED_MSG("Use ofDrawCurve instead", void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3));
-OF_DEPRECATED_MSG("Use ofDrawBezier instead", void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3));
-OF_DEPRECATED_MSG("Use ofDrawBezier instead", void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3));
+[[deprecated("Use ofDrawCurve instead")]]
+	 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+[[deprecated("Use ofDrawCurve instead")]]
+	 void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
+[[deprecated("Use ofDrawBezier instead")]]
+	 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+[[deprecated("Use ofDrawBezier instead")]]
+	 void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 /// \}
 /// \name Custom Shapes Drawing
@@ -997,10 +1027,12 @@ void ofScale(const glm::vec3 & p);
 /// \param vecX specifies the x coordinates of a vector
 /// \param vecY specifies the y coordinates of a vector
 /// \param vecZ specifies the z coordinates of a vector
-OF_DEPRECATED_MSG("Use ofRotateDeg or ofRotateRad", void ofRotate(float degrees, float vecX, float vecY, float vecZ));
+[[deprecated("Use ofRotateDeg or ofRotateRad")]]
+	 void ofRotate(float degrees, float vecX, float vecY, float vecZ);
 
 /// \brief Rotate around the z-axis
-OF_DEPRECATED_MSG("Use ofRotateDeg or ofRotateRad", void ofRotate(float degrees));
+[[deprecated("Use ofRotateDeg or ofRotateRad")]]
+	 void ofRotate(float degrees);
 
 /// \brief Produces a rotation around the X-axis of our coordinate
 /// system represented by the vector (1,0,0).
@@ -1011,7 +1043,8 @@ OF_DEPRECATED_MSG("Use ofRotateDeg or ofRotateRad", void ofRotate(float degrees)
 /// }
 /// ~~~~
 /// \param degrees Specifies the angle of rotation, in degrees.
-OF_DEPRECATED_MSG("Use ofRotateXDeg or ofRotateXRad", void ofRotateX(float degrees));
+[[deprecated("Use ofRotateXDeg or ofRotateXRad")]]
+	 void ofRotateX(float degrees);
 
 /// \brief Produces a rotation around the Y-axis of our coordinate
 /// system represented by the vector (0,1,0).
@@ -1022,7 +1055,8 @@ OF_DEPRECATED_MSG("Use ofRotateXDeg or ofRotateXRad", void ofRotateX(float degre
 /// }
 /// ~~~~
 /// \param degrees Specifies the angle of rotation, in degrees.
-OF_DEPRECATED_MSG("Use ofRotateYDeg or ofRotateYRad", void ofRotateY(float degrees));
+[[deprecated("Use ofRotateYDeg or ofRotateYRad")]]
+	 void ofRotateY(float degrees);
 
 /// \brief Produces a rotation around the Z-axis of our coordinate
 /// system represented by the vector (0,0,1).
@@ -1033,7 +1067,8 @@ OF_DEPRECATED_MSG("Use ofRotateYDeg or ofRotateYRad", void ofRotateY(float degre
 /// }
 /// ~~~~
 /// \param degrees Specifies the angle of rotation, in degrees.
-OF_DEPRECATED_MSG("Use ofRotateZDeg or ofRotateZRad", void ofRotateZ(float degrees));
+[[deprecated("Use ofRotateZDeg or ofRotateZRad")]]
+	 void ofRotateZ(float degrees);
 
 /// \brief Produces a rotation around the vector (vecX,vecY,vecZ).
 ///

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -106,7 +106,7 @@ ofFillFlag ofGetFill();
 /// \brief Returns the current background color as an ofColor.
 ofFloatColor ofGetBackgroundColor();
 [[deprecated("Use ofGetBackgroundColor instead")]]
-	 ofFloatColor ofGetBackground();
+ofFloatColor ofGetBackground();
 
 /// \brief Sets the background color.
 ///
@@ -273,7 +273,7 @@ void ofClear(float r, float g, float b);
 /// ~~~~
 void ofClear(float brightness, float a);
 [[deprecated("Use ofClear(brightness, alpha) instead")]]
-	 void ofClear(float brightness);
+void ofClear(float brightness);
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with
 /// an ofColor.
@@ -296,7 +296,7 @@ void ofClearFloat(const ofFloatColor & c);
 
 // OF's access to settings (bgAuto, origin, corner mode):
 [[deprecated("Use ofGetBackgroundAuto instead")]]
-	 bool ofbClearBg();
+bool ofbClearBg();
 
 /// \}
 /// \name 2D Primitives Drawing
@@ -503,69 +503,69 @@ void ofDrawBezier(float x0, float y0, float x1, float y1, float x2, float y2, fl
 void ofDrawBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 [[deprecated("Use ofDrawTriangle instead")]]
-	 void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
+void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
 [[deprecated("Use ofDrawTriangle instead")]]
-	 void ofTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
+void ofTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 [[deprecated("Use ofDrawTriangle instead")]]
-	 void ofTriangle(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3 & p3);
+void ofTriangle(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3 & p3);
 
 [[deprecated("Use ofDrawCircle instead")]]
-	 void ofCircle(float x, float y, float radius);
+void ofCircle(float x, float y, float radius);
 [[deprecated("Use ofDrawCircle instead")]]
-	 void ofCircle(float x, float y, float z, float radius);
+void ofCircle(float x, float y, float z, float radius);
 [[deprecated("Use ofDrawCircle instead")]]
-	 void ofCircle(const glm::vec3 & p, float radius);
+void ofCircle(const glm::vec3 & p, float radius);
 
 [[deprecated("Use ofDrawEllipse instead")]]
-	 void ofEllipse(float x, float y, float width, float height);
+void ofEllipse(float x, float y, float width, float height);
 [[deprecated("Use ofDrawEllipse instead")]]
-	 void ofEllipse(float x, float y, float z, float width, float height);
+void ofEllipse(float x, float y, float z, float width, float height);
 [[deprecated("Use ofDrawEllipse instead")]]
-	 void ofEllipse(const glm::vec3 & p, float width, float height);
+void ofEllipse(const glm::vec3 & p, float width, float height);
 
 [[deprecated("Use ofDrawLine instead")]]
-	 void ofLine(float x1, float y1, float x2, float y2);
+void ofLine(float x1, float y1, float x2, float y2);
 [[deprecated("Use ofDrawLine instead")]]
-	 void ofLine(float x1, float y1, float z1, float x2, float y2, float z2);
+void ofLine(float x1, float y1, float z1, float x2, float y2, float z2);
 [[deprecated("Use ofDrawLine instead")]]
-	 void ofLine(const glm::vec3 & p1, const glm::vec3 & p2);
+void ofLine(const glm::vec3 & p1, const glm::vec3 & p2);
 
 [[deprecated("Use ofDrawRectangle instead")]]
-	 void ofRect(float x1, float y1, float w, float h);
+void ofRect(float x1, float y1, float w, float h);
 [[deprecated("Use ofDrawRectangle instead")]]
-	 void ofRect(const ofRectangle & r);
+void ofRect(const ofRectangle & r);
 [[deprecated("Use ofDrawRectangle instead")]]
-	 void ofRect(const glm::vec3 & p, float w, float h);
+void ofRect(const glm::vec3 & p, float w, float h);
 [[deprecated("Use ofDrawRectangle instead")]]
-	 void ofRect(float x, float y, float z, float w, float h);
+void ofRect(float x, float y, float z, float w, float h);
 
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(const ofRectangle & b, float r);
+void ofRectRounded(const ofRectangle & b, float r);
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(const glm::vec3 & p, float w, float h, float r);
+void ofRectRounded(const glm::vec3 & p, float w, float h, float r);
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(float x, float y, float w, float h, float r);
+void ofRectRounded(float x, float y, float w, float h, float r);
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(float x, float y, float z, float w, float h, float r);
+void ofRectRounded(float x, float y, float z, float w, float h, float r);
 
 //----------------------------------------------------------
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(const glm::vec3 & p, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
+void ofRectRounded(const glm::vec3 & p, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(const ofRectangle & b, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
+void ofRectRounded(const ofRectangle & b, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
 [[deprecated("Use ofDrawRectRounded instead")]]
-	 void ofRectRounded(float x, float y, float z, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
+void ofRectRounded(float x, float y, float z, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
 [[deprecated("Use ofDrawCurve instead")]]
-	 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 [[deprecated("Use ofDrawCurve instead")]]
-	 void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
+void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 [[deprecated("Use ofDrawBezier instead")]]
-	 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
+void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 [[deprecated("Use ofDrawBezier instead")]]
-	 void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
+void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 /// \}
 /// \name Custom Shapes Drawing
@@ -1236,10 +1236,10 @@ int ofGetViewportHeight();
 void ofSetupScreenPerspective(float width = -1, float height = -1, float fov = 60, float nearDist = 0, float farDist = 0);
 void ofSetupScreenOrtho(float width = -1, float height = -1, float nearDist = -1, float farDist = 1);
 
-OF_DEPRECATED_MSG("ofSetupScreenPerspective() doesn't accept orientation and vflip parameters anymore, use ofSetOrientation() to specify them",
-	void ofSetupScreenPerspective(float width, float height, ofOrientation orientation, bool vFlip = ofIsVFlipped(), float fov = 60, float nearDist = 0, float farDist = 0));
-OF_DEPRECATED_MSG("ofSetupScreenOrtho() doesn't accept orientation and vflip parameters anymore, use ofSetOrientation() to specify them",
-	void ofSetupScreenOrtho(float width, float height, ofOrientation orientation, bool vFlip = ofIsVFlipped(), float nearDist = -1, float farDist = 1));
+[[deprecated("ofSetupScreenPerspective() doesn't accept orientation and vflip parameters anymore, use ofSetOrientation() to specify them")]]
+void ofSetupScreenPerspective(float width, float height, ofOrientation orientation, bool vFlip = ofIsVFlipped(), float fov = 60, float nearDist = 0, float farDist = 0);
+[[deprecated("ofSetupScreenOrtho() doesn't accept orientation and vflip parameters anymore, use ofSetOrientation() to specify them")]]
+void ofSetupScreenOrtho(float width, float height, ofOrientation orientation, bool vFlip = ofIsVFlipped(), float nearDist = -1, float farDist = 1);
 
 int ofOrientationToDegrees(ofOrientation orientation);
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -105,7 +105,7 @@ ofFillFlag ofGetFill();
 
 /// \brief Returns the current background color as an ofColor.
 ofFloatColor ofGetBackgroundColor();
-[[deprecated("Use ofGetBackgroundColor instead")]]
+[[deprecated("Use ofGetBackgroundColor")]]
 ofFloatColor ofGetBackground();
 
 /// \brief Sets the background color.
@@ -272,7 +272,7 @@ void ofClear(float r, float g, float b);
 /// }
 /// ~~~~
 void ofClear(float brightness, float a);
-[[deprecated("Use ofClear(brightness, alpha) instead")]]
+[[deprecated("Use ofClear(brightness, alpha)")]]
 void ofClear(float brightness);
 
 /// \brief Clears the color and depth bits of current renderer and replaces it with
@@ -295,7 +295,7 @@ void ofClearFloat(float brightness, float a);
 void ofClearFloat(const ofFloatColor & c);
 
 // OF's access to settings (bgAuto, origin, corner mode):
-[[deprecated("Use ofGetBackgroundAuto instead")]]
+[[deprecated("Use ofGetBackgroundAuto")]]
 bool ofbClearBg();
 
 /// \}
@@ -502,69 +502,69 @@ void ofDrawCurve(float x0, float y0, float z0, float x1, float y1, float z1, flo
 void ofDrawBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
 void ofDrawBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
-[[deprecated("Use ofDrawTriangle instead")]]
+[[deprecated("Use ofDrawTriangle")]]
 void ofTriangle(float x1, float y1, float x2, float y2, float x3, float y3);
-[[deprecated("Use ofDrawTriangle instead")]]
+[[deprecated("Use ofDrawTriangle")]]
 void ofTriangle(float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
-[[deprecated("Use ofDrawTriangle instead")]]
+[[deprecated("Use ofDrawTriangle")]]
 void ofTriangle(const glm::vec3 & p1, const glm::vec3 & p2, const glm::vec3 & p3);
 
-[[deprecated("Use ofDrawCircle instead")]]
+[[deprecated("Use ofDrawCircle")]]
 void ofCircle(float x, float y, float radius);
-[[deprecated("Use ofDrawCircle instead")]]
+[[deprecated("Use ofDrawCircle")]]
 void ofCircle(float x, float y, float z, float radius);
-[[deprecated("Use ofDrawCircle instead")]]
+[[deprecated("Use ofDrawCircle")]]
 void ofCircle(const glm::vec3 & p, float radius);
 
-[[deprecated("Use ofDrawEllipse instead")]]
+[[deprecated("Use ofDrawEllipse")]]
 void ofEllipse(float x, float y, float width, float height);
-[[deprecated("Use ofDrawEllipse instead")]]
+[[deprecated("Use ofDrawEllipse")]]
 void ofEllipse(float x, float y, float z, float width, float height);
-[[deprecated("Use ofDrawEllipse instead")]]
+[[deprecated("Use ofDrawEllipse")]]
 void ofEllipse(const glm::vec3 & p, float width, float height);
 
-[[deprecated("Use ofDrawLine instead")]]
+[[deprecated("Use ofDrawLine")]]
 void ofLine(float x1, float y1, float x2, float y2);
-[[deprecated("Use ofDrawLine instead")]]
+[[deprecated("Use ofDrawLine")]]
 void ofLine(float x1, float y1, float z1, float x2, float y2, float z2);
-[[deprecated("Use ofDrawLine instead")]]
+[[deprecated("Use ofDrawLine")]]
 void ofLine(const glm::vec3 & p1, const glm::vec3 & p2);
 
-[[deprecated("Use ofDrawRectangle instead")]]
+[[deprecated("Use ofDrawRectangle")]]
 void ofRect(float x1, float y1, float w, float h);
-[[deprecated("Use ofDrawRectangle instead")]]
+[[deprecated("Use ofDrawRectangle")]]
 void ofRect(const ofRectangle & r);
-[[deprecated("Use ofDrawRectangle instead")]]
+[[deprecated("Use ofDrawRectangle")]]
 void ofRect(const glm::vec3 & p, float w, float h);
-[[deprecated("Use ofDrawRectangle instead")]]
+[[deprecated("Use ofDrawRectangle")]]
 void ofRect(float x, float y, float z, float w, float h);
 
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(const ofRectangle & b, float r);
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(const glm::vec3 & p, float w, float h, float r);
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(float x, float y, float w, float h, float r);
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(float x, float y, float z, float w, float h, float r);
 
 //----------------------------------------------------------
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(const glm::vec3 & p, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(const ofRectangle & b, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-[[deprecated("Use ofDrawRectRounded instead")]]
+[[deprecated("Use ofDrawRectRounded")]]
 void ofRectRounded(float x, float y, float z, float w, float h, float topLeftRadius, float topRightRadius, float bottomRightRadius, float bottomLeftRadius);
 
-[[deprecated("Use ofDrawCurve instead")]]
+[[deprecated("Use ofDrawCurve")]]
 void ofCurve(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
-[[deprecated("Use ofDrawCurve instead")]]
+[[deprecated("Use ofDrawCurve")]]
 void ofCurve(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
-[[deprecated("Use ofDrawBezier instead")]]
+[[deprecated("Use ofDrawBezier")]]
 void ofBezier(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3);
-[[deprecated("Use ofDrawBezier instead")]]
+[[deprecated("Use ofDrawBezier")]]
 void ofBezier(float x0, float y0, float z0, float x1, float y1, float z1, float x2, float y2, float z2, float x3, float y3, float z3);
 
 /// \}

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -232,11 +232,11 @@ public:
     /// into the texture.
 	bool load(const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings());
 
-    [[deprecated("Use load instead")]]
+    [[deprecated("Use load")]]
 	bool loadImage(const std::string& fileName);
-    [[deprecated("Use load instead")]]
+    [[deprecated("Use load")]]
 	bool loadImage(const ofBuffer & buffer);
-    [[deprecated("Use load instead")]]
+    [[deprecated("Use load")]]
 	bool loadImage(const ofFile & file);
 
     virtual ~ofImage_();
@@ -621,11 +621,11 @@ public:
     /// \param compressionLevel The ofImageQualityType.
 	bool save(ofBuffer & buffer, ofImageFormat imageFormat = OF_IMAGE_FORMAT_PNG, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
 
-    [[deprecated("Use save instead")]]
+    [[deprecated("Use save")]]
 	void saveImage(const std::string& fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
-    [[deprecated("Use save instead")]]
+    [[deprecated("Use save")]]
 	void saveImage(ofBuffer & buffer, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
-    [[deprecated("Use save instead")]]
+    [[deprecated("Use save")]]
 	void saveImage(const ofFile & file, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
 
     /// \}

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -212,7 +212,8 @@ public:
     /// allocate or by loading pixel data into the image.
     /// \deprecated Use isAllocated() instead
     /// \returns true if the image has been allocated.
-    OF_DEPRECATED_MSG("Use isAllocated()", bool bAllocated());
+    [[deprecated("Use isAllocated()")]]
+	 bool bAllocated();
 
     /// \brief This clears the texture and pixels contained within the ofImage.
 	void clear();
@@ -231,9 +232,12 @@ public:
     /// into the texture.
 	bool load(const ofBuffer & buffer, const ofImageLoadSettings &settings = ofImageLoadSettings());
 
-    OF_DEPRECATED_MSG("Use load instead",bool loadImage(const std::string& fileName));
-    OF_DEPRECATED_MSG("Use load instead",bool loadImage(const ofBuffer & buffer));
-    OF_DEPRECATED_MSG("Use load instead",bool loadImage(const ofFile & file));
+    [[deprecated("Use load instead")]]
+	bool loadImage(const std::string& fileName);
+    [[deprecated("Use load instead")]]
+	bool loadImage(const ofBuffer & buffer);
+    [[deprecated("Use load instead")]]
+	bool loadImage(const ofFile & file);
 
     virtual ~ofImage_();
 
@@ -371,8 +375,10 @@ public:
 	/// \returns A const reference to the texture that the ofImage contains.
     const ofTexture & getTexture() const;
 
-    OF_DEPRECATED_MSG("Use getTexture",ofTexture & getTextureReference());
-    OF_DEPRECATED_MSG("Use getTexture",const ofTexture & getTextureReference() const);
+    [[deprecated("Use getTexture")]]
+	ofTexture & getTextureReference();
+    [[deprecated("Use getTexture")]]
+	const ofTexture & getTextureReference() const;
 
     /// \brief Binds the oftexture instance that the ofImage contains so that
     /// it can be used for advanced drawing.
@@ -414,8 +420,10 @@ public:
     /// Make sure you call either update() after making changes to the ofPixels.
     ///
     /// \returns An ofPixels reference that you can use to manipulate the raw pixel data of the ofImage.
-    OF_DEPRECATED_MSG("Use getPixels() instead ", ofPixels_<PixelType> & getPixelsRef());
-    OF_DEPRECATED_MSG("Use getPixels() instead ", const ofPixels_<PixelType> & getPixelsRef() const);
+    [[deprecated("Use getPixels() instead ")]]
+	 ofPixels_<PixelType> & getPixelsRef();
+    [[deprecated("Use getPixels() instead ")]]
+	 const ofPixels_<PixelType> & getPixelsRef() const;
 
     operator ofPixels_<PixelType>&();
 
@@ -613,9 +621,12 @@ public:
     /// \param compressionLevel The ofImageQualityType.
 	bool save(ofBuffer & buffer, ofImageFormat imageFormat = OF_IMAGE_FORMAT_PNG, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
 
-    OF_DEPRECATED_MSG("Use save instead",void saveImage(const std::string& fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const);
-    OF_DEPRECATED_MSG("Use save instead",void saveImage(ofBuffer & buffer, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const);
-    OF_DEPRECATED_MSG("Use save instead",void saveImage(const ofFile & file, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const);
+    [[deprecated("Use save instead")]]
+	void saveImage(const std::string& fileName, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
+    [[deprecated("Use save instead")]]
+	void saveImage(ofBuffer & buffer, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
+    [[deprecated("Use save instead")]]
+	void saveImage(const ofFile & file, ofImageQualityType compressionLevel = OF_IMAGE_QUALITY_BEST) const;
 
     /// \}
     /// \name Operators

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -213,7 +213,7 @@ public:
     /// \deprecated Use isAllocated() instead
     /// \returns true if the image has been allocated.
     [[deprecated("Use isAllocated()")]]
-	 bool bAllocated();
+    bool bAllocated();
 
     /// \brief This clears the texture and pixels contained within the ofImage.
 	void clear();
@@ -421,9 +421,9 @@ public:
     ///
     /// \returns An ofPixels reference that you can use to manipulate the raw pixel data of the ofImage.
     [[deprecated("Use getPixels() instead ")]]
-	 ofPixels_<PixelType> & getPixelsRef();
+    ofPixels_<PixelType> & getPixelsRef();
     [[deprecated("Use getPixels() instead ")]]
-	 const ofPixels_<PixelType> & getPixelsRef() const;
+    const ofPixels_<PixelType> & getPixelsRef() const;
 
     operator ofPixels_<PixelType>&();
 

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -420,9 +420,9 @@ public:
     /// Make sure you call either update() after making changes to the ofPixels.
     ///
     /// \returns An ofPixels reference that you can use to manipulate the raw pixel data of the ofImage.
-    [[deprecated("Use getPixels() instead ")]]
+    [[deprecated("Use getPixels()")]]
     ofPixels_<PixelType> & getPixelsRef();
-    [[deprecated("Use getPixels() instead ")]]
+    [[deprecated("Use getPixels()")]]
     const ofPixels_<PixelType> & getPixelsRef() const;
 
     operator ofPixels_<PixelType>&();

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -3,7 +3,7 @@
 #include "ofPolyline.h"
 #include "ofVboMesh.h"
 #include "ofTessellator.h"
-// FIXME: deprecated and targets
+// FIXME: ofConstants targets
 #include "ofConstants.h"
 
 template<typename T>
@@ -301,9 +301,9 @@ public:
 	int getCircleResolution() const;
 
 	[[deprecated("Use setCircleResolution instead.")]]
-	 void setArcResolution(int res);
+	void setArcResolution(int res);
 	[[deprecated("Use getCircleResolution instead.")]]
-	 int getArcResolution() const;
+	int getArcResolution() const;
 
 	void setUseShapeColor(bool useColor);
 	bool getUseShapeColor() const;
@@ -336,14 +336,14 @@ public:
 	void rotateDeg(float degrees, const glm::vec3& axis);
 	void rotateRad(float radians, const glm::vec3& axis);
 	[[deprecated("Use Deg/Rad versions.")]]
-	 void rotate(float degrees, const glm::vec3& axis );
+	void rotate(float degrees, const glm::vec3& axis );
 
 	void translate(const glm::vec2 & p);
 
 	void rotateDeg(float degrees, const glm::vec2& axis);
 	void rotateRad(float radians, const glm::vec2& axis);
 	[[deprecated("Use Deg/Rad versions.")]]
-	 void rotate(float degrees, const glm::vec2& axis );
+	void rotate(float degrees, const glm::vec2& axis );
 
 	/// \brief Change the size of either the ofPolyline or ofSubPath instances that
 	/// the ofPath contains. These changes are non-reversible, so for instance

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -300,9 +300,9 @@ public:
 	void setCircleResolution(int circleResolution);
 	int getCircleResolution() const;
 
-	[[deprecated("Use setCircleResolution instead.")]]
+	[[deprecated("Use setCircleResolution")]]
 	void setArcResolution(int res);
-	[[deprecated("Use getCircleResolution instead.")]]
+	[[deprecated("Use getCircleResolution")]]
 	int getArcResolution() const;
 
 	void setUseShapeColor(bool useColor);

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -300,8 +300,10 @@ public:
 	void setCircleResolution(int circleResolution);
 	int getCircleResolution() const;
 
-	OF_DEPRECATED_MSG("Use setCircleResolution instead.", void setArcResolution(int res));
-	OF_DEPRECATED_MSG("Use getCircleResolution instead.", int getArcResolution() const);
+	[[deprecated("Use setCircleResolution instead.")]]
+	 void setArcResolution(int res);
+	[[deprecated("Use getCircleResolution instead.")]]
+	 int getArcResolution() const;
 
 	void setUseShapeColor(bool useColor);
 	bool getUseShapeColor() const;
@@ -333,13 +335,15 @@ public:
 
 	void rotateDeg(float degrees, const glm::vec3& axis);
 	void rotateRad(float radians, const glm::vec3& axis);
-	OF_DEPRECATED_MSG("Use Deg/Rad versions.", void rotate(float degrees, const glm::vec3& axis ));
+	[[deprecated("Use Deg/Rad versions.")]]
+	 void rotate(float degrees, const glm::vec3& axis );
 
 	void translate(const glm::vec2 & p);
 
 	void rotateDeg(float degrees, const glm::vec2& axis);
 	void rotateRad(float radians, const glm::vec2& axis);
-	OF_DEPRECATED_MSG("Use Deg/Rad versions.", void rotate(float degrees, const glm::vec2& axis ));
+	[[deprecated("Use Deg/Rad versions.")]]
+	 void rotate(float degrees, const glm::vec2& axis );
 
 	/// \brief Change the size of either the ofPolyline or ofSubPath instances that
 	/// the ofPath contains. These changes are non-reversible, so for instance

--- a/libs/openFrameworks/graphics/ofPixels.h
+++ b/libs/openFrameworks/graphics/ofPixels.h
@@ -315,10 +315,10 @@ public:
 	PixelType * getData();
 	const PixelType * getData() const;
 
-	[[deprecated("Use getData instead")]]
+	[[deprecated("Use getData")]]
 	PixelType * getPixels();
 
-	[[deprecated("Use getData instead")]]
+	[[deprecated("Use getData")]]
 	const PixelType * getPixels() const;
 
 	/// \brief Get the pixel index at a x,y position

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -203,7 +203,7 @@ public:
 		float simplifyAmt = 0.0f,
 		int dpi = 0);
 
-	[[deprecated("Use load instead")]]
+	[[deprecated("Use load")]]
 	bool loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0);
 
 	bool load(const ofTrueTypeFontSettings & settings);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -204,7 +204,7 @@ public:
 		int dpi = 0);
 
 	[[deprecated("Use load instead")]]
-	 bool loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0);
+	bool loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0);
 
 	bool load(const ofTrueTypeFontSettings & settings);
 

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -203,7 +203,8 @@ public:
 		float simplifyAmt = 0.0f,
 		int dpi = 0);
 
-	OF_DEPRECATED_MSG("Use load instead", bool loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0));
+	[[deprecated("Use load instead")]]
+	 bool loadFont(std::string filename, int fontsize, bool _bAntiAliased = true, bool _bFullCharacterSet = false, bool makeContours = false, float simplifyAmt = 0.0f, int dpi = 0);
 
 	bool load(const ofTrueTypeFontSettings & settings);
 

--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -81,7 +81,7 @@ void ofSetRandomSeed(unsigned long new_seed);
 /// setup.  This can be useful for debugging and testing.
 ///
 /// \param val The value with which to seed the generator.
-[[deprecated("use ofSetRandomSeed() or of::random::seed() instead")]] void ofSeedRandom(int val);
+[[deprecated("use ofSetRandomSeed() or of::random::seed()")]] void ofSeedRandom(int val);
 
 /// \}
 

--- a/libs/openFrameworks/math/ofVec2f.h
+++ b/libs/openFrameworks/math/ofVec2f.h
@@ -939,37 +939,37 @@ public:
     // this methods are deprecated in 006 please dont use:
 	/// \cond INTERNAL
 
-    [[deprecated("Use member method getScaled() instead.")]]
+    [[deprecated("Use member method getScaled()")]]
 	ofVec2f rescaled( const float length ) const;
 	
-    [[deprecated("Use member method scale() instead.")]]
+    [[deprecated("Use member method scale()")]]
 	ofVec2f& rescale( const float length );
 	
-    [[deprecated("Use member method getRotated() instead.")]]
+    [[deprecated("Use member method getRotated()")]]
 	ofVec2f rotated( float angle ) const;
 	
-    [[deprecated("Use member method getNormalized() instead.")]]
+    [[deprecated("Use member method getNormalized()")]]
 	ofVec2f normalized() const;
 	
-    [[deprecated("Use member method getLimited() instead.")]]
+    [[deprecated("Use member method getLimited()")]]
 	ofVec2f limited(float max) const;
 	
-    [[deprecated("Use member method getPerpendicular() instead.")]]
+    [[deprecated("Use member method getPerpendicular()")]]
 	ofVec2f perpendiculared() const;
 	
-    [[deprecated("Use member method getInterpolated() instead.")]]
+    [[deprecated("Use member method getInterpolated()")]]
 	ofVec2f interpolated( const ofVec2f& pnt, float p ) const;
     
-    [[deprecated("Use member method getMiddled() instead.")]]
+    [[deprecated("Use member method getMiddled()")]]
 	ofVec2f middled( const ofVec2f& pnt ) const;
     
-    [[deprecated("Use member method getMapped() instead.")]]
+    [[deprecated("Use member method getMapped()")]]
 	ofVec2f mapped( const ofVec2f& origin, const ofVec2f& vx, const ofVec2f& vy ) const;
     
-    [[deprecated("Use member method squareDistance() instead.")]]
+    [[deprecated("Use member method squareDistance()")]]
 	float distanceSquared( const ofVec2f& pnt ) const;
     
-    [[deprecated("Use member method getRotated() instead.")]]
+    [[deprecated("Use member method getRotated()")]]
 	ofVec2f rotated( float angle, const ofVec2f& pivot ) const;   
     
     // return all zero vector

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -992,60 +992,49 @@ public:
     // this methods are deprecated in 006 please use:
 	/// \cond INTERNAL
 
-    // getScaled
-    [[deprecated("Use member method getScaled() instead.")]]
-	 ofVec3f rescaled( const float length ) const;
-	
-    // scale
-    [[deprecated("Use member method scale() instead.")]]
-	 ofVec3f& rescale( const float length );
-	
-    // getRotated
-    [[deprecated("Use member method getRotated() instead.")]]
-	 ofVec3f rotated( float angle, const ofVec3f& axis ) const;
-	
-    // getRotated should this be const???
-    [[deprecated("Use member method getRotated() instead.")]]
-	 ofVec3f rotated(float ax, float ay, float az);
-	
-    // getNormalized
-    [[deprecated("Use member method getNormalized() instead.")]]
-	 ofVec3f normalized() const;
-	
-    // getLimited
-    [[deprecated("Use member method getLimited() instead.")]]
-	 ofVec3f limited(float max) const;
-	
-    // getCrossed
-    [[deprecated("Use member method getCrossed() instead.")]]
-	 ofVec3f crossed( const ofVec3f& vec ) const;
-	
-    // getPerpendicular
-    [[deprecated("Use member method getPerpendicular() instead.")]]
-	 ofVec3f perpendiculared( const ofVec3f& vec ) const;
+	[[deprecated("Use member method getScaled() instead.")]]
+	ofVec3f rescaled( const float length ) const;
+
+	[[deprecated("Use member method scale() instead.")]]
+	ofVec3f& rescale( const float length );
+
+	[[deprecated("Use member method getRotated() instead.")]]
+	ofVec3f rotated( float angle, const ofVec3f& axis ) const;
+
+	[[deprecated("Use member method getRotated() instead.")]]
+	ofVec3f rotated(float ax, float ay, float az);
+
+	[[deprecated("Use member method getNormalized() instead.")]]
+	ofVec3f normalized() const;
+
+	[[deprecated("Use member method getLimited() instead.")]]
+	ofVec3f limited(float max) const;
+
+	[[deprecated("Use member method getCrossed() instead.")]]
+	ofVec3f crossed( const ofVec3f& vec ) const;
+
+	[[deprecated("Use member method getPerpendicular() instead.")]]
+	ofVec3f perpendiculared( const ofVec3f& vec ) const;
     
-    // use getMapped
-    OF_DEPRECATED_MSG("Use member method getMapped() instead.", ofVec3f mapped( const ofVec3f& origin,
+    [[deprecated("Use member method getMapped() instead.")]]
+	ofVec3f mapped( const ofVec3f& origin,
 					const ofVec3f& vx,
 					const ofVec3f& vy,
-					const ofVec3f& vz ) const);
+					const ofVec3f& vz ) const;
 	
-    // use squareDistance
-    [[deprecated("Use member method squareDistance() instead.")]]
-	 float  distanceSquared( const ofVec3f& pnt ) const;
-	
-    // use getInterpolated
-    [[deprecated("Use member method getInterpolated() instead.")]]
-	 ofVec3f interpolated( const ofVec3f& pnt, float p ) const;
-	
-    // use getMiddle
-    [[deprecated("Use member method getMiddle() instead.")]]
-	 ofVec3f middled( const ofVec3f& pnt ) const;
+	[[deprecated("Use member method squareDistance() instead.")]]
+	float distanceSquared( const ofVec3f & pnt ) const;
+
+	[[deprecated("Use member method getInterpolated() instead.")]]
+	ofVec3f interpolated( const ofVec3f & pnt, float p ) const;
+
+	[[deprecated("Use member method getMiddle() instead.")]]
+	ofVec3f middled( const ofVec3f & pnt ) const;
     
-    // use getRotated
-    OF_DEPRECATED_MSG("Use member method getRotated() instead.", ofVec3f rotated( float angle,
-						const ofVec3f& pivot,
-						const ofVec3f& axis ) const);    
+    [[deprecated("Use member method getRotated() instead.")]]
+	ofVec3f rotated(float angle,
+					const ofVec3f & pivot,
+					const ofVec3f & axis ) const;
 
     // return all zero vector
     static ofVec3f zero() { return ofVec3f(0, 0, 0); }

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -992,46 +992,46 @@ public:
     // this methods are deprecated in 006 please use:
 	/// \cond INTERNAL
 
-	[[deprecated("Use member method getScaled() instead.")]]
+	[[deprecated("Use member method getScaled()")]]
 	ofVec3f rescaled( const float length ) const;
 
-	[[deprecated("Use member method scale() instead.")]]
+	[[deprecated("Use member method scale()")]]
 	ofVec3f& rescale( const float length );
 
-	[[deprecated("Use member method getRotated() instead.")]]
+	[[deprecated("Use member method getRotated()")]]
 	ofVec3f rotated( float angle, const ofVec3f& axis ) const;
 
-	[[deprecated("Use member method getRotated() instead.")]]
+	[[deprecated("Use member method getRotated()")]]
 	ofVec3f rotated(float ax, float ay, float az);
 
-	[[deprecated("Use member method getNormalized() instead.")]]
+	[[deprecated("Use member method getNormalized()")]]
 	ofVec3f normalized() const;
 
-	[[deprecated("Use member method getLimited() instead.")]]
+	[[deprecated("Use member method getLimited()")]]
 	ofVec3f limited(float max) const;
 
-	[[deprecated("Use member method getCrossed() instead.")]]
+	[[deprecated("Use member method getCrossed()")]]
 	ofVec3f crossed( const ofVec3f& vec ) const;
 
-	[[deprecated("Use member method getPerpendicular() instead.")]]
+	[[deprecated("Use member method getPerpendicular()")]]
 	ofVec3f perpendiculared( const ofVec3f& vec ) const;
     
-    [[deprecated("Use member method getMapped() instead.")]]
+    [[deprecated("Use member method getMapped()")]]
 	ofVec3f mapped( const ofVec3f& origin,
 					const ofVec3f& vx,
 					const ofVec3f& vy,
 					const ofVec3f& vz ) const;
 	
-	[[deprecated("Use member method squareDistance() instead.")]]
+	[[deprecated("Use member method squareDistance()")]]
 	float distanceSquared( const ofVec3f & pnt ) const;
 
-	[[deprecated("Use member method getInterpolated() instead.")]]
+	[[deprecated("Use member method getInterpolated()")]]
 	ofVec3f interpolated( const ofVec3f & pnt, float p ) const;
 
-	[[deprecated("Use member method getMiddle() instead.")]]
+	[[deprecated("Use member method getMiddle()")]]
 	ofVec3f middled( const ofVec3f & pnt ) const;
     
-    [[deprecated("Use member method getRotated() instead.")]]
+    [[deprecated("Use member method getRotated()")]]
 	ofVec3f rotated(float angle,
 					const ofVec3f & pivot,
 					const ofVec3f & axis ) const;

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -993,28 +993,36 @@ public:
 	/// \cond INTERNAL
 
     // getScaled
-    OF_DEPRECATED_MSG("Use member method getScaled() instead.", ofVec3f rescaled( const float length ) const);
+    [[deprecated("Use member method getScaled() instead.")]]
+	 ofVec3f rescaled( const float length ) const;
 	
     // scale
-    OF_DEPRECATED_MSG("Use member method scale() instead.", ofVec3f& rescale( const float length ));
+    [[deprecated("Use member method scale() instead.")]]
+	 ofVec3f& rescale( const float length );
 	
     // getRotated
-    OF_DEPRECATED_MSG("Use member method getRotated() instead.", ofVec3f rotated( float angle, const ofVec3f& axis ) const);
+    [[deprecated("Use member method getRotated() instead.")]]
+	 ofVec3f rotated( float angle, const ofVec3f& axis ) const;
 	
     // getRotated should this be const???
-    OF_DEPRECATED_MSG("Use member method getRotated() instead.", ofVec3f rotated(float ax, float ay, float az));
+    [[deprecated("Use member method getRotated() instead.")]]
+	 ofVec3f rotated(float ax, float ay, float az);
 	
     // getNormalized
-    OF_DEPRECATED_MSG("Use member method getNormalized() instead.", ofVec3f normalized() const);
+    [[deprecated("Use member method getNormalized() instead.")]]
+	 ofVec3f normalized() const;
 	
     // getLimited
-    OF_DEPRECATED_MSG("Use member method getLimited() instead.", ofVec3f limited(float max) const);
+    [[deprecated("Use member method getLimited() instead.")]]
+	 ofVec3f limited(float max) const;
 	
     // getCrossed
-    OF_DEPRECATED_MSG("Use member method getCrossed() instead.", ofVec3f crossed( const ofVec3f& vec ) const);
+    [[deprecated("Use member method getCrossed() instead.")]]
+	 ofVec3f crossed( const ofVec3f& vec ) const;
 	
     // getPerpendicular
-    OF_DEPRECATED_MSG("Use member method getPerpendicular() instead.", ofVec3f perpendiculared( const ofVec3f& vec ) const);
+    [[deprecated("Use member method getPerpendicular() instead.")]]
+	 ofVec3f perpendiculared( const ofVec3f& vec ) const;
     
     // use getMapped
     OF_DEPRECATED_MSG("Use member method getMapped() instead.", ofVec3f mapped( const ofVec3f& origin,
@@ -1023,13 +1031,16 @@ public:
 					const ofVec3f& vz ) const);
 	
     // use squareDistance
-    OF_DEPRECATED_MSG("Use member method squareDistance() instead.", float  distanceSquared( const ofVec3f& pnt ) const);
+    [[deprecated("Use member method squareDistance() instead.")]]
+	 float  distanceSquared( const ofVec3f& pnt ) const;
 	
     // use getInterpolated
-    OF_DEPRECATED_MSG("Use member method getInterpolated() instead.", ofVec3f interpolated( const ofVec3f& pnt, float p ) const);
+    [[deprecated("Use member method getInterpolated() instead.")]]
+	 ofVec3f interpolated( const ofVec3f& pnt, float p ) const;
 	
     // use getMiddle
-    OF_DEPRECATED_MSG("Use member method getMiddle() instead.", ofVec3f middled( const ofVec3f& pnt ) const);
+    [[deprecated("Use member method getMiddle() instead.")]]
+	 ofVec3f middled( const ofVec3f& pnt ) const;
     
     // use getRotated
     OF_DEPRECATED_MSG("Use member method getRotated() instead.", ofVec3f rotated( float angle,

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -248,31 +248,31 @@ public:
 	/// \cond INTERNAL
 	
 	// getScaled
-	[[deprecated("Use member method getScaled() instead.")]]
+	[[deprecated("Use member method getScaled()")]]
 	ofVec4f rescaled( const float length ) const;
 	
 	// scale
-	[[deprecated("Use member method scale() instead.")]]
+	[[deprecated("Use member method scale()")]]
 	ofVec4f& rescale( const float length );
 	
 	// getNormalized
-	[[deprecated("Use member method getNormalized() instead.")]]
+	[[deprecated("Use member method getNormalized()")]]
 	ofVec4f normalized() const;
 	
 	// getLimited
-	[[deprecated("Use member method getLimited() instead.")]]
+	[[deprecated("Use member method getLimited()")]]
 	ofVec4f limited(float max) const;
 	
 	// use squareDistance
-	[[deprecated("Use member method squareDistance() instead.")]]
+	[[deprecated("Use member method squareDistance()")]]
 	float  distanceSquared( const ofVec4f& pnt ) const;
 	
 	// use getInterpolated
-	[[deprecated("Use member method getInterpolated() instead.")]]
+	[[deprecated("Use member method getInterpolated()")]]
 	ofVec4f interpolated( const ofVec4f& pnt, float p ) const;
 	
 	// use getMiddle
-	[[deprecated("Use member method getMiddle() instead.")]]
+	[[deprecated("Use member method getMiddle()")]]
 	ofVec4f middled( const ofVec4f& pnt ) const;
 	
 	// return all zero vector

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.h
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: FS only
+// FIXME: ofConstants FS
 #include "ofConstants.h"
 #include <functional>
 

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
-// FIXME: Deprecated and FS
+// FIXME: ofConstants FS
 #include "ofConstants.h"
 
 /// \brief Stops all active sound players on FMOD-based systems (windows, osx).
@@ -48,11 +48,13 @@ public:
     /// \param fileName Path to the sound file, relative to your app's data folder.
     /// \param stream set "true" to enable streaming from disk (for large files).
     bool load(const of::filesystem::path& fileName, bool stream = false);
-    OF_DEPRECATED_MSG("Use load",bool loadSound(std::string fileName, bool stream = false));
+    [[deprecated("Use load")]]
+	bool loadSound(std::string fileName, bool stream = false);
 
     /// \brief Stops and unloads the current sound.
     void unload();
-    OF_DEPRECATED_MSG("Use unload",void unloadSound());
+	[[deprecated("Use unload")]]
+	void unloadSound();
     
     /// \brief Starts playback.
     void play();
@@ -103,7 +105,8 @@ public:
     /// \brief Gets current playback state.
     /// \return true if the player is currently playing a file.
     bool isPlaying() const;
-    OF_DEPRECATED_MSG("Use isPlaying",bool getIsPlaying() const);
+    [[deprecated("Use isPlaying")]]
+	bool getIsPlaying() const;
 
     /// \brief Gets playback speed.
     /// \return playback speed (see ofSoundPlayer::setSpeed()).

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -2,8 +2,6 @@
 
 #include "ofBaseApp.h"
 #include "ofSoundBaseTypes.h"
-// FIXME: Deprecated
-#include "ofConstants.h"
 #include <climits>
 #include <functional>
 

--- a/libs/openFrameworks/sound/ofSoundStream.h
+++ b/libs/openFrameworks/sound/ofSoundStream.h
@@ -179,7 +179,7 @@ public:
 	int getBufferSize() const;
 
 	/// \brief Retrieves a list of available audio devices and prints device descriptions to the console
-	[[deprecated("Use printDeviceList instead")]]
+	[[deprecated("Use printDeviceList")]]
 	std::vector<ofSoundDevice> listDevices() const;
 
 protected:

--- a/libs/openFrameworks/types/ofRectangle.h
+++ b/libs/openFrameworks/types/ofRectangle.h
@@ -770,7 +770,7 @@ public:
 	/// \returns The rectangle's position.
 	const glm::vec3 & getPosition() const;
 
-	[[deprecated("Use getPosition() instead.")]]
+	[[deprecated("Use getPosition()")]]
 	glm::vec3 & getPositionRef();
 
 	/// \brief Get the coordiantes of the ofRectangle's center as glm::vec3.

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -59,6 +59,7 @@ enum ofTargetPlatform{
 #endif
 
 
+// FIXME: not used anymore in OF Core. Only kept for addons compatibility - 20231206
 // Cross-platform deprecation warning
 #ifdef __GNUC__
 	// clang also has this defined. deprecated(message) is only for gcc>=4.5

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -58,27 +58,6 @@ enum ofTargetPlatform{
     #define OF_TARGET_IPHONE OF_TARGET_IOS
 #endif
 
-
-// Cross-platform deprecation warning
-#ifdef __GNUC__
-	// clang also has this defined. deprecated(message) is only for gcc>=4.5
-	#if ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)) || __GNUC__ > 4
-        #define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__ __attribute__ ((deprecated(message)))
-    #else
-        #define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__ __attribute__ ((deprecated))
-    #endif
-	#define OF_DEPRECATED(...) __VA_ARGS__ __attribute__ ((deprecated))
-	#define OF_INTERNAL_DEPRECATED(...) __VA_ARGS__ __attribute__ ((deprecated("OF core deprecated")))
-#elif defined(_MSC_VER)
-	#define OF_DEPRECATED_MSG(message, ...) __declspec(deprecated(message)) __VA_ARGS__
-	#define OF_DEPRECATED(...) __declspec(deprecated) __VA_ARGS__
-	#define OF_INTERNAL_DEPRECATED(...) __declspec(deprecated("OF core deprecated")) __VA_ARGS__
-#else
-	#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-	#define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__
-	#define OF_DEPRECATED(...) __VA_ARGS__
-#endif
-
 //-------------------------------
 //  find the system type --------
 //-------------------------------

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -58,6 +58,27 @@ enum ofTargetPlatform{
     #define OF_TARGET_IPHONE OF_TARGET_IOS
 #endif
 
+
+// Cross-platform deprecation warning
+#ifdef __GNUC__
+	// clang also has this defined. deprecated(message) is only for gcc>=4.5
+	#if ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)) || __GNUC__ > 4
+        #define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__ __attribute__ ((deprecated(message)))
+    #else
+        #define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__ __attribute__ ((deprecated))
+    #endif
+	#define OF_DEPRECATED(...) __VA_ARGS__ __attribute__ ((deprecated))
+	#define OF_INTERNAL_DEPRECATED(...) __VA_ARGS__ __attribute__ ((deprecated("OF core deprecated")))
+#elif defined(_MSC_VER)
+	#define OF_DEPRECATED_MSG(message, ...) __declspec(deprecated(message)) __VA_ARGS__
+	#define OF_DEPRECATED(...) __declspec(deprecated) __VA_ARGS__
+	#define OF_INTERNAL_DEPRECATED(...) __declspec(deprecated("OF core deprecated")) __VA_ARGS__
+#else
+	#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+	#define OF_DEPRECATED_MSG(message, ...) __VA_ARGS__
+	#define OF_DEPRECATED(...) __VA_ARGS__
+#endif
+
 //-------------------------------
 //  find the system type --------
 //-------------------------------

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: FS
+// FIXME: ofConstants FS
 #include "ofConstants.h"
 #include <fstream>
 

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -105,9 +105,9 @@ public:
 	/// \warning Do not access bytes at indices beyond size()!
 	/// \returns const pointer to internal raw bytes
 	const char * getData() const;
-	[[deprecated("Use getData instead")]]
+	[[deprecated("Use getData")]]
 	char * getBinaryBuffer();
-	[[deprecated("Use getData instead")]]
+	[[deprecated("Use getData")]]
 	const char * getBinaryBuffer() const;
 
 	/// get the contents of the buffer as a string.
@@ -128,13 +128,13 @@ public:
 	/// \returns the size of the buffer's content in bytes
 	std::size_t size() const;
 
-	[[deprecated("use a lines iterator instead")]]
+	[[deprecated("use a lines iterator")]]
 	std::string getNextLine();
-	[[deprecated("use a lines iterator instead")]]
+	[[deprecated("use a lines iterator")]]
 	std::string getFirstLine();
-	[[deprecated("use a lines iterator instead")]]
+	[[deprecated("use a lines iterator")]]
 	bool isLastLine();
-	[[deprecated("use a lines iterator instead")]]
+	[[deprecated("use a lines iterator")]]
 	void resetLineReader();
 
 	friend std::ostream & operator<<(std::ostream & ostr, const ofBuffer & buf);

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1138,7 +1138,7 @@ public:
 	/// \returns number of paths
 	std::size_t size() const;
 
-	[[deprecated("Use size() instead.")]]
+	[[deprecated("Use size()")]]
 	int numFiles();
 
 	// this allows to compare directories by their paths, also provides sorting

--- a/libs/openFrameworks/utils/ofSystemUtils.cpp
+++ b/libs/openFrameworks/utils/ofSystemUtils.cpp
@@ -3,7 +3,7 @@
 #include "ofFileUtils.h"
 #include "ofLog.h"
 #include "ofUtils.h"
-// FIXME: Targets
+// FIXME: ofConstants Targets
 #include "ofConstants.h"
 
 #include <condition_variable>

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -25,7 +25,8 @@ public:
 
 	/// \return the unique id for this request
 	int getId() const;
-	OF_DEPRECATED_MSG("Use getId().", int getID());
+	[[deprecated("Use getId().")]]
+	 int getID();
 
 	/// HTTP request type
 	enum Method {

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -26,7 +26,7 @@ public:
 	/// \return the unique id for this request
 	int getId() const;
 	[[deprecated("Use getId().")]]
-	 int getID();
+	int getID();
 
 	/// HTTP request type
 	enum Method {

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -94,7 +94,7 @@ uint64_t ofGetUnixTime();
 /// \brief Get the system time in milliseconds (system uptime).
 /// \returns the system time in milliseconds.
 [[deprecated("Use ofGetSystemTimeMillis() instead")]]
-	 uint64_t ofGetSystemTime();
+uint64_t ofGetSystemTime();
 
 /// \brief Get the system time in milliseconds (system uptime).
 /// \returns the system time in milliseconds.
@@ -256,7 +256,8 @@ void ofShuffle(Args &&... args) {
 /// \param values The vector of values to modify.
 
 template <class T>
-[[deprecated("use ofShuffle or of::shuffle")]] void ofRandomize(std::vector<T> & values) {
+[[deprecated("use ofShuffle or of::shuffle")]]
+void ofRandomize(std::vector<T> & values) {
 	of::shuffle(values);
 }
 
@@ -544,7 +545,7 @@ std::string ofTrimBack(const std::string & src, const std::string & locale = "")
 std::string ofTrim(const std::string & src, const std::string & locale = "");
 
 [[deprecated("Use ofUTF8Append instead")]]
-	 void ofAppendUTF8(std::string & str, uint32_t utf8);
+void ofAppendUTF8(std::string & str, uint32_t utf8);
 
 /// \brief Append a Unicode codepoint to a UTF8-encoded std::string.
 ///

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -93,7 +93,7 @@ uint64_t ofGetUnixTime();
 
 /// \brief Get the system time in milliseconds (system uptime).
 /// \returns the system time in milliseconds.
-[[deprecated("Use ofGetSystemTimeMillis() instead")]]
+[[deprecated("Use ofGetSystemTimeMillis()")]]
 uint64_t ofGetSystemTime();
 
 /// \brief Get the system time in milliseconds (system uptime).
@@ -544,7 +544,7 @@ std::string ofTrimBack(const std::string & src, const std::string & locale = "")
 /// \returns a front-trimmed std::string.
 std::string ofTrim(const std::string & src, const std::string & locale = "");
 
-[[deprecated("Use ofUTF8Append instead")]]
+[[deprecated("Use ofUTF8Append")]]
 void ofAppendUTF8(std::string & str, uint32_t utf8);
 
 /// \brief Append a Unicode codepoint to a UTF8-encoded std::string.

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -93,7 +93,8 @@ uint64_t ofGetUnixTime();
 
 /// \brief Get the system time in milliseconds (system uptime).
 /// \returns the system time in milliseconds.
-OF_DEPRECATED_MSG("Use ofGetSystemTimeMillis() instead", uint64_t ofGetSystemTime());
+[[deprecated("Use ofGetSystemTimeMillis() instead")]]
+	 uint64_t ofGetSystemTime();
 
 /// \brief Get the system time in milliseconds (system uptime).
 /// \returns the system time in milliseconds.
@@ -542,7 +543,8 @@ std::string ofTrimBack(const std::string & src, const std::string & locale = "")
 /// \returns a front-trimmed std::string.
 std::string ofTrim(const std::string & src, const std::string & locale = "");
 
-OF_DEPRECATED_MSG("Use ofUTF8Append instead", void ofAppendUTF8(std::string & str, uint32_t utf8));
+[[deprecated("Use ofUTF8Append instead")]]
+	 void ofAppendUTF8(std::string & str, uint32_t utf8);
 
 /// \brief Append a Unicode codepoint to a UTF8-encoded std::string.
 ///

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -27,56 +27,56 @@ public:
 	ofAVFoundationPlayer();
 	~ofAVFoundationPlayer();
 	   
-    bool load(std::string name);
+	bool load(std::string name);
 	void loadAsync(std::string name);
-    void close();
-    void update();
+	void close();
+	void update();
 
-    void draw();
-    void draw(float x, float y);
-    void draw(const ofRectangle & rect);
-    void draw(float x, float y, float w, float h);
-    
+	void draw();
+	void draw(float x, float y);
+	void draw(const ofRectangle & rect);
+	void draw(float x, float y, float w, float h);
+	
 	bool setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat getPixelFormat() const;
 	
-    void play();
-    void stop();
+	void play();
+	void stop();
 	
-    bool isFrameNew() const;
-    const ofPixels & getPixels() const;
-    ofPixels & getPixels();
-    ofTexture * getTexturePtr();
-    void initTextureCache();
-    void killTexture();
-    void killTextureCache();
+	bool isFrameNew() const;
+	const ofPixels & getPixels() const;
+	ofPixels & getPixels();
+	ofTexture * getTexturePtr();
+	void initTextureCache();
+	void killTexture();
+	void killTextureCache();
 	
-    float getWidth() const;
-    float getHeight() const;
+	float getWidth() const;
+	float getHeight() const;
 	
-    bool isPaused() const;
-    bool isLoaded() const;
-    bool isPlaying() const;
+	bool isPaused() const;
+	bool isLoaded() const;
+	bool isPlaying() const;
 	
-    float getPosition() const;
-    float getSpeed() const;
-    float getDuration() const;
-    bool getIsMovieDone() const;
+	float getPosition() const;
+	float getSpeed() const;
+	float getDuration() const;
+	bool getIsMovieDone() const;
 	
-    void setPaused(bool bPause);
-    void setPosition(float pct);
-    void setVolume(float volume); // 0..1
-    void setLoopState(ofLoopType state);
-    void setSpeed(float speed);
-    void setFrame(int frame);  // frame 0 = first frame...
+	void setPaused(bool bPause);
+	void setPosition(float pct);
+	void setVolume(float volume); // 0..1
+	void setLoopState(ofLoopType state);
+	void setSpeed(float speed);
+	void setFrame(int frame);  // frame 0 = first frame...
 	
-    int	getCurrentFrame() const;
-    int	getTotalNumFrames() const;
-    ofLoopType getLoopState() const;
+	int	getCurrentFrame() const;
+	int	getTotalNumFrames() const;
+	ofLoopType getLoopState() const;
 	
-    void firstFrame();
-    void nextFrame();
-    void previousFrame();
+	void firstFrame();
+	void nextFrame();
+	void previousFrame();
 
 	ofAVFoundationPlayer& operator=(ofAVFoundationPlayer other);
 	
@@ -85,35 +85,35 @@ public:
 #else
 	void * getAVFoundationVideoPlayer();
 #endif
-    
-    [[deprecated("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.")]]
-	 bool loadMovie(std::string name);
-    [[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
-	 ofPixels & getPixelsRef();
-    [[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
-	 const ofPixels & getPixelsRef() const;
-    [[deprecated("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
-	 ofTexture * getTexture();
-    
+	
+	[[deprecated("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.")]]
+	bool loadMovie(std::string name);
+	[[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	ofPixels & getPixelsRef();
+	[[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	const ofPixels & getPixelsRef() const;
+	[[deprecated("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+	ofTexture * getTexture();
+	
 protected:
 	
-    bool loadPlayer(std::string name, bool bAsync);
+	bool loadPlayer(std::string name, bool bAsync);
 	void disposePlayer();
-    bool isReady() const;
+	bool isReady() const;
 
 #ifdef __OBJC__
-    ofAVFoundationVideoPlayer * videoPlayer;
+	ofAVFoundationVideoPlayer * videoPlayer;
 #else
-    void * videoPlayer;
+	void * videoPlayer;
 #endif
-    
-    bool bFrameNew;
-    bool bResetPixels;
-    bool bUpdatePixels;
-    bool bUpdateTexture;
+	
+	bool bFrameNew;
+	bool bResetPixels;
+	bool bUpdatePixels;
+	bool bUpdateTexture;
 	bool bUseTextureCache;
 	
-    ofPixels pixels;
+	ofPixels pixels;
 	ofPixelFormat pixelFormat;
 	ofTexture videoTexture;
 	

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -86,13 +86,13 @@ public:
 	void * getAVFoundationVideoPlayer();
 #endif
 	
-	[[deprecated("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.")]]
+	[[deprecated("use load() instead.")]]
 	bool loadMovie(std::string name);
-	[[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	ofPixels & getPixelsRef();
-	[[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	[[deprecated("use getPixels() instead.")]]
 	const ofPixels & getPixelsRef() const;
-	[[deprecated("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+	[[deprecated("use getTexturePtr() instead.")]]
 	ofTexture * getTexture();
 	
 protected:

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -86,10 +86,14 @@ public:
 	void * getAVFoundationVideoPlayer();
 #endif
     
-    OF_DEPRECATED_MSG("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.", bool loadMovie(std::string name));
-    OF_DEPRECATED_MSG("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.", ofPixels & getPixelsRef());
-    OF_DEPRECATED_MSG("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.", const ofPixels & getPixelsRef() const);
-    OF_DEPRECATED_MSG("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.", ofTexture * getTexture());
+    [[deprecated("ofAVFoundationPlayer::loadMovie() is deprecated, use load() instead.")]]
+	 bool loadMovie(std::string name);
+    [[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	 ofPixels & getPixelsRef();
+    [[deprecated("ofAVFoundationPlayer::getPixelsRef() is deprecated, use getPixels() instead.")]]
+	 const ofPixels & getPixelsRef() const;
+    [[deprecated("ofAVFoundationPlayer::getTexture() is deprecated, use getTexturePtr() instead.")]]
+	 ofTexture * getTexture();
     
 protected:
 	

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -86,13 +86,13 @@ public:
 	void * getAVFoundationVideoPlayer();
 #endif
 	
-	[[deprecated("use load() instead.")]]
+	[[deprecated("use load()")]]
 	bool loadMovie(std::string name);
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	ofPixels & getPixelsRef();
-	[[deprecated("use getPixels() instead.")]]
+	[[deprecated("use getPixels()")]]
 	const ofPixels & getPixelsRef() const;
-	[[deprecated("use getTexturePtr() instead.")]]
+	[[deprecated("use getTexturePtr()")]]
 	ofTexture * getTexture();
 	
 protected:

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -10,83 +10,87 @@ typedef ofPixels_<float> ofFloatPixels;
 typedef ofPixels_<unsigned short> ofShortPixels;
 typedef ofPixels& ofPixelsRef;
 
+class ofVideoGrabber : public ofBaseVideoGrabber, public ofBaseVideoDraws{
+public:
 
-class ofVideoGrabber : public ofBaseVideoGrabber,public ofBaseVideoDraws{
+	ofVideoGrabber();
+	virtual ~ofVideoGrabber();
 
-	public :
+	std::vector<ofVideoDevice> listDevices() const;
+	bool				isFrameNew() const;
+	void				update();
+	void				close();
+	bool				setup(int w, int h){return setup(w,h,bUseTexture);}
+	bool				setup(int w, int h, bool bTexture);
+	[[deprecated("Use setup instead")]]
+	bool initGrabber(int w, int h){return setup(w,h);}
+	[[deprecated("Use setup instead")]]
+	bool initGrabber(int w, int h, bool bTexture);
+	
+	bool				setPixelFormat(ofPixelFormat pixelFormat);
+	ofPixelFormat 		getPixelFormat() const;
+	
+	void				videoSettings();
+	ofPixels& 			getPixels();
+	const ofPixels&		getPixels() const;
+	[[deprecated("Use getPixels() instead")]]
+	 ofPixels&	getPixelsRef();
+	[[deprecated("Use getPixels() instead")]]
+	 const ofPixels&  getPixelsRef() const;
+	ofTexture &			getTexture();
+	const ofTexture &	getTexture() const;
+	[[deprecated("Use getTexture")]]
+	ofTexture &			getTextureReference();
+	[[deprecated("Use getTexture")]]
+	const ofTexture &	getTextureReference() const;
+	std::vector<ofTexture> & getTexturePlanes();
+	const std::vector<ofTexture> & getTexturePlanes() const;
+	void				setVerbose(bool bTalkToMe);
+	void				setDeviceID(int _deviceID);
+	void				setDesiredFrameRate(int framerate);
+	void				setUseTexture(bool bUse);
+	bool 				isUsingTexture() const;
+	void				draw(float x, float y, float w, float h) const;
+	void				draw(float x, float y) const;
+	using ofBaseDraws::draw;
 
-		ofVideoGrabber();
-		virtual ~ofVideoGrabber();
+	void 				bind() const;
+	void 				unbind() const;
 
-		std::vector<ofVideoDevice> listDevices() const;
-		bool				isFrameNew() const;
-		void				update();
-		void				close();	
-		bool				setup(int w, int h){return setup(w,h,bUseTexture);}
-		bool				setup(int w, int h, bool bTexture);
-		OF_DEPRECATED_MSG("Use setup instead",bool initGrabber(int w, int h){return setup(w,h);})
-		OF_DEPRECATED_MSG("Use setup instead",bool initGrabber(int w, int h, bool bTexture));
-		
-		bool				setPixelFormat(ofPixelFormat pixelFormat);
-		ofPixelFormat 		getPixelFormat() const;
-		
-		void				videoSettings();
-		ofPixels& 			getPixels();
-		const ofPixels&		getPixels() const;
-        OF_DEPRECATED_MSG("Use getPixels() instead", ofPixels&	getPixelsRef());
-        OF_DEPRECATED_MSG("Use getPixels() instead", const ofPixels&  getPixelsRef() const);
-		ofTexture &			getTexture();
-		const ofTexture &	getTexture() const;
-		OF_DEPRECATED_MSG("Use getTexture",ofTexture &			getTextureReference());
-		OF_DEPRECATED_MSG("Use getTexture",const ofTexture &	getTextureReference() const);
-		std::vector<ofTexture> & getTexturePlanes();
-		const std::vector<ofTexture> & getTexturePlanes() const;
-		void				setVerbose(bool bTalkToMe);
-		void				setDeviceID(int _deviceID);
-		void				setDesiredFrameRate(int framerate);
-		void				setUseTexture(bool bUse);
-		bool 				isUsingTexture() const;
-		void				draw(float x, float y, float w, float h) const;
-		void				draw(float x, float y) const;
-		using ofBaseDraws::draw;
+	//the anchor is the point the image is drawn around.
+	//this can be useful if you want to rotate an image around a particular point.
+	void				setAnchorPercent(float xPct, float yPct);	//set the anchor as a percentage of the image width/height ( 0.0-1.0 range )
+	void				setAnchorPoint(float x, float y);				//set the anchor point in pixels
+	void				resetAnchor();								//resets the anchor to (0, 0)
 
-		void 				bind() const;
-		void 				unbind() const;
+	float				getHeight() const;
+	float				getWidth() const;
 
-		//the anchor is the point the image is drawn around.
-		//this can be useful if you want to rotate an image around a particular point.
-        void				setAnchorPercent(float xPct, float yPct);	//set the anchor as a percentage of the image width/height ( 0.0-1.0 range )
-        void				setAnchorPoint(float x, float y);				//set the anchor point in pixels
-        void				resetAnchor();								//resets the anchor to (0, 0)
+	bool				isInitialized() const;
 
-		float				getHeight() const;
-		float				getWidth() const;
+	void					setGrabber(std::shared_ptr<ofBaseVideoGrabber> newGrabber);
+	std::shared_ptr<ofBaseVideoGrabber> getGrabber();
+	const std::shared_ptr<ofBaseVideoGrabber> getGrabber() const;
 
-		bool				isInitialized() const;
+	template<typename GrabberType>
+	std::shared_ptr<GrabberType> getGrabber(){
+		return std::dynamic_pointer_cast<GrabberType>(getGrabber());
+	}
 
-		void					setGrabber(std::shared_ptr<ofBaseVideoGrabber> newGrabber);
-		std::shared_ptr<ofBaseVideoGrabber> getGrabber();
-		const std::shared_ptr<ofBaseVideoGrabber> getGrabber() const;
+	template<typename GrabberType>
+	const std::shared_ptr<GrabberType> getGrabber() const{
+		return std::dynamic_pointer_cast<GrabberType>(getGrabber());
+	}
 
-		template<typename GrabberType>
-		std::shared_ptr<GrabberType> getGrabber(){
-			return std::dynamic_pointer_cast<GrabberType>(getGrabber());
-		}
+private:
+	
+	std::vector<ofTexture> tex;
+	bool bUseTexture;
+	std::shared_ptr<ofBaseVideoGrabber> grabber;
+	int requestedDeviceID;
 
-		template<typename GrabberType>
-		const std::shared_ptr<GrabberType> getGrabber() const{
-			return std::dynamic_pointer_cast<GrabberType>(getGrabber());
-		}
-
-	private:
-		
-		std::vector<ofTexture> tex;
-		bool bUseTexture;
-		std::shared_ptr<ofBaseVideoGrabber> grabber;
-		int requestedDeviceID;
-
-		mutable ofPixelFormat internalPixelFormat;
-		int desiredFramerate;
+	mutable ofPixelFormat internalPixelFormat;
+	int desiredFramerate;
 };
 
 

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -10,7 +10,7 @@ typedef ofPixels_<float> ofFloatPixels;
 typedef ofPixels_<unsigned short> ofShortPixels;
 typedef ofPixels& ofPixelsRef;
 
-class ofVideoGrabber : public ofBaseVideoGrabber, public ofBaseVideoDraws{
+class ofVideoGrabber : public ofBaseVideoGrabber, public ofBaseVideoDraws {
 public:
 
 	ofVideoGrabber();
@@ -34,9 +34,9 @@ public:
 	ofPixels& 			getPixels();
 	const ofPixels&		getPixels() const;
 	[[deprecated("Use getPixels() instead")]]
-	 ofPixels&	getPixelsRef();
+	ofPixels&	getPixelsRef();
 	[[deprecated("Use getPixels() instead")]]
-	 const ofPixels&  getPixelsRef() const;
+	const ofPixels&  getPixelsRef() const;
 	ofTexture &			getTexture();
 	const ofTexture &	getTexture() const;
 	[[deprecated("Use getTexture")]]
@@ -92,6 +92,3 @@ private:
 	mutable ofPixelFormat internalPixelFormat;
 	int desiredFramerate;
 };
-
-
-

--- a/libs/openFrameworks/video/ofVideoGrabber.h
+++ b/libs/openFrameworks/video/ofVideoGrabber.h
@@ -22,9 +22,9 @@ public:
 	void				close();
 	bool				setup(int w, int h){return setup(w,h,bUseTexture);}
 	bool				setup(int w, int h, bool bTexture);
-	[[deprecated("Use setup instead")]]
+	[[deprecated("Use setup")]]
 	bool initGrabber(int w, int h){return setup(w,h);}
-	[[deprecated("Use setup instead")]]
+	[[deprecated("Use setup")]]
 	bool initGrabber(int w, int h, bool bTexture);
 	
 	bool				setPixelFormat(ofPixelFormat pixelFormat);
@@ -33,9 +33,9 @@ public:
 	void				videoSettings();
 	ofPixels& 			getPixels();
 	const ofPixels&		getPixels() const;
-	[[deprecated("Use getPixels() instead")]]
+	[[deprecated("Use getPixels()")]]
 	ofPixels&	getPixelsRef();
-	[[deprecated("Use getPixels() instead")]]
+	[[deprecated("Use getPixels()")]]
 	const ofPixels&  getPixelsRef() const;
 	ofTexture &			getTexture();
 	const ofTexture &	getTexture() const;

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -15,7 +15,8 @@ class ofVideoPlayer : public ofBaseVideoDraws{
 
 		bool 				load(std::string name);
 		void				loadAsync(std::string name);
-		OF_DEPRECATED_MSG("Use load instead",bool loadMovie(std::string name));
+		[[deprecated("Use load instead")]]
+	bool loadMovie(std::string name);
 
 
 		/// \brief Get the path to the loaded video file.
@@ -52,8 +53,10 @@ class ofVideoPlayer : public ofBaseVideoDraws{
 		bool 				isFrameNew() const;
 		ofPixels& 			getPixels();
 		const ofPixels&		getPixels() const;
-        OF_DEPRECATED_MSG("Use getPixels() instead", ofPixels&	getPixelsRef());
-        OF_DEPRECATED_MSG("Use getPixels() instead", const ofPixels&  getPixelsRef() const);
+        [[deprecated("Use getPixels() instead")]]
+	 ofPixels&	getPixelsRef();
+        [[deprecated("Use getPixels() instead")]]
+	 const ofPixels&  getPixelsRef() const;
 		float 				getPosition() const;
 		float 				getSpeed() const;
 		float 				getDuration() const;
@@ -70,8 +73,10 @@ class ofVideoPlayer : public ofBaseVideoDraws{
 		bool 				isUsingTexture() const;
 		ofTexture &			getTexture();
 		const ofTexture &	getTexture() const;
-		OF_DEPRECATED_MSG("Use getTexture",ofTexture &			getTextureReference());
-		OF_DEPRECATED_MSG("Use getTexture",const ofTexture &	getTextureReference() const);
+		[[deprecated("Use getTexture")]]
+	ofTexture &			getTextureReference();
+		[[deprecated("Use getTexture")]]
+	const ofTexture &	getTextureReference() const;
 		std::vector<ofTexture> & getTexturePlanes();
 		const std::vector<ofTexture> & getTexturePlanes() const;
 		void 				draw(float x, float y, float w, float h) const;

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -11,7 +11,7 @@ public:
 
 	bool 				load(std::string name);
 	void				loadAsync(std::string name);
-	[[deprecated("Use load instead")]]
+	[[deprecated("Use load")]]
 	bool loadMovie(std::string name);
 
 
@@ -49,9 +49,9 @@ public:
 	bool 				isFrameNew() const;
 	ofPixels& 			getPixels();
 	const ofPixels&		getPixels() const;
-	[[deprecated("Use getPixels() instead")]]
+	[[deprecated("Use getPixels()")]]
 	ofPixels&	getPixelsRef();
-	[[deprecated("Use getPixels() instead")]]
+	[[deprecated("Use getPixels()")]]
 	const ofPixels&  getPixelsRef() const;
 	float 				getPosition() const;
 	float 				getSpeed() const;

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -4,191 +4,187 @@
 #include "ofVideoBaseTypes.h"
 #include "ofConstants.h"
 
-
 //---------------------------------------------
-class ofVideoPlayer : public ofBaseVideoDraws{
+class ofVideoPlayer : public ofBaseVideoDraws {
+public:
+	ofVideoPlayer ();
 
-	public:
-
-		ofVideoPlayer ();
-
-
-		bool 				load(std::string name);
-		void				loadAsync(std::string name);
-		[[deprecated("Use load instead")]]
+	bool 				load(std::string name);
+	void				loadAsync(std::string name);
+	[[deprecated("Use load instead")]]
 	bool loadMovie(std::string name);
 
 
-		/// \brief Get the path to the loaded video file.
-		///
-		/// If no video file is loaded this returns an empty string.
-		///
-		/// \returns A path to the loaded video or an empty string if not loaded.
-		std::string				getMoviePath() const;
+	/// \brief Get the path to the loaded video file.
+	///
+	/// If no video file is loaded this returns an empty string.
+	///
+	/// \returns A path to the loaded video or an empty string if not loaded.
+	std::string				getMoviePath() const;
 
-		bool				setPixelFormat(ofPixelFormat pixelFormat);
-		ofPixelFormat		getPixelFormat() const;
+	bool				setPixelFormat(ofPixelFormat pixelFormat);
+	ofPixelFormat		getPixelFormat() const;
 
-		/// \brief Closes the movie file and releases its resources.
-		///
-		/// This is an alias for close().
-		///
-		/// \sa close()
-		void 				closeMovie();
-		/// \brief Closes the movie file releases its resources.
-		///
-		/// This is an alias for closeMovie().
-		///
-		/// \sa closeMovie()
-		void 				close();
+	/// \brief Closes the movie file and releases its resources.
+	///
+	/// This is an alias for close().
+	///
+	/// \sa close()
+	void 				closeMovie();
+	/// \brief Closes the movie file releases its resources.
+	///
+	/// This is an alias for closeMovie().
+	///
+	/// \sa closeMovie()
+	void 				close();
 
-		/// \brief Update the video player's internal state to continue playback.
-		///
-		/// If normal video playback is desired, this method is usually called
-		/// once per animation frame inside of ofApp::update().
-		void				update();
-		void 				play();
-		void 				stop();
+	/// \brief Update the video player's internal state to continue playback.
+	///
+	/// If normal video playback is desired, this method is usually called
+	/// once per animation frame inside of ofApp::update().
+	void				update();
+	void 				play();
+	void 				stop();
 
-		bool 				isFrameNew() const;
-		ofPixels& 			getPixels();
-		const ofPixels&		getPixels() const;
-        [[deprecated("Use getPixels() instead")]]
-	 ofPixels&	getPixelsRef();
-        [[deprecated("Use getPixels() instead")]]
-	 const ofPixels&  getPixelsRef() const;
-		float 				getPosition() const;
-		float 				getSpeed() const;
-		float 				getDuration() const;
-		bool				getIsMovieDone() const;
+	bool 				isFrameNew() const;
+	ofPixels& 			getPixels();
+	const ofPixels&		getPixels() const;
+	[[deprecated("Use getPixels() instead")]]
+	ofPixels&	getPixelsRef();
+	[[deprecated("Use getPixels() instead")]]
+	const ofPixels&  getPixelsRef() const;
+	float 				getPosition() const;
+	float 				getSpeed() const;
+	float 				getDuration() const;
+	bool				getIsMovieDone() const;
 
-		void 				setPosition(float pct);
-		void 				setVolume(float volume);
-		void 				setLoopState(ofLoopType state);
-		ofLoopType			getLoopState() const;
-		void   				setSpeed(float speed);
-		void				setFrame(int frame);
+	void 				setPosition(float pct);
+	void 				setVolume(float volume);
+	void 				setLoopState(ofLoopType state);
+	ofLoopType			getLoopState() const;
+	void   				setSpeed(float speed);
+	void				setFrame(int frame);
 
-		void 				setUseTexture(bool bUse);
-		bool 				isUsingTexture() const;
-		ofTexture &			getTexture();
-		const ofTexture &	getTexture() const;
-		[[deprecated("Use getTexture")]]
+	void 				setUseTexture(bool bUse);
+	bool 				isUsingTexture() const;
+	ofTexture &			getTexture();
+	const ofTexture &	getTexture() const;
+	[[deprecated("Use getTexture")]]
 	ofTexture &			getTextureReference();
-		[[deprecated("Use getTexture")]]
+	[[deprecated("Use getTexture")]]
 	const ofTexture &	getTextureReference() const;
-		std::vector<ofTexture> & getTexturePlanes();
-		const std::vector<ofTexture> & getTexturePlanes() const;
-		void 				draw(float x, float y, float w, float h) const;
-		void 				draw(float x, float y) const;
-		using ofBaseDraws::draw;
-		/// \brief Binds the video texture to the current rendering context.
-		///
-		/// For advanced users who need to manually manage texture drawing
-		/// without calling draw(). Only binds the texture if one exists.
-		///
-		/// \sa ofTexture::bind()
-		/// \sa http://www.opengl.org/sdk/docs/man4/html/glBindTexture.xhtml
-		void 				bind() const;
-		/// \brief Unbinds the video texture from the current rendering context.
-		///
-		/// For advanced users who need to manually manage texture drawing
-		/// without calling draw(). Only binds the texture if one exists.
-		///
-		/// \sa ofTexture::unbind()
-		void 				unbind() const;
+	std::vector<ofTexture> & getTexturePlanes();
+	const std::vector<ofTexture> & getTexturePlanes() const;
+	void 				draw(float x, float y, float w, float h) const;
+	void 				draw(float x, float y) const;
+	using ofBaseDraws::draw;
+	/// \brief Binds the video texture to the current rendering context.
+	///
+	/// For advanced users who need to manually manage texture drawing
+	/// without calling draw(). Only binds the texture if one exists.
+	///
+	/// \sa ofTexture::bind()
+	/// \sa http://www.opengl.org/sdk/docs/man4/html/glBindTexture.xhtml
+	void 				bind() const;
+	/// \brief Unbinds the video texture from the current rendering context.
+	///
+	/// For advanced users who need to manually manage texture drawing
+	/// without calling draw(). Only binds the texture if one exists.
+	///
+	/// \sa ofTexture::unbind()
+	void 				unbind() const;
 
-        void				setAnchorPercent(float xPct, float yPct);
-        void				setAnchorPoint(float x, float y);
-        void				resetAnchor();
+	void				setAnchorPercent(float xPct, float yPct);
+	void				setAnchorPoint(float x, float y);
+	void				resetAnchor();
 
-		void 				setPaused(bool bPause);
+	void 				setPaused(bool bPause);
 
-		int					getCurrentFrame() const;
-		int					getTotalNumFrames() const;
+	int					getCurrentFrame() const;
+	int					getTotalNumFrames() const;
 
-		void				firstFrame();
-		void				nextFrame();
-		void				previousFrame();
+	void				firstFrame();
+	void				nextFrame();
+	void				previousFrame();
 
-		float 				getHeight() const;
-		float 				getWidth() const;
+	float 				getHeight() const;
+	float 				getWidth() const;
 
-		bool				isPaused() const;
-		bool				isLoaded() const;
-		bool				isPlaying() const;
-		bool 				isInitialized() const;
+	bool				isPaused() const;
+	bool				isLoaded() const;
+	bool				isPlaying() const;
+	bool 				isInitialized() const;
 
-		/// \brief Set the internal video player implementation.
-		///
-		/// Advanced users may find it useful to set a custom internal video
-		/// player implementation. The custom video player must implment the
-		/// ofBaseVideoPlayer interface.
-		///
-		/// \param newPlayer Shared pointer to the new video player that extends
-		/// from ofBaseVideoPlayer.
-		void				setPlayer(std::shared_ptr<ofBaseVideoPlayer> newPlayer);
-		/// \brief Get a pointer to the internal video player implementation.
-		///
-		/// This returns a pointer to the ofBaseVideoPlayer interface. For
-		/// implementation-specfic features, this can be cast to the subtype
-		/// using dynamic_cast<MyVideoPlayerImplementation>(getPlayer()) or the
-		/// templated getPlayer<MyVideoPlayerImplementation>() method.
-		///
-		/// \returns A pointer to the internal video player implementation.
-		std::shared_ptr<ofBaseVideoPlayer>	getPlayer();
-		/// \brief Get a const pointer to the internal video player implementation.
-		///
-		/// This returns a pointer to the ofBaseVideoPlayer interface. For
-		/// implementation-specfic features, this can be cast to the subtype
-		/// using dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer())
-		/// or the templated getPlayer<MyVideoPlayerImplementation>() method.
-		///
-		/// \returns A const pointer to the internal video player implementation.
-		const std::shared_ptr<ofBaseVideoPlayer>	getPlayer() const;
+	/// \brief Set the internal video player implementation.
+	///
+	/// Advanced users may find it useful to set a custom internal video
+	/// player implementation. The custom video player must implment the
+	/// ofBaseVideoPlayer interface.
+	///
+	/// \param newPlayer Shared pointer to the new video player that extends
+	/// from ofBaseVideoPlayer.
+	void				setPlayer(std::shared_ptr<ofBaseVideoPlayer> newPlayer);
+	/// \brief Get a pointer to the internal video player implementation.
+	///
+	/// This returns a pointer to the ofBaseVideoPlayer interface. For
+	/// implementation-specfic features, this can be cast to the subtype
+	/// using dynamic_cast<MyVideoPlayerImplementation>(getPlayer()) or the
+	/// templated getPlayer<MyVideoPlayerImplementation>() method.
+	///
+	/// \returns A pointer to the internal video player implementation.
+	std::shared_ptr<ofBaseVideoPlayer>	getPlayer();
+	/// \brief Get a const pointer to the internal video player implementation.
+	///
+	/// This returns a pointer to the ofBaseVideoPlayer interface. For
+	/// implementation-specfic features, this can be cast to the subtype
+	/// using dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer())
+	/// or the templated getPlayer<MyVideoPlayerImplementation>() method.
+	///
+	/// \returns A const pointer to the internal video player implementation.
+	const std::shared_ptr<ofBaseVideoPlayer>	getPlayer() const;
 
-		/// \brief Get a pointer to the internal video player implementation.
-		///
-		/// Calling getPlayer<MyVideoPlayerImplementation>() is equivalent to
-		/// dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer()).
-		///
-		/// \returns A pointer to the internal video player implementation or
-		///			 nullptr if the cast fails.
-		template<typename PlayerType>
-		std::shared_ptr<PlayerType> getPlayer(){
-			return std::dynamic_pointer_cast<PlayerType>(getPlayer());
-		}
+	/// \brief Get a pointer to the internal video player implementation.
+	///
+	/// Calling getPlayer<MyVideoPlayerImplementation>() is equivalent to
+	/// dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer()).
+	///
+	/// \returns A pointer to the internal video player implementation or
+	///			 nullptr if the cast fails.
+	template<typename PlayerType>
+	std::shared_ptr<PlayerType> getPlayer(){
+		return std::dynamic_pointer_cast<PlayerType>(getPlayer());
+	}
 
-		/// \brief Get a const pointer to the internal video player implementation.
-		///
-		/// Calling getPlayer<MyVideoPlayerImplementation>() is equivalent to
-		/// dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer()).
-		///
-		/// \returns A const pointer to the internal video player implementation
-		///			 or nullptr if the cast fails.
-		template<typename PlayerType>
-		const std::shared_ptr<PlayerType> getPlayer() const{
-			return std::dynamic_pointer_cast<PlayerType>(getPlayer());
-		}
+	/// \brief Get a const pointer to the internal video player implementation.
+	///
+	/// Calling getPlayer<MyVideoPlayerImplementation>() is equivalent to
+	/// dynamic_pointer_cast<MyVideoPlayerImplementation>(getPlayer()).
+	///
+	/// \returns A const pointer to the internal video player implementation
+	///			 or nullptr if the cast fails.
+	template<typename PlayerType>
+	const std::shared_ptr<PlayerType> getPlayer() const{
+		return std::dynamic_pointer_cast<PlayerType>(getPlayer());
+	}
 
-	private:
-		/// \brief Initialize the default player implementations.
-		void initDefaultPlayer();
-		/// \brief A pointer to the internal video player implementation.
-		std::shared_ptr<ofBaseVideoPlayer>		player;
-		/// \brief A collection of texture planes used by the video player.
-		std::vector<ofTexture> tex;
-		/// \brief A pointer to the internal player's texture if available.
-		///
-		/// Video players that implement ofBaseVideoPlayer::getTexturePtr()
-		/// can provide a pointer to an internal texture. When possible,
-		/// ofVideoPlayer will use the internal texture to avoid extra pixel
-		/// copies.
-		ofTexture * playerTex;
-		/// \brief True if the video player is using a texture.
-		bool bUseTexture;
-		/// \brief The internal pixel format.
-		mutable ofPixelFormat internalPixelFormat;
-		/// \brief The stored path to the video's path.
-		std::string moviePath;
+private:
+	/// \brief Initialize the default player implementations.
+	void initDefaultPlayer();
+	/// \brief A pointer to the internal video player implementation.
+	std::shared_ptr<ofBaseVideoPlayer>		player;
+	/// \brief A collection of texture planes used by the video player.
+	std::vector<ofTexture> tex;
+	/// \brief A pointer to the internal player's texture if available.
+	///
+	/// Video players that implement ofBaseVideoPlayer::getTexturePtr()
+	/// can provide a pointer to an internal texture. When possible,
+	/// ofVideoPlayer will use the internal texture to avoid extra pixel
+	/// copies.
+	ofTexture * playerTex;
+	/// \brief True if the video player is using a texture.
+	bool bUseTexture;
+	/// \brief The internal pixel format.
+	mutable ofPixelFormat internalPixelFormat;
+	/// \brief The stored path to the video's path.
+	std::string moviePath;
 };


### PR DESCRIPTION
All OF_DEPRECATED_MSG replaced by [[deprecated]] by regex
both in OF Core and addons.

Using Visual Studio Code -> replace in files
and some indent fix after.
```regex
OF_DEPRECATED_MSG\("(.*?)",\s?(.*?)\);
[[deprecated("$1")]]\n$2;
```

```regex
\[\[deprecated\("(.*?) is deprecated, 
[[deprecated("
```

```regex
(.*?) instead."\)\]\]
(.*?) instead"\)\]\]
```

closes https://github.com/openframeworks/openFrameworks/issues/7673