### PR TITLE
ofParameter: deprecate newReference() in favour of getSharedPtr()

### DIFF
--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -170,8 +170,12 @@ void ofParameter<void>::setSerializable(bool serializable) {
     obj->serializable = serializable;
 }
 
+std::shared_ptr<ofAbstractParameter> ofParameter<void>::getSharedPtr() const {
+	return std::make_shared<ofParameter<void>>(*this);
+}
+
 std::shared_ptr<ofAbstractParameter> ofParameter<void>::newReference() const {
-    return std::make_shared<ofParameter<void>>(*this);
+	return getSharedPtr();
 }
 
 void ofParameter<void>::setParent(ofParameterGroup & parent) {

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -72,7 +72,10 @@ public:
 
 	virtual bool isSerializable() const = 0;
 	virtual bool isReadOnly() const = 0;
+	
+	[[deprecated("use getSharedPtr")]]
 	virtual std::shared_ptr<ofAbstractParameter> newReference() const = 0;
+	virtual std::shared_ptr<ofAbstractParameter> getSharedPtr() const = 0;
 
 	virtual bool isReferenceTo(const ofAbstractParameter & other) const;
 
@@ -249,7 +252,10 @@ public:
 	void setSerializable(bool serializable);
 	bool isSerializable() const;
 	bool isReadOnly() const;
+	
+	[[deprecated("use getSharedPtr")]]
 	std::shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> getSharedPtr() const;
 
 	void setParent(ofParameterGroup & parent);
 
@@ -593,7 +599,10 @@ public:
 	bool isInit() const;
 
 	void setSerializable(bool serializable);
+	
+	[[deprecated("use getSharedPtr")]]
 	std::shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> getSharedPtr() const;
 
 	void setParent(ofParameterGroup & _parent);
 
@@ -1006,6 +1015,11 @@ void ofParameter<ParameterType>::makeReferenceTo(ofParameter<ParameterType> & mo
 
 template <typename ParameterType>
 std::shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::newReference() const {
+	return getSharedPtr();
+}
+
+template <typename ParameterType>
+std::shared_ptr<ofAbstractParameter> ofParameter<ParameterType>::getSharedPtr() const {
 	return std::make_shared<ofParameter<ParameterType>>(*this);
 }
 
@@ -1073,7 +1087,10 @@ public:
 	void makeReferenceTo(ofParameter<void> & mom);
 
 	void setSerializable(bool serializable);
+	
+	[[deprecated("use getSharedPtr")]]
 	std::shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> getSharedPtr() const;
 
 	void setParent(ofParameterGroup & _parent);
 
@@ -1148,7 +1165,9 @@ public:
 	template <class ListenerClass, typename ListenerMethod>
 	void removeListener(ListenerClass * listener, ListenerMethod method, int prio = OF_EVENT_ORDER_AFTER_APP);
 
+	[[deprecated("use getSharedPtr")]]
 	std::shared_ptr<ofAbstractParameter> newReference() const;
+	std::shared_ptr<ofAbstractParameter> getSharedPtr() const;
 
 	template <typename... Args>
 	std::unique_ptr<of::priv::AbstractEventToken> newListener(Args... args);
@@ -1509,6 +1528,11 @@ inline void ofReadOnlyParameter<ParameterType, Friend>::fromString(const std::st
 
 template <typename ParameterType, typename Friend>
 std::shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType, Friend>::newReference() const {
+	return getSharedPtr();
+}
+
+template <typename ParameterType, typename Friend>
+std::shared_ptr<ofAbstractParameter> ofReadOnlyParameter<ParameterType, Friend>::getSharedPtr() const {
 	return std::make_shared<ofReadOnlyParameter<ParameterType, Friend>>(*this);
 }
 

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -18,7 +18,7 @@ ofParameterGroup::ofParameterGroup()
 }
 
 void ofParameterGroup::add(ofAbstractParameter & parameter){
-	shared_ptr<ofAbstractParameter> param = parameter.newReference();
+	auto param = parameter.getSharedPtr();
 	const std::string name = param->getEscapedName();
 	if(obj->parametersIndex.find(name) != obj->parametersIndex.end()){
 		ofLogWarning() << "Adding another parameter with same name '" << param->getName() << "' to group '" << getName() << "'";
@@ -486,6 +486,10 @@ const void* ofParameterGroup::getInternalObject() const{
 }
 
 shared_ptr<ofAbstractParameter> ofParameterGroup::newReference() const{
+	return getSharedPtr();
+}
+
+shared_ptr<ofAbstractParameter> ofParameterGroup::getSharedPtr() const{
 	return std::make_shared<ofParameterGroup>(*this);
 }
 


### PR DESCRIPTION
after a good discussion in a workshop on the subtleties of references vs pointers (and shared_ptr) it became evident that the `ofParameter::newReference()` method is ill-named, as it does not return a &reference but a shared_ptr.

this deprecates and uses a more correct `getSharedPtr()` name for the same function. it does not seem very widely used — one even wonders why not simply use `std::make_shared()` at the call site...

(perhaps the method above used the term "reference" in a more philosophical way, as yes a pointer "refers" to an object, but in C++ "reference" is very specific term that should not be used unless talking about actual &references, even more so in an API)