### PR TITLE
ofThreadChannel::clear() to clear the channel

### DIFF
--- a/libs/openFrameworks/utils/ofThreadChannel.h
+++ b/libs/openFrameworks/utils/ofThreadChannel.h
@@ -266,6 +266,16 @@ public:
 		condition.notify_all();
 	}
 
+	/// \brief Clear  channel.
+	///
+	/// Clears the queue (useful if only the latest
+	/// data is meant to be transferred (i.e. no queue))
+	void clear() {
+		if (!queue.empty) {
+			std::unique_lock<std::mutex> lock(mutex);
+			queue = {};
+		}
+	}
 
 	/// \brief Queries empty channel.
 	///

--- a/libs/openFrameworks/utils/ofThreadChannel.h
+++ b/libs/openFrameworks/utils/ofThreadChannel.h
@@ -271,7 +271,7 @@ public:
 	/// Clears the queue (useful if only the latest
 	/// data is meant to be transferred (i.e. no queue))
 	void clear() {
-		if (!queue.empty) {
+		if (!queue.empty()) {
 			std::unique_lock<std::mutex> lock(mutex);
 			queue = {};
 		}


### PR DESCRIPTION
title says it all; proves useful if unconsumed data in the channel is known to be stale