### PR TITLE
Remove boost as alternative in ofConstants.h

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -436,37 +436,23 @@ typedef TESSindex ofIndexType;
 #endif
 
 
-#if defined(OF_USING_STD_FS)
-    #if defined(OF_USE_EXPERIMENTAL_FS)
-        // C++17 experimental fs support
-        #include <experimental/filesystem>
-		namespace std {
-			namespace experimental{
-				namespace filesystem {
-					using path = v1::path;
-				}
+#if defined(OF_USE_EXPERIMENTAL_FS)
+	// C++17 experimental fs support
+	#include <experimental/filesystem>
+	namespace std {
+		namespace experimental{
+			namespace filesystem {
+				using path = v1::path;
 			}
 		}
-
-		namespace of {
-			namespace filesystem = std::experimental::filesystem;
-		}
-    #else
-		#include <filesystem>
-		namespace of {
-			namespace filesystem = std::filesystem;
-		}
-    #endif
-#else //not OF_USING_STD_FS
-    // No experimental or c++17 filesytem support use boost
-    #if !_MSC_VER
-        #define BOOST_NO_CXX11_SCOPED_ENUMS
-        #define BOOST_NO_SCOPED_ENUMS
-    #endif
-
-    #include <boost/filesystem.hpp>
-	namespace of {
-		namespace filesystem = boost::filesystem;
 	}
 
+	namespace of {
+		namespace filesystem = std::experimental::filesystem;
+	}
+#else
+	#include <filesystem>
+	namespace of {
+		namespace filesystem = std::filesystem;
+	}
 #endif

--- a/scripts/templates/macos/Project.xcconfig
+++ b/scripts/templates/macos/Project.xcconfig
@@ -67,13 +67,6 @@ GCC_PREPROCESSOR_DEFINITIONS=$(inherited)$(USER_PREPROCESSOR_DEFINITIONS)
 //OF_BUNDLE_DATA_FOLDER = 1
 //OF_BUNDLE_DYLIBS = 1
 
-// BOOST - UNCOMMENT BELOW TO ENABLE BOOST
-//HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
-//LIB_BOOST_SYSTEM = "$(OF_PATH)/libs/boost/lib/osx/boost_system.a"
-//LIB_BOOST_FS = "$(OF_PATH)/libs/boost/lib/osx/boost_filesystem.a"
-//OF_CORE_LIBS = $(inherited) $(LIB_BOOST_FS) $(LIB_BOOST_SYSTEM)
-//OF_CORE_HEADERS = $(inherited) $(HEADER_BOOST)
-
 // Optional include to keep any permanent settings as CODE_SIGN_IDENTITY. 
 #include? "App.xcconfig"
 

--- a/scripts/templates/osx/Project.xcconfig
+++ b/scripts/templates/osx/Project.xcconfig
@@ -63,13 +63,6 @@ ICON_FILE = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/$(ICON_NAME)
 //OF_BUNDLE_DATA_FOLDER = 1
 //OF_BUNDLE_DYLIBS = 1
 
-// BOOST - UNCOMMENT BELOW TO ENABLE BOOST
-//HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
-//LIB_BOOST_SYSTEM = "$(OF_PATH)/libs/boost/lib/osx/boost_system.a"
-//LIB_BOOST_FS = "$(OF_PATH)/libs/boost/lib/osx/boost_filesystem.a"
-//OF_CORE_LIBS = $(inherited) $(LIB_BOOST_FS) $(LIB_BOOST_SYSTEM)
-//OF_CORE_HEADERS = $(inherited) $(HEADER_BOOST)
-
 HIGH_RESOLUTION_CAPABLE = NO
 
 // Optional include to keep any permanent settings as CODE_SIGN_IDENTITY. 


### PR DESCRIPTION
boost is also referenced in a few make files; like openFrameworksCompiled / project / osx / config.osx.default.mk; since it's an exclusion, it's been left there.
Referenced for v0.12.1 here: #7588