### PR TITLE
[actions] tests/io/loadImage https image fix

### DIFF
--- a/tests/io/loadImage/src/main.cpp
+++ b/tests/io/loadImage/src/main.cpp
@@ -9,7 +9,10 @@ class ofApp: public ofxUnitTestsApp{
 		ofxTest(img.load("indispensable.jpg"), "load from fs");
 		ofxTest(img.load(ofToDataPath("indispensable.jpg", true)), "load from fs");
 		ofxTest(img.load("http://openframeworks.cc/about/0.jpg"), "load from http");
-		ofxTest(img.load("https://forum.openframeworks.cc/user_avatar/forum.openframeworks.cc/arturo/45/3965_1.png"), "load from https");
+		// ofxTest(img.load("https://forum.openframeworks.cc/user_avatar/forum.openframeworks.cc/arturo/45/3965_1.png"), "load from https");
+		// ar 48240 / th 144000 / dm 58289
+		ofxTest(img.load("https://avatars.githubusercontent.com/u/48240?v=4"), "load from https");
+		
 	}
 };
 


### PR DESCRIPTION
I've noticed tests loading https image from openframeworks forums fails from time to time ~ not sure why.
But changing to a github image helps

