### PR TITLE
Enable shared libs for Linux

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/compile.core.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/compile.core.mk
@@ -61,7 +61,7 @@ $(info 💾 CC = $(CC))
 ################################################################################
 
 # clean it
-ALL_CFLAGS =
+ALL_CFLAGS = -fPIC
 
 # add the core flags (platform flags are aggregated in here)
 ALL_CFLAGS += $(OF_CORE_BASE_CFLAGS)


### PR DESCRIPTION
Not sure if this is the right position of code and if there are any drawbacks. But when I want to compile OF as a shared lib with Linux I need to compile with -fPIC. There are also some apothecary libs that need to be rebuild with -fPIC for that (kiss and pugixml for example). My use case is, that I want to compile https://github.com/Jonathhhan/ofxOfeliaExtended as an external for Pure Data, which works if I compile OF core with -fPIC and leave the mentioned libs out.