### PR TITLE
ofxOscMessage: extra implicit adds [fixes something noted through #7938 debugging]

### DIFF
--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -191,6 +191,7 @@ public:
 	/// \return a reference to this ofxOscMessage
 	ofxOscMessage & addInt64Arg(std::int64_t argument);
 	ofxOscMessage & add(std::int64_t argument) { return addInt64Arg(argument); }
+	ofxOscMessage & add(size_t argument) { return addInt64Arg(argument); }
 
 	/// add a 32-bit float
 	/// \return a reference to this ofxOscMessage

--- a/addons/ofxOsc/src/ofxOscMessage.h
+++ b/addons/ofxOsc/src/ofxOscMessage.h
@@ -207,6 +207,7 @@ public:
 	/// \return a reference to this ofxOscMessage
 	ofxOscMessage & addStringArg(const std::string & argument);
 	ofxOscMessage & add(const std::string & argument) { return addStringArg(argument); }
+	ofxOscMessage & add(const char * argument) { return addStringArg(argument); }
 
 	/// add a symbol (string)
 	/// \return a reference to this ofxOscMessage


### PR DESCRIPTION
Some cases were not caught correctly with the implicit `add` argument.