### PR TITLE
download scripts - projectGenerator optimisations - location

### DIFF
--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -297,21 +297,37 @@ for PKG in $PKGS; do
         tar xjf download/$PKG
         # rm -r download/$PKG
     fi
-    echo " Deployed libraries from [download/$PKG]to [/libs]"
+    echo " Deployed libraries from [download/$PKG] to [/libs]"
 done
 
-if [ "$PLATFORM" == "osx" ]; then
-    addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco" "openssl")
-    addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco" "ofxPoco")
-elif [ "$PLATFORM" == "vs" ]; then
-    addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco")
-    addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
-elif [ "$PLATFORM" == "ios" ] || [ "$PLATFORM" == "tvos" ]; then
-    addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco" "openssl")
-    addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco" "ofxPoco")
+if [[ $BLEEDING_EDGE = 1 ]] ; then
+    if [ "$PLATFORM" == "osx" ]; then
+        addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco" )
+    elif [ "$PLATFORM" == "vs" ]; then
+        addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    elif [ "$PLATFORM" == "ios" ] || [ "$PLATFORM" == "tvos" ]; then
+        addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco" )
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    else
+        addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    fi
 else
-    addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco")
-    addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    if [ "$PLATFORM" == "osx" ]; then
+        addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco" "openssl")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco" "ofxPoco")
+    elif [ "$PLATFORM" == "vs" ]; then
+        addonslibs=("opencv" "ippicv" "libusb" "assimp" "libxml2" "svgtiny" "poco")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxKinect" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    elif [ "$PLATFORM" == "ios" ] || [ "$PLATFORM" == "tvos" ]; then
+        addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco" )
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    else
+        addonslibs=("opencv" "ippicv" "assimp" "libxml2" "svgtiny" "poco")
+        addons=("ofxOpenCv" "ofxOpenCv" "ofxAssimpModelLoader" "ofxSvg" "ofxSvg" "ofxPoco")
+    fi
 fi
 
 echo "   ------ "

--- a/scripts/dev/download_pg.sh
+++ b/scripts/dev/download_pg.sh
@@ -157,7 +157,7 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
-OUTDIR=../../
+OUTDIR=../../../../
 
 
 if [[ $BLEEDING_EDGE = 1 ]] ; then
@@ -176,15 +176,27 @@ else
     GUI=""
 fi
 PKG="projectGenerator-${PLATFORM}${GUI}.zip"
+
+
+echo " openFrameworks download_pg.sh"
+
+cd ../../
+mkdir -p libs
+cd libs
+
+mkdir -p download
+cd download
+
+
 download $PKG
 
-echo "Uncompressing Project Generator for $PLATFORM from $PKG"
+echo " Uncompressing Project Generator for $PLATFORM from $PKG"
 if [ "$PLATFORM" == "msys2" ] || [ "$PLATFORM" == "vs" ]; then
     unzip -q "$PKG" -d "$OUTPUT"
-    rm $PKG
+    #rm $PKG
 else
     tar xjf "$PKG"
-    rm $PKG
+    #rm $PKG
 fi
 
 if [ -d "${OUTDIR}/${OUTPUT}" ] || [ -f "${OUTDIR}/${OUTPUT}" ]; then
@@ -212,9 +224,10 @@ else
 fi
 
 rm -rf $OUTPUT
-rm -rf $PKG
+# rm -rf $PKG
 
-echo "Completed projectGenerator in place"
+echo " ------ "
+echo " openFrameworks download projectGenerator and install complete!"
 
 
 


### PR DESCRIPTION
Download ProjectGenerator 
- optimise wont re-download if in sync with GitHub release /size/time via wget2/curl 
- now outputs to libs/downloads rather than dev/scripts

Download libs 
- addon deploy modified for bleeding with alternative deploys for addons 