### PR TITLE
ofParameterGroup::add(std::shared_ptr<ofAbstractParameter> param);

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -109,6 +109,7 @@ public:
 		add(parameters...);
 	}
 
+	void add(std::shared_ptr<ofAbstractParameter> param);
 	void add(ofAbstractParameter & param);
 	std::string valueType() const;
 

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -17,8 +17,7 @@ ofParameterGroup::ofParameterGroup()
 
 }
 
-void ofParameterGroup::add(ofAbstractParameter & parameter){
-	shared_ptr<ofAbstractParameter> param = parameter.newReference();
+void ofParameterGroup::add(shared_ptr<ofAbstractParameter> param){
 	const std::string name = param->getEscapedName();
 	if(obj->parametersIndex.find(name) != obj->parametersIndex.end()){
 		ofLogWarning() << "Adding another parameter with same name '" << param->getName() << "' to group '" << getName() << "'";
@@ -26,6 +25,10 @@ void ofParameterGroup::add(ofAbstractParameter & parameter){
 	obj->parameters.push_back(param);
 	obj->parametersIndex[name] = obj->parameters.size()-1;
 	param->setParent(*this);
+}
+
+void ofParameterGroup::add(ofAbstractParameter & parameter){
+	add(parameter.newReference());
 }
 
 void ofParameterGroup::remove(ofAbstractParameter &param){


### PR DESCRIPTION
`ofParameterGroup::add()` takes a reference to add a parameter, but internally manages a container of shared_ptr. 

As discussed here https://forum.openframeworks.cc/t/ofparametergroup-add-with-a-local-ofparameter/43666 sometimes one already has hold of a shared_ptr pointing to a param, and would want to pass it to a group. or someone want to create a parameter and have the group being the sole container for it.

This implements ofParameterGroup::add(std::shared_ptr<ofAbstractParameter> param) (which, incidentally, is everything but the first line of the original ofParameterGroup::add(ofAbstractParameter & param)

So it is now possible to do: 
```
group.add(std::make_shared<ofParameter<float>>("f",2));
```

and the group holds onto the shared_ptr. of course this is a pretty specific application (where you will have to go through the group to get to the parameter).