### PR TITLE
ofVideoPlayer using fs::path

### DIFF
--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.cpp
@@ -28,11 +28,12 @@ ofxEmscriptenVideoPlayer::~ofxEmscriptenVideoPlayer() {
 	html5video_player_delete(player_id);
 }
 
-bool ofxEmscriptenVideoPlayer::load(string name){
+bool ofxEmscriptenVideoPlayer::load(const of::filesystem::path & fileName){
+	std::string name = ofPathToString(fileName);
 	if (name.substr(0, 7) == "http://" || name.substr(0, 8) == "https://"){
-		html5video_player_load_url(player_id, name.c_str());
+		html5video_player_load_url(player_id, fileName.c_str());
 	} else{
-		html5video_player_load(player_id, ofToDataPath(name).c_str());
+		html5video_player_load(player_id, ofToDataPath(fileName).c_str());
 	}
 	return true;
 }

--- a/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.h
+++ b/addons/ofxEmscripten/src/ofxEmscriptenVideoPlayer.h
@@ -16,7 +16,7 @@ public:
 	~ofxEmscriptenVideoPlayer();
 
 	//needs implementing
-	bool				load(const std::string fileName);
+	bool load(const of::filesystem::path & fileName);
 	void				close();
 	void				update();
 

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.h
@@ -15,7 +15,7 @@ public:
 	void enableTextureCache();
 	void disableTextureCache();
 	
-	bool load(std::string name);
+	bool load(const of::filesystem::path & fileName);
 	void close();
 	void update();
 	
@@ -62,7 +62,7 @@ public:
 	void * getAVFoundationVideoPlayer();
 	
 	[[deprecated("use load()")]]
-	bool loadMovie(std::string name);
+	bool loadMovie(const of::filesystem::path & fileName);
 	[[deprecated("use getPixels()")]]
 	ofPixels & getPixelsRef();
 	[[deprecated("use getPixels()")]]

--- a/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
+++ b/addons/ofxiOS/src/video/ofxiOSVideoPlayer.mm
@@ -41,14 +41,14 @@ void ofxiOSVideoPlayer::disableTextureCache() {
 }
 
 //----------------------------------------
-bool ofxiOSVideoPlayer::load(string name) {
+bool ofxiOSVideoPlayer::load(const of::filesystem::path & fileName) {
 	
     if(!videoPlayer) {
         videoPlayer = (__bridge_retained void *)[[AVFoundationVideoPlayer alloc] init];
         [(__bridge AVFoundationVideoPlayer *)videoPlayer setWillBeUpdatedExternally:YES];
     }
     
-    NSString * videoPath = [NSString stringWithUTF8String:ofToDataPath(name).c_str()];
+    NSString * videoPath = [NSString stringWithUTF8String:ofToDataPath(fileName).c_str()];
     [(__bridge AVFoundationVideoPlayer*)videoPlayer loadWithPath:videoPath];
     
     bResetPixels = true;
@@ -589,8 +589,8 @@ void * ofxiOSVideoPlayer::getAVFoundationVideoPlayer() {
 }
 
 //---------------------------------------- DEPRECATED.
-bool ofxiOSVideoPlayer::loadMovie(string name) {
-    return load(name);
+bool ofxiOSVideoPlayer::loadMovie(const of::filesystem::path & fileName) {
+    return load(fileName);
 }
 
 ofPixels & ofxiOSVideoPlayer::getPixelsRef() {

--- a/libs/openFrameworks/types/ofBaseTypes.cpp
+++ b/libs/openFrameworks/types/ofBaseTypes.cpp
@@ -47,9 +47,9 @@ ofBaseVideoPlayer::~ofBaseVideoPlayer(){
 
 }
 
-void ofBaseVideoPlayer::loadAsync(std::string name){
+void ofBaseVideoPlayer::loadAsync(const of::filesystem::path & fileName){
 	ofLogWarning("ofBaseVideoPlayer") << "loadAsync() not implemented, loading synchronously";
-	load(name);
+	load(fileName);
 }
 
 //---------------------------------------------------------------------------

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -28,8 +28,8 @@ public:
 	~ofAVFoundationPlayer();
 	
 	//FIXME: FS
-	bool load(std::string name);
-	void loadAsync(std::string name);
+	bool load(const of::filesystem::path & fileName);
+	void loadAsync(const of::filesystem::path & fileName);
 	void close();
 	void update();
 
@@ -88,7 +88,7 @@ public:
 #endif
 	
 	[[deprecated("use load()")]]
-	bool loadMovie(std::string name);
+	bool loadMovie(const of::filesystem::path & fileName);
 	[[deprecated("use getPixels()")]]
 	ofPixels & getPixelsRef();
 	[[deprecated("use getPixels()")]]
@@ -98,7 +98,7 @@ public:
 	
 protected:
 	
-	bool loadPlayer(std::string name, bool bAsync);
+	bool loadPlayer(const of::filesystem::path & fileName, bool bAsync);
 	void disposePlayer();
 	bool isReady() const;
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.h
@@ -27,9 +27,8 @@ public:
 	ofAVFoundationPlayer();
 	~ofAVFoundationPlayer();
 	
-	//FIXME: FS
-	bool load(const of::filesystem::path & fileName);
-	void loadAsync(const of::filesystem::path & fileName);
+	bool load(const of::filesystem::path & fileName) override;
+	void loadAsync(const of::filesystem::path & fileName) override;
 	void close();
 	void update();
 

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -62,7 +62,6 @@ bool ofAVFoundationPlayer::load(const of::filesystem::path & fileName) {
 }
 
 //--------------------------------------------------------------
-// FIXME: fs::path
 bool ofAVFoundationPlayer::loadPlayer(const of::filesystem::path & fileName, bool bAsync) {
 	if( ofGetUsingArbTex() == false ){
         killTextureCache();
@@ -74,7 +73,7 @@ bool ofAVFoundationPlayer::loadPlayer(const of::filesystem::path & fileName, boo
 
 	BOOL bStream = NO;
 
-    string fileNameStr { ofPathToString(fileName) };
+    std::string fileNameStr { ofPathToString(fileName) };
 	bStream = bStream || (ofIsStringInString(fileNameStr, "http://"));
 	bStream = bStream || (ofIsStringInString(fileNameStr, "https://"));
 	bStream = bStream || (ofIsStringInString(fileNameStr, "rtsp://"));

--- a/libs/openFrameworks/video/ofAVFoundationPlayer.mm
+++ b/libs/openFrameworks/video/ofAVFoundationPlayer.mm
@@ -52,31 +52,32 @@ ofAVFoundationPlayer& ofAVFoundationPlayer::operator=(ofAVFoundationPlayer other
 }
 
 //--------------------------------------------------------------
-void ofAVFoundationPlayer::loadAsync(std::string name){
-    loadPlayer(name, true);
+void ofAVFoundationPlayer::loadAsync(const of::filesystem::path & fileName){
+    loadPlayer(fileName, true);
 }
 
 //--------------------------------------------------------------
-bool ofAVFoundationPlayer::load(std::string name) {
-    return loadPlayer(name, false);
+bool ofAVFoundationPlayer::load(const of::filesystem::path & fileName) {
+    return loadPlayer(fileName, false);
 }
 
 //--------------------------------------------------------------
 // FIXME: fs::path
-bool ofAVFoundationPlayer::loadPlayer(std::string name, bool bAsync) {
+bool ofAVFoundationPlayer::loadPlayer(const of::filesystem::path & fileName, bool bAsync) {
 	if( ofGetUsingArbTex() == false ){
         killTextureCache();
 		bUseTextureCache = false;
     }
 
-	NSString * videoPath = [NSString stringWithUTF8String:name.c_str()];
-	NSString * videoLocalPath = [NSString stringWithUTF8String:ofToDataPath(name).c_str()];
+	NSString * videoPath = [NSString stringWithUTF8String:fileName.c_str()];
+	NSString * videoLocalPath = [NSString stringWithUTF8String:ofToDataPath(fileName).c_str()];
 
 	BOOL bStream = NO;
 
-	bStream = bStream || (ofIsStringInString(name, "http://"));
-	bStream = bStream || (ofIsStringInString(name, "https://"));
-	bStream = bStream || (ofIsStringInString(name, "rtsp://"));
+    string fileNameStr { ofPathToString(fileName) };
+	bStream = bStream || (ofIsStringInString(fileNameStr, "http://"));
+	bStream = bStream || (ofIsStringInString(fileNameStr, "https://"));
+	bStream = bStream || (ofIsStringInString(fileNameStr, "rtsp://"));
 
 	NSURL * url = nil;
 	if(bStream == YES) {
@@ -762,8 +763,8 @@ void * ofAVFoundationPlayer::getAVFoundationVideoPlayer() {
 #endif
 
 //-------------------------------------------------------------- DEPRECATED.
-bool ofAVFoundationPlayer::loadMovie(std::string name) {
-    return load(name);
+bool ofAVFoundationPlayer::loadMovie(const of::filesystem::path & fileName) {
+    return load(fileName);
 }
 
 ofPixels & ofAVFoundationPlayer::getPixelsRef() {

--- a/libs/openFrameworks/video/ofDirectShowPlayer.cpp
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.cpp
@@ -1146,9 +1146,8 @@ ofDirectShowPlayer & ofDirectShowPlayer::operator=(ofDirectShowPlayer&& other) {
 	return *this;
 }
 
-// FIXME: fs::path
-bool ofDirectShowPlayer::load(std::string stringPath){
-    auto path = ofToDataPath(of::filesystem::path(stringPath));
+bool ofDirectShowPlayer::load(const of::filesystem::path & fileName){
+    auto path = ofToDataPath(fileName);
 
     close();
     player.reset(new DirectShowVideo());

--- a/libs/openFrameworks/video/ofDirectShowPlayer.h
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.h
@@ -20,7 +20,7 @@ class ofDirectShowPlayer : public ofBaseVideoPlayer{
 		ofDirectShowPlayer(ofDirectShowPlayer &&);
 		ofDirectShowPlayer & operator=(ofDirectShowPlayer&&);
 
-        bool                load(std::string path);
+        bool load(const of::filesystem::path & fileName);
         void                update();
 
         void                close();

--- a/libs/openFrameworks/video/ofDirectShowPlayer.h
+++ b/libs/openFrameworks/video/ofDirectShowPlayer.h
@@ -20,7 +20,7 @@ class ofDirectShowPlayer : public ofBaseVideoPlayer{
 		ofDirectShowPlayer(ofDirectShowPlayer &&);
 		ofDirectShowPlayer & operator=(ofDirectShowPlayer&&);
 
-        bool load(const of::filesystem::path & fileName);
+        bool load(const of::filesystem::path & fileName) override;
         void                update();
 
         void                close();

--- a/libs/openFrameworks/video/ofGstVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.cpp
@@ -187,13 +187,14 @@ bool ofGstVideoPlayer::createPipeline(std::string name){
 #endif
 }
 
-void ofGstVideoPlayer::loadAsync(std::string name){
+void ofGstVideoPlayer::loadAsync(const of::filesystem::path & fileName){
 	bAsyncLoad = true;
-	load(name);
+	load(fileName);
 }
 
 // FIXME: fs::path
-bool ofGstVideoPlayer::load(std::string name){
+bool ofGstVideoPlayer::load(const of::filesystem::path & fileName){
+	std::string name { ofPathToString(fileName) };
 	if( name.find( "file://",0 ) != std::string::npos){
 		bIsStream = bAsyncLoad;
 	}else if( name.find( "://",0 ) == std::string::npos){
@@ -217,7 +218,7 @@ bool ofGstVideoPlayer::load(std::string name){
 		internalPixelFormat = OF_PIXELS_NATIVE;
 		bIsAllocated = false;
 		videoUtils.reallocateOnNextFrame();
-		g_object_set(G_OBJECT(videoUtils.getPipeline()), "uri", name.c_str(), (void*)NULL);
+		g_object_set(G_OBJECT(videoUtils.getPipeline()), "uri", fileName.c_str(), (void*)NULL);
 		gst_element_set_state (videoUtils.getPipeline(), GST_STATE_PAUSED);
 		if(!bIsStream){
 			gst_element_get_state (videoUtils.getPipeline(), NULL, NULL, -1);
@@ -227,7 +228,7 @@ bool ofGstVideoPlayer::load(std::string name){
 		}
 	}else{
 		ofGstUtils::startGstMainLoop();
-		return createPipeline(name) &&
+		return createPipeline(fileName) &&
 				videoUtils.startPipeline() &&
 				(bIsStream || allocate());
 	}

--- a/libs/openFrameworks/video/ofGstVideoPlayer.h
+++ b/libs/openFrameworks/video/ofGstVideoPlayer.h
@@ -13,8 +13,8 @@ public:
 	bool 	setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat	getPixelFormat() const;
 	
-	void	loadAsync(std::string name);
-	bool 	load(std::string uri);
+	void loadAsync(const of::filesystem::path & fileName) override;
+	bool load(const of::filesystem::path & fileName) override;
 
 	void 	update();
 

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.cpp
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.cpp
@@ -658,19 +658,20 @@ std::shared_ptr<ofMediaFoundationPlayer::MEDXDeviceManager> ofMediaFoundationPla
 }
 
 //----------------------------------------------
-bool ofMediaFoundationPlayer::load(std::string name) {
-    return _load(name, false);
+bool ofMediaFoundationPlayer::load(const of::filesystem::path & fileName) {
+    return _load(fileName, false);
 }
 
 //----------------------------------------------
-void ofMediaFoundationPlayer::loadAsync(std::string name) {
-    _load(name, true);
+void ofMediaFoundationPlayer::loadAsync(const of::filesystem::path & fileName) {
+    _load(fileName, true);
 }
 
 //----------------------------------------------
-bool ofMediaFoundationPlayer::_load(std::string name, bool abAsync) {
+bool ofMediaFoundationPlayer::_load(const of::filesystem::path & fileName, bool abAsync) {
     close();
 
+    std::string name = ofPathToString(fileName);
     mBLoadAsync = abAsync;
 
     bool bStream = false;
@@ -679,7 +680,7 @@ bool ofMediaFoundationPlayer::_load(std::string name, bool abAsync) {
     bStream = bStream || ofIsStringInString(name, "rtsp://");
     bStream = bStream || ofIsStringInString(name, "rtmp://");
 
-    of::filesystem::path absPath = name;
+    of::filesystem::path absPath = fileName;
 
     if (!bStream) {
         if (ofFile::doesFileExist(absPath)) {

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.h
@@ -159,7 +159,7 @@ public:
     ofEvent<MF_MEDIA_ENGINE_ERR> MFErrorEvent;
 
 protected:
-    bool _load(std::string name, bool abAsync);
+    bool _load(const of::filesystem::path & fileName, bool abAsync);
     void OnMediaEngineEvent(DWORD aEvent, DWORD_PTR param1, DWORD param2) override;
 
     class MEDXDeviceManager {

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.h
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.h
@@ -99,9 +99,9 @@ public:
 
     static void setDurationHackEnabled(bool ab);
 
-    bool                load(std::string name) override;
-    void				loadAsync(std::string name) override;
-    void                close() override;
+    bool load(const of::filesystem::path & fileName) override;
+    void loadAsync(const of::filesystem::path & fileName) override;
+    void close() override;
 
     bool                isInitialized() const override;
 

--- a/libs/openFrameworks/video/ofVideoBaseTypes.h
+++ b/libs/openFrameworks/video/ofVideoBaseTypes.h
@@ -207,8 +207,8 @@ public:
 	/// \param name The name of the video resource to load.
 	/// \return True if the video was loaded successfully.
 	/// \sa loadAsync()
-	// FIXME: FS
-	virtual bool load(std::string name) = 0;
+
+	virtual bool load(const of::filesystem::path & fileName) = 0;
 	/// \brief Asynchronously load a video resource by name.
 	///
 	/// The list of supported video types and sources (e.g. rtsp:// sources) is
@@ -219,7 +219,7 @@ public:
 	///
 	/// \param name The name of the video resource to load.
 	/// \sa isLoaded()
-	virtual void loadAsync(std::string name);
+	virtual void loadAsync(const of::filesystem::path & fileName);
 
 	/// \brief Play the video from the current playhead position.
 	///

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -200,7 +200,7 @@ bool ofVideoPlayer::loadMovie(const of::filesystem::path & fileName){
 }
 
 //---------------------------------------------------------------------------
-string ofVideoPlayer::getMoviePath() const{
+of::filesystem::path ofVideoPlayer::getMoviePath() const {
     return moviePath;	
 }
 

--- a/libs/openFrameworks/video/ofVideoPlayer.cpp
+++ b/libs/openFrameworks/video/ofVideoPlayer.cpp
@@ -96,8 +96,7 @@ ofVideoPlayer::ofVideoPlayer() {
 
 //---------------------------------------------------------------------------
 ofVideoPlayer::ofVideoPlayer(const of::filesystem::path & fileName) : ofVideoPlayer() {
-	// FIXME: Convert internally everything to FS
-	load(ofPathToString(fileName));
+	load(fileName);
 }
 
 //---------------------------------------------------------------------------
@@ -152,16 +151,16 @@ ofPixelFormat ofVideoPlayer::getPixelFormat() const{
 }
 
 //---------------------------------------------------------------------------
-bool ofVideoPlayer::load(string name){
+bool ofVideoPlayer::load(const of::filesystem::path & fileName){
 	if( !player ){
 		setPlayer(std::make_shared<OF_VID_PLAYER_TYPE>());
 		player->setPixelFormat(internalPixelFormat);
 	}
 	
-	bool bOk = player->load(name);
+	bool bOk = player->load(fileName);
 
 	if( bOk){
-        moviePath = name;
+        moviePath = fileName;
         if(bUseTexture){
         	if(player->getTexturePtr()==nullptr){
 				if(tex.empty()) {
@@ -185,19 +184,19 @@ bool ofVideoPlayer::load(string name){
 }
 
 //---------------------------------------------------------------------------
-void ofVideoPlayer::loadAsync(string name){
+void ofVideoPlayer::loadAsync(const of::filesystem::path & fileName){
 	if( !player ){
 		setPlayer(std::make_shared<OF_VID_PLAYER_TYPE>());
 		player->setPixelFormat(internalPixelFormat);
 	}
 	
-	player->loadAsync(name);
-	moviePath = name;
+	player->loadAsync(fileName);
+	moviePath = fileName;
 }
 
 //---------------------------------------------------------------------------
-bool ofVideoPlayer::loadMovie(string name){
-	return load(name);
+bool ofVideoPlayer::loadMovie(const of::filesystem::path & fileName){
+	return load(fileName);
 }
 
 //---------------------------------------------------------------------------

--- a/libs/openFrameworks/video/ofVideoPlayer.h
+++ b/libs/openFrameworks/video/ofVideoPlayer.h
@@ -9,10 +9,10 @@ public:
 	ofVideoPlayer();
 	ofVideoPlayer(const of::filesystem::path & fileName);
 
-	bool load(std::string name);
-	void loadAsync(std::string name);
+	bool load(const of::filesystem::path & fileName);
+	void loadAsync(const of::filesystem::path & fileName);
 	[[deprecated("Use load")]]
-	bool loadMovie(std::string name);
+	bool loadMovie(const of::filesystem::path & fileName);
 
 
 	/// \brief Get the path to the loaded video file.
@@ -20,7 +20,7 @@ public:
 	/// If no video file is loaded this returns an empty string.
 	///
 	/// \returns A path to the loaded video or an empty string if not loaded.
-	std::string				getMoviePath() const;
+	of::filesystem::path				getMoviePath() const;
 
 	bool				setPixelFormat(ofPixelFormat pixelFormat);
 	ofPixelFormat		getPixelFormat() const;
@@ -186,5 +186,5 @@ private:
 	/// \brief The internal pixel format.
 	mutable ofPixelFormat internalPixelFormat;
 	/// \brief The stored path to the video's path.
-	std::string moviePath;
+	of::filesystem::path moviePath;
 };


### PR DESCRIPTION
this PR intends to use fs::path internally for video player functions 
(load, loadAsync, loadMovie [[deprecated]] )