### PR TITLE
Make - using automatic number of cores

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/compile.project.mk
@@ -136,7 +136,7 @@ endif
 
 Debug:
 	@echo Compiling OF library for Debug
-	$(MAKE) -C $(OF_ROOT)/libs/openFrameworksCompiled/project/ Debug PLATFORM_OS=$(PLATFORM_OS) ABIS_TO_COMPILE_DEBUG="$(ABIS_TO_COMPILE_DEBUG)"
+	$(MAKE) -j -C $(OF_ROOT)/libs/openFrameworksCompiled/project/ Debug PLATFORM_OS=$(PLATFORM_OS) ABIS_TO_COMPILE_DEBUG="$(ABIS_TO_COMPILE_DEBUG)"
 	@echo
 	@echo
 	@echo Compiling $(APPNAME) for Debug

--- a/scripts/ci/addons/build.cmd
+++ b/scripts/ci/addons/build.cmd
@@ -7,6 +7,6 @@ if "%BUILDER%"=="VS" (
   
 if "%BUILDER%"=="MSYS2" (    
      for /D %%e in (addons\%APPVEYOR_PROJECT_NAME%\example*) do (
-         %MSYS2_PATH%\usr\bin\bash -lc "make -j2 -C addons/%APPVEYOR_PROJECT_NAME%/%%~ne Debug"
+         %MSYS2_PATH%\usr\bin\bash -lc "make -j -C addons/%APPVEYOR_PROJECT_NAME%/%%~ne Debug"
      )
 )

--- a/scripts/ci/addons/build.sh
+++ b/scripts/ci/addons/build.sh
@@ -37,7 +37,7 @@ elif [ "$TARGET" == "linuxarmv7l" ]; then
         export CXXFLAGS="${CXXFLAGS} -ftrack-macro-expansion=0";
         export GCCVER=7.1.1
         cd \$1
-        make -j2 DebugNoOF PLATFORM_VARIANT=raspberry2
+        make -j DebugNoOF PLATFORM_VARIANT=raspberry2
 EOF
     export PATH=~/.local/share/junest/bin:$PATH
     chmod 755 build_junest.sh
@@ -70,18 +70,18 @@ if ls example* 1> /dev/null 2>&1; then
         if [ "$TARGET" == "android" ]; then
             cd $example
             echo "ABIS_TO_COMPILE_DEBUG = $OPT" >> config.make
-            make -j2 DebugNoOF PLATFORM_OS=Android
+            make -j DebugNoOF PLATFORM_OS=Android
             cd ..
         elif [ "$TARGET" == "emscripten" ]; then
             cd $example
-            emmake make -j2 DebugNoOF
+            emmake make -j DebugNoOF
             cd ..
         elif [ "$TARGET" == "linuxarmv7l" ]; then
             #make DebugNoOF PLATFORM_VARIANT=raspberry2
             junest ./build_junest.sh $(cd $example; pwd -P)
         else
             cd $example
-            make -j2 DebugNoOF
+            make -j DebugNoOF
             cd ..
         fi
     done

--- a/scripts/ci/android/install.sh
+++ b/scripts/ci/android/install.sh
@@ -53,7 +53,7 @@ else
     cd $OF_ROOT/
     scripts/linux/download_libs.sh
     cd $OF_ROOT/apps/projectGenerator/commandLine
-    make -j2 Debug -C .
+    make -j Debug -C .
     ret=$?
     if [ $ret -ne 0 ]; then
           echo "Failed building Project Generator"

--- a/scripts/ci/emscripten/build.sh
+++ b/scripts/ci/emscripten/build.sh
@@ -15,11 +15,11 @@ cd $ROOT
 #echo "PLATFORM_CFLAGS += $CUSTOMFLAGS" >> libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
 sed -i "s/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = .*/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = -g0/" libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
 cd libs/openFrameworksCompiled/project
-emmake make -j2 Debug # USE_CCACHE=1
+emmake make -j Debug # USE_CCACHE=1
 
 echo "**** Building emptyExample ****"
 cd $ROOT/scripts/templates/linux64
-emmake make -j2 Debug # USE_CCACHE=1
+emmake make -j Debug # USE_CCACHE=1
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
@@ -45,4 +45,4 @@ sed -i "s/ofxKinect kinect;//" src/ofApp.h
 sed -i "s/ofxThreadedImageLoader .*;//" src/ofApp.h
 sed -i "s/ofxXmlPoco .*;//" src/ofApp.h
 
-emmake make -j2 Debug # USE_CCACHE=1
+emmake make -j Debug # USE_CCACHE=1

--- a/scripts/ci/emscripten/examples_to_build.sh
+++ b/scripts/ci/emscripten/examples_to_build.sh
@@ -191,7 +191,7 @@ for folder in "${folders[@]}"; do
         cd $folder
         cp ../../../scripts/templates/emscripten/Makefile .
 		cp ../../../scripts/templates/emscripten/config.make .
-        emmake make -j2 Release
+        emmake make -j Release
         
         errorcode=$?
 		if [[ $errorcode -ne 0 ]]; then

--- a/scripts/ci/linux64/build.sh
+++ b/scripts/ci/linux64/build.sh
@@ -25,16 +25,16 @@ else
     echo "PLATFORM_CFLAGS += $CUSTOMFLAGS" >> libs/openFrameworksCompiled/project/linux64/config.linux64.default.mk
     sed -i "s/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = .*/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = -g0/" libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
     cd libs/openFrameworksCompiled/project
-    make -j2
+    make -j
 
     echo "**** Building emptyExample ****"
     cd $ROOT/scripts/templates/linux64
-    make -j2
+    make -j
 
     echo "**** Building allAddonsExample ****"
     cd $ROOT
     cp scripts/templates/linux64/Makefile examples/templates/allAddonsExample/
     cp scripts/templates/linux64/config.make examples/templates/allAddonsExample/
     cd examples/templates/allAddonsExample/
-    make -j2
+    make -j
 fi

--- a/scripts/ci/linux64/run_tests.sh
+++ b/scripts/ci/linux64/run_tests.sh
@@ -15,7 +15,7 @@ else
 					cd $test
 					cp ../../../scripts/templates/linux/Makefile .
 					cp ../../../scripts/templates/linux/config.make .
-					make -j2 Debug
+					make -j Debug
 					cd bin
 					binname=$(basename ${test})
 	                #gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug

--- a/scripts/ci/linuxaarch64/build.sh
+++ b/scripts/ci/linuxaarch64/build.sh
@@ -23,7 +23,7 @@ cd $OF_ROOT
 cp scripts/templates/linuxaarch64/Makefile examples/templates/emptyExample/
 cp scripts/templates/linuxaarch64/config.make examples/templates/emptyExample/
 cd examples/templates/emptyExample/
-make Debug -j2
+make Debug -j
 
 #TODO:
 #echo "**** Building allAddonsExample ****"
@@ -31,4 +31,4 @@ make Debug -j2
 #cp scripts/templates/linuxaarch64/Makefile examples/templates/allAddonsExample/
 #cp scripts/templates/linuxaarch64/config.make examples/templates/allAddonsExample/
 #cd examples/templates/allAddonsExample/
-#make Debug -j2
+#make Debug -j

--- a/scripts/ci/linuxarmv6l/build.sh
+++ b/scripts/ci/linuxarmv6l/build.sh
@@ -25,11 +25,11 @@ cd $OF_ROOT
 cp scripts/templates/linuxarmv6l/Makefile examples/templates/emptyExample/
 cp scripts/templates/linuxarmv6l/config.make examples/templates/emptyExample/
 cd examples/templates/emptyExample/
-make Debug -j2
+make Debug -j
 
 echo "**** Building allAddonsExample ****"
 cd $OF_ROOT
 cp scripts/templates/linuxarmv6l/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/linuxarmv6l/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
-make Debug -j2
+make Debug -j

--- a/scripts/ci/linuxarmv7l/build_junest.sh
+++ b/scripts/ci/linuxarmv7l/build_junest.sh
@@ -37,18 +37,18 @@ sed -i "s/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = .*/PLATFORM_OPTIMIZATION_CFLAGS_D
 cd $PROJECTS
 
 
-make -j2 Debug PLATFORM_VARIANT=raspberry2 -j2
+make -j Debug PLATFORM_VARIANT=raspberry2 -j
 
 echo "**** Building emptyExample ****"
 cd $OF_ROOT/scripts/templates/linuxarmv7l
-make -j2 Debug PLATFORM_VARIANT=raspberry2 -j2
+make -j Debug PLATFORM_VARIANT=raspberry2 -j
 
 echo "**** Building allAddonsExample ****"
 #cd $OF_ROOT
 #cp scripts/templates/linuxarmv7l/Makefile examples/addons/allAddonsExample/
 #cp scripts/templates/linuxarmv7l/config.make examples/addons/allAddonsExample/
 #cd examples/addons/allAddonsExample/
-#make -j2 Debug PLATFORM_VARIANT=raspberry2
+#make -j Debug PLATFORM_VARIANT=raspberry2
 
 git checkout $PROJECTS/makefileCommon/config.linux.common.mk
 git checkout $PROJECTS/linuxarmv7l/config.linuxarmv7l.default.mk

--- a/scripts/ci/msys2/build.sh
+++ b/scripts/ci/msys2/build.sh
@@ -5,15 +5,15 @@ source $ROOT/scripts/ci/ccache.sh
 
 echo "**** Building OF core ****"
 cd $ROOT/libs/openFrameworksCompiled/project
-make ${USE_CCACHE} -j2 -s Debug
+make ${USE_CCACHE} -j -s Debug
 
 echo "**** Building emptyExample ****"
 cd $ROOT/scripts/templates/msys2
-make ${USE_CCACHE} -j2 -s Debug
+make ${USE_CCACHE} -j -s Debug
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
 cp scripts/templates/msys2/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/msys2/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
-make ${USE_CCACHE} -j2 -s Debug
+make ${USE_CCACHE} -j -s Debug

--- a/scripts/ci/msys2/run_tests.sh
+++ b/scripts/ci/msys2/run_tests.sh
@@ -12,7 +12,7 @@ for group in *; do
 				cd $test
 				cp ../../../scripts/templates/msys2/Makefile .
 				cp ../../../scripts/templates/msys2/config.make .
-				make ${USE_CCACHE} -j2 Debug
+				make ${USE_CCACHE} -j Debug
 				cd bin
 				binname=$(basename ${test})
                 #gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug

--- a/scripts/ci/osx/run_tests.sh
+++ b/scripts/ci/osx/run_tests.sh
@@ -12,14 +12,14 @@ cd $ROOT
 cp scripts/templates/osx/Makefile examples/templates/emptyExample/
 cp scripts/templates/osx/config.make examples/templates/emptyExample/
 cd examples/templates/emptyExample/
-make -j2 -s Debug
+make -j -s Debug
 
 echo "**** Building allAddonsExample ****"
 cd $ROOT
 cp scripts/templates/osx/Makefile examples/templates/allAddonsExample/
 cp scripts/templates/osx/config.make examples/templates/allAddonsExample/
 cd examples/templates/allAddonsExample/
-make -j2 -s Debug
+make -j -s Debug
 
 echo "**** Running unit tests ****"
 cd $ROOT/tests
@@ -30,7 +30,7 @@ for group in *; do
                 cd $test
                 cp ../../../scripts/templates/osx/Makefile .
                 cp ../../../scripts/templates/osx/config.make .
-                make -j2 -s Debug
+                make -j -s Debug
                 make RunDebug
 				errorcode=$?
 				if [[ $errorcode -ne 0 ]]; then

--- a/scripts/linux/buildAllExamples.sh
+++ b/scripts/linux/buildAllExamples.sh
@@ -19,13 +19,13 @@ do
         echo building  $example
 
         #projectGenerator .
-        make Debug -j2 -C "$example"
+        make Debug -j -C "$example"
         ret=$?
         if [ $ret -ne 0 ]; then
             echo error compiling $example
             exit
         fi
-        make Release -j2 -C "$example"
+        make Release -j -C "$example"
         ret=$?
         if [ $ret -ne 0 ]; then
             echo error compiling $example


### PR DESCRIPTION
two changes:

internally build core using multiple cores on make (in compile.project.mk)
and change the -j2 to -j to detect automatic number of available cores

this can improve github actions, and overall performance