### PR TITLE
Fix high-DPI support on macOS by setting NSHighResolutionCapable to true

### DIFF
--- a/scripts/templates/osx/openFrameworks-Info.plist
+++ b/scripts/templates/osx/openFrameworks-Info.plist
@@ -27,6 +27,6 @@
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs to access the microphone</string>
 	<key>NSHighResolutionCapable</key>
-	<false/>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
### Description
This pull request addresses the issue of high-DPI support on macOS for openFrameworks applications. By default, the `NSHighResolutionCapable` key is not set to `true` in the `Info.plist` file, causing applications to appear blurry on Retina displays.

### Changes Made
- Updated the `Info.plist` template in the project generator to include the `NSHighResolutionCapable` key set to `true`.

### Testing
- Created a new project using the updated project generator.
- Verified that the `Info.plist` file includes the `NSHighResolutionCapable` key set to `true`.
- Tested the application on a Retina display to ensure it renders correctly.

This fix ensures that all new projects will support high-DPI displays on macOS by default, improving the user experience.
