### PR TITLE
Fix: ofGetLastFrameTime() always returns 0 (Filtered/System timeMode) Bug

### DIFF
--- a/.github/workflows/of.yml
+++ b/.github/workflows/of.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Docker Step
-        run: "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:3.1.73 bash"
+        run: "docker run -di --name emscripten -v $PWD:/src emscripten/emsdk:3.1.74 bash"
       # - name: Determine Release
       #   id: vars
       #   shell: bash

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -220,11 +220,12 @@ void ofCoreEvents::setFrameRate(int _targetRate) {
 //		timer.setPeriodicEvent(nanosPerFrame);
 		
 		timerFps.setFps(targetRate);
+		fps.setTargetFPS(targetRate);
+		if (timeMode == FixedRate) {
+			ofSetTimeModeFixedRate(ofGetFixedStepForFps(_targetRate));
+		}
 	}
-	fps.setTargetFPS(targetRate);
-	if (timeMode == FixedRate) {
-		ofSetTimeModeFixedRate(ofGetFixedStepForFps(_targetRate));
-	}
+	
 }
 
 bool ofCoreEvents::getTargetFrameRateEnabled() const {

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -48,7 +48,7 @@ double ofGetLastFrameTime() {
 	if (window) {
 		return window->events().getLastFrameTime();
 	} else {
-		return 0.f;
+		return 0.l;
 	}
 }
 
@@ -124,9 +124,9 @@ int ofGetPreviousMouseY() {
 
 ofCoreEvents::ofCoreEvents()
 	: targetRate(60.0f)
-	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60)))
+	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60.0l)))
 	, bFrameRateSet(false)
-	, fps(60)
+	, fps(60.0l)
 	, currentMouseX(0)
 	, currentMouseY(0)
 	, previousMouseX(0)
@@ -184,6 +184,7 @@ void ofCoreEvents::enable() {
 
 void ofCoreEvents::setTimeModeSystem() {
 	timeMode = System;
+	fps.setTimeMode(timeMode);
 }
 
 ofTimeMode ofCoreEvents::getTimeMode() const {
@@ -193,11 +194,13 @@ ofTimeMode ofCoreEvents::getTimeMode() const {
 void ofCoreEvents::setTimeModeFixedRate(uint64_t nanosecsPerFrame) {
 	timeMode = FixedRate;
 	fixedRateTimeNanos = std::chrono::nanoseconds(nanosecsPerFrame);
+	fps.setTimeMode(timeMode);
 }
 
 void ofCoreEvents::setTimeModeFiltered(float alpha) {
 	timeMode = Filtered;
 	fps.setFilterAlpha(alpha);
+	fps.setTimeMode(timeMode);
 }
 
 //--------------------------------------
@@ -217,6 +220,10 @@ void ofCoreEvents::setFrameRate(int _targetRate) {
 //		timer.setPeriodicEvent(nanosPerFrame);
 		
 		timerFps.setFps(targetRate);
+	}
+	fps.setTargetFPS(targetRate);
+	if (timeMode == FixedRate) {
+		ofSetTimeModeFixedRate(ofGetFixedStepForFps(_targetRate));
 	}
 }
 
@@ -303,7 +310,7 @@ bool ofCoreEvents::notifyUpdate() {
 //------------------------------------------
 bool ofCoreEvents::notifyDraw() {
 	if (fps.getNumFrames() == 0) {
-		if (bFrameRateSet) fps = ofFpsCounter(targetRate);
+		if (bFrameRateSet) fps = ofFpsCounter(targetRate, timeMode);
 	} else {
 		/*if(ofIsVerticalSyncEnabled()){
 			float rate = ofGetRefreshRate();

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -123,7 +123,7 @@ int ofGetPreviousMouseY() {
 }
 
 ofCoreEvents::ofCoreEvents()
-	: targetRate(60.0f)
+	: targetRate(60.0)
 	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60.0)))
 	, bFrameRateSet(false)
 	, fps(60.0)
@@ -214,15 +214,15 @@ void ofCoreEvents::setFrameRate(int _targetRate) {
 		bFrameRateSet = false;
 	} else {
 		bFrameRateSet = true;
-		targetRate = _targetRate;
+		targetRate = static_cast<float>(_targetRate);
 		
 //		uint64_t nanosPerFrame = 1000000000.0 / (double)targetRate;
 //		timer.setPeriodicEvent(nanosPerFrame);
 		
-		timerFps.setFps(static_cast<int>(targetRate));
-		fps.setTargetFPS(static_cast<double>(targetRate));
+		timerFps.setFps(_targetRate);
+		fps.setTargetFPS(targetRate);
 		if (timeMode == FixedRate) {
-			ofSetTimeModeFixedRate(ofGetFixedStepForFps(static_cast<double>(_targetRate)));
+			ofSetTimeModeFixedRate(ofGetFixedStepForFps(targetRate));
 		}
 	}
 	
@@ -311,7 +311,7 @@ bool ofCoreEvents::notifyUpdate() {
 //------------------------------------------
 bool ofCoreEvents::notifyDraw() {
 	if (fps.getNumFrames() == 0) {
-		if (bFrameRateSet) fps = ofFpsCounter(static_cast<double>(targetRate), timeMode);
+		if (bFrameRateSet) fps = ofFpsCounter(targetRate, timeMode);
 	} else {
 		/*if(ofIsVerticalSyncEnabled()){
 			float rate = ofGetRefreshRate();

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -123,7 +123,8 @@ int ofGetPreviousMouseY() {
 }
 
 ofCoreEvents::ofCoreEvents()
-	: targetRate(0)
+	: targetRate(60.0f)
+	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60)))
 	, bFrameRateSet(false)
 	, fps(60)
 	, currentMouseX(0)
@@ -301,13 +302,6 @@ bool ofCoreEvents::notifyUpdate() {
 
 //------------------------------------------
 bool ofCoreEvents::notifyDraw() {
-	auto attended = ofNotifyEvent(draw, voidEventArgs);
-
-	if (bFrameRateSet) {
-//		timer.waitNext();
-		timerFps.waitNext();
-	}
-
 	if (fps.getNumFrames() == 0) {
 		if (bFrameRateSet) fps = ofFpsCounter(targetRate);
 	} else {
@@ -318,7 +312,12 @@ bool ofCoreEvents::notifyDraw() {
 			lastFrameTime = intervals*1000000/rate;
 		}*/
 	}
+	if (bFrameRateSet) {
+//		timer.waitNext();
+		timerFps.waitNext();
+	}
 	fps.newFrame();
+	auto attended = ofNotifyEvent(draw, voidEventArgs);
 	return attended;
 }
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -219,10 +219,10 @@ void ofCoreEvents::setFrameRate(int _targetRate) {
 //		uint64_t nanosPerFrame = 1000000000.0 / (double)targetRate;
 //		timer.setPeriodicEvent(nanosPerFrame);
 		
-		timerFps.setFps(targetRate);
-		fps.setTargetFPS(targetRate);
+		timerFps.setFps(static_cast<int>(targetRate));
+		fps.setTargetFPS(static_cast<double>(targetRate));
 		if (timeMode == FixedRate) {
-			ofSetTimeModeFixedRate(ofGetFixedStepForFps(_targetRate));
+			ofSetTimeModeFixedRate(ofGetFixedStepForFps(static_cast<double>(_targetRate)));
 		}
 	}
 	
@@ -311,7 +311,7 @@ bool ofCoreEvents::notifyUpdate() {
 //------------------------------------------
 bool ofCoreEvents::notifyDraw() {
 	if (fps.getNumFrames() == 0) {
-		if (bFrameRateSet) fps = ofFpsCounter(targetRate, timeMode);
+		if (bFrameRateSet) fps = ofFpsCounter(static_cast<double>(targetRate), timeMode);
 	} else {
 		/*if(ofIsVerticalSyncEnabled()){
 			float rate = ofGetRefreshRate();

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -48,7 +48,7 @@ double ofGetLastFrameTime() {
 	if (window) {
 		return window->events().getLastFrameTime();
 	} else {
-		return 0.l;
+		return 0.0;
 	}
 }
 

--- a/libs/openFrameworks/events/ofEvents.cpp
+++ b/libs/openFrameworks/events/ofEvents.cpp
@@ -124,9 +124,9 @@ int ofGetPreviousMouseY() {
 
 ofCoreEvents::ofCoreEvents()
 	: targetRate(60.0f)
-	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60.0l)))
+	, fixedRateTimeNanos(std::chrono::nanoseconds(ofGetFixedStepForFps(60.0)))
 	, bFrameRateSet(false)
-	, fps(60.0l)
+	, fps(60.0)
 	, currentMouseX(0)
 	, currentMouseY(0)
 	, previousMouseX(0)

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -406,7 +406,7 @@ public:
 	bool notifyDragEvent(ofDragInfo info);
 
 private:
-	float targetRate;
+	float targetRate = 60.0f;
 	bool bFrameRateSet;
 	ofTimerFps timerFps;
 //	ofTimer timer;

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -420,7 +420,7 @@ private:
 	int modifiers = 0;
 
 	enum TimeMode {
-		System,
+		System = 0,
 		FixedRate,
 		Filtered,
 	} timeMode

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -244,8 +244,12 @@ enum ofTargetPlatform{
 	#else // desktop linux
         #define TARGET_GLFW_WINDOW
         #define OF_RTAUDIO
-		#define __LINUX_PULSE__
-		#define __LINUX_ALSA__
+		#ifndef __LINUX_PULSE__
+			#define __LINUX_PULSE__
+		#endif
+		#ifndef __LINUX_ALSA__
+			#define __LINUX_ALSA__
+		#endif
 		#define __LINUX_OSS__
 		#include <GL/glew.h>
 	#endif

--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -29,7 +29,7 @@ void ofFpsCounter::newFrame(){
 	// std::lerp from c++20 on
 	if (timeMode == 2) { // Filtered
 		filterAlpha = std::clamp(filterAlpha, 0.0, 1.0);
-		filteredTime = filteredTime * filterAlpha + getLastFrameSecs() * (1.0l - filterAlpha);
+		filteredTime = filteredTime * filterAlpha + getLastFrameSecs() * (1.0 - filterAlpha);
 		filteredTime = std::clamp(filteredTime, 0.0, 1.0 / targetFPS);
 	}
 	then = now;
@@ -50,7 +50,7 @@ void ofFpsCounter::update(time_point<steady_clock> now){
 		return;
 	}
 	diff = now - timestamps.front();		
-	if (std::chrono::duration<double>(diff).count() > 0.0) {
+	if (diff > std::chrono::duration<double>(0)) {
 		fps = static_cast<double>(timestamps.size()) / std::chrono::duration<double>(diff).count();
 	} else {
 		fps = timestamps.size();

--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -3,33 +3,45 @@
 using namespace std::chrono;
 
 ofFpsCounter::ofFpsCounter()
-	: fps(60)
+	: fps(0)
 	, targetFPS(60)
-	, lastFrameTime(0)
-	, diff(0)
+	, lastFrameTime(std::chrono::duration<long long, std::nano>(0))
+	, diff(std::chrono::duration<long long, std::nano>(0))
 	, nFrameCount(0)
 	, then(std::chrono::steady_clock::now())
-	, filteredTime(0)
-	, filterAlpha(0.9) { }
+	, filteredTime(0.0l)
+	, filterAlpha(0.9l)
+	, timeMode(0) {
+	timestamps.clear();
+	timestamps.resize(fps);
 
-ofFpsCounter::ofFpsCounter(double targetFPS)
-	: fps(targetFPS)
+	}
+
+ofFpsCounter::ofFpsCounter(double targetFPS, int mode)
+	: fps(0)
 	, targetFPS(targetFPS)
-	, lastFrameTime(0)
-	, diff(0)
+	, lastFrameTime(std::chrono::duration<long long, std::nano>(0))
+	, diff(std::chrono::duration<long long, std::nano>(0))
 	, nFrameCount(0)
 	, then(std::chrono::steady_clock::now())
-	, filteredTime(0)
-	, filterAlpha(0.9) { }
+	, filteredTime(0.0l)
+	, filterAlpha(0.9l)
+	, timeMode(mode) {
+		timestamps.clear();
+		timestamps.resize(fps);
+	}
 
 void ofFpsCounter::newFrame(){
 	now = steady_clock::now();
-	update(now);
-	timestamps.push(now);
+	timestamps.push_back(now);
 	lastFrameTime = now - then;
-
+	update(now);	
 	// std::lerp from c++20 on
-	filteredTime = filteredTime * filterAlpha + getLastFrameSecs() * (1-filterAlpha);
+	if (timeMode == 2) { // Filtered
+		filterAlpha = std::clamp(filterAlpha, 0.0, 1.0);
+		filteredTime = filteredTime * filterAlpha + getLastFrameSecs() * (1.0l - filterAlpha);
+		filteredTime = std::clamp(filteredTime, 0.0, 1.0 / targetFPS);
+	}
 	then = now;
 	nFrameCount++;
 }
@@ -41,18 +53,19 @@ void ofFpsCounter::update(){
 
 void ofFpsCounter::update(time_point<steady_clock> now){
 	while(!timestamps.empty() && timestamps.front() + 2s < now){
-		timestamps.pop();
+		timestamps.pop_front();
 	}
-
-	space diff;
-	if(!timestamps.empty() && timestamps.front() + 0.5s < now){
-		diff = now - timestamps.front();
+	if (timestamps.size() < 2) {
+		fps = targetFPS; // if no sample size then set fps to target until can sample
+		return;
 	}
-	if(diff > 0.0s){
-		fps = (double)timestamps.size() / std::chrono::duration<double>(diff).count();
-	}else{
+	diff = now - timestamps.front();		
+	if (diff > 0.0s) {
+		fps = static_cast<double>(timestamps.size()) / std::chrono::duration<double>(diff).count();
+	} else {
 		fps = timestamps.size();
 	}
+	
 }
 
 double ofFpsCounter::getFps() const{
@@ -68,7 +81,7 @@ uint64_t ofFpsCounter::getLastFrameNanos() const{
 }
 
 double ofFpsCounter::getLastFrameSecs() const{
-	return duration_cast<seconds>(lastFrameTime).count();
+	return std::chrono::duration<double>(lastFrameTime).count();
 }
 
 uint64_t ofFpsCounter::getLastFrameFilteredNanos() const{
@@ -76,9 +89,20 @@ uint64_t ofFpsCounter::getLastFrameFilteredNanos() const{
 }
 
 double ofFpsCounter::getLastFrameFilteredSecs() const{
-	return filteredTime;
+	return std::chrono::duration<double>(filteredTime).count();
 }
 
 void ofFpsCounter::setFilterAlpha(float alpha){
 	filterAlpha = alpha;
+}
+
+void ofFpsCounter::setTimeMode(int mode) {
+	timeMode = mode;
+}
+
+void ofFpsCounter::setTargetFPS(double fps) {
+	targetFPS = fps;
+	if (fps > timestamps.max_size()) {
+		timestamps.resize(fps);
+	}
 }

--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -1,9 +1,26 @@
 #include "ofFpsCounter.h"
+#include <ofUtils.h>
 using namespace std::chrono;
 
-ofFpsCounter::ofFpsCounter() {}
+ofFpsCounter::ofFpsCounter()
+	: fps(60)
+	, targetFPS(60)
+	, lastFrameTime(0)
+	, diff(0)
+	, nFrameCount(0)
+	, then(std::chrono::steady_clock::now())
+	, filteredTime(0)
+	, filterAlpha(0.9) { }
 
-ofFpsCounter::ofFpsCounter(double targetFPS) : fps(targetFPS) {}
+ofFpsCounter::ofFpsCounter(double targetFPS)
+	: fps(targetFPS)
+	, targetFPS(targetFPS)
+	, lastFrameTime(0)
+	, diff(0)
+	, nFrameCount(0)
+	, then(std::chrono::steady_clock::now())
+	, filteredTime(0)
+	, filterAlpha(0.9) { }
 
 void ofFpsCounter::newFrame(){
 	now = steady_clock::now();

--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -50,7 +50,7 @@ void ofFpsCounter::update(time_point<steady_clock> now){
 		return;
 	}
 	diff = now - timestamps.front();		
-	if (diff > 0.0s) {
+	if (std::chrono::duration<double>(diff).count() > 0.0) {
 		fps = static_cast<double>(timestamps.size()) / std::chrono::duration<double>(diff).count();
 	} else {
 		fps = timestamps.size();

--- a/libs/openFrameworks/utils/ofFpsCounter.cpp
+++ b/libs/openFrameworks/utils/ofFpsCounter.cpp
@@ -3,32 +3,22 @@
 using namespace std::chrono;
 
 ofFpsCounter::ofFpsCounter()
-	: fps(0)
-	, targetFPS(60)
-	, lastFrameTime(std::chrono::duration<long long, std::nano>(0))
+	: lastFrameTime(std::chrono::duration<long long, std::nano>(0))
 	, diff(std::chrono::duration<long long, std::nano>(0))
-	, nFrameCount(0)
 	, then(std::chrono::steady_clock::now())
-	, filteredTime(0.0l)
-	, filterAlpha(0.9l)
 	, timeMode(0) {
-	timestamps.clear();
-	timestamps.resize(fps);
-
+		timestamps.clear();
+		timestamps.resize(targetFPS + 7);
 	}
 
 ofFpsCounter::ofFpsCounter(double targetFPS, int mode)
-	: fps(0)
-	, targetFPS(targetFPS)
+	: targetFPS(targetFPS)
 	, lastFrameTime(std::chrono::duration<long long, std::nano>(0))
 	, diff(std::chrono::duration<long long, std::nano>(0))
-	, nFrameCount(0)
 	, then(std::chrono::steady_clock::now())
-	, filteredTime(0.0l)
-	, filterAlpha(0.9l)
 	, timeMode(mode) {
 		timestamps.clear();
-		timestamps.resize(fps);
+		timestamps.resize(targetFPS + 7);
 	}
 
 void ofFpsCounter::newFrame(){

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <queue>
+#include <deque>
 #include <chrono>
 
 class ofFpsCounter {
 public:
 	ofFpsCounter();
-	ofFpsCounter(double targetFps);
+	ofFpsCounter(double targetFps, int mode = 0);
 	void newFrame();
 
 	// no need to call it usually, useful if
@@ -22,6 +22,8 @@ public:
 	uint64_t getLastFrameFilteredNanos() const;
 	double getLastFrameFilteredSecs() const;
 	void setFilterAlpha(float alpha);
+	void setTimeMode(int mode);
+	void setTargetFPS(double fps);
 
 private:
 	void update(std::chrono::time_point<std::chrono::steady_clock> now);
@@ -36,5 +38,6 @@ private:
 	space diff;
 	double filteredTime = 0;
 	double filterAlpha = 0.9;
-	std::queue<std::chrono::time_point<std::chrono::steady_clock>> timestamps;
+	std::deque<std::chrono::time_point<std::chrono::steady_clock>> timestamps;
+	int timeMode;
 };

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -28,7 +28,7 @@ public:
 private:
 	void update(std::chrono::time_point<std::chrono::steady_clock> now);
 	uint64_t nFrameCount = 0;
-	double fps = 60;
+	double fps = 0;
 	double targetFPS = 60;
 
 	using space = std::chrono::duration<long long, std::nano>;
@@ -36,8 +36,8 @@ private:
 	std::chrono::time_point<std::chrono::steady_clock> then = std::chrono::steady_clock::now();
 	space lastFrameTime;
 	space diff;
-	double filteredTime = 0;
-	double filterAlpha = 0.9;
+	double filteredTime = 0.0l;
+	double filterAlpha = 0.9l;
 	std::deque<std::chrono::time_point<std::chrono::steady_clock>> timestamps;
-	int timeMode;
+	int timeMode = 0;
 };

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -26,12 +26,14 @@ public:
 private:
 	void update(std::chrono::time_point<std::chrono::steady_clock> now);
 	uint64_t nFrameCount = 0;
-	double fps = 0;
+	double fps = 60;
+	double targetFPS = 60;
 
 	using space = std::chrono::duration<long long, std::nano>;
 	std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
 	std::chrono::time_point<std::chrono::steady_clock> then = std::chrono::steady_clock::now();
 	space lastFrameTime;
+	space diff;
 	double filteredTime = 0;
 	double filterAlpha = 0.9;
 	std::queue<std::chrono::time_point<std::chrono::steady_clock>> timestamps;

--- a/libs/openFrameworks/utils/ofFpsCounter.h
+++ b/libs/openFrameworks/utils/ofFpsCounter.h
@@ -28,16 +28,16 @@ public:
 private:
 	void update(std::chrono::time_point<std::chrono::steady_clock> now);
 	uint64_t nFrameCount = 0;
-	double fps = 0;
-	double targetFPS = 60;
+	double fps = 0.0;
+	double targetFPS = 60.0;
 
 	using space = std::chrono::duration<long long, std::nano>;
 	std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
 	std::chrono::time_point<std::chrono::steady_clock> then = std::chrono::steady_clock::now();
 	space lastFrameTime;
 	space diff;
-	double filteredTime = 0.0l;
-	double filterAlpha = 0.9l;
+	double filteredTime = 0.0;
+	double filterAlpha = 0.9;
 	std::deque<std::chrono::time_point<std::chrono::steady_clock>> timestamps;
 	int timeMode = 0;
 };

--- a/libs/openFrameworks/utils/ofTimerFps.cpp
+++ b/libs/openFrameworks/utils/ofTimerFps.cpp
@@ -7,9 +7,8 @@ void ofTimerFps::reset() {
    wakeTime = steady_clock::now();
 }
 
-ofTimerFps::ofTimerFps()
-	: currentFPS(60),
-	interval(duration_cast<microseconds>(1s) / currentFPS) {
+ofTimerFps::ofTimerFps() :
+	interval(duration_cast<microseconds>(1s) / currentFPS){
 	reset();
 };
 

--- a/libs/openFrameworks/utils/ofTimerFps.cpp
+++ b/libs/openFrameworks/utils/ofTimerFps.cpp
@@ -7,9 +7,9 @@ void ofTimerFps::reset() {
    wakeTime = steady_clock::now();
 }
 
-ofTimerFps::ofTimerFps() :
-	interval(duration_cast<microseconds>(1s) / currentFPS){
+ofTimerFps::ofTimerFps() {
 	reset();
+	interval = duration_cast<microseconds>(1s) / currentFPS;
 };
 
 void ofTimerFps::setFps(int fps) {

--- a/libs/openFrameworks/utils/ofTimerFps.cpp
+++ b/libs/openFrameworks/utils/ofTimerFps.cpp
@@ -7,13 +7,16 @@ void ofTimerFps::reset() {
    wakeTime = steady_clock::now();
 }
 
-ofTimerFps::ofTimerFps(){
+ofTimerFps::ofTimerFps()
+	: currentFPS(60),
+	interval(duration_cast<microseconds>(1s) / currentFPS) {
 	reset();
 };
 
 void ofTimerFps::setFps(int fps) {
 //	interval = std::ratio<1s, fps>;
-   interval = duration_cast<microseconds>(1s) / fps;
+	currentFPS = fps;
+	interval = duration_cast<microseconds>(1s) / fps;
 }
 
 void ofTimerFps::waitNext() {

--- a/libs/openFrameworks/utils/ofTimerFps.cpp
+++ b/libs/openFrameworks/utils/ofTimerFps.cpp
@@ -15,8 +15,12 @@ ofTimerFps::ofTimerFps()
 
 void ofTimerFps::setFps(int fps) {
 //	interval = std::ratio<1s, fps>;
+	if (fps <= 0) {
+		fps = 60; // fallback
+	}
 	currentFPS = fps;
-	interval = duration_cast<microseconds>(1s) / fps;
+
+	interval = duration_cast<microseconds>(1s) / currentFPS;
 }
 
 void ofTimerFps::waitNext() {

--- a/libs/openFrameworks/utils/ofTimerFps.h
+++ b/libs/openFrameworks/utils/ofTimerFps.h
@@ -18,6 +18,6 @@ public:
 	space interval;
 	std::chrono::time_point<std::chrono::steady_clock> wakeTime;
 	std::chrono::time_point<std::chrono::steady_clock> lastWakeTime;
-	int currentFPS;
+	int currentFPS = 60;
 	
 };

--- a/libs/openFrameworks/utils/ofTimerFps.h
+++ b/libs/openFrameworks/utils/ofTimerFps.h
@@ -18,5 +18,6 @@ public:
 	space interval;
 	std::chrono::time_point<std::chrono::steady_clock> wakeTime;
 	std::chrono::time_point<std::chrono::steady_clock> lastWakeTime;
+	int currentFPS;
 	
 };

--- a/scripts/ci/emscripten/build.sh
+++ b/scripts/ci/emscripten/build.sh
@@ -14,34 +14,10 @@ cd $ROOT
 #echo "PLATFORM_CFLAGS += $CUSTOMFLAGS" >> libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
 sed -i "s/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = .*/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = -g0/" libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
 cd libs/openFrameworksCompiled/project
-emmake make -j Debug
+EMCC_DEBUG=1 emmake make -j Debug
 
 echo "**** Building emptyExample ****"
 cd $ROOT/scripts/templates/linux64
-emmake make -j Debug
+EMCC_DEBUG=1 emmake make -j Debug
 
-echo "**** Building allAddonsExample ****"
-cd $ROOT
-cp scripts/templates/linux64/Makefile examples/templates/allAddonsExample/
-cp scripts/templates/linux64/config.make examples/templates/allAddonsExample/
-cd examples/templates/allAddonsExample/
-sed -i s/ofxOsc// addons.make
-sed -i s/ofxNetwork// addons.make
-sed -i s/ofxKinect// addons.make
-sed -i s/ofxThreadedImageLoader// addons.make
-sed -i s/ofxPoco// addons.make
-
-sed -i "s/#include \"ofxOsc.h\"//" src/ofApp.h
-sed -i "s/#include \"ofxNetwork.h\"//" src/ofApp.h
-sed -i "s/#include \"ofxKinect.h\"//" src/ofApp.h
-sed -i "s/#include \"ofxThreadedImageLoader.h\"//" src/ofApp.h
-sed -i "s/#include \"ofxXmlPoco.h\"//" src/ofApp.h
-
-sed -i "s/ofxTCPClient client;//" src/ofApp.h
-sed -i "s/ofxTCPServer server;//" src/ofApp.h
-sed -i "s/ofxOscSender osc_sender;//" src/ofApp.h
-sed -i "s/ofxKinect kinect;//" src/ofApp.h
-sed -i "s/ofxThreadedImageLoader .*;//" src/ofApp.h
-sed -i "s/ofxXmlPoco .*;//" src/ofApp.h
-
-emmake make -j Debug
+echo "**** Building default template complete ****"

--- a/scripts/ci/emscripten/build_addons.sh
+++ b/scripts/ci/emscripten/build_addons.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ev
+ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../../.." ; pwd -P )"}
+
+echo "**** Building OF core ****"
+cd $ROOT
+# this carries over to subsequent compilations of examples
+#echo "PLATFORM_CFLAGS += $CUSTOMFLAGS" >> libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+sed -i "s/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = .*/PLATFORM_OPTIMIZATION_CFLAGS_DEBUG = -g0/" libs/openFrameworksCompiled/project/emscripten/config.emscripten.default.mk
+cd libs/openFrameworksCompiled/project
+EMCC_DEBUG=1 emmake make -j Debug
+
+echo "**** Building allAddonsExample ****"
+cd $ROOT
+cp scripts/templates/linux64/Makefile examples/templates/allAddonsExample/
+cp scripts/templates/linux64/config.make examples/templates/allAddonsExample/
+cd examples/templates/allAddonsExample/
+sed -i s/ofxOsc// addons.make
+sed -i s/ofxNetwork// addons.make
+sed -i s/ofxKinect// addons.make
+sed -i s/ofxThreadedImageLoader// addons.make
+sed -i s/ofxPoco// addons.make
+
+sed -i "s/#include \"ofxOsc.h\"//" src/ofApp.h
+sed -i "s/#include \"ofxNetwork.h\"//" src/ofApp.h
+sed -i "s/#include \"ofxKinect.h\"//" src/ofApp.h
+sed -i "s/#include \"ofxThreadedImageLoader.h\"//" src/ofApp.h
+sed -i "s/#include \"ofxXmlPoco.h\"//" src/ofApp.h
+
+sed -i "s/ofxTCPClient client;//" src/ofApp.h
+sed -i "s/ofxTCPServer server;//" src/ofApp.h
+sed -i "s/ofxOscSender osc_sender;//" src/ofApp.h
+sed -i "s/ofxKinect kinect;//" src/ofApp.h
+sed -i "s/ofxThreadedImageLoader .*;//" src/ofApp.h
+sed -i "s/ofxXmlPoco .*;//" src/ofApp.h
+
+EMCC_DEBUG=1 emmake make -j Debug

--- a/scripts/ci/linux64/build.sh
+++ b/scripts/ci/linux64/build.sh
@@ -5,7 +5,7 @@ ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../../.." ; pwd -P )"}
 # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56746#c7
 # the "proper" way does not work currently:
 #export CXXFLAGS="$(CXXFLAGS) --param ftrack-macro-expansion=0"
-CUSTOMFLAGS="-ftrack-macro-expansion=0 -fpic" #-fsanitize=undefined,float-divide-by-zero -fno-omit-frame-pointer
+CUSTOMFLAGS="-ftrack-macro-expansion=0 -fpic"
 
 if [ "$OPT" == "qbs" ]; then
     echo "building with qbs"

--- a/scripts/ci/linux64/build.sh
+++ b/scripts/ci/linux64/build.sh
@@ -5,7 +5,7 @@ ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../../.." ; pwd -P )"}
 # see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56746#c7
 # the "proper" way does not work currently:
 #export CXXFLAGS="$(CXXFLAGS) --param ftrack-macro-expansion=0"
-CUSTOMFLAGS="-ftrack-macro-expansion=0 -fpic"
+CUSTOMFLAGS="-ftrack-macro-expansion=0 -fpic" #-fsanitize=undefined,float-divide-by-zero -fno-omit-frame-pointer
 
 if [ "$OPT" == "qbs" ]; then
     echo "building with qbs"

--- a/scripts/ci/linux64/run_tests.sh
+++ b/scripts/ci/linux64/run_tests.sh
@@ -16,13 +16,22 @@ for group in *; do
 				cd $test
 				cp ../../../scripts/templates/linux/Makefile .
 				cp ../../../scripts/templates/linux/config.make .
+				sleep 1 
 				make -j2 Debug
+				sleep 1 
 				cd bin
 				binname=$(basename ${test})
-				#gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug
-				./${binname}_debug
+				
+				if [[ -f ./${binname}_debug ]]; then
+					gdb -batch -ex "run" -ex "bt" -ex "q \$_exitcode" ./${binname}_debug
+					#./${binname}_debug
+				else
+					echo "Binary not found: ${binname}_debug"
+					exit 1
+				fi
 				errorcode=$?
 				if [[ $errorcode -ne 0 ]]; then
+					echo "Test failed: ${binname}_debug with error code: $errorcode"
 					exit $errorcode
 				fi
 				cd $ROOT/tests

--- a/scripts/ci/linux64/run_tests.sh
+++ b/scripts/ci/linux64/run_tests.sh
@@ -16,9 +16,9 @@ for group in *; do
 				cd $test
 				cp ../../../scripts/templates/linux/Makefile .
 				cp ../../../scripts/templates/linux/config.make .
-				sleep 1 
+				sleep 0.3 
 				make -j2 Debug
-				sleep 1 
+				sleep 0.3 
 				cd bin
 				binname=$(basename ${test})
 				


### PR DESCRIPTION
Fixes: https://github.com/openframeworks/openFrameworks/issues/8238

## Changes:
### ofFPSCounter 
- fixed default values
- fixed ofGetLastFrameTimeSecs() to return double duration as to spec 
- fixed ofGetLastFrameFilteredTimeSecs()  to return double duration as to spec 
- fixed timestamp calculation for < 2
- fixed filteredTime calculation with clamps for anomalies 
- fixed filteredTime calculation to only occur with timeMode FilteredTime
- passing timeMode as int in ctor / setter added
- queue to deque (for size optimisation)
- allowed for FPS change with functions added


### ofEvents
- fixed setting of ofFPSCounter and timeMode 
- fixed changing of FPS not changing fps counter