### PR TITLE
Nightly packages Fixes / Updates to projectGenerator

### DIFF
--- a/scripts/ci/package_builds.sh
+++ b/scripts/ci/package_builds.sh
@@ -36,20 +36,21 @@ git submodule update --init --recursive
 git submodule update --recursive --remote
 cd apps/projectGenerator
 git pull origin master
-
 cd $OUTPUT_FOLDER
-
-$ROOT/scripts/dev/create_package.sh linux64 $lastversion master gcc6
-$ROOT/scripts/dev/create_package.sh linuxarmv6l $lastversion master
-$ROOT/scripts/dev/create_package.sh linuxaarch64 $lastversion master
+pwd
+if [[ "$(uname -s)" == "Linux" ]]; then
+	$ROOT/scripts/dev/create_package.sh linux64 $lastversion master gcc6
+	$ROOT/scripts/dev/create_package.sh linuxarmv6l $lastversion master
+	$ROOT/scripts/dev/create_package.sh linuxaarch64 $lastversion master
+	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master mingw64
+	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master clang64
+	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master ucrt64
+	$ROOT/scripts/dev/create_package.sh vs $lastversion master
+	$ROOT/scripts/dev/create_package.sh vs $lastversion master 64
+fi
 $ROOT/scripts/dev/create_package.sh osx $lastversion master
 $ROOT/scripts/dev/create_package.sh ios $lastversion master
 # $ROOT/scripts/dev/create_package.sh macos $lastversion master
-$ROOT/scripts/dev/create_package.sh msys2 $lastversion master mingw64
-$ROOT/scripts/dev/create_package.sh msys2 $lastversion master clang64
-$ROOT/scripts/dev/create_package.sh msys2 $lastversion master ucrt64
-$ROOT/scripts/dev/create_package.sh vs $lastversion master
-$ROOT/scripts/dev/create_package.sh vs $lastversion master 64
 
 ls -la
 cd $ROOT
@@ -58,4 +59,6 @@ cd $ROOT
 FILES_OUT=$( (ls -t out/*.zip 2> /dev/null || true) && (ls -t out/*.tar* 2> /dev/null || true) )
 #remove new lines
 FILES_OUT=$(echo $FILES_OUT | tr '\n' ' ')
-echo "FILES_OUT=$FILES_OUT" >> $GITHUB_OUTPUT
+if [ -n "$GITHUB_OUTPUT" ]; then
+	echo "FILES_OUT=$FILES_OUT" >> $GITHUB_OUTPUT
+fi

--- a/scripts/ci/package_builds.sh
+++ b/scripts/ci/package_builds.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
 set -ev
+
 ROOT=${GITHUB_WORKSPACE}
 
-sudo apt-get -y install aptitude
+P_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Check if ROOT is empty
+if [[ -z "$ROOT" ]]; then
+  # Set ROOT to ../../../ if it's empty
+  ROOT="../../"
+fi
 
-#for ubuntu 22.04 we need to install wine32
-#sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo aptitude -y install wine64
+ROOT=$(realpath "$ROOT")
 
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+    sudo apt-get -y install aptitude
+    #for ubuntu 22.04 we need to install wine32
+    #sudo dpkg --add-architecture i386
+    sudo apt-get update
+    sudo aptitude -y install wine64
+fi
+echo "Where is ROOT: $ROOT"
 cd $ROOT
+ls
 
 OUTPUT_FOLDER=$ROOT/out
-mkdir $OUTPUT_FOLDER
+mkdir -p $OUTPUT_FOLDER
 
 lastversion=$(date +%Y%m%d)
 if [ -n "$1" ] && [ "$1" != "nightly" ]; then

--- a/scripts/ci/simulate_nightly.sh
+++ b/scripts/ci/simulate_nightly.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR
+
+OF_SCRIPT_DIR=$SCRIPT_DIR/../
+OF_ROOT=$SCRIPT_DIR/../../
+
+# Define environment variables
+TARGET="linux64"
+LIBS="64gcc6"
+RELEASE="nightly"  # Set default release value
+
+# Parse command line arguments
+while getopts "r:" opt; do
+  case ${opt} in
+    r )
+      RELEASE=$OPTARG
+      ;;
+    \? )
+      echo "Usage: cmd [-r release]"
+      exit 1
+      ;;
+  esac
+done
+
+echo "OF_ROOT: $OF_ROOT"
+echo "OF_SCRIPT_DIR: $OF_SCRIPT_DIR"
+# Install libunwind
+# echo "Installing libunwind..."
+# sudo apt-get update
+# sudo apt-get install -y libunwind-dev
+
+# Cache packages
+# echo "Caching packages..."
+# This part would require a custom implementation or external tool as caching 
+# packages is specific to GitHub Actions and not easily replicated in bash.
+
+# Checkout the repository (make sure the script is executed in a repository context)
+# echo "Checking out the repository..."
+# git checkout master
+
+# Run ccache (assumes ccache is installed and configured)
+echo "Running ccache..."
+ccache --show-stats
+
+# Install dependencies
+echo "Installing dependencies..."
+$SCRIPT_DIR/$TARGET/install.sh
+
+# Update submodules
+echo "Updating submodules..."
+$OF_ROOT/scripts/dev/init_submodules.sh
+
+# Download libraries
+echo "Downloading libraries..."
+$OF_ROOT/scripts/linux/download_libs.sh -a $LIBS
+
+# Create package
+echo "Creating package..."
+$SCRIPT_DIR/package_builds.sh $RELEASE
+
+# List output directory
+echo "Listing output directory..."
+ls -lah out/
+
+# Update Release (assuming you have a script or tool to handle GitHub releases)
+# echo "Updating release..."
+# This part would require a custom implementation or external tool as updating 
+# releases is specific to GitHub Actions and not easily replicated in bash.
+# Replace this with your custom update release script or API call.
+

--- a/scripts/ci/simulate_nightly.sh
+++ b/scripts/ci/simulate_nightly.sh
@@ -26,10 +26,15 @@ done
 
 echo "OF_ROOT: $OF_ROOT"
 echo "OF_SCRIPT_DIR: $OF_SCRIPT_DIR"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
 # Install libunwind
 # echo "Installing libunwind..."
-# sudo apt-get update
-# sudo apt-get install -y libunwind-dev
+sudo apt-get update
+sudo apt-get install -y libunwind-dev
+sudo apt-get install -y npm
+sudo apt-get install -y curl
+fi
 
 # Cache packages
 # echo "Caching packages..."

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -284,10 +284,10 @@ function createPackage {
         rm -Rf utils/fileBufferLoadingCSVExample
         rm -Rf 3d/modelNoiseExample
         rm -Rf windowing
-		rm -Rf input_output
-		rm -Rf shader
-		rm -Rf sound
-		rm -Rf threads
+	rm -Rf input_output
+	rm -Rf shader
+	rm -Rf sound
+	rm -Rf threads
         rm -Rf windowing
 	fi
 
@@ -297,7 +297,7 @@ function createPackage {
 
 	if [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ] || [ "$pkg_platform" == "linuxaarch64" ]; then
 
-	    rm -Rf gl/glInfoExample
+	rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
         rm -Rf gl/billboardExample
         rm -Rf gl/billboardRotationExample
@@ -423,8 +423,8 @@ function createPackage {
   
   		# use prepackaged gui
         downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-vs-gui.zip 2> /dev/null
-        mkdir projectGenerator
-        unzip -d "projectGenerator" projectGenerator-vs-gui.zip 2> /dev/null
+        mkdir -p projectGenerator
+        unzip projectGenerator-vs-gui.zip -d "projectGenerator" 2> /dev/null
 		# if [ "$pkg_platform" = "msys2" ]; then
 		# 	sed -i "s/osx/msys2/g" projectGenerator/resources/app/settings.json
 		# else
@@ -435,7 +435,7 @@ function createPackage {
 	fi
 
     if [ "$pkg_platform" = "osx" ] || [ "$pkg_platform" = "ios" ] || [ "$pkg_platform" = "macos" ]; then
-		downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-osx.zip 2> /dev/null
+	downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-osx.zip 2> /dev/null
         unzip projectGenerator-osx.zip
         mv projectGenerator-osx/ projectGenerator
         rm projectGenerator-osx.zip
@@ -605,6 +605,8 @@ function createPackage {
     rm -Rf .travis.yml
     rm -Rf .gitmodules
     rm -Rf .gitattributes
+    
+    find /examples -type f -name "*.dll" -exec rm -f {} +
 
     if [ "$platform" = "linux" ] || [ "$platform" = "linux64" ] || [ "$platform" = "linuxarmv6l" ] || [ "$platform" = "linuxarmv7l" ] || [ "$platform" = "linuxaarch64" ]; then
         cp docs/linux.md INSTALL.md


### PR DESCRIPTION
Further fixes to nightly packages applied: 
# Scripts:
- ```scripts/ci/simulate_nightly.sh``` 
Added new developer script to build nightly locally / test on Linux machine or macOS for iOS/macOS targets.
![image](https://github.com/user-attachments/assets/2e146bf5-558c-4c62-b12e-31996fcaed7a)
-```scripts/ci/create_package.sh``` - removed addon DLLs from example folders 
- ```scripts/ci/package_builds.sh``` modified to support being run from any platform / not just actions

## projectGenerator 0.70.0  https://github.com/openframeworks/projectGenerator/releases/tag/nightly
- Fixes for addons paths for VS for nightly
- Updated submodules
- optional -b backup with Backup folder generated with some critical projectfiles that are usually user modified. 
- gitignore for example backup folders
- commandLine will return JSON interpretable string on failure / success as last response now
- https://github.com/openframeworks/projectGenerator/pull/567 
- v69: https://github.com/openframeworks/projectGenerator/pull/566

## downloader [4.2.5 ~ 4.2.6] 
- verbose log off for closing connection 
- wget2 disabled on windows due to upstream bug on multi files. removed local file if outdated to prevent override issues when detected outdated for cURL / wget2 other platforms 

