### PR TITLE
restore default-copy-constructibility of ofEvent

### DIFF
--- a/examples/events/notifyEventExample/src/ofApp.cpp
+++ b/examples/events/notifyEventExample/src/ofApp.cpp
@@ -27,7 +27,7 @@ void ofApp::update() {
 		}
 	}
 
-	if (auto what = params.parameterChangedE().did_notify()) { // this is the Events::did_notify()
+	if (auto what = params.parameterChangedE().didNotify()) { // this is the Events::did_notify()
 		// something happended in params, but you don't know what
 	}
 }
@@ -41,7 +41,7 @@ void ofApp::draw() {
 		if (size > 100) size -= 100;
 	}
 	ofDrawBitmapString("<a> to toggle automation", 10, 10);
-	ofDrawBitmapString("<s> to randomize size", 10, 20);
+	ofDrawBitmapString("<r> to randomize size", 10, 20);
 	ofDrawBitmapString("<c> to change color", 10, 30);
 }
 


### PR DESCRIPTION
this limitation was introduced around the `didNotify()` feature which is based on an `std::atomic<bool>` which is not default-copy-constructible. this was not raised as a problem because the core and builtin-addons do not inherit ofEvent in a way that triggers the copy constructors. but some addons do, which makes them incompatible.

fixed by moving the `notified_` member up into ::priv, which already has custom copy constructors. this revert the copy-constructibility of ofEvent. 