### PR TITLE
oscpack / udpSocket: invert the "break_" semaphore

### DIFF
--- a/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
@@ -356,7 +356,8 @@ class SocketReceiveMultiplexer::Implementation{
 	std::vector< std::pair< PacketListener*, UdpSocket* > > socketListeners_;
 	std::vector< AttachedTimerListener > timerListeners_;
 
-	volatile bool break_;
+	std::atomic<bool> break_ = false;
+
 	int breakPipe_[2]; // [0] is the reader descriptor and [1] the writer
 
 	double GetCurrentTimeMs() const

--- a/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
+++ b/addons/ofxOsc/libs/oscpack/src/ip/posix/UdpSocket.cpp
@@ -424,7 +424,6 @@ public:
 
     void Run()
 	{
-		break_ = false;
         char *data = 0;
         
         try{
@@ -541,11 +540,16 @@ public:
             }
 
             delete [] data;
+			break_ = false;
+
         }catch(...){
             if( data )
                 delete [] data;
+			break_ = false;
+
             throw;
         }
+		
 	}
 
     void Break()


### PR DESCRIPTION
In the oscpack udpSocket listener thread there is a flag named `break_` which breaks the endless loop, resolving into the thread exiting "properly". because of the threading approach of ofxOscReceiver being changed from `detach()` to` join()`, a new race condition emerges:  in the `close()` of the ofxOscSender the `asynchronousBreak()` function is called, which sets the flag to true in order to break the listener, but there are cases where the listener thread has not spun up yet, but will be forced to by the `join()`, and the first thing it does in `Run()` is to reset `break_` to false, this removing the flag and creating the hang (the `Run()` will never return).

this changes inverses the logic: the `break_` is initialized to false, and changed back to false at the end of `Run()`. this way if it's changed to true before the thread start, the thread immediately stops. resetting the flag to false makes the object reusable (even though the ofxOscReceiver pattern will re-create a new object when re-started())

(note: the `volatile bool` is also upgraded to `std::atomic<bool>`)

this solves the `INSTANTLY_OUT_OF_SCOPE` test case documented in #7949 