### PR TITLE
Fix: [macOS] OF nightly minimum system requirement >13

### DIFF
--- a/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
+++ b/addons/ofxiOS/src/video/AVFoundationVideoGrabber.mm
@@ -53,15 +53,23 @@
 }
 
 - (BOOL)initCapture:(int)framerate capWidth:(int)w capHeight:(int)h{
-    AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-        AVCaptureDeviceTypeBuiltInWideAngleCamera,
-        AVCaptureDeviceTypeBuiltInTelephotoCamera,
-        AVCaptureDeviceTypeBuiltInUltraWideCamera,
-        AVCaptureDeviceTypeBuiltInDualCamera,
-        AVCaptureDeviceTypeBuiltInDualWideCamera,
-        AVCaptureDeviceTypeBuiltInTripleCamera,
-        AVCaptureDeviceTypeExternal
-    ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+
+	NSMutableArray *deviceTypes = [NSMutableArray arrayWithObjects:AVCaptureDeviceTypeBuiltInWideAngleCamera,
+	AVCaptureDeviceTypeBuiltInTelephotoCamera,
+	AVCaptureDeviceTypeBuiltInUltraWideCamera,
+	AVCaptureDeviceTypeBuiltInDualCamera,
+	AVCaptureDeviceTypeBuiltInDualWideCamera,
+	AVCaptureDeviceTypeBuiltInTripleCamera,
+	AVCaptureDeviceTypeBuiltInTrueDepthCamera, nil];
+	if (@available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, *)) {
+		if (&AVCaptureDeviceTypeContinuityCamera != nil) {
+			[deviceTypes addObject:AVCaptureDeviceTypeContinuityCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeBuiltInTrueDepthCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeExternal];
+		}
+	}
+    AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:deviceTypes mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 
     NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
 	if([devices count] > 0) {
@@ -251,28 +259,26 @@
 -(std::vector <std::string>)listDevices{
     std::vector <std::string> deviceNames;
     NSArray<AVCaptureDevice *> *devices;
-    if (@available(iOS 17.0, *)) {
-        AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-            AVCaptureDeviceTypeBuiltInWideAngleCamera,
-            AVCaptureDeviceTypeBuiltInTelephotoCamera,
-            AVCaptureDeviceTypeBuiltInUltraWideCamera,
-            AVCaptureDeviceTypeBuiltInDualCamera,
-            AVCaptureDeviceTypeBuiltInDualWideCamera,
-            AVCaptureDeviceTypeBuiltInTripleCamera,
-            AVCaptureDeviceTypeExternal
-        ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-        devices = session.devices;
-    } else {
-        AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-            AVCaptureDeviceTypeBuiltInWideAngleCamera,
-            AVCaptureDeviceTypeBuiltInTelephotoCamera,
-            AVCaptureDeviceTypeBuiltInUltraWideCamera,
-            AVCaptureDeviceTypeBuiltInDualCamera,
-            AVCaptureDeviceTypeBuiltInDualWideCamera,
-            AVCaptureDeviceTypeBuiltInTripleCamera,
-        ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-        devices = session.devices;
-    }
+	
+	NSMutableArray *deviceTypes = [NSMutableArray arrayWithObjects:AVCaptureDeviceTypeBuiltInWideAngleCamera,
+	AVCaptureDeviceTypeBuiltInTelephotoCamera,
+	AVCaptureDeviceTypeBuiltInUltraWideCamera,
+	AVCaptureDeviceTypeBuiltInDualCamera,
+	AVCaptureDeviceTypeBuiltInDualWideCamera,
+	AVCaptureDeviceTypeBuiltInTripleCamera,
+	AVCaptureDeviceTypeBuiltInTrueDepthCamera,
+							   nil
+	];
+	if (@available(iOS 17.0, macCatalyst 17.0, tvOS 17.0, *)) {
+		if (&AVCaptureDeviceTypeContinuityCamera != nil) {
+			[deviceTypes addObject:AVCaptureDeviceTypeContinuityCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeBuiltInLiDARDepthCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeBuiltInTrueDepthCamera];
+			[deviceTypes addObject:AVCaptureDeviceTypeExternal];
+		}
+	}
+	AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:deviceTypes mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+        devices = discoverySession.devices;
 	int i=0;
 	for (AVCaptureDevice * captureDevice in devices){
         deviceNames.push_back([captureDevice.localizedName UTF8String]);
@@ -320,8 +326,8 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 				// Create a CGImageRef from the CVImageBufferRef
 				CGColorSpaceRef colorSpace	= CGColorSpaceCreateDeviceRGB(); 
 				
-				CGContextRef newContext		= CGBitmapContextCreate(baseAddress, widthIn, heightIn, 8, bytesPerRow, colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst);
-				CGImageRef newImage			= CGBitmapContextCreateImage(newContext); 
+				CGContextRef newContext		= CGBitmapContextCreate(baseAddress, widthIn, heightIn, 8, bytesPerRow, colorSpace, (CGBitmapInfo)kCGBitmapByteOrder32Little | (CGBitmapInfo)kCGImageAlphaPremultipliedFirst);
+				CGImageRef newImage			= CGBitmapContextCreateImage(newContext);
 
 				CGImageRelease(currentFrame);	
 				currentFrame = CGImageCreateCopy(newImage);		

--- a/libs/openFrameworks/video/ofAVFoundationGrabber.mm
+++ b/libs/openFrameworks/video/ofAVFoundationGrabber.mm
@@ -38,33 +38,29 @@
 - (BOOL)initCapture:(int)framerate capWidth:(int)w capHeight:(int)h{
 	NSArray * devices;
 	if (@available(macOS 10.15, *)) {
-        if (@available(macOS 14.0, *)) {
-            AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-                AVCaptureDeviceTypeBuiltInWideAngleCamera,
-                AVCaptureDeviceTypeExternal
-            ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-            devices = [session devices];
-        } else {
-            AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
-                discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera]
-                mediaType:AVMediaTypeVideo
-                position:AVCaptureDevicePositionUnspecified];
-            devices = [session devices];
-        }
+		NSMutableArray *deviceTypes = [NSMutableArray arrayWithObject:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+		if (@available(macOS 14.0, *)) {
+			if (&AVCaptureDeviceTypeExternal != nil) {
+				[deviceTypes addObject:AVCaptureDeviceTypeExternal];
+				[deviceTypes addObject:AVCaptureDeviceTypeContinuityCamera];
+			}
+		}
+#endif
+		AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
+			discoverySessionWithDeviceTypes:deviceTypes
+			mediaType:AVMediaTypeVideo
+			position:AVCaptureDevicePositionUnspecified];
+		devices = [session devices];
 	} else {
-        AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
-            discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera]
-            mediaType:AVMediaTypeVideo
-            position:AVCaptureDevicePositionUnspecified];
-        devices = [session devices];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#pragma clang diagnostic pop
 	}
-	
 	if([devices count] > 0) {
 		if(deviceID>[devices count]-1)
 			deviceID = [devices count]-1;
-
-
 		// We set the device
 		device = [devices objectAtIndex:deviceID];
 
@@ -267,24 +263,25 @@
     std::vector <std::string> deviceNames;
 	NSArray * devices;
 	if (@available(macOS 10.15, *)) {
-        if (@available(macOS 14.0, *)) {
-            AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-                AVCaptureDeviceTypeBuiltInWideAngleCamera,
-                AVCaptureDeviceTypeExternal
-            ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-            devices = [session devices];
-        } else {
-            AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[
-                AVCaptureDeviceTypeBuiltInWideAngleCamera
-            ] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
-            devices = [session devices];
-        }
+		NSMutableArray *deviceTypes = [NSMutableArray arrayWithObject:AVCaptureDeviceTypeBuiltInWideAngleCamera];
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
+		if (@available(macOS 14.0, *)) {
+			if (&AVCaptureDeviceTypeExternal != nil) {
+				[deviceTypes addObject:AVCaptureDeviceTypeExternal];
+				[deviceTypes addObject:AVCaptureDeviceTypeContinuityCamera];
+			}
+		}
+#endif
+		AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
+			discoverySessionWithDeviceTypes:deviceTypes
+			mediaType:AVMediaTypeVideo
+			position:AVCaptureDevicePositionUnspecified];
+		devices = [session devices];
 	} else {
-        AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
-            discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera]
-            mediaType:AVMediaTypeVideo
-            position:AVCaptureDevicePositionUnspecified];
-        devices = [session devices];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#pragma clang diagnostic pop
 	}
 
 	int i=0;


### PR DESCRIPTION
Fixes reported: https://github.com/openframeworks/openFrameworks/issues/8230

Where system OS macOS 13 having issues with SDK types not defined in macOS 13.

## Solution:
### AVFoundationGrabber:
```#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000```
- Also fixed prior to 10.15 where AVCaptureDeviceDiscoverySession not defined use old api with deprecations pragma'd.
- Simplified code using device target list
- Did test @gllmAR the ifdef solution and didn't work for macOS 14+ so definitely test this out 

## ofxiOS AVFoundationGrabber
- Fixed with same logic. Added iOS 17+ BuiltInLiDARDepthCamera, ContinuityCamera, TrueDepthCamera and External 
- Fixed issue with CGBitmapInfo cast
- Simplified code using device target list