### PR TITLE
OF default plane with less resolution (rows, cols)

### DIFF
--- a/libs/openFrameworks/graphics/of3dGraphics.cpp
+++ b/libs/openFrameworks/graphics/of3dGraphics.cpp
@@ -22,7 +22,7 @@ enum of3dPrimitiveType {
 
 of3dGraphics::of3dGraphics(ofBaseRenderer * renderer)
 :renderer(renderer)
-,plane(1.0f, 1.0f, 1, 1)
+,plane(1.0f, 1.0f, 2, 2)
 ,sphere(1.0f, 20)
 ,icoSphere(1.0f, 2)
 ,box(1.f, 1.f, 1.f, 1, 1, 1)

--- a/libs/openFrameworks/graphics/of3dGraphics.cpp
+++ b/libs/openFrameworks/graphics/of3dGraphics.cpp
@@ -22,7 +22,7 @@ enum of3dPrimitiveType {
 
 of3dGraphics::of3dGraphics(ofBaseRenderer * renderer)
 :renderer(renderer)
-,plane(1.0f, 1.0f, 6, 4)
+,plane(1.0f, 1.0f, 1, 1)
 ,sphere(1.0f, 20)
 ,icoSphere(1.0f, 2)
 ,box(1.f, 1.f, 1.f, 1, 1, 1)


### PR DESCRIPTION
I've noticed the default OF plane comes with 6 cols, 4 rows
this plane is used for ofLight::draw (areaLight) for example
This is a suggestion of using a 1x1 plane as a default, and increase resolution if / when needed.
