### PR TITLE
Removing fmod from macos and osx makefile configs

### DIFF
--- a/libs/openFrameworksCompiled/project/macos/config.macos.default.mk
+++ b/libs/openFrameworksCompiled/project/macos/config.macos.default.mk
@@ -270,11 +270,11 @@ PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/app/ofAppEGLWindow.cp
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/boost/%
 
 
-ifeq ($(USE_FMOD),0)
-	PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%
-	PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/sound/ofFmodSoundPlayer.cpp
-	PLATFORM_CFLAGS += -DUSE_FMOD=0
-endif
+# ifeq ($(USE_FMOD),0)
+PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%
+PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/sound/ofFmodSoundPlayer.cpp
+PLATFORM_CFLAGS += -DUSE_FMOD=0
+# endif
 
 ##########################################################################################
 # PLATFORM HEADER SEARCH PATHS
@@ -431,10 +431,11 @@ afterplatform: $(TARGET_NAME)
 	@echo TARGET=$(TARGET)
 	@mv $(TARGET) bin/$(BIN_NAME).app/Contents/MacOS
 
-ifneq ($(USE_FMOD),0)
-	@mkdir -p bin/$(BIN_NAME).app/Contents/Frameworks
-	@cp $(OF_LIBS_PATH)/*/lib/$(PLATFORM_LIB_SUBPATH)/*.$(SHARED_LIB_EXTENSION) bin/$(BIN_NAME).app/Contents/Frameworks/;
-endif
+# ifneq ($(USE_FMOD),0)
+# 	@mkdir -p bin/$(BIN_NAME).app/Contents/Frameworks
+# 	@cp $(OF_LIBS_PATH)/*/lib/$(PLATFORM_LIB_SUBPATH)/*.$(SHARED_LIB_EXTENSION) bin/$(BIN_NAME).app/Contents/Frameworks/;
+# endif
+
 
 	@echo
 	@echo "     compiling done"

--- a/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
+++ b/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
@@ -270,11 +270,11 @@ PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/app/ofAppEGLWindow.cp
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/boost/%
 
 
-ifeq ($(USE_FMOD),0)
-	PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%
-	PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/sound/ofFmodSoundPlayer.cpp
-	PLATFORM_CFLAGS += -DUSE_FMOD=0
-endif
+# ifeq ($(USE_FMOD),0)
+PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%
+PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/sound/ofFmodSoundPlayer.cpp
+PLATFORM_CFLAGS += -DUSE_FMOD=0
+# endif
 
 ##########################################################################################
 # PLATFORM HEADER SEARCH PATHS
@@ -431,10 +431,10 @@ afterplatform: $(TARGET_NAME)
 	@echo TARGET=$(TARGET)
 	@mv $(TARGET) bin/$(BIN_NAME).app/Contents/MacOS
 
-ifneq ($(USE_FMOD),0)
-	@mkdir -p bin/$(BIN_NAME).app/Contents/Frameworks
-	@cp $(OF_LIBS_PATH)/*/lib/$(PLATFORM_LIB_SUBPATH)/*.$(SHARED_LIB_EXTENSION) bin/$(BIN_NAME).app/Contents/Frameworks/;
-endif
+# ifneq ($(USE_FMOD),0)
+# 	@mkdir -p bin/$(BIN_NAME).app/Contents/Frameworks
+# 	@cp $(OF_LIBS_PATH)/*/lib/$(PLATFORM_LIB_SUBPATH)/*.$(SHARED_LIB_EXTENSION) bin/$(BIN_NAME).app/Contents/Frameworks/;
+# endif
 
 	@echo
 	@echo "     compiling done"


### PR DESCRIPTION
I missed this from commit https://github.com/openframeworks/openFrameworks/commit/f3b9aa6007277ee2fbb9de447250ff20b69a8262

It no longer copies libfmod.dylib when using make, nor compiling ofFmodSoundPlayer. 
