### PR TITLE
makefile no boost

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
@@ -332,9 +332,9 @@ endif
 PLATFORM_LIBRARIES += freeimage
 ifeq ($(OF_USING_STD_FS),1)
 PLATFORM_LIBRARIES += stdc++fs
-else
-PLATFORM_LIBRARIES += boost_filesystem
-PLATFORM_LIBRARIES += boost_system
+# else
+# PLATFORM_LIBRARIES += boost_filesystem
+# PLATFORM_LIBRARIES += boost_system
 endif
 PLATFORM_LIBRARIES += pugixml
 PLATFORM_LIBRARIES += uriparser


### PR DESCRIPTION
this PR removes the boost from compiling path, improving a little bit the compiling / linking time.
