### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/manual-nightly.yml
+++ b/.github/workflows/manual-nightly.yml
@@ -25,12 +25,29 @@ env:
 jobs:
   manual-nightly:
     runs-on: ubuntu-24.04
-    if: github.repository == 'openframeworks/openFrameworks' && github.ref == 'refs/heads/master'
+    if: github.repository == 'openframeworks/openframeworks' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
     strategy:
         matrix:
           cfg:
           - {target: linux64, libs: 64gcc6}
     steps:
+    - name: Determine Release
+        id: vars
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "RELEASE=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "RELEASE=nightly" >> $GITHUB_ENV
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/bleeding" ]]; then
+            echo "RELEASE=latest" >> $GITHUB_ENV
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "RELEASE=latest" >> $GITHUB_ENV
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          fi
     - name: Install libunwind
       run:  sudo apt-get install libunwind-dev    
     - name: Cache Packages
@@ -65,13 +82,10 @@ jobs:
     #     name: openFrameworks-all-artefact-${{ env.TARGET }}-${{ matrix.bundle }}
     #     path: out/manual-mega_artefact.tar.bz2
     #     retention-days: 1
-    - name: Update Release
-      uses: IsaacShelton/update-existing-release@v1.3.4
-      if: github.repository == 'openframeworks/openFrameworks' && github.ref == 'refs/heads/master'
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ github.event.inputs.release }}
-        release: ${{ github.event.inputs.release }}
-        prerelease: false
-        replace: true
-        files: ${{ steps.createpackage.outputs.FILES_OUT }}
+    - name: Update Release arm64
+        if: github.repository == 'openframeworks/openframeworks' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        uses: softprops/action-gh-release@v2.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.RELEASE }}
+          files: ${{ steps.createpackage.outputs.FILES_OUT }}

--- a/.github/workflows/nightly-linux64.yml
+++ b/.github/workflows/nightly-linux64.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   build-nightly:
     runs-on: ubuntu-24.04
-    if: github.repository == 'openframeworks/openFrameworks' && github.ref == 'refs/heads/master'
+    if: github.repository == 'openframeworks/openframeworks' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
     strategy:
         matrix:
           cfg:
@@ -44,6 +44,23 @@ jobs:
     env:
      TARGET: ${{matrix.cfg.target}}
     steps:
+    - name: Determine Release
+        id: vars
+        shell: bash
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "RELEASE=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "RELEASE=nightly" >> $GITHUB_ENV
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == "refs/heads/bleeding" ]]; then
+            echo "RELEASE=latest" >> $GITHUB_ENV
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "RELEASE=latest" >> $GITHUB_ENV
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          fi
     - name: Install libunwind
       run:  sudo apt-get install libunwind-dev    
     - name: Cache Packages
@@ -69,12 +86,10 @@ jobs:
       id: createpackage
     - name: List output directory
       run: ls -lah out/
-    - name: Update Release
-      uses: IsaacShelton/update-existing-release@v1.3.4
-      with:
-       token: ${{ secrets.GITHUB_TOKEN }}
-       tag: nightly
-       release: nightly
-       prerelease: false
-       replace: true
-       files: ${{ steps.createpackage.outputs.FILES_OUT }}
+    - name: Update Release arm64
+        if: github.repository == 'openframeworks/openframeworks' && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bleeding')
+        uses: softprops/action-gh-release@v2.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.RELEASE }}
+          files: ${{ steps.createpackage.outputs.FILES_OUT }}

--- a/.github/workflows/of.yml
+++ b/.github/workflows/of.yml
@@ -191,7 +191,7 @@ jobs:
       run: ./scripts/ci/$TARGET/build.sh;
 
       env:
-        DEVELOPER_DIR: "/Applications/Xcode_15.4.app/Contents/Developer"
+        DEVELOPER_DIR: "/Applications/Xcode.app/Contents/Developer"
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
@@ -301,8 +301,8 @@ jobs:
           scripts/ci/${{ matrix.cfg.target }}/run_tests.sh;
         fi
       env:
-        DEVELOPER_DIR: "/Applications/Xcode_15.4.app/Contents/Developer"
-        SDKROOT: "/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+        DEVELOPER_DIR: "/Applications/Xcode.app/Contents/Developer"
+        SDKROOT: "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -7,7 +7,8 @@ OVERWRITE=1
 SILENT_ARGS=""
 NO_SSL=""
 BLEEDING_EDGE=0
-DL_VERSION=2.5.0
+DL_VERSION=2.6.0
+TAG=""
 
 printHelp(){
 cat << EOF
@@ -28,6 +29,7 @@ cat << EOF
     -s, --silent                Silent download progress
     -h, --help                  Shows this message
     -k, --no-ssl                Allow no SSL validation
+    -t, --tag                   tag release for libraries
 EOF
 }
 
@@ -43,7 +45,11 @@ download(){
     COMMAND=" "
     REPO="nightly"
     if [[ $BLEEDING_EDGE = 1 ]] ; then
-        REPO="bleeding"
+        REPO="latest"
+    fi
+
+    if [[ $TAG != "" ]] ; then
+        REPO="$TAG"
     fi
 
     for PKG in $1; do
@@ -106,6 +112,10 @@ while [[ $# -gt 0 ]]; do
         ;;
         -m|--msystem)
         MSYSTEM="$2"
+        shift # past argument
+        ;;
+        -t|--tag)
+        TAG="$2"
         shift # past argument
         ;;
         -h|--help)
@@ -193,7 +203,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 if [[ $BLEEDING_EDGE = 1 ]] ; then
-    VER=bleeding
+    VER=latest
+fi
+
+if [[ $TAG != "" ]] ; then
+    VER="$TAG"
 fi
 
 if [ "$PLATFORM" == "linux" ] && [ "$ARCH" == "64" ]; then


### PR DESCRIPTION
## Download Libs - [2.5.0~ 2.6.0] 
- Change for release tag default from bleeding to Latest (for apothecary). 
- Allow to download libs of --tag (or version target for libs i.e v12.1.0, v13.0.0 etc) Allowing locking off of libraries to versions

## GitHub Actions
- Fix Xcode change for install Xcode 16 Nov5th change  https://github.com/actions/runner-images/issues/10703
- Nightly update release to softprops/action gh release.
- Nighty - Add determine release type.
- Nighty -Allow for future night to build for tags (more to do with local scripts for that). (So manually can tag and it will build nighty to say v13.0.0)