### PR TITLE
prevent misinterpretation ofParameter<bool> ctor when single arg is string

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -498,17 +498,46 @@ typename std::enable_if<!of::priv::has_loading_support<ParameterType>::value, Pa
 template <typename ParameterType>
 class ofParameter : public ofAbstractParameter {
 public:
+	
+	/// \brief constructs a default ofParameter of type ParameterType
+	/// \tparam ParameterType the type of the Value held by the ofParameter
 	ofParameter();
-	ofParameter(const ofParameter<ParameterType> & v);
-	ofParameter(const ParameterType & v);
 
+	/// \brief constructs an ofParameter of type ParameterType as an alias of the Value of another ofParameter
+	/// \tparam ParameterType the type of the value held by the ofParameter
+	/// \param v the ofParameter to link to it's value
+	ofParameter(const ofParameter<ParameterType> & v);
+
+	/// \brief constructs an ofParameter of type ParameterType initialized to value of same-type v
+	/// \tparam ParameterType the type of the value held by the ofParameter
+	/// \param v the value to initialize to
+	ofParameter(const ParameterType & v);
+	
+	/// \brief constructs an ofParameter of type ParameterType initialized to value of v
+	/// where v is convertible to ParameterType, with an exception for bool which can cause
+	/// unexpected behavious (as string and char arrays are convertible to bool)
+	/// \tparam ParameterType the type of the value held by the ofParameter
+	/// \tparam Arg a type convertible to ParameterType
+	/// \param v the value to initialize to
 	template <
 		typename Arg,
 		typename = std::enable_if_t<(std::is_convertible_v<Arg, ParameterType>  and
 									 !((std::is_same_v<ParameterType, bool>)and!(std::is_arithmetic_v<Arg>)))>>
 	ofParameter(const Arg & v);
 
+	/// \brief constructs a named ofParameter of type ParameterType initialized to value of v
+	/// \tparam ParameterType the type of the value held by the ofParameter
+	/// \param name name of the parameter
+	/// \param v the value to initialize to
 	ofParameter(const std::string & name, const ParameterType & v);
+
+	/// \brief constructs a named ofParameter of type ParameterType initialized to value of v,
+	/// with non-enforced constraints on the range of possible values
+	/// \tparam ParameterType the type of the value held by the ofParameter
+	/// \param name name of the parameter
+	/// \param v the value to initialize to
+	/// \param min the minimum value to be held
+	/// \param max the maximum value to be held
 	ofParameter(const std::string & name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
 	const ParameterType & get() const;

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -501,6 +501,14 @@ public:
 	ofParameter();
 	ofParameter(const ofParameter<ParameterType> & v);
 	ofParameter(const ParameterType & v);
+	
+	template <
+	typename Arg,
+	typename = std::enable_if_t<(std::is_convertible_v<Arg, ParameterType> and
+								 !((std::is_same_v<ParameterType,bool>) and !(std::is_arithmetic_v<Arg>)))>
+	>
+	ofParameter(const Arg & v);
+	
 	ofParameter(const std::string & name, const ParameterType & v);
 	ofParameter(const std::string & name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 
@@ -677,7 +685,8 @@ ofParameter<ParameterType>::ofParameter(const ofParameter<ParameterType> & v)
 	, setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)) { }
 
 template <typename ParameterType>
-ofParameter<ParameterType>::ofParameter(const ParameterType & v)
+template <typename Arg, typename>
+ofParameter<ParameterType>::ofParameter(const Arg & v)
 	: obj(std::make_shared<Value>(v))
 	, setMethod(std::bind(&ofParameter<ParameterType>::eventsSetValue, this, std::placeholders::_1)) { }
 

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -8,8 +8,8 @@
 
 #include "ofColor.h"
 #include "ofLog.h"
-#include "ofRectangle.h"
 #include "ofMathConstants.h"
+#include "ofRectangle.h"
 #include "ofUtils.h" // ofToString
 
 template <typename ParameterType>
@@ -501,14 +501,13 @@ public:
 	ofParameter();
 	ofParameter(const ofParameter<ParameterType> & v);
 	ofParameter(const ParameterType & v);
-	
+
 	template <
-	typename Arg,
-	typename = std::enable_if_t<(std::is_convertible_v<Arg, ParameterType> and
-								 !((std::is_same_v<ParameterType,bool>) and !(std::is_arithmetic_v<Arg>)))>
-	>
+		typename Arg,
+		typename = std::enable_if_t<(std::is_convertible_v<Arg, ParameterType>  and
+									 !((std::is_same_v<ParameterType, bool>)and!(std::is_arithmetic_v<Arg>)))>>
 	ofParameter(const Arg & v);
-	
+
 	ofParameter(const std::string & name, const ParameterType & v);
 	ofParameter(const std::string & name, const ParameterType & v, const ParameterType & min, const ParameterType & max);
 


### PR DESCRIPTION
this concerns the constructor of ofParameter, and attempts to sanitize the treatment of single-arg construction such as:
```
ofParameter<Type> name {some_value};
```
as described in #7671 currently the implicit conversion will convert string and char * to bool . this is error prone as:
```
ofParameter<bool> name {"activate shields"};
```
is not flagged as an error, but creates an unnamed bool param with true as the default value (`activate shields` implicitly converts to true).

this PR does 2 things:
- ensures the arg is convertible to the type (better error message, otherwise they come deeper in the template stuff)
- if the type is bool, ensure arg is also arithmetic (so implicit conversion from 0, 1, or whatever arithmetic value is allowed)

note that it still allows the exception for `void` parameters, where the first argument is the name, because there is no value associated with `void`.

![image](https://github.com/user-attachments/assets/b00b72c3-8a73-4843-95f9-7fd2f821d235)

this passes the ofParameterGroup/GUI example. closes #7671 

(PS: simply marking the constructor `explicit` was attempted, but that triggers a cascade of errors in ofxGui and friends, which is another can of worms).