### PR TITLE
ofScopedMatrix

### DIFF
--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -972,6 +972,23 @@ void ofPushMatrix();
 /// \sa ofPushMatrix()
 void ofPopMatrix();
 
+struct ofScopedMatrix {
+	ofScopedMatrix() { ofPushMatrix(); }
+	~ofScopedMatrix() { ofPopMatrix(); }
+	ofScopedMatrix(std::function<void()> f): ofScopedMatrix() {f();}
+};
+
+struct ofScopedStyle {
+	ofScopedStyle() { ofPushStyle(); }
+	~ofScopedStyle() { ofPopStyle(); }
+	ofScopedStyle(std::function<void()> f): ofScopedStyle() {f();}
+};
+
+struct ofScopedMatrixStyle: public ofScopedMatrix, public ofScopedStyle {
+	ofScopedMatrixStyle(std::function<void()> f): ofScopedStyle(), ofScopedMatrix() {f();}
+	ofScopedMatrixStyle() {}
+};
+
 /// \brief Query the current (oF internal) Transformation Matrix state.
 glm::mat4 ofGetCurrentMatrix(ofMatrixMode matrixMode);
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -975,19 +975,14 @@ void ofPopMatrix();
 struct ofScopedMatrix {
 	ofScopedMatrix() { ofPushMatrix(); }
 	~ofScopedMatrix() { ofPopMatrix(); }
-	ofScopedMatrix(std::function<void()> f): ofScopedMatrix() {f();}
 };
 
 struct ofScopedStyle {
 	ofScopedStyle() { ofPushStyle(); }
 	~ofScopedStyle() { ofPopStyle(); }
-	ofScopedStyle(std::function<void()> f): ofScopedStyle() {f();}
 };
 
-struct ofScopedMatrixStyle: public ofScopedMatrix, public ofScopedStyle {
-	ofScopedMatrixStyle(std::function<void()> f): ofScopedStyle(), ofScopedMatrix() {f();}
-	ofScopedMatrixStyle() {}
-};
+struct ofScopedMatrixStyle: public ofScopedMatrix, public ofScopedStyle { };
 
 /// \brief Query the current (oF internal) Transformation Matrix state.
 glm::mat4 ofGetCurrentMatrix(ofMatrixMode matrixMode);

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -972,16 +972,22 @@ void ofPushMatrix();
 /// \sa ofPushMatrix()
 void ofPopMatrix();
 
+/// \brief Manages a an ofPush/Pop Matrix cycle with an anonymous scoped object
+///
 struct ofScopedMatrix {
 	ofScopedMatrix() { ofPushMatrix(); }
 	~ofScopedMatrix() { ofPopMatrix(); }
 };
 
+/// \brief Manages a an ofPush/Pop Style cycle with an anonymous scoped object
+///
 struct ofScopedStyle {
 	ofScopedStyle() { ofPushStyle(); }
 	~ofScopedStyle() { ofPopStyle(); }
 };
 
+/// \brief Combines ofScopeMatrix and Style
+///
 struct ofScopedMatrixStyle: public ofScopedMatrix, public ofScopedStyle { };
 
 /// \brief Query the current (oF internal) Transformation Matrix state.


### PR DESCRIPTION
<img width="682" alt="image" src="https://github.com/openframeworks/openFrameworks/assets/2172370/9d50be83-02b3-4f79-a267-9ab92097a5c9">

makes use of the lifetime of an object to frame push and pop matrix and style.

OLD-SCHOOL FLAT
```c++
ofPushMatrix()
ofTranslate()
// (…)
ofPushMatrix()
ofTranslate();
// (…)
ofPopMatrx();
// (…)
ofPopMatrix();
// easy to lose track and get push pop errors
```
ARTISANAL BRACING — TRYING TO UNDERSTAND WHAT’S GOING ON
```c++
ofPushMatrix()
{
	ofTranslate()
	// (…)
	ofPushMatrix()
	{
		ofTranslate();
		// (…)
	}
	ofPopMatrx();
	// (…)
}
ofPopMatrix();
// as good as the artisanal visual tabbing 
```
INTRODUCING SCOPED MATRIX BRACING-AWARE OBJECT
```c++
{
	ofScopedMatrix _ ;
	ofTranslate()
	// (…)
	{
		ofScopedMatrix _ ;
		ofTranslate();
		// (…)
	}
	// (…)
} 
// push:pop balanced garanteed
```
~~FOR THE HARDCORE: LAMBDA IN ANONYMOUS OBJECT ENFORCES STRUCTURE~~
```c++
ofScopedMatrix{[&]{
	ofTranslate();
	// (…)
	ofScopedMatrix{[&]{
		ofTranslate();
		// (…)
	}};
        // (...)
}};
// terse and resilient, at the cost of double-bracing…
```
A TYPICAL CASE
```c++
// MyClass.h
void drawWidget(float x, float y, float w, float h) {
	ofScopedMatrixStyle _ ;
	ofTranslate(x,y); 
	ofScale(w,h);
        ofDrawWidget(etc);
} 
// automatically pops back because _ goes out of scope
```