### PR TITLE
Fix ofTrueTypeFont: wrong width calc (only when string contains \n)

### DIFF
--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1192,11 +1192,14 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const string& c, float x, float
 	float w = 0;
 	iterateString( c, x, y, vflip, [&]( uint32_t c, glm::vec2 pos ){
 		auto props = getGlyphProperties( c );
-		if ( c == '\t' ){
-			w += props.advance * spaceSize * TAB_WIDTH;
-		} else {
-			w += props.advance;
-		}
+        float cWidth = 0;
+        if ( c == '\t' ){
+            cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+        } else {
+            cWidth = getGlyphProperties( c ).advance;
+        }
+        
+        w = std::max(w, std::abs(pos.x - x) + cWidth);
 
 		minX = min( minX, pos.x );
 		if ( vflip ){

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1162,16 +1162,16 @@ float ofTrueTypeFont::stringWidth(const string& c) const{
 //	return getStringBoundingBox(c, 0,0).width;
 	float w = 0;
 	iterateString( c, 0, 0, false, [&]( uint32_t c, glm::vec2 pos ){
-        float cWidth = 0;
-        
-        if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
-            if ( c == '\t' ){
-                cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-            } else {
-                cWidth = getGlyphProperties( c ).advance;
-            }
-        }
-        w = std::max(w, std::abs(pos.x + cWidth));
+		float cWidth = 0;
+
+		if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
+			if ( c == '\t' ){
+				cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+			} else {
+				cWidth = getGlyphProperties( c ).advance;
+			}
+		}
+		w = std::max(w, std::abs(pos.x + cWidth));
 	});
 	return w;
 }
@@ -1198,17 +1198,17 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const string& c, float x, float
 	iterateString( c, x, y, vflip, [&]( uint32_t c, glm::vec2 pos ){
 		auto props = getGlyphProperties( c );
 
-        float cWidth = 0;
+		float cWidth = 0;
 
-        if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
-            if ( c == '\t' ){
-                cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-            } else {
-                cWidth = getGlyphProperties( c ).advance;
-            }
-        }
-        
-        w = std::max(w, std::abs(pos.x - x) + cWidth);
+		if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
+			if ( c == '\t' ){
+				cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+			} else {
+				cWidth = getGlyphProperties( c ).advance;
+			}
+		}
+
+		w = std::max(w, std::abs(pos.x - x) + cWidth);
 
 		minX = min( minX, pos.x );
 		if ( vflip ){

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1163,12 +1163,14 @@ float ofTrueTypeFont::stringWidth(const string& c) const{
 	float w = 0;
 	iterateString( c, 0, 0, false, [&]( uint32_t c, glm::vec2 pos ){
         float cWidth = 0;
-        if ( c == '\t' ){
-            cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-		} else {
-            cWidth = getGlyphProperties( c ).advance;
-		}
         
+        if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
+            if ( c == '\t' ){
+                cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+            } else {
+                cWidth = getGlyphProperties( c ).advance;
+            }
+        }
         w = std::max(w, std::abs(pos.x + cWidth));
 	});
 	return w;
@@ -1195,11 +1197,15 @@ ofRectangle ofTrueTypeFont::getStringBoundingBox(const string& c, float x, float
 	float w = 0;
 	iterateString( c, x, y, vflip, [&]( uint32_t c, glm::vec2 pos ){
 		auto props = getGlyphProperties( c );
+
         float cWidth = 0;
-        if ( c == '\t' ){
-            cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
-        } else {
-            cWidth = getGlyphProperties( c ).advance;
+
+        if(settings.direction == OF_TTF_LEFT_TO_RIGHT){
+            if ( c == '\t' ){
+                cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+            } else {
+                cWidth = getGlyphProperties( c ).advance;
+            }
         }
         
         w = std::max(w, std::abs(pos.x - x) + cWidth);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1160,13 +1160,16 @@ void ofTrueTypeFont::drawCharAsShape(uint32_t c, float x, float y, bool vFlipped
 //-----------------------------------------------------------
 float ofTrueTypeFont::stringWidth(const string& c) const{
 //	return getStringBoundingBox(c, 0,0).width;
-	int w = 0;
+	float w = 0;
 	iterateString( c, 0, 0, false, [&]( uint32_t c, glm::vec2 pos ){
-		if ( c == '\t' ){
-			w += getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
+        float cWidth = 0;
+        if ( c == '\t' ){
+            cWidth = getGlyphProperties(' ').advance * spaceSize * TAB_WIDTH;
 		} else {
-			w += getGlyphProperties( c ).advance;
+            cWidth = getGlyphProperties( c ).advance;
 		}
+        
+        w = std::max(w, std::abs(pos.x + cWidth));
 	});
 	return w;
 }


### PR DESCRIPTION
# Problem
`ofTrueTypeFont::stringWidth()` and `ofTrueTypeFont::getStringBoundingBox()` give a wrong width value because these ignore `\n`, and width value piles up, getting longer and longer if you have multiple `\n`.


# screenshots
- Before
![Screenshot 2024-01-21 at 15 03 40](https://github.com/openframeworks/openFrameworks/assets/193280/ff2386d4-7e88-4dce-a6a7-e5282481a26b)

- After
![Screenshot 2024-01-21 at 15 53 27](https://github.com/openframeworks/openFrameworks/assets/193280/e9c950a0-5579-4ff6-bea6-bdc928799469)


- After (OF_TTF_RIGHT_TO_LEFT)
![Screenshot 2024-01-21 at 15 53 24](https://github.com/openframeworks/openFrameworks/assets/193280/6281fbe6-69d7-4e3a-8f72-30eea8b38007)


## Link to the current code
- stringWidth
https://github.com/openframeworks/openFrameworks/blob/2b8cab27d5b2dfc85be6cffc5119dce3d609f79c/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L1164-L1169

- getStringBoundingBox
https://github.com/openframeworks/openFrameworks/blob/2b8cab27d5b2dfc85be6cffc5119dce3d609f79c/libs/openFrameworks/graphics/ofTrueTypeFont.cpp#L1193-L1199

## Tested with ...
- latest master
- on macOS 13.4
- OF_TTF_LEFT_TO_RIGHT
- OF_TTF_RIGHT_TO_LEFT

## Gist 
https://gist.github.com/hiroMTB/e5c746c6403da714f74cf4f37b711451