### PR TITLE
ofxGui fix for symbols on iOS

### DIFF
--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -806,6 +806,6 @@ template class ofxInputField<double>;
 template class ofxInputField<std::string>;
 
 //for some reason osx errors if this isn't defined
-#if defined TARGET_OSX || defined TARGET_EMSCRIPTEN
+#if defined (__APPLE__) || defined TARGET_EMSCRIPTEN
 	template class ofxInputField<typename std::conditional<std::is_same<uint32_t, size_t>::value || std::is_same<uint64_t, size_t>::value, bool, size_t>::type>;
 #endif

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -378,7 +378,7 @@ template class ofxSlider<float>;
 template class ofxSlider<double>;
 
 //for some reason osx errors if this isn't defined 
-#if defined TARGET_OSX || defined TARGET_EMSCRIPTEN
+#if defined (__APPLE__) || defined TARGET_EMSCRIPTEN
 	template class ofxSlider<typename std::conditional<std::is_same<uint32_t, size_t>::value || std::is_same<uint64_t, size_t>::value, bool, size_t>::type>;
 #endif
 


### PR DESCRIPTION
ofParameter / ofxSlider linking error
Fixes https://github.com/openframeworks/openFrameworks/issues/7458

Found when using ofxGui - ofxAssimpExample 

 ~~removed conditional define and using template class define as fix for all platforms~~
 edited define for apple targets 