### PR TITLE
fix ofPixels <float> allocation issue

### DIFF
--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -401,7 +401,7 @@ void ofPixels_<PixelType>::setFromExternalPixels(PixelType * newPixels, size_t w
 	width= w;
 	height = h;
 
-	pixelsSize = bytesFromPixelFormat(w,h,_pixelFormat) / sizeof(PixelType);
+	pixelsSize = bytesFromPixelFormat(w,h,_pixelFormat);
 
 	pixels = newPixels;
 	pixelsOwner = false;
@@ -535,7 +535,7 @@ void ofPixels_<PixelType>::allocate(size_t w, size_t h, ofPixelFormat format){
 	width 		= w;
 	height 		= h;
 
-	pixelsSize = newSize / sizeof(PixelType);
+	pixelsSize = newSize;
 
 	pixels = new PixelType[pixelsSize];
 	bAllocated = true;

--- a/libs/openFrameworks/graphics/ofPixels.cpp
+++ b/libs/openFrameworks/graphics/ofPixels.cpp
@@ -1328,6 +1328,9 @@ float ofPixels_<PixelType>::bicubicInterpolate (const float *patch, float x,floa
 	a20 * x2 + a21 * x2 * y + a22 * x2 * y2 + a23 * x2 * y3 +
 	a30 * x3 + a31 * x3 * y + a32 * x3 * y2 + a33 * x3 * y3;
 
+	if (std::is_floating_point<PixelType>::value) {
+		return std::min(1.0f, std::max(out, 0.0f));
+	}
 	return std::min(static_cast<size_t>(255), std::max(static_cast<size_t>(out), static_cast<size_t>(0)));
 }
 


### PR DESCRIPTION
minimal changes to make it work
so now the pixels buffer is allocated with the exact number of bytes used.
it used to work ok with char because sizeof(char) is 1

related to some part of
 https://github.com/openframeworks/openFrameworks/issues/6226
addresses crash / artifacts