### PR TITLE
ofEasyCam : fix wrong scaling center in ortho mode

### DIFF
--- a/libs/openFrameworks/3d/ofEasyCam.cpp
+++ b/libs/openFrameworks/3d/ofEasyCam.cpp
@@ -296,16 +296,16 @@ void ofEasyCam::updateTranslation(){
 		if(getOrtho()){
 			//In ortho mode moving along the z axis has no effect besides clipping.
 			// Instead, scale is applied to achieve the effect of getting near or far from the target.
-			glm::vec3 mousePre ;
+			glm::vec3 mousePre;
 			bool bDoScale = (currentTransformType == TRANSFORM_SCALE || currentTransformType == TRANSFORM_TRANSLATE_Z);
 			if (bDoScale) {
-				mousePre = screenToWorld(glm::vec3((bIsScrolling?mouseAtScroll:lastPressMouse),0));
+				mousePre = screenToWorld(glm::vec3((bIsScrolling?mouseAtScroll:lastPressMouse),0), viewport);
 			}
 			move(glm::vec3(lastPressAxisX * translate.x) + (lastPressAxisY * translate.y));
 			if (bDoScale) {
 				setScale(getScale() + translate.z);
 				// this move call is to keep the scaling centered below the mouse.
-				move(mousePre - screenToWorld(glm::vec3((bIsScrolling?mouseAtScroll:lastPressMouse),0)));
+				move(mousePre - screenToWorld(glm::vec3((bIsScrolling?mouseAtScroll:lastPressMouse),0), viewport));
 			}
 		}else{
 			move(glm::vec3(lastPressAxisX * translate.x) + (lastPressAxisY * translate.y) + (lastPressAxisZ * translate.z));


### PR DESCRIPTION
This only happens with ofEasyCam's **ortho mode + custom viewport**.

## Expected behavour
Expected behavour is to zoom in/out into the mouse pointer position when user scroll mouse wheel (or R click drag). It works fine with normal viewport with 0,0 position and full window w, h. But when we use custom viewport (e.g. camera.begin(viewport); ) then it zoom in/out into wrong position.

## Issue
The problem is that ofEasyCam forgots to give viewport parameter to `screenToWorld()`. `screenToWorld()` calls `ofCamera::getViewport()` internaly but ofCamera seems not storing custom viewport parameter but just get current window's viewport, which is {0,0,fullW, fullH}. Hence it gives wrong world position.


## Reproducing this bug
tested on
- macOS 14.5
- Xcode 15.4
- openFrameworks(latest master at the time of this writting)

ofApp.h
```
#pragma once

#include "ofMain.h"

class ofApp : public ofBaseApp {
public:
    void setup();
    void draw();
    void drawViewportOutline(const ofRectangle & viewport);

    ofRectangle viewport;
    ofEasyCam camera;
};
```

ofApp.cpp
```
#include "ofApp.h"

void ofApp::setup(){
    ofBackground(90);
    ofEnableSmoothing();
    
    camera.enableOrtho();
    camera.setNearClip(-1000000);
    camera.setFarClip(1000000);
    // camera.setVFlip(true);
    
    viewport.x = 500;
    viewport.y = 200;
    viewport.width = 500;
    viewport.height = 500;
}

void ofApp::draw(){

    drawViewportOutline(viewport);
    //camera.setControlArea(viewport);
	
    camera.begin(viewport);
    ofSetColor(255, 0, 0);
    ofFill();
    ofDrawCircle(0,0,0,10);
    ofDrawGrid(100);
    camera.end();
}
```

## Before and after
### Before
![before](https://github.com/openframeworks/openFrameworks/assets/193280/9f0aaa4b-c5a5-4070-9202-7dec7bf2cedf)

### After
![after](https://github.com/openframeworks/openFrameworks/assets/193280/53574b2e-ca33-4615-b96a-8681a0db6cbe)
