### PR TITLE
Fixes ofThread non-virtual dtor and examples

### DIFF
--- a/examples/threads/threadExample/src/threadedObject.h
+++ b/examples/threads/threadExample/src/threadedObject.h
@@ -2,7 +2,7 @@
 
 #include "ofMain.h"
 #include <atomic>
-
+#include "ofPixels.h"
 /// This is a simple example of a ThreadedObject created by extending ofThread.
 /// It contains data (count) that will be accessed from within and outside the
 /// thread and demonstrates several of the data protection mechanisms (aka
@@ -69,17 +69,15 @@ public:
 			// The mutex is now locked so we can modify
 			// the shared memory without problem
 			auto t = ofGetElapsedTimef();
-			for(auto line: pixels.getLines()){
-				auto x = 0;
-				for(auto pixel: line.getPixels()){
-					auto ux = x/float(pixels.getWidth());
-					auto uy = line.getLineNum()/float(pixels.getHeight());
-					pixel[0] = ofNoise(ux, uy, t);
-					pixel[1] = ofNoise(ux, uy, t);
-					pixel[2] = ofNoise(ux, uy, t);
-					pixel[3] = 1;
-					x++;
-				}
+			auto pixelData = pixels.getData();
+			int totalPixels = pixels.getWidth() * pixels.getHeight();
+			for (int i = 0; i < totalPixels; i++) {
+				float ux = (i % pixels.getWidth()) / float(pixels.getWidth());
+				float uy = (i / pixels.getWidth()) / float(pixels.getHeight());
+				pixelData[i * 4 + 0] = ofNoise(ux, uy, t);
+				pixelData[i * 4 + 1] = ofNoise(ux, uy, t);
+				pixelData[i * 4 + 2] = ofNoise(ux, uy, t);
+				pixelData[i * 4 + 3] = 1;
 			}
 
 			// Now we wait for the main thread to finish

--- a/examples/threads/threadedImageLoaderExample/src/ofApp.cpp
+++ b/examples/threads/threadedImageLoaderExample/src/ofApp.cpp
@@ -42,6 +42,7 @@ void ofApp::draw(){
 
 //--------------------------------------------------------------
 void ofApp::exit(){
+	ofStopURLLoader();
 	loader.stopThread();
 }
 

--- a/libs/openFrameworks/utils/ofThread.h
+++ b/libs/openFrameworks/utils/ofThread.h
@@ -43,6 +43,7 @@ class ofThread {
 public:
 	/// \brief Create an ofThread.
 	ofThread();
+	virtual ~ofThread() { }
 
 	/// \brief Check the running status of the thread.
 	/// \returns true iff the thread is currently running.
@@ -300,6 +301,7 @@ private:
 
 class ofThread {
 public:
+	virtual ~ofThread() { }
 	void lock() { }
 	void unlock() { }
 	void startThread() { }


### PR DESCRIPTION
Fixes https://github.com/openframeworks/openFrameworks/issues/7912

ofThread has virtual function - threadedFunction() and no virtual destructor. 
This PR adds virtual dtor.

Also I tested the examples and fixed a crash on exit for threadedImageLoader and something was wrong with pixel[0] access on the other. 

All working now