### PR TITLE
[ifx] remove superfluous ofParameter ctor

### DIFF
--- a/libs/openFrameworks/types/ofParameter.h
+++ b/libs/openFrameworks/types/ofParameter.h
@@ -511,11 +511,6 @@ public:
 	/// \tparam ParameterType the type of the value held by the ofParameter
 	/// \param v the ofParameter to link to it's value
 	ofParameter(const ofParameter<ParameterType> & v);
-
-	/// \brief constructs an ofParameter of type ParameterType initialized to value of same-type v
-	/// \tparam ParameterType the type of the value held by the ofParameter
-	/// \param v the value to initialize to
-	ofParameter(const ParameterType & v);
 	
 	/// \brief constructs an ofParameter of type ParameterType initialized to value of v
 	/// where v is convertible to ParameterType, with an exception for bool which can cause


### PR DESCRIPTION
#8132 introduced a templated constructor for ofParameter, with more precise conversions rules. some init circumstances documented in #8216 reveals that it covers more territory than initially figured, and creates ambiguity between deductions and linker. removing the const & ctor resolves the ambiguity (the templated ctor consumes the case just as well). closes #8216