### PR TITLE
ofVideoPlayer AVFoundation, setPosition can work with arbitrary frames.

### DIFF
--- a/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
+++ b/libs/openFrameworks/video/ofAVFoundationVideoPlayer.m
@@ -1180,7 +1180,7 @@ static const void *PlayerRateContext = &ItemStatusContext;
 }
 
 - (void)seekToTime:(CMTime)time {
-	[self seekToTime:time withTolerance:kCMTimePositiveInfinity];
+	[self seekToTime:time withTolerance:kCMTimeZero];
 }
 
 - (void)seekToTime:(CMTime)time


### PR DESCRIPTION
by lowering seekToTime tolerance to zero it will force the video frame to be displayed correctly.


Today if I load a video recorded with a camera, lets say Sony alpha 6500 in h264, it makes one keyframe each second. 
if I'm trying to setPosition in an arbitrary position it will only display one frame per second (the keyframe)

with this change we assure it will be positioned in the correct frame even if it takes more cpu cycles to calculate (in the case of random access or backwards access). 
it doesn't change anything for normal play because frame difference will be accumulating.

quick way of testing
```c++
	float pos = ofMap(mouseX, 0, ofGetWindowWidth(), 0, 1);
	video.setPosition(pos);
	video.update();
```