### PR TITLE
RPI armv6l - put back /opt/vc if not cross compiling

### DIFF
--- a/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
+++ b/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
@@ -213,7 +213,7 @@ PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/IL
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/interface/vcos/pthreads
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/interface/vmcs_host/linux
-fi
+endif
 
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/userland/host_applications/linux/libs/bcm_host/include
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/userland

--- a/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
+++ b/libs/openFrameworksCompiled/project/linuxarmv6l/config.linuxarmv6l.default.mk
@@ -208,6 +208,13 @@ endif
 ################################################################################
 
 # Broadcom hardware interface library
+ifneq ($(CROSS_COMPILING),1)
+PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include
+PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/IL
+PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/interface/vcos/pthreads
+PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/opt/vc/include/interface/vmcs_host/linux
+fi
+
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/userland/host_applications/linux/libs/bcm_host/include
 PLATFORM_HEADER_SEARCH_PATHS += $(RPI_ROOT)/userland
 


### PR DESCRIPTION
If anybody is using RPI with an old OS.
I've left the includes for userland repositories, so it is still possible to clone userland repo
https://github.com/raspberrypi/userland
in RPI_ROOT 

cc @ofTheo 