### PR TITLE
pg use nightly vs

### DIFF
--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -92,9 +92,9 @@ osx:
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
 
-android:
-	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
-	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+# android:
+# 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+# 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
 
 emscripten:
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%

--- a/addons/ofxOsc/addon_config.mk
+++ b/addons/ofxOsc/addon_config.mk
@@ -62,21 +62,63 @@ common:
 
 	# when parsing the file system looking for sources exclude this for all or
 	# a specific platform
-	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
- 	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+	#ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+ 	#ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
 	# when parsing the file system looking for include paths exclude this for all or
 	# a specific platform
 	# ADDON_INCLUDES_EXCLUDE =
+
+linuxarmv6l:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+linuxarmv7l:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+linuxaarch64:
+	AADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+linux:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+linux64:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+osx:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+android:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+emscripten:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+ios:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
+
+macos:
+	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/win32/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/win32
 
 msys2:
 	# when parsing the file system looking for sources exclude this for all or
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/posix/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/posix
 
 vs:
 	# when parsing the file system looking for sources exclude this for all or
 	# a specific platform
 	ADDON_SOURCES_EXCLUDE = libs/oscpack/src/ip/posix/%
+	ADDON_INCLUDES_EXCLUDE = libs/oscpack/src/ip/posix
 	ADDON_DEFINES = OSC_HOST_LITTLE_ENDIAN
 
 	

--- a/scripts/ci/vs/install_bleeding.sh
+++ b/scripts/ci/vs/install_bleeding.sh
@@ -14,7 +14,7 @@ mkdir -p ~/projectGenerator
 cd ~/projectGenerator
 
 echo "Downloading projectGenerator from Github Bleeding"
-downloader https://github.com/openframeworks/projectGenerator/releases/download/bleeding/projectGenerator-vs.zip 2> /dev/null
+downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-vs.zip 2> /dev/null
 unzip projectGenerator-vs.zip 2> /dev/null
 rm projectGenerator-vs.zip
 


### PR DESCRIPTION
Fixes download ci script to link to correct projectGenerator download (nightly)
Fixes Issue was traced to addon_config.mk in ofxOSC common excluding win32 folder... causing recent problems in builds and debugging in projectGenerator... who would have thought