### PR TITLE
ofxAssimp: Updated gitignore and addon_config.mk

### DIFF
--- a/addons/.gitignore
+++ b/addons/.gitignore
@@ -10,6 +10,7 @@
 ofxAndroid/ofAndroidLib/bin
 ofxAndroid/ofAndroidLib/gen
 !ofxAssimpModelLoader
+!ofxAssimp
 !ofxGui
 !ofxiOS
 !ofxKinect

--- a/addons/ofxAssimp/addon_config.mk
+++ b/addons/ofxAssimp/addon_config.mk
@@ -109,7 +109,7 @@ ios:
 	
 osx:
 	ADDON_LIBS=
-	ADDON_LIBS=../ofxAssimpModelLoader/libs/assimp/lib/osx/assimp.xcframework/macos-arm64_x86_64/assimp.a
+	ADDON_LIBS=../ofxAssimpModelLoader/libs/assimp/lib/macos/assimp.xcframework/macos-arm64_x86_64/assimp.a
 	
 emscripten:
 	ADDON_LIBS=


### PR DESCRIPTION
ofxAssimp was missing in the addons gitignore (not really sure how it was getting into the repo).
The lib path for macos was using the "old" folder named "osx". I would guess that this addon is not tested through CI.
I think it is safe to merge this one,