### PR TITLE
Reducing .h includes in .h files

### DIFF
--- a/libs/openFrameworks/3d/of3dUtils.cpp
+++ b/libs/openFrameworks/3d/of3dUtils.cpp
@@ -2,6 +2,10 @@
 #include "ofAppRunner.h"
 #include "ofGraphicsBaseTypes.h"
 
+#define GLM_FORCE_CTOR_INIT
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/vec3.hpp>
+
 //--------------------------------------------------------------
 void ofDrawAxis(float size) {
 	ofGetCurrentRenderer()->drawAxis(size);

--- a/libs/openFrameworks/3d/of3dUtils.h
+++ b/libs/openFrameworks/3d/of3dUtils.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/vec3.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<3, float, defaultp>		vec3;
+}
 
 /// \brief Draws x,y,z axes representing the current reference frame.
 ///

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -1657,7 +1657,7 @@ const std::vector<ofMeshFace_<V,N,C,T>> & ofMesh_<V,N,C,T>::getUniqueFaces() con
 		bool bHasTexcoords  = hasTexCoords();
 
 		if( getMode() == OF_PRIMITIVE_TRIANGLES) {
-			for(std::size_t j = 0; j < indices.size(); j += 3) {
+			for(ofIndexType j = 0; j < indices.size(); j += 3) {
 				ofMeshFace_<V,N,C,T> & tri = faces[triindex];
 				for(std::size_t k = 0; k < 3; k++) {
 					index = indices[j+k];

--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -2,6 +2,10 @@
 #include "ofNode.h"
 #include "of3dGraphics.h"
 
+#define GLM_FORCE_CTOR_INIT
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/mat4x4.hpp>
+
 //----------------------------------------
 ofNode::ofNode()
 :parent(nullptr)

--- a/libs/openFrameworks/3d/ofNode.h
+++ b/libs/openFrameworks/3d/ofNode.h
@@ -5,7 +5,6 @@
 
 #define GLM_FORCE_CTOR_INIT
 #define GLM_ENABLE_EXPERIMENTAL
-#include <glm/mat4x4.hpp>
 #include <glm/gtc/quaternion.hpp>
 
 #include <array>

--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -6,7 +6,7 @@
 #include "ofFileUtils.h"
 #include "ofGLProgrammableRenderer.h"
 #include "ofGLRenderer.h"
-#include "ofVectorMath.h"
+// #include "ofVectorMath.h"
 #include <assert.h>
 // x11
 #include <X11/Xutil.h>

--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -10,9 +10,16 @@
 // MARK: ofConstants Targets
 #include "ofConstants.h"
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/fwd.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+	typedef vec<4, float, defaultp>		vec4;
+
+	typedef float					f32;
+	typedef mat<3, 3, f32, defaultp>	mat3;
+	typedef mat<4, 4, f32, defaultp>	mat4;
+}
 
 #include <unordered_map>
 

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -3,9 +3,11 @@
 #include "ofConstants.h"
 #include "ofGraphicsBaseTypes.h"
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/fwd.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+}
 
 class ofVec3f;
 class ofVec2f;

--- a/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
+++ b/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
@@ -45,9 +45,13 @@ enum ofLoopType : short;
 enum ofOrientation : short;
 
 struct ofBoundingBox{
-    glm::vec3 min = glm::vec3(0,0,0);
-    glm::vec3 max = glm::vec3(0,0,0);
+	glm::vec3 min { 0, 0, 0 };
+	glm::vec3 max { 0, 0, 0 };
 };
+
+#define GLM_FORCE_CTOR_INIT
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/mat4x4.hpp>
 
 /// \brief Contains general information about the style of ofGraphics
 /// elements such as color, line width and others.
@@ -198,6 +202,11 @@ public:
 	///
 	/// \return the width.
 	virtual float getWidth() const = 0;
+	
+	// TODO: Implement correctly for texture, videos, etc.
+	virtual glm::vec2 getSize() {
+		return { getWidth(), getHeight() };
+	}
 
 	/// \brief Set the anchor point the item is drawn around as a percentage.
 	///

--- a/libs/openFrameworks/graphics/ofPolyline.h
+++ b/libs/openFrameworks/graphics/ofPolyline.h
@@ -3,9 +3,11 @@
 #ifndef OF_POLYLINE_H
 #define OF_POLYLINE_H
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/fwd.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+}
 
 #include <deque>
 #include <vector>

--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -10,7 +10,7 @@ namespace glm {
 
 #include <cstdlib>
 #include <algorithm>
-#include <cmath>
+#include <cmath> //std::cos
 
 /// \file
 /// ofMath provides a collection of mathematical utilities and functions.

--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -10,6 +10,7 @@ namespace glm {
 
 #include <cstdlib>
 #include <algorithm>
+#include <cmath>
 
 /// \file
 /// ofMath provides a collection of mathematical utilities and functions.

--- a/libs/openFrameworks/math/ofMath.h
+++ b/libs/openFrameworks/math/ofMath.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/fwd.hpp>
 #include <glm/gtc/constants.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+	typedef vec<4, float, defaultp>		vec4;
+}
 
 #include <cstdlib>
-#include <cmath>
 #include <algorithm>
 
 /// \file

--- a/libs/openFrameworks/math/ofMathConstants.h
+++ b/libs/openFrameworks/math/ofMathConstants.h
@@ -11,9 +11,12 @@ using ofDefaultVec2 = ofVec2f;
 using ofDefaultVec3 = ofVec3f;
 using ofDefaultVec4 = ofVec4f;
 #else
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/fwd.hpp>
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+	typedef vec<4, float, defaultp>		vec4;
+}
 using ofDefaultVec2 = glm::vec2;
 using ofDefaultVec3 = glm::vec3;
 using ofDefaultVec4 = glm::vec4;

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -8,7 +8,7 @@ namespace glm {
 
 #include <glm/vec4.hpp>
 #include <iostream>
-#include <cmath> //sqrt
+#include <cmath> // std::sqrt
 
 class ofVec2f;
 class ofVec3f;

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -8,6 +8,7 @@ namespace glm {
 
 #include <glm/vec4.hpp>
 #include <iostream>
+#include <cmath> //sqrt
 
 class ofVec2f;
 class ofVec3f;

--- a/libs/openFrameworks/math/ofVec4f.h
+++ b/libs/openFrameworks/math/ofVec4f.h
@@ -1,11 +1,13 @@
 #pragma once
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/detail/qualifier.hpp>
+namespace glm {
+	typedef vec<2, float, defaultp>		vec2;
+	typedef vec<3, float, defaultp>		vec3;
+}
+
 #include <glm/vec4.hpp>
-#include <glm/fwd.hpp>
 #include <iostream>
-#include <cmath>
 
 class ofVec2f;
 class ofVec3f;

--- a/libs/openFrameworks/types/ofColor.cpp
+++ b/libs/openFrameworks/types/ofColor.cpp
@@ -1,4 +1,6 @@
 #include "ofColor.h"
+#include <limits>
+
 
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::gray(limit() / 2, limit() / 2, limit() / 2);
 template<typename PixelType> const ofColor_<PixelType> ofColor_<PixelType>::white(limit(), limit(), limit());

--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -2,9 +2,10 @@
 
 #define GLM_FORCE_CTOR_INIT
 #define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/wrap.hpp>
+//#include <glm/gtx/wrap.hpp>
+#include <glm/ext/scalar_common.hpp>
+#include <glm/vec3.hpp>
 #include <iostream>
-#include <limits>
 
 /// \class ofColor_
 ///
@@ -684,6 +685,7 @@ void ofColor_<PixelType>::copyFrom(const ofColor_<SrcType> & mom){
 	if(typeid(SrcType) == typeid(float) || typeid(SrcType) == typeid(double)) {
 		// coming from float we need a special case to clamp the values
 		for(int i = 0; i < 4; i++){
+			// FIXME: replace by std::clamp when it is exclusive C++17
 			v[i] = glm::clamp(float(mom[i]), 0.f, 1.f) * factor;
 		}
 	} else{

--- a/libs/openFrameworks/types/ofColor.h
+++ b/libs/openFrameworks/types/ofColor.h
@@ -2,7 +2,6 @@
 
 #define GLM_FORCE_CTOR_INIT
 #define GLM_ENABLE_EXPERIMENTAL
-//#include <glm/gtx/wrap.hpp>
 #include <glm/ext/scalar_common.hpp>
 #include <glm/vec3.hpp>
 #include <iostream>

--- a/libs/openFrameworks/types/ofRectangle.cpp
+++ b/libs/openFrameworks/types/ofRectangle.cpp
@@ -286,7 +286,7 @@ void ofRectangle::scaleTo(const ofRectangle& targetRect,
 
     if(aspectRatioMode == OF_ASPECT_RATIO_KEEP_BY_EXPANDING ||
        aspectRatioMode == OF_ASPECT_RATIO_KEEP) {
-        if(std::abs(sw) >= std::numeric_limits<float>::epsilon() || std::abs(sh) >= FLT_EPSILON) {
+        if(std::abs(sw) >= std::numeric_limits<float>::epsilon() || std::abs(sh) >= std::numeric_limits<float>::epsilon()) {
             float wRatio = std::abs(tw) / std::abs(sw);
             float hRatio = std::abs(th) / std::abs(sh);
             if(aspectRatioMode == OF_ASPECT_RATIO_KEEP_BY_EXPANDING) {

--- a/libs/openFrameworks/video/ofAVFoundationGrabber.mm
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.mm
@@ -3,7 +3,7 @@
  */
 
 #include "ofAVFoundationGrabber.h"
-#include "ofVectorMath.h"
+//#include "ofVectorMath.h"
 #include "ofRectangle.h"
 #include "ofGLUtils.h"
 #include <TargetConditionals.h>


### PR DESCRIPTION
Another PR to move weight from .h files to .cpp files. 
it is using forward declaration from glm objects whenever possible 