### PR TITLE
RtAudio / ofRtAudioSoundStream / ofSoundBaseTypes 

### DIFF
--- a/examples/sound/audioOutputExample/src/ofApp.cpp
+++ b/examples/sound/audioOutputExample/src/ofApp.cpp
@@ -45,10 +45,17 @@ void ofApp::setup(){
 	// Latest linux versions default to the HDMI output
 	// this usually fixes that. Also check the list of available
 	// devices if sound doesn't work
+
+	//settings.setApi(ofSoundDevice::MS_ASIO);
+	//settings.setApi(ofSoundDevice::MS_WASAPI);
+	//settings.setApi(ofSoundDevice::MS_DS);
+
 	auto devices = soundStream.getMatchingDevices("default");
 	if(!devices.empty()){
 		settings.setOutDevice(devices[0]);
 	}
+
+
 
 
 	settings.setOutListener(this);

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -140,13 +140,16 @@ bool ofRtAudioSoundStream::setup(const ofSoundStreamSettings & settings_)
 
 	try {
 		if (settings.getApi() != ofSoundDevice::Api::UNSPECIFIED) {
+			ofLog() << "Initialing RtAudio Requested API: " << settings.getApi();
 			audio = std::make_shared<RtAudio>(toRtAudio(settings.getApi()));
 		}else{
+			ofLog() << "Initialing RtAudio with UNSPECIFIED API";
 			audio = std::make_shared<RtAudio>();
 		}
+		ofLog() << "Initialized RtAudio with API: " << RtAudio::getApiName(audio->getCurrentApi());
 	}
 	catch (std::exception &error) {
-		ofLogError() << error.what();
+		ofLogError() << "Failed to initialize RtAudio: " << error.what();
 		return false;
 	}
 

--- a/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofRtAudioSoundStream.cpp
@@ -140,13 +140,13 @@ bool ofRtAudioSoundStream::setup(const ofSoundStreamSettings & settings_)
 
 	try {
 		if (settings.getApi() != ofSoundDevice::Api::UNSPECIFIED) {
-			ofLog() << "Initialing RtAudio Requested API: " << settings.getApi();
+			ofLogNotice() << "Initialing RtAudio Requested API: " << settings.getApi();
 			audio = std::make_shared<RtAudio>(toRtAudio(settings.getApi()));
 		}else{
-			ofLog() << "Initialing RtAudio with UNSPECIFIED API";
+			ofLogNotice() << "Initialing RtAudio with UNSPECIFIED API";
 			audio = std::make_shared<RtAudio>();
 		}
-		ofLog() << "Initialized RtAudio with API: " << RtAudio::getApiName(audio->getCurrentApi());
+		ofLogNotice() << "Initialized RtAudio with API: " << RtAudio::getApiName(audio->getCurrentApi());
 	}
 	catch (std::exception &error) {
 		ofLogError() << "Failed to initialize RtAudio: " << error.what();
@@ -158,6 +158,7 @@ bool ofRtAudioSoundStream::setup(const ofSoundStreamSettings & settings_)
 	if (settings.numInputChannels > 0) {
 		if (!settings.getInDevice()) {
 			ofSoundDevice device;
+			device.api = settings.getApi();
 			device.deviceID = audio->getDefaultInputDevice();
 			settings.setInDevice(device);
 		}
@@ -168,6 +169,7 @@ bool ofRtAudioSoundStream::setup(const ofSoundStreamSettings & settings_)
 	if (settings.numOutputChannels > 0) {
 		if (!settings.getOutDevice()) {
 			ofSoundDevice device;
+			device.api = settings.getApi();
 			device.deviceID = audio->getDefaultOutputDevice();
 			settings.setOutDevice(device);
 		}

--- a/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
+++ b/libs/openFrameworks/sound/ofSoundBaseTypes.cpp
@@ -22,7 +22,7 @@ std::string toString(ofSoundDevice::Api api){
 		case ofSoundDevice::MS_DS:
 			return "MS DirectShow";
 		default:
-			return "Unkown API";
+			return "Unknown API";
 	}
 }
 
@@ -30,10 +30,17 @@ std::string toString(ofSoundDevice::Api api){
 void ofBaseSoundStream::printDeviceList() const {
 	ofLogNotice("ofBaseSoundStream::printDeviceList") << std::endl;
 #ifndef TARGET_EMSCRIPTEN
-	for(int i=ofSoundDevice::ALSA; i<ofSoundDevice::NUM_APIS; ++i){
-		ofSoundDevice::Api api = (ofSoundDevice::Api)i;
+	std::vector<ofSoundDevice::Api> platformApis;
+#ifdef TARGET_LINUX
+	platformApis = { ofSoundDevice::ALSA, ofSoundDevice::PULSE, ofSoundDevice::OSS, ofSoundDevice::JACK };
+#elif defined(TARGET_OSX)
+	platformApis = { ofSoundDevice::OSX_CORE };
+#elif defined(TARGET_WIN32)
+	platformApis = { ofSoundDevice::MS_WASAPI, ofSoundDevice::MS_ASIO, ofSoundDevice::MS_DS };
+#endif
+	for (auto api : platformApis) {
 		auto devices = getDeviceList(api);
-		if(!devices.empty()){
+		if (!devices.empty()) {
 			ofLogNotice("ofBaseSoundStream::printDeviceList") << "Api: " << toString(api);
 			ofLogNotice("ofBaseSoundStream::printDeviceList") << devices;
 		}

--- a/libs/openFrameworks/sound/ofSoundStream.cpp
+++ b/libs/openFrameworks/sound/ofSoundStream.cpp
@@ -66,6 +66,7 @@ bool ofSoundStreamSettings::setInDevice(const ofSoundDevice & device){
 	}
 	api = device.api;
 	inDevice = device;
+	inDevice.api = api;
 	return true;
 }
 
@@ -76,6 +77,7 @@ bool ofSoundStreamSettings::setOutDevice(const ofSoundDevice & device){
 	}
 	api = device.api;
 	outDevice = device;
+	outDevice.api = api;
 	return true;
 }
 
@@ -86,7 +88,7 @@ bool ofSoundStreamSettings::setApi(ofSoundDevice::Api api){
 		return false;
 	}
 	if(api!=ofSoundDevice::UNSPECIFIED && outDevice.deviceID!=-1 && outDevice.api != api){
-		ofLogError("ofSoundStreamSettings") << "Setting API after setting IN device with api: " << toString(outDevice.api) << " won't do anything";
+		ofLogError("ofSoundStreamSettings") << "Setting API after setting OUT device with api: " << toString(outDevice.api) << " won't do anything";
 		return false;
 	}
 	this->api = api;

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -150,11 +150,13 @@ enum ofTargetPlatform{
 	#define GLEW_NO_GLU
     #define TARGET_GLFW_WINDOW
     #define OF_CAIRO
-    #define OF_RTAUDIO
 	#include "GL/glew.h"
 	#include "GL/wglew.h"
+	#define OF_RTAUDIO
 	#define __WINDOWS_DS__
-	#define __WINDOWS_MM__
+	#define __WINDOWS_WASAPI__
+	#define __WINDOWS_ASIO__
+	#define __WINDOWS_MM__ // rtMidi?
 	#if (_MSC_VER)       // microsoft visual studio
 		//TODO: Fix this in the code instead of disabling the warnings
 		#define _CRT_SECURE_NO_WARNINGS
@@ -200,18 +202,15 @@ enum ofTargetPlatform{
 #endif
 
 #if defined(TARGET_OS_OSX) && !defined(TARGET_OF_IOS)
-	#ifndef __MACOSX_CORE__
-		#define __MACOSX_CORE__
-	#endif
     #define TARGET_GLFW_WINDOW
     #define OF_CAIRO
     #define OF_RTAUDIO
-    
+	#ifndef __MACOSX_CORE__
+		#define __MACOSX_CORE__ // rtAudio
+	#endif
 	#ifndef OF_NO_FMOD
 		#define OF_NO_FMOD
 	#endif
-
-    
 	#include "GL/glew.h"
     #include "OpenGL/OpenGL.h"
 
@@ -245,6 +244,9 @@ enum ofTargetPlatform{
 	#else // desktop linux
         #define TARGET_GLFW_WINDOW
         #define OF_RTAUDIO
+		#define __LINUX_PULSE__
+		#define __LINUX_ALSA__
+		#define __LINUX_OSS__
 		#include <GL/glew.h>
 	#endif
 


### PR DESCRIPTION
# RtAudio 6.0.1 - updates / fixes 
Fixes: https://github.com/openframeworks/openFrameworks/issues/8224 for issues with Windows and deeper issues 

## Code changes to:
- ofRtAudioSoundStream - Fix for device api not being set in setup causing reinit or warning / errors
- ofSoundBaseTypes -Fix for ofSoundBaseTypes for printing device list (now apis by platform) and spelling of unknown
- ofSoundStream - api setting explicit 
- ofConstants.h - Missing constants for RTAudio platforms
```
    #define __WINDOWS_DS__
    #define __WINDOWS_MM__
    #define __WINDOWS_WASAPI__
    #define __WINDOWS_ASIO__
```  
```
    #define __LINUX_PULSE__
    #define __LINUX_ALSA__
    #define __LINUX_OSS__
```` 


## Apothecary Updated 
- with RTAudio cmake fixes applied - Build 3
https://github.com/openframeworks/apothecary/pull/464
