### PR TITLE
ofFilePath::ofGetAppName()

### DIFF
--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -452,10 +452,11 @@ public:
 	/// \returns the App name as native string
 	static const auto getAppName(bool strip_debug = true) {
 		auto name = ofFilePath::getCurrentExePathFS().filename().native();
-		const std::filesystem::path::string_type debug_suffix = "Debug";
+		typename std::filesystem::path::string_type debug_suffix = std::filesystem::path::string_type("Debug");
+		auto dbsize = debug_suffix.size();
 		if (strip_debug) {
-			if (name.size() > 5 && name.compare(name.size() - 5, 5, debug_suffix) == 0) {
-				name.erase(name.size() - 5);
+			if (name.size() > dbsize && name.compare(name.size() -dbsize , dbsize, debug_suffix) == 0) {
+				name.erase(name.size() - dbsize);
 			}
 		}
 		return name;

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -452,7 +452,7 @@ public:
 	/// \returns the App name as native string
 	static const auto getAppName(bool strip_debug = true) {
 		auto name = ofFilePath::getCurrentExePathFS().filename().native();
-		typename std::filesystem::path::string_type debug_suffix = std::filesystem::path::string_type("Debug");
+		auto debug_suffix = std::filesystem::path("Debug").native();
 		auto dbsize = debug_suffix.size();
 		if (strip_debug) {
 			if (name.size() > dbsize && name.compare(name.size() -dbsize , dbsize, debug_suffix) == 0) {

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -452,7 +452,11 @@ public:
 	/// \returns the App name as native string
 	static const auto getAppName(bool strip_debug = true) {
 		auto name = ofFilePath::getCurrentExePathFS().filename().native();
+#if defined(TARGET_OSX)
 		auto debug_suffix = std::filesystem::path("Debug").native();
+#else
+		auto debug_suffix = std::filesystem::path("_debug").native();
+#endif
 		auto dbsize = debug_suffix.size();
 		if (strip_debug) {
 			if (name.size() > dbsize && name.compare(name.size() -dbsize , dbsize, debug_suffix) == 0) {

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -446,6 +446,20 @@ public:
 	static of::filesystem::path getCurrentExeDirFS();
 	static std::string getCurrentExeDir();
 
+	/// Get the App name of the running binary
+	///
+	/// \param strip_debug removes a trailing "Debug" if present
+	/// \returns the App name as native string
+	static auto getAppName(bool strip_debug = true) {
+		auto name = ofFilePath::getCurrentExePathFS().filename().native();
+		if (strip_debug) {
+			if (name.size() > 5 && name.compare(name.size() - 5, 5, "Debug") == 0) {
+				name.erase(name.size() - 5);
+			}
+		}
+		return name;
+	}
+
 	/// Get the absolute path to the user's home directory.
 	///
 	/// Mac OSX: /Users/<username>

--- a/libs/openFrameworks/utils/ofFileUtils.h
+++ b/libs/openFrameworks/utils/ofFileUtils.h
@@ -450,10 +450,11 @@ public:
 	///
 	/// \param strip_debug removes a trailing "Debug" if present
 	/// \returns the App name as native string
-	static auto getAppName(bool strip_debug = true) {
+	static const auto getAppName(bool strip_debug = true) {
 		auto name = ofFilePath::getCurrentExePathFS().filename().native();
+		const std::filesystem::path::string_type debug_suffix = "Debug";
 		if (strip_debug) {
-			if (name.size() > 5 && name.compare(name.size() - 5, 5, "Debug") == 0) {
+			if (name.size() > 5 && name.compare(name.size() - 5, 5, debug_suffix) == 0) {
 				name.erase(name.size() - 5);
 			}
 		}


### PR DESCRIPTION
mini utility that returns the app name of the running binary as native string, optionally removing the trailing `Debug`, if present.