### PR TITLE
#ifdef TARGET_WIN32 #include <iso646.h> #endif

### DIFF
--- a/libs/openFrameworks/ofMain.h
+++ b/libs/openFrameworks/ofMain.h
@@ -18,6 +18,10 @@
 #include "ofJson.h"
 #include "ofXml.h"
 
+#ifdef TARGET_WIN32
+#include <iso646.h>
+#endif
+
 //--------------------------
 // types
 #include "ofColor.h"


### PR DESCRIPTION
to tighten ISO conformance in MSVC without `/permissive-`

https://github.com/microsoft/STL/blob/main/stl/inc/iso646.h