### PR TITLE
VS download addons fix paths

### DIFF
--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -263,10 +263,11 @@ for ((i=0;i<${#addonslibs[@]};++i)); do
         mkdir -p ../addons/${addons[i]}/libs/${addonslibs[i]}
         if ! command -v rsync &> /dev/null
         then      
-            cp -a ${addonslibs[i]}/ ../addons/${addons[i]}/libs/${addonslibs[i]}     
+            cp -a ${addonslibs[i]}/* ../addons/${addons[i]}/libs/${addonslibs[i]}    
         else
-            rsync -a ${addonslibs[i]}/ ../addons/${addons[i]}/libs/${addonslibs[i]}
+            rsync -a ${addonslibs[i]}/ ../addons/${addons[i]}/libs/${addonslibs[i]}/
         fi
         rm -rf ${addonslibs[i]}
     fi
 done
+


### PR DESCRIPTION
Fixes addon paths when using download_libs.sh 

https://github.com/openframeworks/apothecary/issues/315