### PR TITLE
fix msys2 libs downloading

### DIFF
--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -165,21 +165,16 @@ EOF
             exit 1
         fi
     elif [ "$PLATFORM" == "msys2" ]; then
-
-        if [ -n "$MINGW_PACKAGE_PREFIX" ]; then
-            ARCH=$MINGW_PACKAGE_PREFIX
+        if [ "$MSYSTEM" == "MINGW64" ] || [ "$MSYSTEM" == "mingw64" ]; then
+            ARCH=mingw64
+        elif [ "$MSYSTEM" == "CLANGARM64" ] || [ "$MSYSTEM" == "clangarm64" ]; then
+            ARCH=clangarm64
+        elif [ "$MSYSTEM" == "UCRT64" ]; then
+            ARCH=ucrt64
+        elif [ "$MSYSTEM" == "CLANG64" ]; then
+            ARCH=clang64
         else
-            if [ "$MSYSTEM" == "MINGW64" ] || [ "$MSYSTEM" == "mingw64" ]; then
-                ARCH=mingw64
-            elif [ "$MSYSTEM" == "CLANGARM64" ] || [ "$MSYSTEM" == "clangarm64" ]; then
-                ARCH=clangarm64
-            elif [ "$MSYSTEM" == "UCRT64" ]; then
-                ARCH=ucrt64
-            elif [ "$MSYSTEM" == "CLANG64" ]; then
-                ARCH=clang64
-            else
-                ARCH=clang64
-            fi
+            ARCH=clang64
         fi
     fi
 


### PR DESCRIPTION
fix #8049 

libs are suffixed with MSYSTEM.
Removing invalid condition on MINGW_PACKAGE_PREFIX