### PR TITLE
[Idea] - Test removing legacy math from core

### DIFF
--- a/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
+++ b/addons/ofxAssimpModelLoader/src/ofxAssimpModelLoader.cpp
@@ -5,7 +5,7 @@
 #include "ofPixels.h"
 #include "ofGraphics.h"
 #include "ofConstants.h"
-#include "ofMatrix4x4.h"
+//#include "ofMatrix4x4.h"
 #include "ofUtils.h" // ofGetElapsedTimef
 
 #include <assimp/cimport.h>
@@ -587,10 +587,17 @@ void ofxAssimpModelLoader::updateMeshes(aiNode * node, glm::mat4 parentMatrix) {
 
 	aiMatrix4x4 m = node->mTransformation;
 	m.Transpose();
-	ofMatrix4x4 matrix(m.a1, m.a2, m.a3, m.a4,
-					   m.b1, m.b2, m.b3, m.b4,
-					   m.c1, m.c2, m.c3, m.c4,
-					   m.d1, m.d2, m.d3, m.d4);
+	// FIXME: - mat4
+	glm::mat4 matrix(
+		m.a1, m.a2, m.a3, m.a4,
+		m.b1, m.b2, m.b3, m.b4,
+		m.c1, m.c2, m.c3, m.c4,
+		m.d1, m.d2, m.d3, m.d4
+	);
+//	ofMatrix4x4 matrix(m.a1, m.a2, m.a3, m.a4,
+//					   m.b1, m.b2, m.b3, m.b4,
+//					   m.c1, m.c2, m.c3, m.c4,
+//					   m.d1, m.d2, m.d3, m.d4);
 	matrix *= parentMatrix;
 
 	for(unsigned int i = 0; i < node->mNumMeshes; i++) {
@@ -685,7 +692,7 @@ void ofxAssimpModelLoader::updateGLResources(){
 
 void ofxAssimpModelLoader::updateModelMatrix() {
 	modelMatrix = glm::identity<glm::mat4>();
-	modelMatrix = glm::translate(modelMatrix, toGlm(pos));
+	modelMatrix = glm::translate(modelMatrix, pos);
 	modelMatrix = glm::rotate(modelMatrix, ofDegToRad(180), glm::vec3(0,0,1));
 
 	if(normalizeScale) {
@@ -696,7 +703,7 @@ void ofxAssimpModelLoader::updateModelMatrix() {
 		modelMatrix = glm::rotate(modelMatrix, ofDegToRad(rotAngle[i]), glm::vec3(rotAxis[i].x, rotAxis[i].y, rotAxis[i].z));
 	}
 
-	modelMatrix = glm::scale(modelMatrix, toGlm(scale));
+	modelMatrix = glm::scale(modelMatrix, scale);
 }
 
 //------------------------------------------- animations.

--- a/libs/openFrameworks/3d/of3dPrimitives.cpp
+++ b/libs/openFrameworks/3d/of3dPrimitives.cpp
@@ -249,14 +249,16 @@ void of3dPrimitive::drawNormals(float length, bool bFaceNormals) const{
                     vert = (vertices[i-2]+vertices[i-1]+vertices[i]) / 3;
                 }
                 normalsMesh.setVertex(i*2, vert);
-				normal = glm::normalize(toGlm(normals[i]));
+//				normal = glm::normalize(toGlm(normals[i]));
+				normal = glm::normalize(normals[i]);
                 normal *= length;
 				normalsMesh.setVertex(i*2+1, vert+normal);
             }
         } else {
 			for(size_t i = 0; i < normals.size(); i++) {
                 vert = vertices[i];
-				normal = glm::normalize(toGlm(normals[i]));
+//				normal = glm::normalize(toGlm(normals[i]));
+				normal = glm::normalize(normals[i]);
                 normalsMesh.setVertex( i*2, vert);
                 normal *= length;
 				normalsMesh.setVertex(i*2+1, vert+normal);

--- a/libs/openFrameworks/3d/ofMesh.inl
+++ b/libs/openFrameworks/3d/ofMesh.inl
@@ -2207,9 +2207,9 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::icosphere(float radius, std::size_t iteration
 			auto v3 = vertices[i3];
 			//make 1 vertice at the center of each edge and project it onto the sphere
 			vertices.insert(vertices.end(), {
-				glm::normalize(toGlm(v1+v2)),
-				glm::normalize(toGlm(v2+v3)),
-				glm::normalize(toGlm(v1+v3)),
+				glm::normalize(v1+v2),
+				glm::normalize(v2+v3),
+				glm::normalize(v1+v3),
 			});
 			//now recreate indices
 			newFaces.insert(newFaces.end(), {
@@ -2438,7 +2438,7 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cylinder( float radius, float height, int rad
 			mesh.addVertex( vert );
 			mesh.addNormal( normal );
 
-			normal = glm::rotate(toGlm(normal), -angleIncRadius, up);
+			normal = glm::rotate(normal, -angleIncRadius, up);
 
 		}
 	}
@@ -2585,10 +2585,10 @@ ofMesh_<V,N,C,T> ofMesh_<V,N,C,T>::cone( float radius, float height, int radiusS
 				vert.z = std::sin((float)ix*angleIncRadius) * newRad;
 			}
 
-			auto diff = toGlm(vert - startVec);
-			auto crossed = glm::cross(up, toGlm(vert));
+			auto diff = vert - startVec;
+			auto crossed = glm::cross(up, vert);
 			normal = glm::cross(crossed, diff);
-			mesh.addNormal( glm::normalize(toGlm(normal)) );
+			mesh.addNormal( glm::normalize(normal) );
 
 		}
 	}

--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -1,10 +1,13 @@
+#define GLM_FORCE_CTOR_INIT
+#define GLM_ENABLE_EXPERIMENTAL
+#define GLM_SWIZZLE
+//#define GLM_SWIZZLE_XYZW
 
 #include "ofNode.h"
 #include "of3dGraphics.h"
 
-#define GLM_FORCE_CTOR_INIT
-#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/mat4x4.hpp>
+//#include <glm/vec4.hpp>
 
 //----------------------------------------
 ofNode::ofNode()
@@ -135,9 +138,11 @@ void ofNode::setParent(ofNode& parent, bool bMaintainGlobalTransform) {
 		clearParent(bMaintainGlobalTransform);
 	}
 	if(bMaintainGlobalTransform) {
-		auto postParentPosition = position - parent.getGlobalPosition();
+		glm::vec3 pos { position };
+		glm::vec3 scl { scale };
+		auto postParentPosition = pos - parent.getGlobalPosition();
 		auto postParentOrientation = orientation.get() * glm::inverse(parent.getGlobalOrientation());
-		auto postParentScale = scale / parent.getGlobalScale();
+		auto postParentScale = scl / parent.getGlobalScale();
 		parent.addListener(*this);
 		setOrientation(postParentOrientation);
 		setPosition(postParentPosition);
@@ -632,8 +637,8 @@ void ofNode::orbitDeg(float longitude, float latitude, float radius, const glm::
 	
 	p = q * p;							   // rotate p on unit sphere based on quaternion
 	p = p * radius;						   // scale p by radius from its position on unit sphere
-
-	setGlobalPosition(centerPoint + p);
+	
+	setGlobalPosition(centerPoint + p.xyz());
 	setOrientation(q);
 
 	onOrientationChanged();
@@ -656,7 +661,7 @@ void ofNode::orbitRad(float longitude, float latitude, float radius, const glm::
 	p = q * p;							   // rotate p on unit sphere based on quaternion
 	p = p * radius;						   // scale p by radius from its position on unit sphere
 
-	setGlobalPosition(centerPoint + p);
+	setGlobalPosition(centerPoint + p.xyz());
 	setOrientation(q);
 
 	onOrientationChanged();
@@ -708,9 +713,12 @@ void ofNode::restoreTransformGL(ofBaseRenderer * renderer) const {
 
 //----------------------------------------
 void ofNode::createMatrix() {
-	localTransformMatrix = glm::translate(glm::mat4(1.0), toGlm(position));
+	glm::vec3 pos = position;
+	glm::vec3 scl = scale;
+
+	localTransformMatrix = glm::translate(glm::mat4(1.0), pos);
 	localTransformMatrix = localTransformMatrix * glm::toMat4((const glm::quat&)orientation);
-	localTransformMatrix = glm::scale(localTransformMatrix, toGlm(scale));
+	localTransformMatrix = glm::scale(localTransformMatrix, scl);
 
 	updateAxis();
 }

--- a/libs/openFrameworks/gl/ofMaterial.cpp
+++ b/libs/openFrameworks/gl/ofMaterial.cpp
@@ -1135,6 +1135,7 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 		shared_ptr<ofLight::Data> light = ofLightsData()[i].lock();
 		if(!light || !light->isEnabled){
 			shader.setUniform1f("lights["+idx+"].enabled",0);
+//			lights[i].enabled = 0;
 			continue;
 		}
 		glm::vec4 lightEyePosition = light->position;
@@ -1154,20 +1155,35 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 			}
 			if( light->lightType != OF_LIGHT_POINT ) {
 				shader.setUniform3f("lights["+idx+"].direction", light->direction );
+//				lights[i].direction = light->direction;
 			}
 		}
+
+//		lights[i].enabled = 1;
+//		lights[i].type = light->lightType;
+//		lights[i].position = lightEyePosition;
 
 		shader.setUniform1f("lights["+idx+"].enabled",1);
 		shader.setUniform1f("lights["+idx+"].type", light->lightType);
 		shader.setUniform4f("lights["+idx+"].position", lightEyePosition);
 		if( !isPBR() ) {
+//			lights[i].ambient = light->ambientColor;
+//			lights[i].specular = light->specularColor;
+
 			shader.setUniform4f("lights["+idx+"].ambient", light->ambientColor);
 			shader.setUniform4f("lights["+idx+"].specular", light->specularColor);
 		}
+//		lights[idx].diffuse = light->diffuseColor;
 		shader.setUniform4f("lights["+idx+"].diffuse", light->diffuseColor);
 
 		if(light->lightType!=OF_LIGHT_DIRECTIONAL){
 			// TODO: add in light radius if pbr?
+			
+//			lights[idx].radius = 0.0f;
+//			lights[idx].constantAttenuation = light->attenuation_constant;
+//			lights[idx].linearAttenuation = light->attenuation_linear;
+//			lights[idx].quadraticAttenuation = light->attenuation_quadratic;
+
 			shader.setUniform1f("lights["+idx+"].radius", 0.0f);
 			shader.setUniform1f("lights["+idx+"].constantAttenuation", light->attenuation_constant);
 			shader.setUniform1f("lights["+idx+"].linearAttenuation", light->attenuation_linear);
@@ -1182,9 +1198,16 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 				glm::vec4 direction4 = renderer.getCurrentViewMatrix() * glm::vec4(direction,1.0);
 				direction = glm::vec3(direction4) / direction4.w;
 				direction = direction - glm::vec3(lightEyePosition);
+
 				shader.setUniform3f("lights["+idx+"].spotDirection", glm::normalize(direction));
+//				lights[idx].spotDirection = glm::normalize(direction);
+				
 			}
 			//shader.setUniform3f("lights["+idx+"].spotDirection", glm::normalize(direction));
+//			lights[idx].spotExponent = light->exponent;
+//			lights[idx].spotCutoff = light->spotCutOff;
+//			lights[idx].spotCosCutoff = std::cos(glm::radians(light->spotCutOff)));
+
 			shader.setUniform1f("lights["+idx+"].spotExponent", light->exponent);
 			shader.setUniform1f("lights["+idx+"].spotCutoff", light->spotCutOff);
 			shader.setUniform1f("lights["+idx+"].spotCosCutoff", std::cos(glm::radians(light->spotCutOff)));
@@ -1192,8 +1215,15 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 			if( !isPBR() ) {
 				glm::vec3 halfVector(glm::normalize(glm::vec4(0.f, 0.f, 1.f, 0.f) + lightEyePosition));
 				shader.setUniform3f("lights["+idx+"].halfVector", halfVector);
+				
+//				lights[idx].halfVector = light->halfVector;
+
 			}
 		}else if(light->lightType==OF_LIGHT_AREA){
+			
+//			lights[idx].width = light->width;
+//			lights[idx].height = light->height;
+			
 			shader.setUniform1f("lights["+idx+"].width", light->width);
 			shader.setUniform1f("lights["+idx+"].height", light->height);
 			glm::vec3 direction = light->direction;
@@ -1202,6 +1232,9 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 				glm::vec4 direction4 = renderer.getCurrentViewMatrix() * glm::vec4(direction, 1.0);
 				direction = glm::vec3(direction4) / direction4.w;
 				direction = direction - glm::vec3(lightEyePosition);
+				
+//				lights[idx].spotDirection = glm::normalize(direction);
+
 				shader.setUniform3f("lights["+idx+"].spotDirection", glm::normalize(direction));
 			}
 			
@@ -1214,7 +1247,12 @@ void ofMaterial::updateLights(const ofShader & shader,ofGLProgrammableRenderer &
 				right = right - glm::vec3(lightEyePosition);
 				up = glm::cross(right, direction);
 			}
-			shader.setUniform3f("lights["+idx+"].right", glm::normalize(toGlm(right)));
+			
+			// FIXME: why toGlm in one and not in another?
+//			lights[idx].right = glm::normalize(toGlm(right));
+//			lights[idx].up = glm::normalize(up));
+
+			shader.setUniform3f("lights["+idx+"].right", glm::normalize(right));
 			shader.setUniform3f("lights["+idx+"].up", glm::normalize(up));
 		}
 	}

--- a/libs/openFrameworks/gl/ofShader.cpp
+++ b/libs/openFrameworks/gl/ofShader.cpp
@@ -112,9 +112,9 @@ ofShader::ofShader(const ofShader & mom)
     , shaders(mom.shaders)
     , uniformsCache(mom.uniformsCache)
     , attributesBindingsCache(mom.attributesBindingsCache)
-#ifndef TARGET_OPENGLES
+//#ifndef TARGET_OPENGLES
     , uniformBlocksCache(mom.uniformBlocksCache)
-#endif
+//#endif
 {
     if (mom.bLoaded) {
         retainProgram(program);
@@ -713,9 +713,9 @@ bool ofShader::linkProgram() {
             }
         }
 
-#ifndef TARGET_OPENGLES
+//#ifndef TARGET_OPENGLES
     #ifdef GLEW_ARB_uniform_buffer_object
-        if (GLEW_ARB_uniform_buffer_object) {
+       if (GLEW_ARB_uniform_buffer_object) {
             // Pre-cache all active uniforms blocks
             GLint numUniformBlocks = 0;
             glGetProgramiv(program, GL_ACTIVE_UNIFORM_BLOCKS, &numUniformBlocks);
@@ -726,11 +726,13 @@ bool ofShader::linkProgram() {
             for (GLint i = 0; i < numUniformBlocks; i++) {
                 glGetActiveUniformBlockName(program, i, uniformMaxLength, &length, uniformBlockName.data());
                 string name(uniformBlockName.begin(), uniformBlockName.begin() + length);
+//				std::cout << "WOW name " << name << std::endl;
+				bufferObjectsCache[name] = std::make_unique<ofBufferObject>();
                 uniformBlocksCache[name] = glGetUniformBlockIndex(program, name.c_str());
             }
-        }
+       }
     #endif
-#endif
+//#endif
 
 #ifdef TARGET_ANDROID
         ofAddListener(ofxAndroidEvents().unloadGL, this, &ofShader::unloadGL);
@@ -766,11 +768,11 @@ void ofShader::reloadGL() {
     auto bindings = attributesBindingsCache;
     shaders.clear();
     uniformsCache.clear();
-    #ifndef TARGET_OPENGLES
+    //#ifndef TARGET_OPENGLES
         #ifdef GLEW_ARB_uniform_buffer_object // Core in OpenGL 3.1
     uniformBlocksCache.clear();
         #endif
-    #endif
+    //#endif
     attributesBindingsCache.clear();
     for (auto & shader : source) {
         auto source = shader.second.source;
@@ -821,11 +823,11 @@ void ofShader::unload() {
 
         shaders.clear();
         uniformsCache.clear();
-#ifndef TARGET_OPENGLES
+//#ifndef TARGET_OPENGLES
     #ifdef GLEW_ARB_uniform_buffer_object // Core in OpenGL 3.1
         uniformBlocksCache.clear();
     #endif
-#endif
+//#endif
         attributesBindingsCache.clear();
 #ifdef TARGET_ANDROID
         ofRemoveListener(ofxAndroidEvents().reloadGL, this, &ofShader::reloadGL);
@@ -1019,6 +1021,23 @@ void ofShader::setUniform4i(const string & name, int v1, int v2, int v3, int v4)
 }
 
 //--------------------------------------------------------------
+void ofShader::setUniformBufferObject(const std::string & name, const void * data, GLsizeiptr dataSize) const {
+	if (bufferObjectsCache.find(name) != bufferObjectsCache.end()) {
+		if (!bufferObjectsCache.at(name)->isAllocated()) {
+			bufferObjectsCache.at(name)->allocate(dataSize, GL_STATIC_DRAW);
+		}
+		bufferObjectsCache.at(name)->updateData(dataSize, data);
+		bufferObjectsCache.at(name)->bindBase(GL_UNIFORM_BUFFER, getUniformBlockIndex(name));
+	} else {
+//		bufferObjectsCache.at(name) = std::make_unique<ofBufferObject>();
+//		for (const auto & b : bufferObjectsCache) {
+//			std::cout << b.first << std::endl;
+//		}
+//		std::cout << "setUniformBufferObject don't exist " << name << std::endl;
+	}
+}
+	
+//--------------------------------------------------------------
 void ofShader::setUniform1f(const string & name, float v1) const {
     if (bLoaded) {
         int loc = getUniformLocation(name);
@@ -1151,9 +1170,11 @@ void ofShader::setUniforms(const ofParameterGroup & parameters) const {
             setUniform2f(parameters[i].getEscapedName(), parameters[i].cast<glm::vec2>());
         } else if (parameters[i].type() == typeid(ofParameter<ofVec3f>).name()) {
             setUniform3f(parameters[i].getEscapedName(), parameters[i].cast<glm::vec3>());
-        } else if (parameters[i].type() == typeid(ofParameter<ofVec4f>).name()) {
-            setUniform4f(parameters[i].getEscapedName(), parameters[i].cast<glm::vec4>());
-        } else if (parameters[i].type() == typeid(ofParameterGroup).name()) {
+        }
+//		else if (parameters[i].type() == typeid(ofParameter<ofVec4f>).name()) {
+//            setUniform4f(parameters[i].getEscapedName(), parameters[i].cast<glm::vec4>());
+//        }
+		else if (parameters[i].type() == typeid(ofParameterGroup).name()) {
             setUniforms((ofParameterGroup &)parameters[i]);
         }
     }
@@ -1311,45 +1332,52 @@ GLint ofShader::getUniformLocation(const string & name) const {
     }
 }
 
-#ifndef TARGET_OPENGLES
-    #ifdef GLEW_ARB_uniform_buffer_object
+//#ifndef TARGET_OPENGLES
+//    #ifdef GLEW_ARB_uniform_buffer_object
 //--------------------------------------------------------------
 GLint ofShader::getUniformBlockIndex(const string & name) const {
     if (!bLoaded) return -1;
 
-    if (GLEW_ARB_uniform_buffer_object) {
+//    if (GLEW_ARB_uniform_buffer_object) {
+#ifdef GLEW_ARB_uniform_buffer_object
         auto it = uniformBlocksCache.find(name);
         if (it == uniformBlocksCache.end()) {
             return -1;
         } else {
             return it->second;
         }
-    } else {
+#else
+		//    } else {
         ofLogError("ofShader::getUniformBlockIndex") << "Sorry, it looks like you can't run 'ARB_uniform_buffer_object'";
         return -1;
-    }
+//    }
+#endif
 }
 
 //--------------------------------------------------------------
 GLint ofShader::getUniformBlockBinding(const string & name) const {
     if (!bLoaded) return -1;
 
-    if (GLEW_ARB_uniform_buffer_object) {
+#ifdef GLEW_ARB_uniform_buffer_object
+//    if (GLEW_ARB_uniform_buffer_object) {
         GLint index = getUniformBlockIndex(name);
         if (index == -1) return -1;
 
         GLint blockBinding;
         glGetActiveUniformBlockiv(program, index, GL_UNIFORM_BLOCK_BINDING, &blockBinding);
         return blockBinding;
-    } else {
+#else
+//} else {
         ofLogError("ofShader::getUniformBlockBinding") << "Sorry, it looks like you can't run 'ARB_uniform_buffer_object'";
         return -1;
-    }
+//    }
+#endif
 }
 
 //--------------------------------------------------------------
 void ofShader::printActiveUniformBlocks() const {
-    if (GLEW_ARB_uniform_buffer_object) {
+#ifdef GLEW_ARB_uniform_buffer_object
+//    if (GLEW_ARB_uniform_buffer_object) {
         GLint numUniformBlocks = 0;
         glGetProgramiv(program, GL_ACTIVE_UNIFORM_BLOCKS, &numUniformBlocks);
         ofLogNotice("ofShader") << numUniformBlocks << " uniform blocks";
@@ -1376,25 +1404,32 @@ void ofShader::printActiveUniformBlocks() const {
             line.str("");
         }
         delete[] uniformBlockName;
-    } else {
+#else
+//} else {
         ofLogError("ofShader::printActiveUniformBlocks") << "Sorry, it looks like you can't run 'ARB_uniform_buffer_object'";
-    }
+#endif
+//}
 }
 
 void ofShader::bindUniformBlock(GLuint binding, const string & name) const {
-    if (bLoaded) {
-        if (GLEW_ARB_uniform_buffer_object) {
+	if (!bLoaded) return;
+
+
+#ifdef GLEW_ARB_uniform_buffer_object
+//        if (GLEW_ARB_uniform_buffer_object) {
             GLint index = getUniformBlockIndex(name);
             if (index != -1) {
                 glUniformBlockBinding(program, index, binding);
             }
-        } else {
+#else
+//	} else {
             ofLogError("ofShader::bindUniformBlock") << "Sorry, it looks like you can't run 'ARB_uniform_buffer_object'";
-        }
-    }
-}
-    #endif
+//    }
 #endif
+	
+}
+//    #endif
+//#endif
 
 //--------------------------------------------------------------
 void ofShader::printActiveUniforms() const {

--- a/libs/openFrameworks/gl/ofVbo.cpp
+++ b/libs/openFrameworks/gl/ofVbo.cpp
@@ -327,9 +327,9 @@ void ofVbo::setVertexData(const glm::vec3 * verts, int total, int usage) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::setVertexData(const ofVec3f * verts, int total, int usage) {
-	setVertexData(&verts[0].x,3,total,usage,sizeof(glm::vec3));
-}
+//void ofVbo::setVertexData(const ofVec3f * verts, int total, int usage) {
+//	setVertexData(&verts[0].x,3,total,usage,sizeof(glm::vec3));
+//}
 
 //--------------------------------------------------------------
 void ofVbo::setVertexData(const glm::vec2 * verts, int total, int usage) {
@@ -337,9 +337,9 @@ void ofVbo::setVertexData(const glm::vec2 * verts, int total, int usage) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::setVertexData(const ofVec2f * verts, int total, int usage) {
-	setVertexData(&verts[0].x,2,total,usage,sizeof(glm::vec2));
-}
+//void ofVbo::setVertexData(const ofVec2f * verts, int total, int usage) {
+//	setVertexData(&verts[0].x,2,total,usage,sizeof(glm::vec2));
+//}
 
 //--------------------------------------------------------------
 void ofVbo::setVertexData(const float * vert0x, int numCoords, int total, int usage, int stride) {
@@ -365,9 +365,9 @@ void ofVbo::setNormalData(const glm::vec3 * normals, int total, int usage) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::setNormalData(const ofVec3f * normals, int total, int usage) {
-	setNormalData(&normals[0].x,total,usage,sizeof(glm::vec3));
-}
+//void ofVbo::setNormalData(const ofVec3f * normals, int total, int usage) {
+//	setNormalData(&normals[0].x,total,usage,sizeof(glm::vec3));
+//}
 
 //--------------------------------------------------------------
 void ofVbo::setNormalData(const float * normal0x, int total, int usage, int stride) {
@@ -381,9 +381,9 @@ void ofVbo::setTexCoordData(const glm::vec2 * texCoords, int total, int usage) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::setTexCoordData(const ofVec2f * texCoords, int total, int usage) {
-	setTexCoordData(&texCoords[0].x,total, usage, sizeof(glm::vec2));
-}
+//void ofVbo::setTexCoordData(const ofVec2f * texCoords, int total, int usage) {
+//	setTexCoordData(&texCoords[0].x,total, usage, sizeof(glm::vec2));
+//}
 
 //--------------------------------------------------------------
 void ofVbo::setTexCoordData(const float * texCoord0x, int total, int usage, int stride) {
@@ -472,9 +472,9 @@ void ofVbo::updateVertexData(const glm::vec3 * verts, int total) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::updateVertexData(const ofVec3f * verts, int total) {
-	updateVertexData(&verts[0].x,total);
-}
+//void ofVbo::updateVertexData(const ofVec3f * verts, int total) {
+//	updateVertexData(&verts[0].x,total);
+//}
 
 //--------------------------------------------------------------
 void ofVbo::updateVertexData(const glm::vec2 * verts, int total) {
@@ -482,9 +482,9 @@ void ofVbo::updateVertexData(const glm::vec2 * verts, int total) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::updateVertexData(const ofVec2f * verts, int total) {
-	updateVertexData(&verts[0].x,total);
-}
+//void ofVbo::updateVertexData(const ofVec2f * verts, int total) {
+//	updateVertexData(&verts[0].x,total);
+//}
 
 //--------------------------------------------------------------
 void ofVbo::updateVertexData(const float * vert0x, int total) {
@@ -507,9 +507,9 @@ void ofVbo::updateNormalData(const glm::vec3 * normals, int total) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::updateNormalData(const ofVec3f * normals, int total) {
-	updateNormalData(&normals[0].x,total);
-}
+//void ofVbo::updateNormalData(const ofVec3f * normals, int total) {
+//	updateNormalData(&normals[0].x,total);
+//}
 
 //--------------------------------------------------------------
 void ofVbo::updateNormalData(const float * normal0x, int total) {
@@ -522,9 +522,9 @@ void ofVbo::updateTexCoordData(const glm::vec2 * texCoords, int total) {
 }
 
 //--------------------------------------------------------------
-void ofVbo::updateTexCoordData(const ofVec2f * texCoords, int total) {
-	updateTexCoordData(&texCoords[0].x,total);
-}
+//void ofVbo::updateTexCoordData(const ofVec2f * texCoords, int total) {
+//	updateTexCoordData(&texCoords[0].x,total);
+//}
 
 //--------------------------------------------------------------
 void ofVbo::updateTexCoordData(const float * texCoord0x, int total) {

--- a/libs/openFrameworks/gl/ofVbo.h
+++ b/libs/openFrameworks/gl/ofVbo.h
@@ -12,8 +12,8 @@ template<typename T>
 class ofColor_;
 typedef ofColor_<float> ofFloatColor;
 
-class ofVec2f;
-class ofVec3f;
+//class ofVec2f;
+//class ofVec3f;
 
 template<class V, class N, class C, class T>
 class ofMesh_;
@@ -32,14 +32,14 @@ public:
 	
 	void setVertexData(const glm::vec3 * verts, int total, int usage);
 	void setVertexData(const glm::vec2 * verts, int total, int usage);
-	void setVertexData(const ofVec3f * verts, int total, int usage);
-	void setVertexData(const ofVec2f * verts, int total, int usage);
+//	void setVertexData(const ofVec3f * verts, int total, int usage);
+//	void setVertexData(const ofVec2f * verts, int total, int usage);
 
 	void setColorData(const ofFloatColor * colors, int total, int usage);
 	void setNormalData(const glm::vec3 * normals, int total, int usage);
-	void setNormalData(const ofVec3f * normals, int total, int usage);
+//	void setNormalData(const ofVec3f * normals, int total, int usage);
 	void setTexCoordData(const glm::vec2 * texCoords, int total, int usage);
-	void setTexCoordData(const ofVec2f * texCoords, int total, int usage);
+//	void setTexCoordData(const ofVec2f * texCoords, int total, int usage);
 	void setIndexData(const ofIndexType * indices, int total, int usage);
 
 	void setVertexData(const float * vert0x, int numCoords, int total, int usage, int stride=0);
@@ -85,13 +85,13 @@ public:
 
 	void updateVertexData(const glm::vec3 * verts, int total);
 	void updateVertexData(const glm::vec2 * verts, int total);
-	void updateVertexData(const ofVec3f * verts, int total);
-	void updateVertexData(const ofVec2f * verts, int total);
+//	void updateVertexData(const ofVec3f * verts, int total);
+//	void updateVertexData(const ofVec2f * verts, int total);
 	void updateColorData(const ofFloatColor * colors, int total);
 	void updateNormalData(const glm::vec3 * normals, int total);
-	void updateNormalData(const ofVec3f * normals, int total);
+//	void updateNormalData(const ofVec3f * normals, int total);
 	void updateTexCoordData(const glm::vec2 * texCoords, int total);
-	void updateTexCoordData(const ofVec2f * texCoords, int total);
+//	void updateTexCoordData(const ofVec2f * texCoords, int total);
 	void updateIndexData(const ofIndexType * indices, int total);
 	
 	void updateVertexData(const float * ver0x, int total);

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -1121,18 +1121,18 @@ void ofVertices(const vector<glm::vec2> & polyPoints) {
 }
 
 //----------------------------------------------------------
-void ofVertices(const vector<ofVec3f> & polyPoints) {
-	for (const auto & p : polyPoints) {
-		ofGetCurrentRenderer()->getPath().lineTo(p);
-	}
-}
+//void ofVertices(const vector<ofVec3f> & polyPoints) {
+//	for (const auto & p : polyPoints) {
+//		ofGetCurrentRenderer()->getPath().lineTo(p);
+//	}
+//}
 
 //----------------------------------------------------------
-void ofVertices(const vector<ofVec2f> & polyPoints) {
-	for (const auto & p : polyPoints) {
-		ofGetCurrentRenderer()->getPath().lineTo(p);
-	}
-}
+//void ofVertices(const vector<ofVec2f> & polyPoints) {
+//	for (const auto & p : polyPoints) {
+//		ofGetCurrentRenderer()->getPath().lineTo(p);
+//	}
+//}
 
 //---------------------------------------------------
 void ofCurveVertex(float x, float y) {
@@ -1159,18 +1159,18 @@ void ofCurveVertices(const vector<glm::vec2> & curvePoints) {
 }
 
 //----------------------------------------------------------
-void ofCurveVertices(const vector<ofVec3f> & curvePoints) {
-	for (const auto & p : curvePoints) {
-		ofGetCurrentRenderer()->getPath().curveTo(p);
-	}
-}
+//void ofCurveVertices(const vector<ofVec3f> & curvePoints) {
+//	for (const auto & p : curvePoints) {
+//		ofGetCurrentRenderer()->getPath().curveTo(p);
+//	}
+//}
 
 //----------------------------------------------------------
-void ofCurveVertices(const vector<ofVec2f> & curvePoints) {
-	for (const auto & p : curvePoints) {
-		ofGetCurrentRenderer()->getPath().curveTo(p);
-	}
-}
+//void ofCurveVertices(const vector<ofVec2f> & curvePoints) {
+//	for (const auto & p : curvePoints) {
+//		ofGetCurrentRenderer()->getPath().curveTo(p);
+//	}
+//}
 
 //---------------------------------------------------
 void ofCurveVertex(const glm::vec3 & p) {

--- a/libs/openFrameworks/graphics/ofPath.cpp
+++ b/libs/openFrameworks/graphics/ofPath.cpp
@@ -833,7 +833,7 @@ void ofPath::rotateDeg(float degrees, const glm::vec3& axis ){
     }else{
         for(int i=0;i<(int)polylines.size();i++){
             for(int j=0;j<(int)polylines[i].size();j++){
-                polylines[i][j] = glm::rotate(toGlm(polylines[i][j]), radians, axis);
+                polylines[i][j] = glm::rotate(polylines[i][j], radians, axis);
             }
         }
     }

--- a/libs/openFrameworks/graphics/ofPolyline.inl
+++ b/libs/openFrameworks/graphics/ofPolyline.inl
@@ -560,7 +560,7 @@ inline T getClosestPointUtil(const T& p1, const T& p2, const T& p3, float* norma
 	float u = (p3.x - p1.x) * (p2.x - p1.x);
 	u += (p3.y - p1.y) * (p2.y - p1.y);
 	// perfect place for fast inverse sqrt...
-	float len = glm::length(toGlm(p2 - p1));
+	float len = glm::length(p2 - p1);
 	u /= (len * len);
 	
 	// clamp u
@@ -572,7 +572,7 @@ inline T getClosestPointUtil(const T& p1, const T& p2, const T& p3, float* norma
 	if(normalizedPosition != nullptr) {
 		*normalizedPosition = u;
 	}
-	return glm::mix(toGlm(p1), toGlm(p2), u);
+	return glm::mix(p1, p2, u);
 }
 
 //----------------------------------------------------------
@@ -605,7 +605,7 @@ T ofPolyline_<T>::getClosestPoint(const T& target, unsigned int* nearestIndex) c
 		
 		float curNormalizedPosition = 0;
 		auto curNearestPoint = getClosestPointUtil(cur, next, target, &curNormalizedPosition);
-		float curDistance = glm::distance(toGlm(curNearestPoint), toGlm(target));
+		float curDistance = glm::distance(curNearestPoint, target);
 		if(i == 0 || curDistance < distance) {
 			distance = curDistance;
 			nearest = i;
@@ -710,7 +710,7 @@ namespace of{
 			float   tol2	= tol * tol;  // tolerance squared
 			Segment<T> S	= {v[j], v[k]};  // segment from v[j] to v[k]
 			auto u			= S.P1 - S.P0;   // segment direction vector
-			double  cu		= glm::dot(toGlm(u), toGlm(u));     // segment length squared
+			double  cu		= glm::dot(u, u);     // segment length squared
 
 			// test each vertex v[i] for max distance from S
 			// compute using the Feb 2001 Algorithm's dist_ofPoint_to_Segment()
@@ -722,13 +722,13 @@ namespace of{
 			for (int i=j+1; i<k; i++){
 				// compute distance squared
 				w = v[i] - S.P0;
-				cw = glm::dot(toGlm(w), toGlm(u));
-				if ( cw <= 0 ) dv2 = glm::length2(toGlm(v[i]) - toGlm(S.P0));
-				else if ( cu <= cw ) dv2 = glm::length2(toGlm(v[i]) - toGlm(S.P1));
+				cw = glm::dot(w, u);
+				if ( cw <= 0 ) dv2 = glm::length2(v[i] - S.P0);
+				else if ( cu <= cw ) dv2 = glm::length2(v[i] - S.P1);
 				else {
 					b = (float)(cw / cu);
 					Pb = S.P0 + u*b;
-					dv2 = glm::length2(toGlm(v[i]) - toGlm(Pb));
+					dv2 = glm::length2(v[i] - Pb);
 				}
 				// test with current max distance squared
 				if (dv2 <= maxd2) continue;
@@ -825,7 +825,7 @@ void ofPolyline_<T>::rotateDeg(float degrees, const glm::vec3& axis){
 template<class T>
 void ofPolyline_<T>::rotateRad(float radians, const glm::vec3& axis){
     for(auto & point : points){
-        point = glm::rotate(toGlm(point), radians, axis);
+        point = glm::rotate(point, radians, axis);
     }
     flagHasChanged();
 }
@@ -970,7 +970,7 @@ T ofPolyline_<T>::getPointAtIndexInterpolated(float findex) const {
     getInterpolationParams(findex, i1, i2, t);
 	T leftPoint(points[i1]);
 	T rightPoint(points[i2]);
-	return glm::mix(toGlm(leftPoint), toGlm(rightPoint), t);
+	return glm::mix(leftPoint, rightPoint, t);
 }
 
 
@@ -1039,7 +1039,7 @@ T ofPolyline_<T>::getRotationAtIndexInterpolated(float findex) const {
     int i1, i2;
     float t;
     getInterpolationParams(findex, i1, i2, t);
-	return glm::mix(toGlm(getRotationAtIndex(i1)), toGlm(getRotationAtIndex(i2)), t);
+	return glm::mix(getRotationAtIndex(i1), getRotationAtIndex(i2), t);
 }
 
 //--------------------------------------------------
@@ -1057,7 +1057,7 @@ T ofPolyline_<T>::getTangentAtIndexInterpolated(float findex) const {
     int i1, i2;
     float t;
     getInterpolationParams(findex, i1, i2, t);
-	return glm::mix(toGlm(getTangentAtIndex(i1)), toGlm(getTangentAtIndex(i2)), t);
+	return glm::mix(getTangentAtIndex(i1), getTangentAtIndex(i2), t);
 }
 
 //--------------------------------------------------
@@ -1075,7 +1075,7 @@ T ofPolyline_<T>::getNormalAtIndexInterpolated(float findex) const {
     int i1, i2;
     float t;
     getInterpolationParams(findex, i1, i2, t);
-	return glm::mix(toGlm(getNormalAtIndex(i1)), toGlm(getNormalAtIndex(i2)), t);
+	return glm::mix(getNormalAtIndex(i1), getNormalAtIndex(i2), t);
 }
 
 
@@ -1086,9 +1086,9 @@ void ofPolyline_<T>::calcData(int index, T &tangent, float &angle, T &rotation, 
 	int i2 = getWrappedIndex( index     );
 	int i3 = getWrappedIndex( index + 1 );
 
-	const auto &p1 = toGlm(points[i1]);
-	const auto &p2 = toGlm(points[i2]);
-	const auto &p3 = toGlm(points[i3]);
+	const auto &p1 = points[i1];
+	const auto &p2 = points[i2];
+	const auto &p3 = points[i3];
 
 	auto v1(p1 - p2); // vector to previous point
 	auto v2(p3 - p2); // vector to next point
@@ -1103,9 +1103,9 @@ void ofPolyline_<T>::calcData(int index, T &tangent, float &angle, T &rotation, 
 	bool noSegmentHasZeroLength = (v1 == v1 && v2 == v2);
 
 	if ( noSegmentHasZeroLength ){
-		tangent  = toOf( glm::length2(v2 - v1) > 0 ? glm::normalize(v2 - v1) : -v1 );
-		normal   = toOf( glm::normalize( glm::cross( toGlm( rightVector ), toGlm( tangent ) ) ) );
-		rotation = toOf( glm::cross( v1, v2 ) );
+		tangent  = ( glm::length2(v2 - v1) > 0 ? glm::normalize(v2 - v1) : -v1 );
+		normal   = ( glm::normalize( glm::cross(  rightVector , tangent ) ) );
+		rotation = ( glm::cross( v1, v2 ) );
 		angle    = glm::pi<float>() - acosf( ofClamp( glm::dot( v1, v2 ), -1.f, 1.f ) );
 	} else{
 		rotation = tangent = normal = T( 0.f );
@@ -1194,7 +1194,7 @@ void ofPolyline_<T>::updateCache(bool bForceUpdate) const {
             rotations[i] = rotation;
             normals[i] = normal;
             
-			length += glm::distance(toGlm(points[i]), toGlm(points[getWrappedIndex(i + 1)]));
+			length += glm::distance(points[i], points[getWrappedIndex(i + 1)]);
         }
         
         if(isClosed()) lengths.push_back(length);

--- a/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
+++ b/libs/openFrameworks/graphics/ofTrueTypeFont.cpp
@@ -1262,7 +1262,7 @@ glm::vec2 ofTrueTypeFont::getFirstGlyphPosForTexture(const string & str, bool vf
 			}else{
 				int width = 0;
 				int lineWidth = 0;
-				iterateString(str, 0, 0, vflip, [&](uint32_t c, ofVec2f){
+				iterateString(str, 0, 0, vflip, [&](uint32_t c, glm::vec2){
 					try{
 						if (c != '\n') {
 							auto g = loadGlyph(c);
@@ -1296,7 +1296,7 @@ ofTexture ofTrueTypeFont::getStringTexture(const string& str, bool vflip) const{
 	float height = 0;
 	float width = 0;
 	float lineWidth = 0;
-	iterateString(str, 0, 0, vflip, [&](uint32_t c, ofVec2f pos){
+	iterateString(str, 0, 0, vflip, [&](uint32_t c, glm::vec2 pos){
 		try{
 			if (c != '\n') {
 				auto g = loadGlyph(c);

--- a/libs/openFrameworks/math/ofVectorMath.h
+++ b/libs/openFrameworks/math/ofVectorMath.h
@@ -1,9 +1,5 @@
 #pragma once
 
-class ofMatrix3x3;
-#include "ofMatrix4x4.h"
-#include "ofQuaternion.h"
-
 #define GLM_FORCE_CTOR_INIT
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/vec2.hpp>
@@ -29,80 +25,6 @@ class ofMatrix3x3;
 
 #include <iomanip>
 
-//--------------------------------------------------------------
-inline const ofVec2f & toOf(const glm::vec2 & v){
-	return *reinterpret_cast<const ofVec2f*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const ofVec3f & toOf(const glm::vec3 & v){
-	return *reinterpret_cast<const ofVec3f*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const ofVec4f & toOf(const glm::vec4 & v){
-	return *reinterpret_cast<const ofVec4f*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const ofMatrix4x4 & toOf(const glm::mat4 & v){
-	return *reinterpret_cast<const ofMatrix4x4*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const ofMatrix3x3 & toOf(const glm::mat3 & v){
-	return *reinterpret_cast<const ofMatrix3x3*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::vec2 & toGlm(const ofVec2f & v){
-	return *reinterpret_cast<const glm::vec2*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::vec3 & toGlm(const ofVec3f & v){
-	return *reinterpret_cast<const glm::vec3*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::vec4 & toGlm(const ofVec4f & v){
-	return *reinterpret_cast<const glm::vec4*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::mat4 & toGlm(const ofMatrix4x4 & v){
-	return *reinterpret_cast<const glm::mat4*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::mat3 & toGlm(const ofMatrix3x3 & v){
-	return *reinterpret_cast<const glm::mat3*>(&v);
-}
-
-//--------------------------------------------------------------
-inline const glm::vec2 & toGlm(const glm::vec2 & v){
-	return v;
-}
-
-//--------------------------------------------------------------
-inline const glm::vec3 & toGlm(const glm::vec3 & v){
-	return v;
-}
-
-//--------------------------------------------------------------
-inline const glm::vec4 & toGlm(const glm::vec4 & v){
-	return v;
-}
-
-//--------------------------------------------------------------
-inline const glm::quat toGlm(const ofQuaternion & q){
-	return glm::quat(q.w(), glm::vec3(q.x(), q.y(), q.z()));
-}
-
-//--------------------------------------------------------------
-inline const glm::quat & toGlm(const glm::quat & q){
-	return q;
-}
 
 namespace glm {
 	//--------------------------------------------------------------
@@ -274,6 +196,92 @@ namespace glm {
 	}
 }
 
+
+
+#ifdef OF_LEGACY_MATH_WOW
+
+class ofMatrix3x3;
+#include "ofMatrix4x4.h"
+#include "ofQuaternion.h"
+
+
+// FIXME: -
+//--------------------------------------------------------------
+inline const ofVec2f & toOf(const glm::vec2 & v){
+	return *reinterpret_cast<const ofVec2f*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const ofVec3f & toOf(const glm::vec3 & v){
+	return *reinterpret_cast<const ofVec3f*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const ofVec4f & toOf(const glm::vec4 & v){
+	return *reinterpret_cast<const ofVec4f*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const ofMatrix4x4 & toOf(const glm::mat4 & v){
+	return *reinterpret_cast<const ofMatrix4x4*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const ofMatrix3x3 & toOf(const glm::mat3 & v){
+	return *reinterpret_cast<const ofMatrix3x3*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::vec2 & toGlm(const ofVec2f & v){
+	return *reinterpret_cast<const glm::vec2*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::vec3 & toGlm(const ofVec3f & v){
+	return *reinterpret_cast<const glm::vec3*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::vec4 & toGlm(const ofVec4f & v){
+	return *reinterpret_cast<const glm::vec4*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::mat4 & toGlm(const ofMatrix4x4 & v){
+	return *reinterpret_cast<const glm::mat4*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::mat3 & toGlm(const ofMatrix3x3 & v){
+	return *reinterpret_cast<const glm::mat3*>(&v);
+}
+
+//--------------------------------------------------------------
+inline const glm::vec2 & toGlm(const glm::vec2 & v){
+	return v;
+}
+
+//--------------------------------------------------------------
+inline const glm::vec3 & toGlm(const glm::vec3 & v){
+	return v;
+}
+
+//--------------------------------------------------------------
+inline const glm::vec4 & toGlm(const glm::vec4 & v){
+	return v;
+}
+
+//--------------------------------------------------------------
+inline const glm::quat toGlm(const ofQuaternion & q){
+	return glm::quat(q.w(), glm::vec3(q.x(), q.y(), q.z()));
+}
+
+//--------------------------------------------------------------
+inline const glm::quat & toGlm(const glm::quat & q){
+	return q;
+}
+
+
 //--------------------------------------------------------------
 inline glm::vec3 operator+(const glm::vec3 & v1, const ofVec3f & v2){
 	return v1 + glm::vec3(v2);
@@ -363,3 +371,4 @@ inline glm::vec2 & operator/=(glm::vec2 & v1, const ofVec2f & v2){
 }
 
 
+#endif

--- a/libs/openFrameworks/ofMain.h
+++ b/libs/openFrameworks/ofMain.h
@@ -23,14 +23,14 @@
 #include "ofColor.h"
 #include "ofGraphicsBaseTypes.h"
 #include "ofParameter.h"
-#include "ofPoint.h"
+//#include "ofPoint.h"
 #include "ofRectangle.h"
 #include "ofTypes.h"
 
 //--------------------------
 // math
 #include "ofMath.h"
-#include "ofVectorMath.h"
+//#include "ofVectorMath.h"
 
 //--------------------------
 // communication

--- a/libs/openFrameworks/types/ofParameter.cpp
+++ b/libs/openFrameworks/types/ofParameter.cpp
@@ -1,5 +1,5 @@
 #include "ofParameter.h"
-#include "ofPoint.h"
+//#include "ofPoint.h"
 #include "ofUtils.h"
 
 using std::string;

--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -4,7 +4,7 @@
 
 #include "ofEvents.h"
 // FIXME: crossed references. ofPoint adds ofVec3f which adds ofVec2f and ofVec4f
-#include "ofPoint.h"
+//#include "ofPoint.h"
 
 #include "ofColor.h"
 #include "ofLog.h"
@@ -128,7 +128,7 @@ public:
 	const ofParameter<float> & getFloat(const std::string & name) const;
 	const ofParameter<char> & getChar(const std::string & name) const;
 	const ofParameter<std::string> & getString(const std::string & name) const;
-	const ofParameter<ofPoint> & getPoint(const std::string & name) const;
+//	const ofParameter<ofPoint> & getPoint(const std::string & name) const;
 	const ofParameter<ofDefaultVec2> & getVec2f(const std::string & name) const;
 	const ofParameter<ofDefaultVec3> & getVec3f(const std::string & name) const;
 	const ofParameter<ofDefaultVec4> & getVec4f(const std::string & name) const;
@@ -144,7 +144,7 @@ public:
 	const ofParameter<float> & getFloat(std::size_t pos) const;
 	const ofParameter<char> & getChar(std::size_t pos) const;
 	const ofParameter<std::string> & getString(std::size_t pos) const;
-	const ofParameter<ofPoint> & getPoint(std::size_t pos) const;
+//	const ofParameter<ofPoint> & getPoint(std::size_t pos) const;
 	const ofParameter<ofDefaultVec2> & getVec2f(std::size_t pos) const;
 	const ofParameter<ofDefaultVec3> & getVec3f(std::size_t pos) const;
 	const ofParameter<ofDefaultVec4> & getVec4f(std::size_t pos) const;
@@ -160,7 +160,7 @@ public:
 	ofParameter<float> & getFloat(const std::string & name);
 	ofParameter<char> & getChar(const std::string & name);
 	ofParameter<std::string> & getString(const std::string & name);
-	ofParameter<ofPoint> & getPoint(const std::string & name);
+//	ofParameter<ofPoint> & getPoint(const std::string & name);
 	ofParameter<ofDefaultVec2> & getVec2f(const std::string & name);
 	ofParameter<ofDefaultVec3> & getVec3f(const std::string & name);
 	ofParameter<ofDefaultVec4> & getVec4f(const std::string & name);
@@ -176,7 +176,7 @@ public:
 	ofParameter<float> & getFloat(std::size_t pos);
 	ofParameter<char> & getChar(std::size_t pos);
 	ofParameter<std::string> & getString(std::size_t pos);
-	ofParameter<ofPoint> & getPoint(std::size_t pos);
+//	ofParameter<ofPoint> & getPoint(std::size_t pos);
 	ofParameter<ofDefaultVec2> & getVec2f(std::size_t pos);
 	ofParameter<ofDefaultVec3> & getVec3f(std::size_t pos);
 	ofParameter<ofDefaultVec4> & getVec4f(std::size_t pos);
@@ -381,11 +381,11 @@ struct TypeInfo : public of::priv::TypeInfo_<T, std::numeric_limits<T>::is_speci
 };
 
 // Here we provide some of our own specializations:
-template <>
-struct TypeInfo<ofVec2f> {
-	static ofVec2f min() { return ofVec2f(0); }
-	static ofVec2f max() { return ofVec2f(1); }
-};
+//template <>
+//struct TypeInfo<ofVec2f> {
+//	static ofVec2f min() { return ofVec2f(0); }
+//	static ofVec2f max() { return ofVec2f(1); }
+//};
 
 template <>
 struct TypeInfo<glm::vec2> {
@@ -393,11 +393,11 @@ struct TypeInfo<glm::vec2> {
 	static glm::vec2 max() { return glm::vec2(1); }
 };
 
-template <>
-struct TypeInfo<ofVec3f> {
-	static ofVec3f min() { return ofVec3f(0); }
-	static ofVec3f max() { return ofVec3f(1); }
-};
+//template <>
+//struct TypeInfo<ofVec3f> {
+//	static ofVec3f min() { return ofVec3f(0); }
+//	static ofVec3f max() { return ofVec3f(1); }
+//};
 
 template <>
 struct TypeInfo<glm::vec3> {
@@ -405,11 +405,11 @@ struct TypeInfo<glm::vec3> {
 	static glm::vec3 max() { return glm::vec3(1); }
 };
 
-template <>
-struct TypeInfo<ofVec4f> {
-	static ofVec4f min() { return ofVec4f(0); }
-	static ofVec4f max() { return ofVec4f(1); }
-};
+//template <>
+//struct TypeInfo<ofVec4f> {
+//	static ofVec4f min() { return ofVec4f(0); }
+//	static ofVec4f max() { return ofVec4f(1); }
+//};
 
 template <>
 struct TypeInfo<glm::vec4> {

--- a/libs/openFrameworks/types/ofParameterGroup.cpp
+++ b/libs/openFrameworks/types/ofParameterGroup.cpp
@@ -80,9 +80,9 @@ const ofParameter<std::string> & ofParameterGroup::getString(const std::string &
 	return get<std::string>(name);
 }
 
-const ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string & name) const {
-	return get<ofPoint>(name);
-}
+//const ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string & name) const {
+//	return get<ofPoint>(name);
+//}
 
 const ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const std::string & name) const {
 	return get<ofDefaultVec2>(name);
@@ -140,9 +140,9 @@ const ofParameter<std::string> & ofParameterGroup::getString(std::size_t pos) co
 	return get<std::string>(pos);
 }
 
-const ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos) const {
-	return get<ofPoint>(pos);
-}
+//const ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos) const {
+//	return get<ofPoint>(pos);
+//}
 
 const ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(std::size_t pos) const {
 	return get<ofDefaultVec2>(pos);
@@ -208,9 +208,9 @@ ofParameter<std::string> & ofParameterGroup::getString(const std::string & name)
 	return get<std::string>(name);
 }
 
-ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string & name) {
-	return get<ofPoint>(name);
-}
+//ofParameter<ofPoint> & ofParameterGroup::getPoint(const std::string & name) {
+//	return get<ofPoint>(name);
+//}
 
 ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(const std::string & name) {
 	return get<ofDefaultVec2>(name);
@@ -267,9 +267,9 @@ ofParameter<std::string> & ofParameterGroup::getString(std::size_t pos) {
 	return get<std::string>(pos);
 }
 
-ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos) {
-	return get<ofPoint>(pos);
-}
+//ofParameter<ofPoint> & ofParameterGroup::getPoint(std::size_t pos) {
+//	return get<ofPoint>(pos);
+//}
 
 ofParameter<ofDefaultVec2> & ofParameterGroup::getVec2f(std::size_t pos) {
 	return get<ofDefaultVec2>(pos);

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -3,12 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0353245D2BEFEC7B00B50A35 /* ofTimerFps.h in Headers */ = {isa = PBXBuildFile; fileRef = 0353245B2BEFEC7A00B50A35 /* ofTimerFps.h */; };
-		0353245E2BEFEC7B00B50A35 /* ofTimerFps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0353245C2BEFEC7B00B50A35 /* ofTimerFps.cpp */; };
 		19662F2E2834A44400B622ED /* ofGraphicsCairo.h in Headers */ = {isa = PBXBuildFile; fileRef = 19662F2C2834A44400B622ED /* ofGraphicsCairo.h */; };
 		19662F2F2834A44400B622ED /* ofGraphicsCairo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 19662F2D2834A44400B622ED /* ofGraphicsCairo.cpp */; };
 		22246D93176C9987008A8AF4 /* ofGLProgrammableRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 22246D91176C9987008A8AF4 /* ofGLProgrammableRenderer.cpp */; };
@@ -61,22 +59,6 @@
 		9979E8231A1CCC44007E55D1 /* ofMainLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9979E8201A1CCC44007E55D1 /* ofMainLoop.cpp */; };
 		9979E8241A1CCC44007E55D1 /* ofMainLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979E8211A1CCC44007E55D1 /* ofMainLoop.h */; };
 		BBA81C431FFBE4DB0064EA94 /* ofBaseApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBA81C421FFBE4DB0064EA94 /* ofBaseApp.cpp */; };
-		BF6276A62BAD9900008864C1 /* ofBaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6276A52BAD9900008864C1 /* ofBaseTypes.h */; };
-		BFB0B3F52C50DFE8008FB5A3 /* brotli.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7C462D2C097CCE00461163 /* brotli.xcframework */; };
-		BFB0B3F62C50DFE8008FB5A3 /* curl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6276A32BAD6639008864C1 /* curl.xcframework */; };
-		BFB0B3F72C50DFE8008FB5A3 /* openssl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6276A12BAD6619008864C1 /* openssl.xcframework */; };
-		BFB0B3F82C50DFE8008FB5A3 /* pixman.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8552B737E930049DEF6 /* pixman.xcframework */; };
-		BFB0B3F92C50DFE8008FB5A3 /* libpng.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8532B737E880049DEF6 /* libpng.xcframework */; };
-		BFB0B3FA2C50DFE8008FB5A3 /* glfw.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8512B737E4E0049DEF6 /* glfw.xcframework */; };
-		BFB0B3FB2C50DFE8008FB5A3 /* glew.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF84F2B737E440049DEF6 /* glew.xcframework */; };
-		BFB0B3FC2C50DFE8008FB5A3 /* freetype.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF84D2B737E3B0049DEF6 /* freetype.xcframework */; };
-		BFB0B3FD2C50DFE8008FB5A3 /* FreeImage.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF84B2B737E320049DEF6 /* FreeImage.xcframework */; };
-		BFB0B3FE2C50DFE8008FB5A3 /* cairo.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8492B737E260049DEF6 /* cairo.xcframework */; };
-		BFB0B3FF2C50DFE8008FB5A3 /* pugixml.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8472B737D280049DEF6 /* pugixml.xcframework */; };
-		BFB0B4002C50DFE8008FB5A3 /* rtAudio.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8452B737C870049DEF6 /* rtAudio.xcframework */; };
-		BFB0B4012C50DFE8008FB5A3 /* tess2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8432B737C7C0049DEF6 /* tess2.xcframework */; };
-		BFB0B4022C50DFE8008FB5A3 /* uriparser.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF8412B737C700049DEF6 /* uriparser.xcframework */; };
-		BFB0B4032C50DFE8008FB5A3 /* zlib.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF5BF83F2B737C0A0049DEF6 /* zlib.xcframework */; };
 		DA48FE78131D85A6000062BC /* ofPolyline.h in Headers */ = {isa = PBXBuildFile; fileRef = DA48FE74131D85A6000062BC /* ofPolyline.h */; };
 		DA94C2F01301D32200CCC773 /* ofRendererCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = DA94C2ED1301D32200CCC773 /* ofRendererCollection.h */; };
 		DA97FD3C12F5A61A005C9991 /* ofCairoRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA97FD3612F5A61A005C9991 /* ofCairoRenderer.cpp */; };
@@ -84,6 +66,7 @@
 		DAC22D3F16E7A4AF0020226D /* ofParameter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DAC22D3B16E7A4AF0020226D /* ofParameter.cpp */; };
 		DAC22D4016E7A4AF0020226D /* ofParameter.h in Headers */ = {isa = PBXBuildFile; fileRef = DAC22D3C16E7A4AF0020226D /* ofParameter.h */; };
 		DAC22D4116E7A4AF0020226D /* ofParameterGroup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DAC22D3D16E7A4AF0020226D /* ofParameterGroup.cpp */; };
+		DAC22D4216E7A4AF0020226D /* ofParameterGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = DAC22D3E16E7A4AF0020226D /* ofParameterGroup.h */; };
 		DACFA8DA132D09E8008D4B7A /* ofFbo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DACFA8C9132D09E8008D4B7A /* ofFbo.cpp */; };
 		DACFA8DB132D09E8008D4B7A /* ofFbo.h in Headers */ = {isa = PBXBuildFile; fileRef = DACFA8CA132D09E8008D4B7A /* ofFbo.h */; };
 		DACFA8DC132D09E8008D4B7A /* ofGLRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DACFA8CB132D09E8008D4B7A /* ofGLRenderer.cpp */; };
@@ -101,8 +84,6 @@
 		DACFA8E8132D09E8008D4B7A /* ofVbo.h in Headers */ = {isa = PBXBuildFile; fileRef = DACFA8D7132D09E8008D4B7A /* ofVbo.h */; };
 		DACFA8E9132D09E8008D4B7A /* ofVboMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DACFA8D8132D09E8008D4B7A /* ofVboMesh.cpp */; };
 		DACFA8EA132D09E8008D4B7A /* ofVboMesh.h in Headers */ = {isa = PBXBuildFile; fileRef = DACFA8D9132D09E8008D4B7A /* ofVboMesh.h */; };
-		E43EEAC329E66B78001C7596 /* ofAVEngineSoundPlayer.mm in Sources */ = {isa = PBXBuildFile; fileRef = E43EEAC129E66B78001C7596 /* ofAVEngineSoundPlayer.mm */; };
-		E43EEAC429E66B78001C7596 /* ofAVEngineSoundPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = E43EEAC229E66B78001C7596 /* ofAVEngineSoundPlayer.h */; };
 		E486629A1D8C61B000D1735C /* ofAVFoundationGrabber.h in Headers */ = {isa = PBXBuildFile; fileRef = E48662981D8C61B000D1735C /* ofAVFoundationGrabber.h */; };
 		E486629B1D8C61B000D1735C /* ofAVFoundationGrabber.mm in Sources */ = {isa = PBXBuildFile; fileRef = E48662991D8C61B000D1735C /* ofAVFoundationGrabber.mm */; };
 		E495DF7D178896A900994238 /* ofAppNoWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E495DF7B178896A900994238 /* ofAppNoWindow.cpp */; };
@@ -179,8 +160,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0353245B2BEFEC7A00B50A35 /* ofTimerFps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofTimerFps.h; sourceTree = "<group>"; };
-		0353245C2BEFEC7B00B50A35 /* ofTimerFps.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofTimerFps.cpp; sourceTree = "<group>"; };
 		19662F2C2834A44400B622ED /* ofGraphicsCairo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofGraphicsCairo.h; sourceTree = "<group>"; };
 		19662F2D2834A44400B622ED /* ofGraphicsCairo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofGraphicsCairo.cpp; sourceTree = "<group>"; };
 		22246D91176C9987008A8AF4 /* ofGLProgrammableRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ofGLProgrammableRenderer.cpp; path = gl/ofGLProgrammableRenderer.cpp; sourceTree = "<group>"; };
@@ -235,22 +214,6 @@
 		9979E8201A1CCC44007E55D1 /* ofMainLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMainLoop.cpp; sourceTree = "<group>"; };
 		9979E8211A1CCC44007E55D1 /* ofMainLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMainLoop.h; sourceTree = "<group>"; };
 		BBA81C421FFBE4DB0064EA94 /* ofBaseApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseApp.cpp; sourceTree = "<group>"; };
-		BF5BF83F2B737C0A0049DEF6 /* zlib.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = zlib.xcframework; path = ../../../zlib/lib/macos/zlib.xcframework; sourceTree = "<group>"; };
-		BF5BF8412B737C700049DEF6 /* uriparser.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = uriparser.xcframework; path = ../../../uriparser/lib/macos/uriparser.xcframework; sourceTree = "<group>"; };
-		BF5BF8432B737C7C0049DEF6 /* tess2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = tess2.xcframework; path = ../../../tess2/lib/macos/tess2.xcframework; sourceTree = "<group>"; };
-		BF5BF8452B737C870049DEF6 /* rtAudio.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = rtAudio.xcframework; path = ../../../rtAudio/lib/macos/rtAudio.xcframework; sourceTree = "<group>"; };
-		BF5BF8472B737D280049DEF6 /* pugixml.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = pugixml.xcframework; path = ../../../pugixml/lib/macos/pugixml.xcframework; sourceTree = "<group>"; };
-		BF5BF8492B737E260049DEF6 /* cairo.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = cairo.xcframework; path = ../../../cairo/lib/macos/cairo.xcframework; sourceTree = "<group>"; };
-		BF5BF84B2B737E320049DEF6 /* FreeImage.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FreeImage.xcframework; path = ../../../FreeImage/lib/macos/FreeImage.xcframework; sourceTree = "<group>"; };
-		BF5BF84D2B737E3B0049DEF6 /* freetype.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = freetype.xcframework; path = ../../../freetype/lib/macos/freetype.xcframework; sourceTree = "<group>"; };
-		BF5BF84F2B737E440049DEF6 /* glew.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = glew.xcframework; path = ../../../glew/lib/macos/glew.xcframework; sourceTree = "<group>"; };
-		BF5BF8512B737E4E0049DEF6 /* glfw.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = glfw.xcframework; path = ../../../glfw/lib/macos/glfw.xcframework; sourceTree = "<group>"; };
-		BF5BF8532B737E880049DEF6 /* libpng.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libpng.xcframework; path = ../../../libpng/lib/macos/libpng.xcframework; sourceTree = "<group>"; };
-		BF5BF8552B737E930049DEF6 /* pixman.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = pixman.xcframework; path = ../../../pixman/lib/macos/pixman.xcframework; sourceTree = "<group>"; };
-		BF6276A12BAD6619008864C1 /* openssl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = openssl.xcframework; path = ../../../openssl/lib/macos/openssl.xcframework; sourceTree = "<group>"; };
-		BF6276A32BAD6639008864C1 /* curl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = curl.xcframework; path = ../../../curl/lib/macos/curl.xcframework; sourceTree = "<group>"; };
-		BF6276A52BAD9900008864C1 /* ofBaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofBaseTypes.h; sourceTree = "<group>"; };
-		BF7C462D2C097CCE00461163 /* brotli.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = brotli.xcframework; path = ../../../brotli/lib/macos/brotli.xcframework; sourceTree = "<group>"; };
 		DA48FE74131D85A6000062BC /* ofPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofPolyline.h; sourceTree = "<group>"; };
 		DA94C2ED1301D32200CCC773 /* ofRendererCollection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofRendererCollection.h; sourceTree = "<group>"; };
 		DA97FD3612F5A61A005C9991 /* ofCairoRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofCairoRenderer.cpp; sourceTree = "<group>"; };
@@ -258,6 +221,7 @@
 		DAC22D3B16E7A4AF0020226D /* ofParameter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameter.cpp; sourceTree = "<group>"; };
 		DAC22D3C16E7A4AF0020226D /* ofParameter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameter.h; sourceTree = "<group>"; };
 		DAC22D3D16E7A4AF0020226D /* ofParameterGroup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofParameterGroup.cpp; sourceTree = "<group>"; };
+		DAC22D3E16E7A4AF0020226D /* ofParameterGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofParameterGroup.h; sourceTree = "<group>"; };
 		DACFA8C9132D09E8008D4B7A /* ofFbo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ofFbo.cpp; path = gl/ofFbo.cpp; sourceTree = "<group>"; };
 		DACFA8CA132D09E8008D4B7A /* ofFbo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ofFbo.h; path = gl/ofFbo.h; sourceTree = "<group>"; };
 		DACFA8CB132D09E8008D4B7A /* ofGLRenderer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ofGLRenderer.cpp; path = gl/ofGLRenderer.cpp; sourceTree = "<group>"; };
@@ -278,8 +242,6 @@
 		E432815E138ABFDD0047C5CB /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		E432815F138AC0470047C5CB /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E4328160138AC04A0047C5CB /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		E43EEAC129E66B78001C7596 /* ofAVEngineSoundPlayer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofAVEngineSoundPlayer.mm; sourceTree = "<group>"; };
-		E43EEAC229E66B78001C7596 /* ofAVEngineSoundPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAVEngineSoundPlayer.h; sourceTree = "<group>"; };
 		E48662981D8C61B000D1735C /* ofAVFoundationGrabber.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = ofAVFoundationGrabber.h; sourceTree = "<group>"; };
 		E48662991D8C61B000D1735C /* ofAVFoundationGrabber.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ofAVFoundationGrabber.mm; sourceTree = "<group>"; };
 		E495DF7B178896A900994238 /* ofAppNoWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofAppNoWindow.cpp; sourceTree = "<group>"; };
@@ -372,56 +334,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFB0B3F52C50DFE8008FB5A3 /* brotli.xcframework in Frameworks */,
-				BFB0B3F62C50DFE8008FB5A3 /* curl.xcframework in Frameworks */,
-				BFB0B3F72C50DFE8008FB5A3 /* openssl.xcframework in Frameworks */,
-				BFB0B3F82C50DFE8008FB5A3 /* pixman.xcframework in Frameworks */,
-				BFB0B3F92C50DFE8008FB5A3 /* libpng.xcframework in Frameworks */,
-				BFB0B3FA2C50DFE8008FB5A3 /* glfw.xcframework in Frameworks */,
-				BFB0B3FB2C50DFE8008FB5A3 /* glew.xcframework in Frameworks */,
-				BFB0B3FC2C50DFE8008FB5A3 /* freetype.xcframework in Frameworks */,
-				BFB0B3FD2C50DFE8008FB5A3 /* FreeImage.xcframework in Frameworks */,
-				BFB0B3FE2C50DFE8008FB5A3 /* cairo.xcframework in Frameworks */,
-				BFB0B3FF2C50DFE8008FB5A3 /* pugixml.xcframework in Frameworks */,
-				BFB0B4002C50DFE8008FB5A3 /* rtAudio.xcframework in Frameworks */,
-				BFB0B4012C50DFE8008FB5A3 /* tess2.xcframework in Frameworks */,
-				BFB0B4022C50DFE8008FB5A3 /* uriparser.xcframework in Frameworks */,
-				BFB0B4032C50DFE8008FB5A3 /* zlib.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		BF5BF83E2B7378ED0049DEF6 /* frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BF7C462D2C097CCE00461163 /* brotli.xcframework */,
-				BF6276A32BAD6639008864C1 /* curl.xcframework */,
-				BF6276A12BAD6619008864C1 /* openssl.xcframework */,
-				BF5BF8552B737E930049DEF6 /* pixman.xcframework */,
-				BF5BF8532B737E880049DEF6 /* libpng.xcframework */,
-				BF5BF8512B737E4E0049DEF6 /* glfw.xcframework */,
-				BF5BF84F2B737E440049DEF6 /* glew.xcframework */,
-				BF5BF84D2B737E3B0049DEF6 /* freetype.xcframework */,
-				BF5BF84B2B737E320049DEF6 /* FreeImage.xcframework */,
-				BF5BF8492B737E260049DEF6 /* cairo.xcframework */,
-				BF5BF8472B737D280049DEF6 /* pugixml.xcframework */,
-				BF5BF8452B737C870049DEF6 /* rtAudio.xcframework */,
-				BF5BF8432B737C7C0049DEF6 /* tess2.xcframework */,
-				BF5BF8412B737C700049DEF6 /* uriparser.xcframework */,
-				BF5BF83F2B737C0A0049DEF6 /* zlib.xcframework */,
-			);
-			name = frameworks;
-			sourceTree = "<group>";
-		};
-		BF879F602C0F7FE400200951 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		DACFA8C8132D09C7008D4B7A /* gl */ = {
 			isa = PBXGroup;
 			children = (
@@ -543,19 +461,17 @@
 		E4B69B4A0A3A1720003C02F2 = {
 			isa = PBXGroup;
 			children = (
-				E4EB6916138AFC8500A09F29 /* CoreOF.xcconfig */,
 				E432815E138ABFDD0047C5CB /* Shared.xcconfig */,
+				E4EB6916138AFC8500A09F29 /* CoreOF.xcconfig */,
 				E432815F138AC0470047C5CB /* Debug.xcconfig */,
 				E4328160138AC04A0047C5CB /* Release.xcconfig */,
 				E4B27AAA10CBE92A00536013 /* openFrameworks */,
 				E4B27C1510CBEB8E00536013 /* openFrameworksDebug.a */,
-				BF5BF83E2B7378ED0049DEF6 /* frameworks */,
-				BF879F602C0F7FE400200951 /* Frameworks */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
-			usesTabs = 1;
+			usesTabs = 0;
 		};
 		E4F3BA5212F4C4BF002D19BB /* 3d */ = {
 			isa = PBXGroup;
@@ -580,8 +496,6 @@
 		E4F3BA7B12F4C4C9002D19BB /* sound */ = {
 			isa = PBXGroup;
 			children = (
-				E43EEAC229E66B78001C7596 /* ofAVEngineSoundPlayer.h */,
-				E43EEAC129E66B78001C7596 /* ofAVEngineSoundPlayer.mm */,
 				6944251D1FE4548B00770088 /* ofSoundBaseTypes.cpp */,
 				6944251E1FE4548B00770088 /* ofSoundBaseTypes.h */,
 				E4F3BA7E12F4C4C9002D19BB /* ofFmodSoundPlayer.cpp */,
@@ -628,10 +542,10 @@
 		E4F3BACF12F4C73C002D19BB /* types */ = {
 			isa = PBXGroup;
 			children = (
-				BF6276A52BAD9900008864C1 /* ofBaseTypes.h */,
 				DAC22D3B16E7A4AF0020226D /* ofParameter.cpp */,
 				DAC22D3C16E7A4AF0020226D /* ofParameter.h */,
 				DAC22D3D16E7A4AF0020226D /* ofParameterGroup.cpp */,
+				DAC22D3E16E7A4AF0020226D /* ofParameterGroup.h */,
 				E4F3BAD012F4C73C002D19BB /* ofBaseTypes.cpp */,
 				E4F3BAD212F4C73C002D19BB /* ofColor.cpp */,
 				E4F3BAD312F4C73C002D19BB /* ofColor.h */,
@@ -651,8 +565,6 @@
 				692C298819DC5C5500C27C5D /* ofFpsCounter.h */,
 				692C298919DC5C5500C27C5D /* ofTimer.cpp */,
 				692C298A19DC5C5500C27C5D /* ofTimer.h */,
-				0353245C2BEFEC7B00B50A35 /* ofTimerFps.cpp */,
-				0353245B2BEFEC7A00B50A35 /* ofTimerFps.h */,
 				27DEA30F1796F578000A9E90 /* ofXml.cpp */,
 				27DEA3101796F578000A9E90 /* ofXml.h */,
 				2276958F170D9DD200604FC3 /* ofMatrixStack.cpp */,
@@ -723,7 +635,6 @@
 				30CC5385207A36FD008234AF /* ofMathConstants.h in Headers */,
 				E4F3BA6A12F4C4BF002D19BB /* ofCamera.h in Headers */,
 				E4F3BA6C12F4C4BF002D19BB /* ofEasyCam.h in Headers */,
-				0353245D2BEFEC7B00B50A35 /* ofTimerFps.h in Headers */,
 				E4F3BA7412F4C4BF002D19BB /* ofNode.h in Headers */,
 				E4F3BA8B12F4C4C9002D19BB /* ofFmodSoundPlayer.h in Headers */,
 				E4F3BA8F12F4C4C9002D19BB /* ofSoundPlayer.h in Headers */,
@@ -787,8 +698,7 @@
 				772BDF74146928600030F0EE /* ofOpenALSoundPlayer.h in Headers */,
 				E486629A1D8C61B000D1735C /* ofAVFoundationGrabber.h in Headers */,
 				DAC22D4016E7A4AF0020226D /* ofParameter.h in Headers */,
-				E43EEAC429E66B78001C7596 /* ofAVEngineSoundPlayer.h in Headers */,
-				BF6276A62BAD9900008864C1 /* ofBaseTypes.h in Headers */,
+				DAC22D4216E7A4AF0020226D /* ofParameterGroup.h in Headers */,
 				2E6EA7011603A9E400B7ADF3 /* of3dGraphics.h in Headers */,
 				2292E73F19E3049700DE9411 /* ofBufferObject.h in Headers */,
 				2E6EA7061603AABD00B7ADF3 /* of3dPrimitives.h in Headers */,
@@ -809,11 +719,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E4B27C3210CBEBB200536013 /* Build configuration list for PBXNativeTarget "openFrameworks" */;
 			buildPhases = (
-				BFEF3FA72C50AEC7009B3CD8 /* Run Script */,
 				E4B27C1110CBEB8E00536013 /* Headers */,
 				E4B27C1210CBEB8E00536013 /* Sources */,
 				E4B27C1310CBEB8E00536013 /* Frameworks */,
-				BFF80A5D2C50B2C300784E74 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -830,8 +738,7 @@
 		E4B69B4C0A3A1720003C02F2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 0600;
 			};
 			buildConfigurationList = E4B69B4D0A3A1720003C02F2 /* Build configuration list for PBXProject "openFrameworksLib" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -852,48 +759,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		BFEF3FA72C50AEC7009B3CD8 /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = "/usr/bin/env bash";
-			shellScript = "#!/usr/bin/env bash\nif [ ! -d \"${SRCROOT}/../../../freetype/lib/macos/freetype.xcframework\" ]; then\n\techo \"openFrameworks has missing xcFrameworks for osx. Downloading libaries now via scripts/osx/download_libs.sh\"\n    ${SRCROOT}/../../../../scripts/osx/download_libs.sh\nelse\n\techo \"xcFrameworks found\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		BFF80A5D2C50B2C300784E74 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nTARGET_DIR=\"$SRCROOT/../../lib/macos\"\nATTRIBUTE_CHECK=$(xattr -p com.apple.xcode.CreatedByBuildSystem \"$TARGET_DIR\" 2>/dev/null)\nif [ -z \"$ATTRIBUTE_CHECK\" ]; then\n  xattr -w com.apple.xcode.CreatedByBuildSystem true \"$TARGET_DIR\"\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem set to true for $TARGET_DIR\"\nelse\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem already set for $TARGET_DIR\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		E4B27C1210CBEB8E00536013 /* Sources */ = {
@@ -916,7 +781,6 @@
 				E4F3BA8A12F4C4C9002D19BB /* ofFmodSoundPlayer.cpp in Sources */,
 				E4F3BA8E12F4C4C9002D19BB /* ofSoundPlayer.cpp in Sources */,
 				E4F3BA9012F4C4C9002D19BB /* ofSoundStream.cpp in Sources */,
-				E43EEAC329E66B78001C7596 /* ofAVEngineSoundPlayer.mm in Sources */,
 				E4F3BAC112F4C72F002D19BB /* ofMath.cpp in Sources */,
 				E4F3BAC312F4C72F002D19BB /* ofMatrix3x3.cpp in Sources */,
 				6944251A1FE4547400770088 /* ofGraphicsBaseTypes.cpp in Sources */,
@@ -940,7 +804,6 @@
 				E4F3BB1812F4C752002D19BB /* ofBitmapFont.cpp in Sources */,
 				E4F3BB1C12F4C752002D19BB /* ofGraphics.cpp in Sources */,
 				2E6EA7041603AA7A00B7ADF3 /* of3dGraphics.cpp in Sources */,
-				0353245E2BEFEC7B00B50A35 /* ofTimerFps.cpp in Sources */,
 				E4F3BB1E12F4C752002D19BB /* ofImage.cpp in Sources */,
 				E4F3BB2012F4C752002D19BB /* ofPixels.cpp in Sources */,
 				E4F3BB2A12F4C752002D19BB /* ofTessellator.cpp in Sources */,
@@ -982,7 +845,9 @@
 		E4B27C1610CBEB8E00536013 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/macos/";
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/osx/";
+				COPY_PHASE_STRIP = NO;
 				EXECUTABLE_PREFIX = "";
 				INSTALL_PATH = /usr/local/lib;
 				LIBRARY_SEARCH_PATHS = (
@@ -997,18 +862,22 @@
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
 				);
-				OBJROOT = "$(SRCROOT)/../../lib/macos/build/debug/";
+				OBJROOT = "$(SRCROOT)/../../lib/osx/build/debug/";
 				PRODUCT_NAME = openFrameworksDebug;
 				SDKROOT = "";
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
 		E4B27C1710CBEB8E00536013 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/macos/";
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/osx/";
+				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				EXECUTABLE_PREFIX = "";
+				GCC_FAST_MATH = NO;
 				INSTALL_PATH = /usr/local/lib;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1022,9 +891,10 @@
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_8)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_9)",
 				);
-				OBJROOT = "$(SRCROOT)/../../lib/macos/build/release/";
+				OBJROOT = "$(SRCROOT)/../../lib/osx/build/release/";
 				PRODUCT_NAME = openFrameworks;
 				SDKROOT = "";
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -1032,9 +902,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E432815F138AC0470047C5CB /* Debug.xcconfig */;
 			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/macos/";
-				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/macos/build/debug/";
-				OBJROOT = "$(SRCROOT)/../../lib/macos/build/debug/";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/osx/";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/osx/build/debug/";
+				OBJROOT = "$(SRCROOT)/../../lib/osx/build/debug/";
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = "";
 			};
@@ -1044,9 +914,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E4328160138AC04A0047C5CB /* Release.xcconfig */;
 			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/macos/";
-				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/macos/build/release/";
-				OBJROOT = "$(SRCROOT)/../../lib/macos/build/release";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/../../lib/osx/";
+				CONFIGURATION_TEMP_DIR = "$(SRCROOT)/../../lib/osx/build/release/";
+				OBJROOT = "$(SRCROOT)/../../lib/osx/build/release";
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = "";
 			};


### PR DESCRIPTION
This is a proposition for discussion. 
I think we can do well removing ofPoint ofVec{2, 3, 4}f, ofMatrix{3x3,4x4} usage from core and core addons and substitute for glm equivalent ones. removing toOf / toGlm conversions too.

We can keep all functions related to this functions inside an ifdef, so we can test compile OF without legacy math.
