### PR TITLE
More .h work #7

### DIFF
--- a/libs/openFrameworks/app/ofAppBaseWindow.h
+++ b/libs/openFrameworks/app/ofAppBaseWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ofWindowSettings.h"
+// MARK: Target
 #include "ofConstants.h"
 
 class ofBaseApp;

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -5,6 +5,7 @@
 #include "ofImage.h"
 #include "ofEvents.h"
 #include "ofRectangle.h"
+// MARK: Target
 #include "ofConstants.h"
 #include <queue>
 #include <map>

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -3,6 +3,7 @@
 #include "ofAppBaseWindow.h"
 // MARK: Optimize to Pointer
 #include "ofRectangle.h"
+// MARK: Target
 #include "ofConstants.h"
 
 #if defined(TARGET_LINUX) && !defined(TARGET_RASPBERRY_PI_LEGACY)

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -3,7 +3,6 @@
 #include "ofAppBaseWindow.h"
 #include "ofEvents.h"
 #include "ofTypes.h"
-//#include "ofPixels.h"
 // MARK: Target but optional
 #include "ofConstants.h"
 

--- a/libs/openFrameworks/app/ofAppGlutWindow.h
+++ b/libs/openFrameworks/app/ofAppGlutWindow.h
@@ -4,6 +4,7 @@
 #include "ofEvents.h"
 #include "ofTypes.h"
 //#include "ofPixels.h"
+// MARK: Target but optional
 #include "ofConstants.h"
 
 template <typename T>

--- a/libs/openFrameworks/app/ofAppRunner.h
+++ b/libs/openFrameworks/app/ofAppRunner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// #include "ofConstants.h"
 #include "ofMainLoop.h"
 #include "ofWindowSettings.h"
 

--- a/libs/openFrameworks/communication/ofSerial.h
+++ b/libs/openFrameworks/communication/ofSerial.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: ofConstants targets
+// MARK: ofConstants targets
 #include "ofConstants.h"
 
 class ofBuffer;

--- a/libs/openFrameworks/gl/ofBufferObject.cpp
+++ b/libs/openFrameworks/gl/ofBufferObject.cpp
@@ -1,6 +1,6 @@
 #include "ofBufferObject.h"
 #include "ofAppRunner.h"
-#include "ofPixels.h"
+//#include "ofPixels.h"
 #include "ofGLUtils.h"
 
 

--- a/libs/openFrameworks/gl/ofBufferObject.h
+++ b/libs/openFrameworks/gl/ofBufferObject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: platforms plus GL/ headers
+// MARK: Targets plus GL/ headers
 #include "ofConstants.h"
 
 template<typename T>

--- a/libs/openFrameworks/gl/ofFbo.cpp
+++ b/libs/openFrameworks/gl/ofFbo.cpp
@@ -3,6 +3,7 @@
 #include "ofUtils.h"
 #include "ofGraphics.h"
 #include "ofGLRenderer.h"
+// MARK: Targets
 #include "ofConstants.h"
 #include <unordered_map>
 

--- a/libs/openFrameworks/gl/ofGLUtils.h
+++ b/libs/openFrameworks/gl/ofGLUtils.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "ofGraphicsConstants.h"
+// MARK: Targets / Defines
 #include "ofConstants.h"
 
 class ofShader;

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -7,7 +7,7 @@
  make sure to catch and report that error.
  */
 
-// FIXME: ofConstants Targets
+// MARK: ofConstants Targets
 #include "ofConstants.h"
 
 #define GLM_FORCE_CTOR_INIT

--- a/libs/openFrameworks/gl/ofShadow.cpp
+++ b/libs/openFrameworks/gl/ofShadow.cpp
@@ -11,7 +11,7 @@
 #include "ofGLUtils.h"
 #include "ofLight.h"
 #include "ofGLProgrammableRenderer.h"
-// FIXME: ofConstants Targets
+// MARK: ofConstants Targets
 #include "ofConstants.h"
 
 #define GLM_FORCE_CTOR_INIT

--- a/libs/openFrameworks/gl/ofTexture.h
+++ b/libs/openFrameworks/gl/ofTexture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ofGraphicsBaseTypes.h"
+// MARK: Targets, some can be moved to cpp
 #include "ofConstants.h"
 #include "glm/mat4x4.hpp"
 

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -4,6 +4,7 @@
 
 #include "ofGraphicsConstants.h"
 #include "ofBufferObject.h"
+// FIXME: Targets but it can be optional
 #include "ofConstants.h"
 #include <unordered_map>
 

--- a/libs/openFrameworks/graphics/ofBitmapFont.h
+++ b/libs/openFrameworks/graphics/ofBitmapFont.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofRectangle.h"
-#include "ofPixels.h"
+#include "ofPixels.h" //MARK: unique_ptr
 #include "ofTexture.h"
 #include "ofGraphics.h"
 

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -4,7 +4,7 @@
 #include "ofGraphicsBaseTypes.h"
 // MARK: Optimization opportunity in ofPath, ofPixels pointer.
 #include "ofPath.h"
-#include "ofPixels.h"
+#include "ofPixels.h" // MARK: ofPixels imageBuffer;
 #include "of3dGraphics.h"
 
 #include <deque>

--- a/libs/openFrameworks/graphics/ofImage.h
+++ b/libs/openFrameworks/graphics/ofImage.h
@@ -4,7 +4,6 @@
 #include "ofGLBaseTypes.h"
 #include "ofGraphicsConstants.h"
 #include "ofGLUtils.h"
-#include "ofConstants.h"
 
 template<typename T>
 class ofPixels_;

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -3,7 +3,7 @@
 #include "ofPolyline.h"
 #include "ofVboMesh.h"
 #include "ofTessellator.h"
-// FIXME: ofConstants targets
+// MARK: ofConstants targets
 #include "ofConstants.h"
 
 template<typename T>

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -8,7 +8,7 @@
 #include "ofAppRunner.h"
 #include "ofMath.h"
 #include "ofLog.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 //----------------------------------------------------------
 template<class T>

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.h
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.h
@@ -2,7 +2,7 @@
 
 // MARK: optimization opportunity: unique pointer and remove ofMesh, ofPixels, ofRectangle, ofTexture
 #include "ofMesh.h"
-#include "ofPixels.h"
+#include "ofPixels.h" // Glyph ofPixels pixels
 #include "ofRectangle.h"
 #include "ofTexture.h"
 #include <unordered_map>

--- a/libs/openFrameworks/math/ofMathConstants.h
+++ b/libs/openFrameworks/math/ofMathConstants.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// MARK: if OF_USE_LEGACY_VECTOR_MATH
 #include "ofConstants.h"
 #include "glm/fwd.hpp"
 

--- a/libs/openFrameworks/math/ofMatrix3x3.h
+++ b/libs/openFrameworks/math/ofMatrix3x3.h
@@ -8,6 +8,7 @@
 //#include "ofConstants.h"
 #define GLM_FORCE_CTOR_INIT
 #include <glm/mat3x3.hpp>
+#include <iostream>
 
 
 /// \brief A 3x3 Matrix

--- a/libs/openFrameworks/math/ofMatrix3x3.h
+++ b/libs/openFrameworks/math/ofMatrix3x3.h
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#include "ofConstants.h"
+//#include "ofConstants.h"
+#define GLM_FORCE_CTOR_INIT
 #include <glm/mat3x3.hpp>
 
 

--- a/libs/openFrameworks/math/ofMatrix4x4.h
+++ b/libs/openFrameworks/math/ofMatrix4x4.h
@@ -13,7 +13,8 @@
 #include "ofVec4f.h"
 #include "ofQuaternion.h"
 #include "ofMathConstants.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
+#define GLM_FORCE_CTOR_INIT
 #include "glm/mat4x4.hpp"
 #include <cmath>
 

--- a/libs/openFrameworks/math/ofQuaternion.h
+++ b/libs/openFrameworks/math/ofQuaternion.h
@@ -14,7 +14,7 @@
 #include "ofVec3f.h"
 #include "ofVec4f.h"
 //class ofVec4f;
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include <cmath>
 
 #if (_MSC_VER)       

--- a/libs/openFrameworks/math/ofVec3f.h
+++ b/libs/openFrameworks/math/ofVec3f.h
@@ -3,7 +3,8 @@
 #include "ofVec2f.h"
 #include "ofVec4f.h"
 #include "ofMathConstants.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
+#define GLM_FORCE_CTOR_INIT
 #include "glm/vec3.hpp"
 #include <cmath>
 #include <iostream>

--- a/libs/openFrameworks/ofMain.h
+++ b/libs/openFrameworks/ofMain.h
@@ -115,8 +115,8 @@
 using namespace std;
 #else
 
-    // this will eventually be disabled by default
-    #define OF_USE_MINIMAL_STD
+// this will eventually be disabled by default
+#define OF_USE_MINIMAL_STD
     #ifdef OF_USE_MINIMAL_STD
 using std::cout;
 using std::deque;

--- a/libs/openFrameworks/sound/ofAVEngineSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofAVEngineSoundPlayer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+// MARK: Review later
 #include "ofConstants.h"
 
 #ifdef OF_SOUND_PLAYER_AV_ENGINE

--- a/libs/openFrameworks/sound/ofFmodSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofFmodSoundPlayer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// MARK: Review later
 #include "ofConstants.h"
 
 #ifdef OF_SOUND_PLAYER_FMOD

--- a/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofOpenALSoundPlayer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// MARK: Review later
 #include "ofConstants.h"
 
 #ifdef OF_SOUND_PLAYER_OPENAL

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.h
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.h
@@ -2,7 +2,7 @@
 
 #include "ofSoundBaseTypes.h"
 #include "ofSoundBuffer.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 typedef unsigned int RtAudioStreamStatus;
 class RtAudio;

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.h
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: ofConstants FS
+// MARK: ofConstants FS
 #include "ofConstants.h"
 #include <functional>
 

--- a/libs/openFrameworks/sound/ofSoundPlayer.h
+++ b/libs/openFrameworks/sound/ofSoundPlayer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofSoundBaseTypes.h"
-// FIXME: ofConstants FS
+// MARK: ofConstants FS
 #include "ofConstants.h"
 
 /// \brief Stops all active sound players on FMOD-based systems (windows, osx).

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -6,7 +6,6 @@
 
 #include "ofRectangle.h"
 #include "ofLog.h"
-// #include "ofConstants.h"
 #include "ofColor.h"
 
 #include <map>

--- a/libs/openFrameworks/types/ofTypes.h
+++ b/libs/openFrameworks/types/ofTypes.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// #include "ofConstants.h"
 
 //----------------------------------------------------------
 // ofMutex

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// FIXME: ofConstants FS
+// MARK: ofConstants FS
 #include "ofConstants.h"
 #include <fstream>
 

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -2,7 +2,6 @@
 
 // ofTime only
 #include "ofUtils.h"
-// #include "ofConstants.h"
 #include <queue>
 
 class ofFpsCounter {

--- a/libs/openFrameworks/utils/ofLog.h
+++ b/libs/openFrameworks/utils/ofLog.h
@@ -2,7 +2,6 @@
 
 // Only private ofFile file;
 #include "ofFileUtils.h"
-// #include "ofConstants.h"
 #include "ofUtils.h" // ofVAArgsToString
 #include <sstream>
 

--- a/libs/openFrameworks/utils/ofUtils.h
+++ b/libs/openFrameworks/utils/ofUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// this must be included before the TARGET_MINGW test
+// MARK: TARGET_MINGW test
 #include "ofConstants.h"
 
 #if !defined(TARGET_MINGW)

--- a/libs/openFrameworks/video/ofAVFoundationGrabber.h
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.h
@@ -12,7 +12,7 @@
 #include "ofVideoBaseTypes.h"
 #include "ofTexture.h"
 #include "ofThread.h"
-// FIXME: Template
+// MARK: Template, if 
 #include "ofPixels.h"
 #include <mutex>
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -9,7 +9,7 @@
 #include "ofVideoBaseTypes.h"
 #include "ofTexture.h"
 #include "ofThread.h"
-// FIXME: Template
+// MARK: Template if pixels is changed to unique_ptr
 #include "ofPixels.h"
 
 #ifdef __OBJC__

--- a/libs/openFrameworks/video/ofDirectShowGrabber.h
+++ b/libs/openFrameworks/video/ofDirectShowGrabber.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// MARK: OF_VIDEO_CAPTURE_DIRECTSHOW
 #include "ofConstants.h"
 #include "ofTexture.h"
 #include "ofVideoBaseTypes.h"

--- a/libs/openFrameworks/video/ofDirectShowGrabber.h
+++ b/libs/openFrameworks/video/ofDirectShowGrabber.h
@@ -4,7 +4,7 @@
 #include "ofConstants.h"
 #include "ofTexture.h"
 #include "ofVideoBaseTypes.h"
-#include "ofPixels.h"
+#include "ofPixels.h" // MARK: ofPixels pixels
 
 #ifdef OF_VIDEO_CAPTURE_DIRECTSHOW
 	#include "videoInput.h"
@@ -27,8 +27,8 @@ class ofDirectShowGrabber : public ofBaseVideoGrabber{
 		bool					setPixelFormat(ofPixelFormat pixelFormat);
 		ofPixelFormat			getPixelFormat() const;		
 
-		ofPixels&				getPixels();
-		const ofPixels&			getPixels() const;
+		ofPixels &				getPixels();
+		const ofPixels &		getPixels() const;
 		
 		void					close();
 		void					clearMemory();
@@ -51,7 +51,7 @@ class ofDirectShowGrabber : public ofBaseVideoGrabber{
 		int						deviceID;
 		bool 					bVerbose;
 		bool 					bGrabberInited;
-	    ofPixels		 		pixels;
+	    ofPixels pixels;
 		int						attemptFramerate;
 		bool 					bIsFrameNew;	
 		

--- a/libs/openFrameworks/video/ofDirectShowPlayer.cpp
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.cpp
@@ -1,5 +1,5 @@
 #include "ofDirectShowPlayer.h"
-#include "ofPixels.h"
+#include "ofPixels.h" // MARK: pixels, srcBuffer
 #include "ofMath.h"
 
 #ifdef _MSC_VER

--- a/libs/openFrameworks/video/ofDirectShowPlayer.h
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.h
@@ -3,7 +3,7 @@
 //To allow for QuickTime video playback install the K-Lite Mega Codec Pack 10.2
 
 #pragma once 
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofVideoBaseTypes.h"
 
 template<typename T>

--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -168,8 +168,8 @@ public:
 	void 			reallocateOnNextFrame();
 
 	bool 			isFrameNew() const;
-	ofPixels&		getPixels();
-	const ofPixels&	getPixels() const;
+	ofPixels &		getPixels();
+	const ofPixels &	getPixels() const;
 	ofTexture * 	getTexture();
 	void 			update();
 

--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// MARK: TARGET_ANDROID - maybe it can be removed
 #include "ofConstants.h"
 #ifndef TARGET_ANDROID
 #include "ofPixels.h"

--- a/libs/openFrameworks/video/ofGstVideoGrabber.cpp
+++ b/libs/openFrameworks/video/ofGstVideoGrabber.cpp
@@ -835,7 +835,7 @@ bool ofGstVideoGrabber::isFrameNew() const {
 }
 
 
-ofPixels& ofGstVideoGrabber::getPixels(){
+ofPixels & ofGstVideoGrabber::getPixels(){
 	return videoUtils.getPixels();
 }
 

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.h
@@ -34,7 +34,7 @@
 #include <d3d11_1.h>
 #include <wrl.h>
 #include <wincodec.h>
-#include "ofConstants.h"
+//#include "ofConstants.h"
 #include "ofVideoBaseTypes.h"
 #include "ofPixels.h"
 #include "ofFbo.h"

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.h
@@ -36,7 +36,7 @@
 #include <wincodec.h>
 //#include "ofConstants.h"
 #include "ofVideoBaseTypes.h"
-#include "ofPixels.h"
+#include "ofPixels.h" //mSrcPixels
 #include "ofFbo.h"
 #include "ofEvent.h"
 

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -2,7 +2,7 @@
 
 #include "ofTexture.h"
 #include "ofVideoBaseTypes.h"
-#include "ofConstants.h"
+//#include "ofConstants.h"
 
 //---------------------------------------------
 class ofVideoPlayer : public ofBaseVideoDraws {


### PR DESCRIPTION
Some more .h cleanup
Removing previously commented out includes
Due to recent merged PR [[deprecated]] some inclusions of ofConstants.h are not needed anymore.
There is opportunity of removing more (some functions header defined for specific targets)

both submodules updated to latest