### PR TITLE
ofAppNoWindow.h: #include ofEvents to complete the ofCoreEvents type for C++23 compliance

### DIFF
--- a/libs/openFrameworks/app/ofAppNoWindow.h
+++ b/libs/openFrameworks/app/ofAppNoWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ofAppBaseWindow.h"
+#include "ofEvents.h"
 
 class ofBaseApp;
 class ofBaseRenderer;


### PR DESCRIPTION
otherwise does not satisfy `_LIBCPP_INLINE_VISIBILITY` + `_LIBCPP_CONSTEXPR_SINCE_CXX23`