### PR TITLE
Remove boost references 

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
@@ -47,14 +47,6 @@ OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_OFXIOS) $(HEADER_UTF8) $(HEADER_FREETYPE
 OF_CORE_FRAMEWORKS = -framework AudioToolbox -framework Accelerate -framework AVFoundation -framework CoreAudio -framework CoreGraphics -framework CoreLocation -framework CoreMotion -framework CoreMedia -framework CoreVideo -framework Foundation -framework GameController -framework GLKit -framework MapKit -framework OpenAL -framework OpenGLES -framework UIKit -framework Security -framework QuartzCore -framework CoreHaptics -framework Metal
 
 
-// BOOST can be enabled in OF Core by uncommenting this block
-//HEADER_BOOST = "$(OF_PATH)/libs/boost/include"
-//LIB_BOOST_SYSTEM = "$(OF_PATH)/libs/boost/lib/ios/boost_system.a"
-//LIB_BOOST_FS = "$(OF_PATH)/libs/boost/lib/ios/boost_filesystem.a"
-//LIB_BOOST = $(LIB_BOOST_SYSTEM) $(LIB_BOOST_FS)
-//OF_CORE_LIBS = $(inherited) $(LIB_BOOST)
-//OF_CORE_HEADERS = $(inherited) $(HEADER_BOOST)
-
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) GLES_SILENCE_DEPRECATION=1
 
 //COMPILER SETTINGS WHICH CAN BE OVERRIDDEN BY XCODE BUILD SETTINGS

--- a/libs/openFrameworksCompiled/project/macos/config.macos.default.mk
+++ b/libs/openFrameworksCompiled/project/macos/config.macos.default.mk
@@ -267,8 +267,6 @@ PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/app/ofAppEGLWindow.cp
 
 
 # third party
-PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/boost/%
-
 
 # ifeq ($(USE_FMOD),0)
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%

--- a/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
+++ b/libs/openFrameworksCompiled/project/osx/config.osx.default.mk
@@ -267,8 +267,6 @@ PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/openFrameworks/app/ofAppEGLWindow.cp
 
 
 # third party
-PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/boost/%
-
 
 # ifeq ($(USE_FMOD),0)
 PLATFORM_CORE_EXCLUSIONS += $(OF_LIBS_PATH)/fmod/%


### PR DESCRIPTION
from iOS CoreOF.xcconfig and config.*.default.mk for macOS and osx.