### PR TITLE
download_libs [2.6.1 ~ 2.6.2] Fix issue for latest

### DIFF
--- a/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
+++ b/libs/openFrameworksCompiled/project/vs/openframeworksLib.vcxproj
@@ -95,6 +95,9 @@
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">true</BuildStlModules>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</EnableModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OldStyle</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">OldStyle</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">OldStyle</DebugInformationFormat>
     </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>
@@ -131,6 +134,9 @@
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">true</BuildStlModules>
       <EnableModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</EnableModules>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|x64'">OldStyle</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">OldStyle</DebugInformationFormat>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">OldStyle</DebugInformationFormat>
     </ClCompile>
     <Lib>
       <AdditionalLibraryDirectories>

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -7,7 +7,7 @@ OVERWRITE=1
 SILENT_ARGS=""
 NO_SSL=""
 BLEEDING_EDGE=0
-DL_VERSION=2.6.1
+DL_VERSION=2.6.2
 TAG=""
 
 printHelp(){
@@ -43,10 +43,13 @@ download(){
     # downloader ci.openframeworks.cc/libs/$1 $SILENT_ARGS
 
     COMMAND=" "
-    REPO="nightly"
+    
     if [[ $BLEEDING_EDGE = 1 ]] ; then
         REPO="latest"
+    else
+        REPO="nightly"
     fi
+
 
     if [[ $TAG != "" ]] ; then
         REPO="$TAG"

--- a/scripts/templates/vs/emptyExample.vcxproj
+++ b/scripts/templates/vs/emptyExample.vcxproj
@@ -185,10 +185,12 @@
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|x64'">OldStyle</DebugInformationFormat>
     </ClCompile>
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OldStyle</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64'">
@@ -200,10 +202,12 @@
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">OldStyle</DebugInformationFormat>
     </ClCompile>
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">OldStyle</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Platform)'=='ARM64EC'">
@@ -215,10 +219,12 @@
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64EC'">OldStyle</DebugInformationFormat>
     </ClCompile>
     <ClCompile>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">stdc17</LanguageStandard_C>
       <BuildStlModules Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">true</BuildStlModules>
+      <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Release|ARM64EC'">OldStyle</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix error of download libs nightly instead of latest download

### download_libs [2.6.1 ~ 2.6.2] 

```

  [downloader] [cURL] urls:[https://github.com/openframeworks/apothecary/releases/download/nightly/openFrameworksLibs_latest_macos_1.tar.bz2 -o openFrameworksLibs_latest_macos_1.tar.bz2 https://github.com/openframeworks/apothecary/releases/download/nightly/openFrameworksLibs_latest_macos_2.tar.bz2 -o openFrameworksLibs_latest_macos_2.tar.bz2 https://github.com/openframeworks/apothecary/releases/download/nightly/openFrameworksLibs_latest_macos_3.tar.bz2 -o openFrameworksLibs_latest_macos_3.tar.bz2] args:[--retry-all-errors --remove-on-error -Z  ]

  ```
 https://github.com/openframeworks/apothecary/releases/download/**nightly**/openFrameworksLibs_**latest**_macos_...
 
 mismatch of Tags 
 
  