### PR TITLE
ofBaseVideoPlayer load function was reverted incorrectly

### DIFF
--- a/libs/openFrameworks/types/ofBaseTypes.cpp
+++ b/libs/openFrameworks/types/ofBaseTypes.cpp
@@ -53,7 +53,7 @@ bool ofBaseVideoPlayer::load(const of::filesystem::path & fileName){
 }
 
 //---------------------------------------------------------------------------
-bool ofBaseVideoPlayer::load(const std::string & fileName){
+bool ofBaseVideoPlayer::load(std::string fileName){
 	ofLogError("ofBaseVideoPlayer") << " One of the two load functions need to be implemented ";
 	return false;
 }
@@ -64,7 +64,7 @@ void ofBaseVideoPlayer::loadAsync(const of::filesystem::path & fileName){
 }
 
 //---------------------------------------------------------------------------
-void ofBaseVideoPlayer::loadAsync(const std::string & fileName){
+void ofBaseVideoPlayer::loadAsync(std::string fileName){
 	ofLogWarning("ofBaseVideoPlayer") << "loadAsync() not implemented, loading synchronously";
 	load(fileName);
 }

--- a/libs/openFrameworks/video/ofVideoBaseTypes.h
+++ b/libs/openFrameworks/video/ofVideoBaseTypes.h
@@ -212,7 +212,7 @@ public:
 	/// \brief Legacy approach for loading videos for older inherited classes
 	/// \param name The name of the video resource to load.
 	/// \return True if the video was loaded successfully.
-	virtual bool load(const std::string & fileName);
+	virtual bool load(std::string fileName);
 
 	/// \brief Asynchronously load a video resource by name.
 	///
@@ -228,7 +228,7 @@ public:
 	
 	/// \brief Legacy approach for Asynchronously load a video resource by name.
 	/// \param name The name of the video resource to load.
-	virtual void loadAsync(const std::string & fileName);
+	virtual void loadAsync(std::string fileName);
 
 	/// \brief Play the video from the current playhead position.
 	///


### PR DESCRIPTION
 its argument used to be a string rather than const reference string. This fixes other video players that were affected by that change. 