### PR TITLE
[future] - osx template with dynamic src folder

### DIFF
--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -5,12 +5,9 @@
 	"objects": {
 		"E4B69E1C0A3A1BDC003C02F2": {
 			"path": "src",
-			"isa": "PBXGroup",
-			"children": [
-				"E4B69E1D0A3A1BDC003C02F2",
-				"E4B69E1E0A3A1BDC003C02F2",
-				"E4B69E1F0A3A1BDC003C02F2"
-			],
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "folder",
+			"explicitFileTypes" : [],
 			"sourceTree": "SOURCE_ROOT"
 		},
 		"E4EB6923138AFD0F00A09F29": {
@@ -99,22 +96,6 @@
 			"projectRoot": "",
 			"mainGroup": "E4B69B4A0A3A1720003C02F2"
 		},
-		"E4B69E1E0A3A1BDC003C02F2": {
-			"path": "src/ofApp.cpp",
-			"isa": "PBXFileReference",
-			"fileEncoding": "4",
-			"name": "ofApp.cpp",
-			"sourceTree": "SOURCE_ROOT",
-			"explicitFileType": "sourcecode.cpp.cpp"
-		},
-		"E4B69E1D0A3A1BDC003C02F2": {
-			"path": "src/main.cpp",
-			"isa": "PBXFileReference",
-			"lastKnownFileType": "sourcecode.cpp.cpp",
-			"name": "main.cpp",
-			"sourceTree": "SOURCE_ROOT",
-			"fileEncoding": "4"
-		},
 		"19B789C429E5AB4A0082E9B8": {
 			"buildActionMask": "2147483647",
 			"runOnlyForDeploymentPostprocessing": "0",
@@ -177,6 +158,7 @@
 			"isa": "PBXGroup",
 			"sourceTree": "<group>",
 			"children": [
+				"035ADD3E2CD9886200F9E324",
 				"191CD6FA2847E21E0085CBB6",
 				"E4B6FCAD0C3E899E008CF71C",
 				"E4EB6923138AFD0F00A09F29",
@@ -190,8 +172,7 @@
 			"isa": "PBXSourcesBuildPhase",
 			"buildActionMask": "2147483647",
 			"files": [
-				"E4B69E200A3A1BDC003C02F2",
-				"E4B69E210A3A1BDC003C02F2"
+				"E4B69E200A3A1BDC003C02F2"
 			],
 			"runOnlyForDeploymentPostprocessing": "0"
 		},
@@ -250,11 +231,7 @@
 		},
 		"E4B69E200A3A1BDC003C02F2": {
 			"isa": "PBXBuildFile",
-			"fileRef": "E4B69E1D0A3A1BDC003C02F2"
-		},
-		"E4B69E210A3A1BDC003C02F2": {
-			"isa": "PBXBuildFile",
-			"fileRef": "E4B69E1E0A3A1BDC003C02F2"
+			"fileRef": "E4B69E1C0A3A1BDC003C02F2"
 		},
 		"E4B69B5A0A3A1756003C02F2": {
 			"buildConfigurationList": "E4B69B5F0A3A1757003C02F2",

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -1,35 +1,23 @@
 {
 	"classes": {},
-	"objectVersion": "54",
+	"objectVersion": "70",
 	"archiveVersion": "1",
 	"objects": {
-		"E4B69E1C0A3A1BDC003C02F2": {
-			"path": "src",
-			"isa": "PBXFileReference",
-			"lastKnownFileType": "folder",
-			"explicitFileTypes" : [],
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"E4EB6923138AFD0F00A09F29": {
-			"path": "Project.xcconfig",
-			"isa": "PBXFileReference",
-			"lastKnownFileType": "text.xcconfig",
-			"sourceTree": "<group>",
-			"fileEncoding": "4"
-		},
-		"BF26640B2C634C16004360E2": {
-		    "isa": "PBXShellScriptBuildPhase",
-		    "alwaysOutOfDate": "1",
-		    "buildActionMask": "2147483647",
-		    "files": [],
-		    "inputFileListPaths": [],
-		    "inputPaths": [],
-		    "outputFileListPaths": [],
-		    "outputPaths": [],
-		    "runOnlyForDeploymentPostprocessing": "0",
-		    "shellPath": "/usr/bin/env bash",
-			"showEnvVarsInLog": "0",
-		    "shellScript": "#!/usr/bin/env bash\nif [ ! -d \"${OF_PATH}/libs/freetype/lib/macos/freetype.xcframework\" ]; then\n\techo \"openFrameworks has missing xcFrameworks for osx. Downloading libaries now via scripts/osx/download_libs.sh\"\n    ${OF_PATH}/scripts/osx/download_libs.sh\nelse\n\techo \"xcFrameworks found\"\nfi\n"
+		"E4B69B4F0A3A1720003C02F2": {
+			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
+			"isa": "XCBuildConfiguration",
+			"buildSettings": {
+				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
+				"GCC_UNROLL_LOOPS": "YES",
+				"HEADER_SEARCH_PATHS": [
+					"$(OF_CORE_HEADERS)",
+					"src"
+				],
+				"GCC_OPTIMIZATION_LEVEL": "3",
+				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
+				"COPY_PHASE_STRIP": "YES"
+			},
+			"name": "Release"
 		},
 		"E42962A92163ECCD00A6A9E2": {
 			"alwaysOutOfDate": "1",
@@ -60,20 +48,6 @@
 			"files": [],
 			"runOnlyForDeploymentPostprocessing": "0"
 		},
-		"191EF70929D778A400F35F26": {
-			"path": "../../../libs/openFrameworks",
-			"isa": "PBXFileReference",
-			"name": "openFrameworks",
-			"lastKnownFileType": "folder",
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"191CD6FA2847E21E0085CBB6": {
-			"path": "of.entitlements",
-			"isa": "PBXFileReference",
-			"lastKnownFileType": "text.plist.entitlements",
-			"sourceTree": "<group>",
-			"fileEncoding": "4"
-		},
 		"E4B69B4C0A3A1720003C02F2": {
 			"buildConfigurationList": "E4B69B4D0A3A1720003C02F2",
 			"targets": [
@@ -96,35 +70,54 @@
 			"projectRoot": "",
 			"mainGroup": "E4B69B4A0A3A1720003C02F2"
 		},
+		"191EF70929D778A400F35F26": {
+			"path": "../../../libs/openFrameworks",
+			"isa": "PBXFileReference",
+			"name": "openFrameworks",
+			"lastKnownFileType": "folder",
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"191CD6FA2847E21E0085CBB6": {
+			"path": "of.entitlements",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "text.plist.entitlements",
+			"sourceTree": "<group>",
+			"fileEncoding": "4"
+		},
+		"E4EB6923138AFD0F00A09F29": {
+			"path": "Project.xcconfig",
+			"isa": "PBXFileReference",
+			"lastKnownFileType": "text.xcconfig",
+			"sourceTree": "<group>",
+			"fileEncoding": "4"
+		},
+		"BF26640B2C634C16004360E2": {
+			"buildActionMask": "2147483647",
+			"runOnlyForDeploymentPostprocessing": "0",
+			"outputPaths": [],
+			"shellPath": "/usr/bin/env bash",
+			"inputFileListPaths": [],
+			"showEnvVarsInLog": "0",
+			"isa": "PBXShellScriptBuildPhase",
+			"shellScript": "#!/usr/bin/env bash\nif [ ! -d \"${OF_PATH}/libs/freetype/lib/macos/freetype.xcframework\" ]; then\n\techo \"openFrameworks has missing xcFrameworks for osx. Downloading libaries now via scripts/osx/download_libs.sh\"\n    ${OF_PATH}/scripts/osx/download_libs.sh\nelse\n\techo \"xcFrameworks found\"\nfi\n",
+			"files": [],
+			"alwaysOutOfDate": "1",
+			"inputPaths": [],
+			"outputFileListPaths": []
+		},
 		"19B789C429E5AB4A0082E9B8": {
 			"buildActionMask": "2147483647",
 			"runOnlyForDeploymentPostprocessing": "0",
 			"outputPaths": [],
 			"shellPath": "/bin/sh",
-			"showEnvVarsInLog": "0",
 			"inputFileListPaths": [],
+			"showEnvVarsInLog": "0",
 			"isa": "PBXShellScriptBuildPhase",
 			"shellScript": "\"$OF_PATH/scripts/osx/xcode_project.sh\"\n",
 			"files": [],
 			"alwaysOutOfDate": "1",
 			"inputPaths": [],
 			"outputFileListPaths": []
-		},
-		"E4B69B4F0A3A1720003C02F2": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
-				"GCC_UNROLL_LOOPS": "YES",
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"GCC_OPTIMIZATION_LEVEL": "3",
-				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
-				"COPY_PHASE_STRIP": "YES"
-			},
-			"name": "Release"
 		},
 		"E4B69B610A3A1757003C02F2": {
 			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
@@ -147,34 +140,14 @@
 			},
 			"name": "Release"
 		},
-		"BB4B014C10F69532006C3DED": {
-			"path": "../../../addons",
-			"isa": "PBXGroup",
-			"name": "addons",
-			"children": [],
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"E4B69B4A0A3A1720003C02F2": {
-			"isa": "PBXGroup",
-			"sourceTree": "<group>",
-			"children": [
-				"035ADD3E2CD9886200F9E324",
-				"191CD6FA2847E21E0085CBB6",
-				"E4B6FCAD0C3E899E008CF71C",
-				"E4EB6923138AFD0F00A09F29",
-				"E4B69E1C0A3A1BDC003C02F2",
-				"191EF70929D778A400F35F26",
-				"BB4B014C10F69532006C3DED",
-				"E4B69B5B0A3A1756003C02F2"
+		"E4B69B4D0A3A1720003C02F2": {
+			"isa": "XCConfigurationList",
+			"defaultConfigurationIsVisible": "0",
+			"defaultConfigurationName": "Release",
+			"buildConfigurations": [
+				"E4B69B4E0A3A1720003C02F2",
+				"E4B69B4F0A3A1720003C02F2"
 			]
-		},
-		"E4B69B580A3A1756003C02F2": {
-			"isa": "PBXSourcesBuildPhase",
-			"buildActionMask": "2147483647",
-			"files": [
-				"E4B69E200A3A1BDC003C02F2"
-			],
-			"runOnlyForDeploymentPostprocessing": "0"
 		},
 		"E4B69B4E0A3A1720003C02F2": {
 			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
@@ -214,31 +187,56 @@
 			},
 			"name": "Debug"
 		},
+		"BB4B014C10F69532006C3DED": {
+			"path": "../../../addons",
+			"isa": "PBXGroup",
+			"name": "addons",
+			"children": [],
+			"sourceTree": "SOURCE_ROOT"
+		},
+		"E4B69B580A3A1756003C02F2": {
+			"isa": "PBXSourcesBuildPhase",
+			"buildActionMask": "2147483647",
+			"files": [],
+			"runOnlyForDeploymentPostprocessing": "0"
+		},
+		"E4B69B4A0A3A1720003C02F2": {
+			"isa": "PBXGroup",
+			"sourceTree": "<group>",
+			"children": [
+				"191CD6FA2847E21E0085CBB6",
+				"E4B6FCAD0C3E899E008CF71C",
+				"E4EB6923138AFD0F00A09F29",
+				"035ADD6C2CD98D6E00F9E324",
+				"191EF70929D778A400F35F26",
+				"BB4B014C10F69532006C3DED",
+				"E4B69B5B0A3A1756003C02F2"
+			]
+		},
 		"E4B69B590A3A1756003C02F2": {
 			"isa": "PBXFrameworksBuildPhase",
 			"buildActionMask": "2147483647",
 			"files": [],
 			"runOnlyForDeploymentPostprocessing": "0"
 		},
-		"E4B69B4D0A3A1720003C02F2": {
-			"isa": "XCConfigurationList",
-			"defaultConfigurationIsVisible": "0",
-			"defaultConfigurationName": "Release",
-			"buildConfigurations": [
-				"E4B69B4E0A3A1720003C02F2",
-				"E4B69B4F0A3A1720003C02F2"
-			]
-		},
-		"E4B69E200A3A1BDC003C02F2": {
-			"isa": "PBXBuildFile",
-			"fileRef": "E4B69E1C0A3A1BDC003C02F2"
+		"035ADD6C2CD98D6E00F9E324": {
+			"path": "src",
+			"isa": "PBXFileSystemSynchronizedRootGroup",
+			"explicitFileTypes": {},
+			"sourceTree": "SOURCE_ROOT",
+			"explicitFolders": []
 		},
 		"E4B69B5A0A3A1756003C02F2": {
+			"buildRules": [],
 			"buildConfigurationList": "E4B69B5F0A3A1757003C02F2",
 			"productReference": "E4B69B5B0A3A1756003C02F2",
 			"productType": "com.apple.product-type.application",
 			"productName": "myOFApp",
 			"isa": "PBXNativeTarget",
+			"fileSystemSynchronizedGroups": [
+				"035ADD6C2CD98D6E00F9E324"
+			],
+			"dependencies": [],
 			"buildPhases": [
 				"BF26640B2C634C16004360E2",
 				"E42962A92163ECCD00A6A9E2",
@@ -248,9 +246,7 @@
 				"E4A5B60F29BAAAE400C2D356",
 				"19B789C429E5AB4A0082E9B8"
 			],
-			"dependencies": [],
-			"name": "emptyExample",
-			"buildRules": []
+			"name": "emptyExample"
 		},
 		"E4B6FCAD0C3E899E008CF71C": {
 			"path": "openFrameworks-Info.plist",
@@ -274,14 +270,6 @@
 			"includeInIndex": "0",
 			"explicitFileType": "wrapper.application",
 			"sourceTree": "BUILT_PRODUCTS_DIR"
-		},
-		"E4B69E1F0A3A1BDC003C02F2": {
-			"path": "src/ofApp.h",
-			"isa": "PBXFileReference",
-			"lastKnownFileType": "sourcecode.c.h",
-			"name": "ofApp.h",
-			"sourceTree": "SOURCE_ROOT",
-			"fileEncoding": "4"
 		}
 	},
 	"rootObject": "E4B69B4C0A3A1720003C02F2"


### PR DESCRIPTION
For the future
because it only works on most recent XCode versions, maybe 16+

this brings a dynamic "src" folder that add to compile phase, but at the same time you can choose individual properties in any file (in the case you want to compile a c++ file as objective-c++ for example)
it is very useful so you can just create or bring in new files to the project just using finder, no need to add them or re-generate project

related:
- https://github.com/openframeworks/projectGenerator/issues/485