### PR TITLE
ofxButton: distinguish button from Toggle visually with circle vs square

### DIFF
--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -46,6 +46,49 @@ ofxButton* ofxButton::setup(const std::string& toggleName, float width, float he
 	return this;
 }
 
+void ofxButton::generateDraw(){
+	bg.clear();
+	bg.setFillColor(thisBackgroundColor);
+	bg.rectangle(b);
+
+	fg.clear();
+	if(value){
+		fg.setFilled(true);
+		fg.setFillColor(thisFillColor);
+	}else{
+		fg.setFilled(false);
+		fg.setStrokeWidth(1);
+		fg.setStrokeColor(thisFillColor);
+	}
+	fg.rectRounded(b.getPosition()+checkboxRect.getTopLeft()+glm::vec2{1,1},checkboxRect.width-2,checkboxRect.height-2, 5);
+
+	cross.clear();
+	cross.setStrokeColor(thisTextColor);
+	cross.setFillColor(thisFillColor);
+	cross.setStrokeWidth(2);
+	cross.setFilled(true);
+	cross.rectRounded(b.getPosition()+checkboxRect.getTopLeft()+glm::vec2{1,1},checkboxRect.width-2,checkboxRect.height-2, 5);
+
+	std::string name;
+	auto textX = b.x + textPadding + checkboxRect.width;
+	if(getTextBoundingBox(getName(), textX, 0).getMaxX() > b.getMaxX() - textPadding){
+		for(auto c: ofUTF8Iterator(getName())){
+			auto next = name;
+			ofUTF8Append(next, c);
+			if(getTextBoundingBox(next,textX,0).getMaxX() > b.getMaxX() - textPadding){
+				break;
+			}else{
+				name = next;
+			}
+		}
+	}else{
+		name = getName();
+	}
+
+	textMesh = getTextMesh(name, textX, getTextVCenteredInRect(b));
+}
+
+
 bool ofxButton::mouseReleased(ofMouseEventArgs & args){
 	bool attended = setValue(args.x, args.y, false);
 	bGuiActive = false;

--- a/addons/ofxGui/src/ofxButton.cpp
+++ b/addons/ofxGui/src/ofxButton.cpp
@@ -52,14 +52,9 @@ void ofxButton::generateDraw(){
 	bg.rectangle(b);
 
 	fg.clear();
-	if(value){
-		fg.setFilled(true);
-		fg.setFillColor(thisFillColor);
-	}else{
-		fg.setFilled(false);
-		fg.setStrokeWidth(1);
-		fg.setStrokeColor(thisFillColor);
-	}
+	fg.setFilled(false);
+	fg.setStrokeWidth(1);
+	fg.setStrokeColor(thisFillColor);
 	fg.rectRounded(b.getPosition()+checkboxRect.getTopLeft()+glm::vec2{1,1},checkboxRect.width-2,checkboxRect.height-2, 5);
 
 	cross.clear();

--- a/addons/ofxGui/src/ofxButton.h
+++ b/addons/ofxGui/src/ofxButton.h
@@ -12,6 +12,7 @@ public:
 	~ofxButton();
 	ofxButton* setup(ofParameter<void> _bVal, float width = defaultWidth, float height = defaultHeight);
     ofxButton* setup(const std::string& toggleName, float width = defaultWidth, float height = defaultHeight);
+	void generateDraw();
 
 	virtual bool mouseReleased(ofMouseEventArgs & args);
 	virtual bool mouseMoved(ofMouseEventArgs & args);


### PR DESCRIPTION
It is a bit confusing that the visual representation of an ofxButton is the same as the ofxToggle, as it is not possible to pre-determine that the widget will behave differently without clicking it. Even once clicked, it looks like an active toggle so you only know if if it's going to "stick" or not upon release.

This changes the representation of the Button to a rounded rectangle, completely filled when clicked (much like buttons do, in most environments). it is close enough to the original square to not disturb the visual ambiance of a populated ofxPanel, but still conveys it's operational status clearly.

It does not affect usage or API, nor adds methods or memory requirements as it simply implement it's own `generateDraw` over the one inherited by ofxToggle, by copying the `ofxToggle::generatedDraw` integrally and changing a few draw calls -- no changes in code logic).

https://github.com/user-attachments/assets/f8aacf15-85ff-4075-b079-efeae56584a4


