### PR TITLE
Use getDeviceIds function to list audio devices instead of relying on contiguous IDs

### DIFF
--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -81,9 +81,8 @@ std::vector<ofSoundDevice> ofRtAudioSoundStream::getDeviceList(ofSoundDevice::Ap
 		if(audioTemp.getCurrentApi()!=rtAudioApi && rtAudioApi!=RtAudio::Api::UNSPECIFIED){
 			return deviceList;
 		}
-		auto deviceCount = audioTemp.getDeviceCount();
 		RtAudio::DeviceInfo info;
-		for (unsigned int i = 0; i < deviceCount; i++) {
+		for (unsigned int i: audioTemp.getDeviceIds()) {
 			try {
 				info = audioTemp.getDeviceInfo(i);
 			}


### PR DESCRIPTION
Fixes #8013 

[As of RtAudio 6.0.0][1] you cannot assume that devices will fall in the range [0, getDeviceCount() - 1]. Doing so will potentially cause errors or out of bounds array accesses depending on the platform.

I am not super familiar with this project, but as far as I can tell I couldn't find any documentation or example projects that would need to be updated as a result of this change. However, I do know of at least two projects ([audiostellar][2] and [ofxPDSP][3]) that make this assumption, so it is definitely worth noting in the change log.

[1]: http://www.music.mcgill.ca/~gary/rtaudio/classRtAudio.html#ab1b5af34ddfe84ae2043d1f09c8638d5
[2]: https://gitlab.com/ayrsd/audiostellar
[3]: https://github.com/macramole/ofxPDSP