### PR TITLE
Xcode iOS Target Project Fixes

### DIFF
--- a/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig
@@ -26,7 +26,7 @@ HEADER_OPENSSL = "$(OF_PATH)/libs/openssl/include"
 
 
 //------- Libraries
-LIB_OF = "$(OF_PATH)/libs/openFrameworksCompiled/lib/ios/openFrameworksiOS.a"
+LIB_OF_RELEASE = "$(OF_PATH)/libs/openFrameworksCompiled/lib/ios/openFrameworksiOS.a"
 LIB_OF_DEBUG = "$(OF_PATH)/libs/openFrameworksCompiled/lib/ios/openFrameworksiOSDebug.a"
 
 //LIB_FREEIMAGE = "$(OF_PATH)/libs/FreeImage/lib/ios/freeimage.a"
@@ -36,9 +36,8 @@ LIB_OF_DEBUG = "$(OF_PATH)/libs/openFrameworksCompiled/lib/ios/openFrameworksiOS
 //LIB_URIPARSER = "$(OF_PATH)/libs/uriparser/lib/ios/uriparser.a"
 //LIB_PUGIXML = "$(OF_PATH)/libs/pugixml/lib/ios/pugixml.a"
 
-
-
 MISC_FLAGS = "-ObjC"
+LINK_OBJC_RUNTIME = YES
 
 OF_CORE_LIBS = $(MISC_FLAGS) $(LIB_OF)
 

--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/project.pbxproj
@@ -1140,9 +1140,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		BB24DE5C10DA7A3F00E9C588 /* iOS+OF Static Library */ = {
+		BB24DE5C10DA7A3F00E9C588 /* openFrameworks */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "iOS+OF Static Library" */;
+			buildConfigurationList = BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "openFrameworks" */;
 			buildPhases = (
 				BB24DE5D10DA7A3F00E9C588 /* Headers */,
 				BB24DEB110DA7A3F00E9C588 /* Sources */,
@@ -1153,7 +1153,7 @@
 			);
 			dependencies = (
 			);
-			name = "iOS+OF Static Library";
+			name = openFrameworks;
 			productName = "Static Library";
 			productReference = BB24DED610DA7A3F00E9C588 /* openFrameworksiOSDebug.a */;
 			productType = "com.apple.product-type.library.static";
@@ -1179,7 +1179,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				BB24DE5C10DA7A3F00E9C588 /* iOS+OF Static Library */,
+				BB24DE5C10DA7A3F00E9C588 /* openFrameworks */,
 			);
 		};
 /* End PBXProject section */
@@ -1398,9 +1398,9 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OBJROOT = "$(SRCROOT)/../../lib/ios/build/obj/Debug/";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				OBJROOT = "$(SRCROOT)/../../lib/ios/build/obj/Debug/";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				WARNING_CFLAGS = (
 					"-Wno-non-virtual-dtor",
@@ -1438,8 +1438,8 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				ONLY_ACTIVE_ARCH = NO;
 				OBJROOT = "$(SRCROOT)/../../lib/ios/build/obj/Release/";
+				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				WARNING_CFLAGS = (
 					"-Wno-non-virtual-dtor",
@@ -1451,7 +1451,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "iOS+OF Static Library" */ = {
+		BB24DED210DA7A3F00E9C588 /* Build configuration list for PBXNativeTarget "openFrameworks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BB24DED310DA7A3F00E9C588 /* Debug */,

--- a/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/xcshareddata/xcschemes/openFrameworks.xcscheme
+++ b/libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj/xcshareddata/xcschemes/openFrameworks.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BB24DE5C10DA7A3F00E9C588"
                BuildableName = "openFrameworksiOSDebug.a"
-               BlueprintName = "iOS+OF Static Library"
+               BlueprintName = "openFrameworks"
                ReferencedContainer = "container:iOS+OFLib.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -51,7 +51,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BB24DE5C10DA7A3F00E9C588"
             BuildableName = "openFrameworksiOSDebug.a"
-            BlueprintName = "iOS+OF Static Library"
+            BlueprintName = "openFrameworks"
             ReferencedContainer = "container:iOS+OFLib.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
+++ b/libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig
@@ -26,7 +26,7 @@ HEADER_URIPARSER = "$(OF_PATH)/libs/uriparser/include"
 HEADER_PUGIXML = "$(OF_PATH)/libs/pugixml/include"
 
 //------- Libraries
-LIB_OF = "$(OF_PATH)/libs/openFrameworksCompiled/lib/osx/openFrameworks.a"
+LIB_OF_RELEASE = "$(OF_PATH)/libs/openFrameworksCompiled/lib/osx/openFrameworks.a"
 LIB_OF_DEBUG = "$(OF_PATH)/libs/openFrameworksCompiled/lib/osx/openFrameworksDebug.a"
 
 //LIB_FMOD = "$(OF_PATH)/libs/fmod/lib/macos/libfmod.dylib"

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		9979E8231A1CCC44007E55D1 /* ofMainLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9979E8201A1CCC44007E55D1 /* ofMainLoop.cpp */; };
 		9979E8241A1CCC44007E55D1 /* ofMainLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 9979E8211A1CCC44007E55D1 /* ofMainLoop.h */; };
 		BBA81C431FFBE4DB0064EA94 /* ofBaseApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBA81C421FFBE4DB0064EA94 /* ofBaseApp.cpp */; };
+		BF14DA522D75650400A4B85E /* fmt.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF14DA512D75650400A4B85E /* fmt.xcframework */; };
 		BF6276A62BAD9900008864C1 /* ofBaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BF6276A52BAD9900008864C1 /* ofBaseTypes.h */; };
 		BFB0B3F52C50DFE8008FB5A3 /* brotli.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7C462D2C097CCE00461163 /* brotli.xcframework */; };
 		BFB0B3F62C50DFE8008FB5A3 /* curl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF6276A32BAD6639008864C1 /* curl.xcframework */; };
@@ -235,6 +236,7 @@
 		9979E8201A1CCC44007E55D1 /* ofMainLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMainLoop.cpp; sourceTree = "<group>"; };
 		9979E8211A1CCC44007E55D1 /* ofMainLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMainLoop.h; sourceTree = "<group>"; };
 		BBA81C421FFBE4DB0064EA94 /* ofBaseApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseApp.cpp; sourceTree = "<group>"; };
+		BF14DA512D75650400A4B85E /* fmt.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = fmt.xcframework; path = /Users/one/SOURCE/openFrameworksiOSTIPS/libs/fmt/lib/macos/fmt.xcframework; sourceTree = "<absolute>"; };
 		BF5BF83F2B737C0A0049DEF6 /* zlib.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = zlib.xcframework; path = ../../../zlib/lib/macos/zlib.xcframework; sourceTree = "<group>"; };
 		BF5BF8412B737C700049DEF6 /* uriparser.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = uriparser.xcframework; path = ../../../uriparser/lib/macos/uriparser.xcframework; sourceTree = "<group>"; };
 		BF5BF8432B737C7C0049DEF6 /* tess2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = tess2.xcframework; path = ../../../tess2/lib/macos/tess2.xcframework; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				BFB0B3FF2C50DFE8008FB5A3 /* pugixml.xcframework in Frameworks */,
 				BFB0B4002C50DFE8008FB5A3 /* rtAudio.xcframework in Frameworks */,
 				BFB0B4012C50DFE8008FB5A3 /* tess2.xcframework in Frameworks */,
+				BF14DA522D75650400A4B85E /* fmt.xcframework in Frameworks */,
 				BFB0B4022C50DFE8008FB5A3 /* uriparser.xcframework in Frameworks */,
 				BFB0B4032C50DFE8008FB5A3 /* zlib.xcframework in Frameworks */,
 			);
@@ -396,6 +399,7 @@
 		BF5BF83E2B7378ED0049DEF6 /* frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BF14DA512D75650400A4B85E /* fmt.xcframework */,
 				BF7C462D2C097CCE00461163 /* brotli.xcframework */,
 				BF6276A32BAD6639008864C1 /* curl.xcframework */,
 				BF6276A12BAD6619008864C1 /* openssl.xcframework */,

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 		9979E8201A1CCC44007E55D1 /* ofMainLoop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMainLoop.cpp; sourceTree = "<group>"; };
 		9979E8211A1CCC44007E55D1 /* ofMainLoop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMainLoop.h; sourceTree = "<group>"; };
 		BBA81C421FFBE4DB0064EA94 /* ofBaseApp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofBaseApp.cpp; sourceTree = "<group>"; };
-		BF14DA512D75650400A4B85E /* fmt.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = fmt.xcframework; path = /Users/one/SOURCE/openFrameworksiOSTIPS/libs/fmt/lib/macos/fmt.xcframework; sourceTree = "<absolute>"; };
+		BF14DA512D75650400A4B85E /* fmt.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = fmt.xcframework; path = ../../../fmt/lib/macos/fmt.xcframework; sourceTree = "<group>"; };
 		BF5BF83F2B737C0A0049DEF6 /* zlib.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = zlib.xcframework; path = ../../../zlib/lib/macos/zlib.xcframework; sourceTree = "<group>"; };
 		BF5BF8412B737C700049DEF6 /* uriparser.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = uriparser.xcframework; path = ../../../uriparser/lib/macos/uriparser.xcframework; sourceTree = "<group>"; };
 		BF5BF8432B737C7C0049DEF6 /* tess2.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = tess2.xcframework; path = ../../../tess2/lib/macos/tess2.xcframework; sourceTree = "<group>"; };

--- a/scripts/ci/ios/build.sh
+++ b/scripts/ci/ios/build.sh
@@ -1,9 +1,48 @@
 #!/bin/bash
-set -ev
+set -e
 echo "Building openFrameworks - iOS Template Project"
 ROOT=${TRAVIS_BUILD_DIR:-"$( cd "$(dirname "$0")/../../.." ; pwd -P )"}
 if [[ "$GITHUB_ACTIONS" = true ]]; then
     ROOT=$GITHUB_WORKSPACE
 fi
+SKIP_DEVICE=${SKIP_DEVICE:-1}  ## SKIP until figure out Identity
+HOST_ARCH=$(uname -m)
+if [[ "$HOST_ARCH" == "arm64" ]]; then
+    SIM_ARCH="arm64"
+else
+    SIM_ARCH="x86_64 arm64"
+fi
+if [ -z "${IDENTITY+x}" ]; then
+   IDENTITY="-"
+fi
+echo "Building emptyExample for iphonesimulator"
+xcodebuild -configuration Release \
+    -project "$ROOT/scripts/templates/ios/emptyExample.xcodeproj" \
+    -target emptyExample \
+    -sdk iphonesimulator \
+    -arch "$SIM_ARCH" \
+    CODE_SIGNING_ALLOWED=NO
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to build emptyExample for iphonesimulator"
+    exit 1
+fi
+echo "emptyExample simulotor built successfully"
 
-xcodebuild -configuration Release -project "$ROOT/scripts/templates/ios/emptyExample.xcodeproj"  -target emptyExample -sdk 'iphonesimulator' ARCHS='x86_64'
+if [[ "$SKIP_DEVICE" = 0 ]]; then
+    echo "Building emptyExample for iphoneos"
+    xcodebuild -configuration Release \
+        -project "$ROOT/scripts/templates/ios/emptyExample.xcodeproj" \
+        -target emptyExample \
+        -sdk iphoneos \
+        -arch "arm64" \
+        CODE_SIGN_STYLE=Automatic \
+        DEVELOPMENT_TEAM="$IDENTITY" \
+        CODE_SIGN_IDENTITY="Apple Development"
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to build emptyExample for device"
+        exit 1
+    fi
+    echo "emptyExample device built successfully"
+fi
+
+echo "ios tests complete"

--- a/scripts/templates/ios/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/ios/emptyExample.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
       "buildPhases" : [
         "BF46A0162D754E9E00E4F02F",
         "1D60588D0D05DD3D006BFB54",
-        "BF1D97122D7552820033282F",
         "1D60588E0D05DD3D006BFB54",
         "1D60588F0D05DD3D006BFB54",
         "9255DD331112741900D6945E"
@@ -186,12 +185,6 @@
       ],
       "mainGroup" : "29B97314FDCFA39411CA2CEA",
       "projectDirPath" : "",
-      "projectReferences" : [
-        {
-          "ProductGroup" : "E41D40FE13B3A0D800A75A5D",
-          "ProjectRef" : "E41D40FD13B3A0D800A75A5D"
-        }
-      ],
       "projectRoot" : "",
       "targets" : [
         "1D6058900D05DD3D006BFB54"
@@ -417,7 +410,18 @@
     },
     "BB24E1F710DAA51900E9C588" : {
       "children" : [
-        "E41D40FD13B3A0D800A75A5D",
+        "BF8CFDD22D756AC800AA5C47",
+        "BF8CFDDF2D756AC800AA5C47",
+        "BF8CFDE82D756AC800AA5C47",
+        "BF8CFDE92D756AC800AA5C47",
+        "BF8CFDEE2D756AC800AA5C47",
+        "BF8CFE0B2D756AC800AA5C47",
+        "BF8CFE232D756AC800AA5C47",
+        "BF8CFE332D756AC800AA5C47",
+        "BF8CFE3D2D756AC800AA5C47",
+        "BF8CFE492D756AC800AA5C47",
+        "BF8CFE632D756AC800AA5C47",
+        "BF8CFE682D756AC800AA5C47",
         "32CA4F630368D1EE00C91783",
         "BB24DDC910DA781C00E9C588",
         "E41D3EE513B3906D00A75A5D",
@@ -447,29 +451,1074 @@
       "fileRef" : "BBE5EAB70F49AD8400F28951",
       "isa" : "PBXBuildFile"
     },
-    "BF1D97122D7552820033282F" : {
-      "alwaysOutOfDate" : "1",
-      "buildActionMask" : "2147483647",
-      "files" : [
+    "BF8CFDD22D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "name" : "ofMain.h",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/ofMain.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD32D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text",
+      "path" : "ofMesh.inl",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD42D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "of3dPrimitives.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD52D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "of3dPrimitives.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD62D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "of3dUtils.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD72D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "of3dUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD82D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofCamera.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDD92D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofCamera.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDA2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofEasyCam.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDB2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofEasyCam.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDC2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMesh.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDD2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofNode.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDE2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofNode.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDDF2D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFDD32D756AC800AA5C47",
+        "BF8CFDD42D756AC800AA5C47",
+        "BF8CFDD52D756AC800AA5C47",
+        "BF8CFDD62D756AC800AA5C47",
+        "BF8CFDD72D756AC800AA5C47",
+        "BF8CFDD82D756AC800AA5C47",
+        "BF8CFDD92D756AC800AA5C47",
+        "BF8CFDDA2D756AC800AA5C47",
+        "BF8CFDDB2D756AC800AA5C47",
+        "BF8CFDDC2D756AC800AA5C47",
+        "BF8CFDDD2D756AC800AA5C47",
+        "BF8CFDDE2D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "3d",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/3d",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE02D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofBaseApp.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE12D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofAppBaseWindow.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE22D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofAppRunner.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE32D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofAppRunner.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE42D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofBaseApp.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE52D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMainLoop.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE62D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMainLoop.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE72D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofWindowSettings.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE82D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFDE02D756AC800AA5C47",
+        "BF8CFDE12D756AC800AA5C47",
+        "BF8CFDE22D756AC800AA5C47",
+        "BF8CFDE32D756AC800AA5C47",
+        "BF8CFDE42D756AC800AA5C47",
+        "BF8CFDE52D756AC800AA5C47",
+        "BF8CFDE62D756AC800AA5C47",
+        "BF8CFDE72D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "app",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/app",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDE92D756AC800AA5C47" : {
+      "children" : [
 
       ],
-      "inputFileListPaths" : [
-
+      "isa" : "PBXGroup",
+      "name" : "communication",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/communication",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDEA2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofEvent.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDEB2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofEvents.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDEC2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofEvents.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDED2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofEventUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDEE2D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFDEA2D756AC800AA5C47",
+        "BF8CFDEB2D756AC800AA5C47",
+        "BF8CFDEC2D756AC800AA5C47",
+        "BF8CFDED2D756AC800AA5C47"
       ],
-      "inputPaths" : [
-
+      "isa" : "PBXGroup",
+      "name" : "events",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/events",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDEF2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGLBaseTypes.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF02D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofBufferObject.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF12D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofBufferObject.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF22D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofCubeMap.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF32D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofCubeMap.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF42D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofCubeMapShaders.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF52D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofFbo.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF62D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofFbo.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF72D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofGLProgrammableRenderer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF82D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGLProgrammableRenderer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDF92D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofGLRenderer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFA2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGLRenderer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFB2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofGLUtils.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFC2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGLUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFD2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofLight.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFE2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofLight.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFDFF2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofShadow.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVboMesh.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0B2D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFDEF2D756AC800AA5C47",
+        "BF8CFDF02D756AC800AA5C47",
+        "BF8CFDF12D756AC800AA5C47",
+        "BF8CFDF22D756AC800AA5C47",
+        "BF8CFDF32D756AC800AA5C47",
+        "BF8CFDF42D756AC800AA5C47",
+        "BF8CFDF52D756AC800AA5C47",
+        "BF8CFDF62D756AC800AA5C47",
+        "BF8CFDF72D756AC800AA5C47",
+        "BF8CFDF82D756AC800AA5C47",
+        "BF8CFDF92D756AC800AA5C47",
+        "BF8CFDFA2D756AC800AA5C47",
+        "BF8CFDFB2D756AC800AA5C47",
+        "BF8CFDFC2D756AC800AA5C47",
+        "BF8CFDFD2D756AC800AA5C47",
+        "BF8CFDFE2D756AC800AA5C47",
+        "BF8CFDFF2D756AC800AA5C47",
+        "BF8CFE002D756AC800AA5C47",
+        "BF8CFE012D756AC800AA5C47",
+        "BF8CFE022D756AC800AA5C47",
+        "BF8CFE032D756AC800AA5C47",
+        "BF8CFE042D756AC800AA5C47",
+        "BF8CFE052D756AC800AA5C47",
+        "BF8CFE062D756AC800AA5C47",
+        "BF8CFE072D756AC800AA5C47",
+        "BF8CFE082D756AC800AA5C47",
+        "BF8CFE092D756AC800AA5C47",
+        "BF8CFE0A2D756AC800AA5C47"
       ],
-      "isa" : "PBXShellScriptBuildPhase",
-      "outputFileListPaths" : [
-
+      "isa" : "PBXGroup",
+      "name" : "gl",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/gl",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofGraphicsBaseTypes.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0D2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGraphicsBaseTypes.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGraphicsConstants.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE0F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text",
+      "path" : "ofPolyline.inl",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofPixels.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1B2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofPixels.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofPolyline.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1D2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofRendererCollection.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofRendererCollection.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE1F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofTessellator.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMatrix4x4.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2B2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofQuaternion.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofQuaternion.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2D2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVec2f.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE002D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofShadow.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVec2f.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE2F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVec3f.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofSoundStream.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3B2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSoundStream.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSoundUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3D2D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE342D756AC800AA5C47",
+        "BF8CFE352D756AC800AA5C47",
+        "BF8CFE362D756AC800AA5C47",
+        "BF8CFE372D756AC800AA5C47",
+        "BF8CFE382D756AC800AA5C47",
+        "BF8CFE392D756AC800AA5C47",
+        "BF8CFE3A2D756AC800AA5C47",
+        "BF8CFE3B2D756AC800AA5C47",
+        "BF8CFE3C2D756AC800AA5C47"
       ],
-      "outputPaths" : [
-
+      "isa" : "PBXGroup",
+      "name" : "sound",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/sound",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofBaseTypes.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE3F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofColor.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofConstants.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4B2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofFileUtils.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofFileUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4D2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofFpsCounter.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofFpsCounter.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE4F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofLog.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5A2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTimer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5B2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofTimerFps.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5C2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTimerFps.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5D2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofURLFileLoader.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5E2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofURLFileLoader.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE5F2D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofUtils.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE012D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMaterial.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE022D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMaterial.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE032D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofShader.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE042D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofShader.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE052D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofTexture.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE062D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTexture.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE072D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVbo.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE082D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVbo.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE092D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVboMesh.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE102D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "of3dGraphics.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE112D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "of3dGraphics.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE122D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofBitmapFont.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE132D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofBitmapFont.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE142D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofGraphics.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE152D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofGraphics.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE162D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofImage.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE172D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofImage.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE182D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofPath.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE192D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofPath.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE202D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTessellator.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE212D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofTrueTypeFont.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE222D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTrueTypeFont.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE232D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE0C2D756AC800AA5C47",
+        "BF8CFE0D2D756AC800AA5C47",
+        "BF8CFE0E2D756AC800AA5C47",
+        "BF8CFE0F2D756AC800AA5C47",
+        "BF8CFE102D756AC800AA5C47",
+        "BF8CFE112D756AC800AA5C47",
+        "BF8CFE122D756AC800AA5C47",
+        "BF8CFE132D756AC800AA5C47",
+        "BF8CFE142D756AC800AA5C47",
+        "BF8CFE152D756AC800AA5C47",
+        "BF8CFE162D756AC800AA5C47",
+        "BF8CFE172D756AC800AA5C47",
+        "BF8CFE182D756AC800AA5C47",
+        "BF8CFE192D756AC800AA5C47",
+        "BF8CFE1A2D756AC800AA5C47",
+        "BF8CFE1B2D756AC800AA5C47",
+        "BF8CFE1C2D756AC800AA5C47",
+        "BF8CFE1D2D756AC800AA5C47",
+        "BF8CFE1E2D756AC800AA5C47",
+        "BF8CFE1F2D756AC800AA5C47",
+        "BF8CFE202D756AC800AA5C47",
+        "BF8CFE212D756AC800AA5C47",
+        "BF8CFE222D756AC800AA5C47"
       ],
-      "runOnlyForDeploymentPostprocessing" : "0",
-      "shellPath" : "\/bin\/sh",
-      "shellScript" : "# Type a script or drag a script file from your workspace to insert its path.\necho \"CONFIGURATION: ${CONFIGURATION}\"\necho \"LIB_OF: ${LIB_OF}\"\n",
-      "showEnvVarsInLog" : "0"
+      "isa" : "PBXGroup",
+      "name" : "graphics",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/graphics",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE242D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMathConstants.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE252D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMath.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE262D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMath.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE272D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMatrix3x3.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE282D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMatrix3x3.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE292D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMatrix4x4.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE302D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVec4f.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE312D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVec4f.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE322D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVectorMath.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE332D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE242D756AC800AA5C47",
+        "BF8CFE252D756AC800AA5C47",
+        "BF8CFE262D756AC800AA5C47",
+        "BF8CFE272D756AC800AA5C47",
+        "BF8CFE282D756AC800AA5C47",
+        "BF8CFE292D756AC800AA5C47",
+        "BF8CFE2A2D756AC800AA5C47",
+        "BF8CFE2B2D756AC800AA5C47",
+        "BF8CFE2C2D756AC800AA5C47",
+        "BF8CFE2D2D756AC800AA5C47",
+        "BF8CFE2E2D756AC800AA5C47",
+        "BF8CFE2F2D756AC800AA5C47",
+        "BF8CFE302D756AC800AA5C47",
+        "BF8CFE312D756AC800AA5C47",
+        "BF8CFE322D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "math",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/math",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE342D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofSoundBaseTypes.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE352D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSoundBaseTypes.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE362D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofSoundBuffer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE372D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSoundBuffer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE382D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofSoundPlayer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE392D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSoundPlayer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE402D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofColor.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE412D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofParameter.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE422D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofParameter.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE432D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofParameterGroup.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE442D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofParameterGroup.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE452D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofPoint.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE462D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofRectangle.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE472D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofRectangle.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE482D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofTypes.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE492D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE3E2D756AC800AA5C47",
+        "BF8CFE3F2D756AC800AA5C47",
+        "BF8CFE402D756AC800AA5C47",
+        "BF8CFE412D756AC800AA5C47",
+        "BF8CFE422D756AC800AA5C47",
+        "BF8CFE432D756AC800AA5C47",
+        "BF8CFE442D756AC800AA5C47",
+        "BF8CFE452D756AC800AA5C47",
+        "BF8CFE462D756AC800AA5C47",
+        "BF8CFE472D756AC800AA5C47",
+        "BF8CFE482D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "types",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/types",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE502D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofLog.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE512D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofMatrixStack.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE522D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofMatrixStack.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE532D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofNoise.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE542D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofSystemUtils.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE552D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofSystemUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE562D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofThread.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE572D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofThread.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE582D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofThreadChannel.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE592D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofTimer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE602D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofUtils.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE612D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofXml.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE622D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofXml.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE632D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE4A2D756AC800AA5C47",
+        "BF8CFE4B2D756AC800AA5C47",
+        "BF8CFE4C2D756AC800AA5C47",
+        "BF8CFE4D2D756AC800AA5C47",
+        "BF8CFE4E2D756AC800AA5C47",
+        "BF8CFE4F2D756AC800AA5C47",
+        "BF8CFE502D756AC800AA5C47",
+        "BF8CFE512D756AC800AA5C47",
+        "BF8CFE522D756AC800AA5C47",
+        "BF8CFE532D756AC800AA5C47",
+        "BF8CFE542D756AC800AA5C47",
+        "BF8CFE552D756AC800AA5C47",
+        "BF8CFE562D756AC800AA5C47",
+        "BF8CFE572D756AC800AA5C47",
+        "BF8CFE582D756AC800AA5C47",
+        "BF8CFE592D756AC800AA5C47",
+        "BF8CFE5A2D756AC800AA5C47",
+        "BF8CFE5B2D756AC800AA5C47",
+        "BF8CFE5C2D756AC800AA5C47",
+        "BF8CFE5D2D756AC800AA5C47",
+        "BF8CFE5E2D756AC800AA5C47",
+        "BF8CFE5F2D756AC800AA5C47",
+        "BF8CFE602D756AC800AA5C47",
+        "BF8CFE612D756AC800AA5C47",
+        "BF8CFE622D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "utils",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/utils",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE642D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVideoGrabber.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE652D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVideoGrabber.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE662D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "path" : "ofVideoPlayer.cpp",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE672D756AC800AA5C47" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofVideoPlayer.h",
+      "sourceTree" : "<group>"
+    },
+    "BF8CFE682D756AC800AA5C47" : {
+      "children" : [
+        "BF8CFE642D756AC800AA5C47",
+        "BF8CFE652D756AC800AA5C47",
+        "BF8CFE662D756AC800AA5C47",
+        "BF8CFE672D756AC800AA5C47"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "video",
+      "path" : "..\/..\/..\/libs\/openFrameworks\/video",
+      "sourceTree" : "<group>"
     },
     "BF46A0162D754E9E00E4F02F" : {
       "alwaysOutOfDate" : "1",
@@ -624,21 +1673,6 @@
       "path" : "..\/..\/..\/libs\/openFrameworksCompiled\/project\/ios\/CoreOF.xcconfig",
       "sourceTree" : "SOURCE_ROOT"
     },
-    "E41D40FD13B3A0D800A75A5D" : {
-      "isa" : "PBXFileReference",
-      "lastKnownFileType" : "wrapper.pb-project",
-      "name" : "iOS+OFLib.xcodeproj",
-      "path" : "..\/..\/..\/libs\/openFrameworksCompiled\/project\/ios\/iOS+OFLib.xcodeproj",
-      "sourceTree" : "SOURCE_ROOT"
-    },
-    "E41D40FE13B3A0D800A75A5D" : {
-      "children" : [
-        "E41D410213B3A0D800A75A5D"
-      ],
-      "isa" : "PBXGroup",
-      "name" : "Products",
-      "sourceTree" : "<group>"
-    },
     "E41D400B13B39D2100A75A5D" : {
       "fileRef" : "E41D400613B39D2100A75A5D",
       "isa" : "PBXBuildFile"
@@ -682,20 +1716,6 @@
       "name" : "MapKit.framework",
       "path" : "System\/Library\/Frameworks\/MapKit.framework",
       "sourceTree" : "SDKROOT"
-    },
-    "E41D410113B3A0D800A75A5D" : {
-      "containerPortal" : "E41D40FD13B3A0D800A75A5D",
-      "isa" : "PBXContainerItemProxy",
-      "proxyType" : "2",
-      "remoteGlobalIDString" : "BB24DED610DA7A3F00E9C588",
-      "remoteInfo" : "iPhone+OF Static Library"
-    },
-    "E41D410213B3A0D800A75A5D" : {
-      "fileType" : "archive.ar",
-      "isa" : "PBXReferenceProxy",
-      "path" : "openFrameworksiOSDebug.a",
-      "remoteRef" : "E41D410113B3A0D800A75A5D",
-      "sourceTree" : "BUILT_PRODUCTS_DIR"
     }
   },
   "objectVersion" : "54",

--- a/scripts/templates/ios/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/ios/emptyExample.xcodeproj/project.pbxproj
@@ -1,220 +1,218 @@
 {
-  "classes": {},
-  "objectVersion": "46",
-  "archiveVersion": "1",
-  "objects": {
-    "5326AEA710A23A0500278DE6": {
-      "path": "System/Library/Frameworks/CoreLocation.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreLocation.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+  "archiveVersion" : "1",
+  "classes" : {
+
+  },
+  "objects" : {
+    "1D30AB110D05D00D00671497" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "Foundation.framework",
+      "path" : "System\/Library\/Frameworks\/Foundation.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "BBE5EAB80F49AD8400F28951": {
-      "isa": "PBXBuildFile",
-      "fileRef": "BBE5EAB70F49AD8400F28951"
-    },
-    "BB16EBD90F2B2AB500518274": {
-      "isa": "PBXBuildFile",
-      "fileRef": "BB16EBD80F2B2AB500518274"
-    },
-    "E41D3EE513B3906D00A75A5D": {
-      "path": "../../../libs/openFrameworksCompiled/project/ios/CoreOF.xcconfig",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "text.xcconfig",
-      "name": "CoreOF.xcconfig",
-      "sourceTree": "SOURCE_ROOT",
-      "fileEncoding": "4"
-    },
-    "1D6058910D05DD3D006BFB54": {
-      "path": "emptyExample.app",
-      "isa": "PBXFileReference",
-      "includeInIndex": "0",
-      "explicitFileType": "wrapper.application",
-      "sourceTree": "BUILT_PRODUCTS_DIR"
-    },
-    "19C28FACFE9D520D11CA2CBB": {
-      "isa": "PBXGroup",
-      "name": "Products",
-      "children": [
-        "1D6058910D05DD3D006BFB54"
+    "1D60588D0D05DD3D006BFB54" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
+        "9936F6101BFA4DEE00891288",
+        "9936F6121BFA65F100891288"
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXResourcesBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
     },
-    "1D60588E0D05DD3D006BFB54": {
-      "isa": "PBXSourcesBuildPhase",
-      "buildActionMask": "2147483647",
-      "files": [
+    "1D60588E0D05DD3D006BFB54" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
         "E4D8936E11527B74007E1F53",
         "E4D8936F11527B74007E1F53"
       ],
-      "runOnlyForDeploymentPostprocessing": "0"
+      "isa" : "PBXSourcesBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
     },
-    "BB24DDC910DA781C00E9C588": {
-      "path": "ofxiOS-Info.plist",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "text.plist.xml",
-      "sourceTree": "<group>",
-      "fileEncoding": "4"
+    "1D60588F0D05DD3D006BFB54" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
+        "9969E7561C782C4500DEF0F6",
+        "901808C12053638E004A7774",
+        "1D60589F0D05DD5A006BFB54",
+        "1DF5F4E00D08C38300B7A737",
+        "288765FD0DF74451002DB57D",
+        "BB16EBD20F2B2A9500518274",
+        "BB16EBD90F2B2AB500518274",
+        "BBE5EAB80F49AD8400F28951",
+        "53F323EB10A20EDB00E0DAE4",
+        "5326AEA810A23A0500278DE6",
+        "E41D400B13B39D2100A75A5D",
+        "E41D400C13B39D2100A75A5D",
+        "E41D400D13B39D2100A75A5D",
+        "E41D400E13B39D2100A75A5D",
+        "67DFA53619F92A69003B3434"
+      ],
+      "isa" : "PBXFrameworksBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
     },
-    "1D6058940D05DD3E006BFB54": {
-      "isa": "XCBuildConfiguration",
-      "buildSettings": {
-        "GCC_PREFIX_HEADER": "ofxiOS_Prefix.pch",
-        "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME": "",
-        "TARGETED_DEVICE_FAMILY": "1,2",
-        "INFOPLIST_FILE": "ofxiOS-Info.plist",
-        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": "NO",
-        "ALWAYS_SEARCH_USER_PATHS": "NO",
-        "HEADER_SEARCH_PATHS": [
-          "$(OF_CORE_HEADERS)",
-          "src"
-        ],
-        "PRODUCT_NAME": "${TARGET_NAME}",
-        "VALID_ARCHS": "$(ARCHS_STANDARD)",
-        "GCC_PRECOMPILE_PREFIX_HEADER": "YES",
-        "FRAMEWORK_SEARCH_PATHS": [
+    "1D60589F0D05DD5A006BFB54" : {
+      "fileRef" : "1D30AB110D05D00D00671497",
+      "isa" : "PBXBuildFile"
+    },
+    "1D6058900D05DD3D006BFB54" : {
+      "buildConfigurationList" : "1D6058960D05DD3E006BFB54",
+      "buildPhases" : [
+        "BF46A0162D754E9E00E4F02F",
+        "1D60588D0D05DD3D006BFB54",
+        "BF1D97122D7552820033282F",
+        "1D60588E0D05DD3D006BFB54",
+        "1D60588F0D05DD3D006BFB54",
+        "9255DD331112741900D6945E"
+      ],
+      "buildRules" : [
+
+      ],
+      "dependencies" : [
+
+      ],
+      "isa" : "PBXNativeTarget",
+      "name" : "emptyExample",
+      "productName" : "iPhone",
+      "productReference" : "1D6058910D05DD3D006BFB54",
+      "productType" : "com.apple.product-type.application"
+    },
+    "1D6058910D05DD3D006BFB54" : {
+      "explicitFileType" : "wrapper.application",
+      "includeInIndex" : "0",
+      "isa" : "PBXFileReference",
+      "path" : "emptyExample.app",
+      "sourceTree" : "BUILT_PRODUCTS_DIR"
+    },
+    "1D6058940D05DD3E006BFB54" : {
+      "buildSettings" : {
+        "ALWAYS_SEARCH_USER_PATHS" : "NO",
+        "ASSETCATALOG_COMPILER_APPICON_NAME" : "AppIcon",
+        "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME" : "",
+        "CLANG_LINK_OBJC_RUNTIME" : "YES",
+        "FRAMEWORK_SEARCH_PATHS" : [
           "$(inherited)",
           "$(PROJECT_DIR)"
         ],
-        "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-        "OTHER_LDFLAGS": [
+        "GCC_PRECOMPILE_PREFIX_HEADER" : "YES",
+        "GCC_PREFIX_HEADER" : "ofxiOS_Prefix.pch",
+        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" : "NO",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "INFOPLIST_FILE" : "ofxiOS-Info.plist",
+        "OTHER_LDFLAGS" : [
           "$(OF_CORE_LIBS)",
-          "$(OF_CORE_FRAMEWORKS)"
-        ]
+          "$(OF_CORE_FRAMEWORKS)",
+          "$(LIB_OF_DEBUG)"
+        ],
+        "PRODUCT_NAME" : "${TARGET_NAME}",
+        "TARGETED_DEVICE_FAMILY" : "1,2",
+        "VALID_ARCHS" : "$(ARCHS_STANDARD)"
       },
-      "name": "Debug"
+      "isa" : "XCBuildConfiguration",
+      "name" : "Debug"
     },
-    "E41D410213B3A0D800A75A5D": {
-      "path": "openFrameworksiOSDebug.a",
-      "isa": "PBXReferenceProxy",
-      "fileType": "archive.ar",
-      "remoteRef": "E41D410113B3A0D800A75A5D",
-      "sourceTree": "BUILT_PRODUCTS_DIR"
-    },
-    "9936F6121BFA65F100891288": {
-      "isa": "PBXBuildFile",
-      "fileRef": "9936F6111BFA65F100891288"
-    },
-    "67DFA53619F92A69003B3434": {
-      "isa": "PBXBuildFile",
-      "fileRef": "67DFA53419F92A5E003B3434"
-    },
-    "288765FD0DF74451002DB57D": {
-      "isa": "PBXBuildFile",
-      "fileRef": "288765FC0DF74451002DB57D"
-    },
-    "E4D8936D11527B74007E1F53": {
-      "path": "src/ofApp.mm",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "sourcecode.cpp.objcpp",
-      "name": "ofApp.mm",
-      "sourceTree": "SOURCE_ROOT",
-      "fileEncoding": "4"
-    },
-    "C01FCF4F08A954540054247B": {
-      "baseConfigurationReference": "E41D3ED613B38FB500A75A5D",
-      "isa": "XCBuildConfiguration",
-      "buildSettings": {
-        "VALID_ARCHS": "$(ARCHS_STANDARD)",
-        "GCC_WARN_ABOUT_RETURN_TYPE": "YES",
-        "ONLY_ACTIVE_ARCH": "YES",
-        "GCC_SYMBOLS_PRIVATE_EXTERN": "NO",
-        "GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO": "NO",
-        "COMPRESS_PNG_FILES": "NO",
-        "GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL": "NO",
-        "GCC_OPTIMIZATION_LEVEL": "0",
-        "GCC_C_LANGUAGE_STANDARD": "c17",
-        "TARGETED_DEVICE_FAMILY": "1",
-        "GCC_WARN_PROTOTYPE_CONVERSION": "NO",
-        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": "NO",
-        "ALWAYS_SEARCH_USER_PATHS": "YES",
-        "PROVISIONING_PROFILE[sdk=iphoneos*]": "",
-        "SDKROOT": "iphoneos",
-        "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "iPhone Developer",
-        "CODE_SIGN_IDENTITY": "",
-        "WARNING_LDFLAGS": "-no_arch_warnings",
-        "GCC_WARN_ABOUT_POINTER_SIGNEDNESS": "NO",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "CODE_SIGN_IDENTITY[sdk=iphonesimulator*]": "",
-        "GCC_WARN_UNUSED_VARIABLE": "YES"
+    "1D6058950D05DD3E006BFB54" : {
+      "buildSettings" : {
+        "ASSETCATALOG_COMPILER_APPICON_NAME" : "AppIcon",
+        "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME" : "",
+        "CLANG_LINK_OBJC_RUNTIME" : "YES",
+        "FRAMEWORK_SEARCH_PATHS" : [
+          "$(inherited)",
+          "$(PROJECT_DIR)"
+        ],
+        "GCC_PRECOMPILE_PREFIX_HEADER" : "YES",
+        "GCC_PREFIX_HEADER" : "ofxiOS_Prefix.pch",
+        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" : "NO",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "INFOPLIST_FILE" : "ofxiOS-Info.plist",
+        "OTHER_LDFLAGS" : [
+          "$(OF_CORE_LIBS)",
+          "$(OF_CORE_FRAMEWORKS)",
+          "$(LIB_OF_RELEASE)"
+        ],
+        "PRODUCT_NAME" : "${TARGET_NAME}",
+        "TARGETED_DEVICE_FAMILY" : "1,2",
+        "VALID_ARCHS" : "$(ARCHS_STANDARD)"
       },
-      "name": "Debug"
+      "isa" : "XCBuildConfiguration",
+      "name" : "Release"
     },
-    "901808BF2053636F004A7774": {
-      "path": "System/Library/Frameworks/GLKit.framework",
-      "isa": "PBXFileReference",
-      "name": "GLKit.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "E41D400D13B39D2100A75A5D": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E41D400813B39D2100A75A5D"
-    },
-    "53F323EB10A20EDB00E0DAE4": {
-      "isa": "PBXBuildFile",
-      "fileRef": "53F323EA10A20EDB00E0DAE4"
-    },
-    "901808C02053638E004A7774": {
-      "isa": "PBXGroup",
-      "name": "Frameworks",
-      "children": [],
-      "sourceTree": "<group>"
-    },
-    "6948EE371B920CB800B5AC1A": {
-      "isa": "PBXGroup",
-      "name": "local_addons",
-      "children": [],
-      "sourceTree": "<group>"
-    },
-    "E4D8936A11527B74007E1F53": {
-      "path": "src",
-      "isa": "PBXGroup",
-      "children": [
-        "E4D8936B11527B74007E1F53",
-        "E4D8936D11527B74007E1F53",
-        "E4D8936C11527B74007E1F53"
+    "1D6058960D05DD3E006BFB54" : {
+      "buildConfigurations" : [
+        "1D6058940D05DD3E006BFB54",
+        "1D6058950D05DD3E006BFB54"
       ],
-      "sourceTree": "SOURCE_ROOT"
+      "defaultConfigurationIsVisible" : "0",
+      "defaultConfigurationName" : "Release",
+      "isa" : "XCConfigurationList"
     },
-    "29B97313FDCFA39411CA2CEA": {
-      "projectReferences": [
-        {
-          "ProjectRef": "E41D40FD13B3A0D800A75A5D",
-          "ProductGroup": "E41D40FE13B3A0D800A75A5D"
-        }
+    "1DF5F4DF0D08C38300B7A737" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "UIKit.framework",
+      "path" : "System\/Library\/Frameworks\/UIKit.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "1DF5F4E00D08C38300B7A737" : {
+      "fileRef" : "1DF5F4DF0D08C38300B7A737",
+      "isa" : "PBXBuildFile"
+    },
+    "19C28FACFE9D520D11CA2CBB" : {
+      "children" : [
+        "1D6058910D05DD3D006BFB54"
       ],
-      "buildConfigurationList": "C01FCF4E08A954540054247B",
-      "targets": [
-        "1D6058900D05DD3D006BFB54"
-      ],
-      "developmentRegion": "en",
-      "knownRegions": [
+      "isa" : "PBXGroup",
+      "name" : "Products",
+      "sourceTree" : "<group>"
+    },
+    "29B97313FDCFA39411CA2CEA" : {
+      "attributes" : {
+        "LastUpgradeCheck" : "0600"
+      },
+      "buildConfigurationList" : "C01FCF4E08A954540054247B",
+      "compatibilityVersion" : "Xcode 3.2",
+      "developmentRegion" : "en",
+      "hasScannedForEncodings" : "1",
+      "isa" : "PBXProject",
+      "knownRegions" : [
         "en",
         "Base"
       ],
-      "isa": "PBXProject",
-      "compatibilityVersion": "Xcode 3.2",
-      "projectDirPath": "",
-      "attributes": {
-        "LastUpgradeCheck": "0600"
-      },
-      "hasScannedForEncodings": "1",
-      "projectRoot": "",
-      "mainGroup": "29B97314FDCFA39411CA2CEA"
+      "mainGroup" : "29B97314FDCFA39411CA2CEA",
+      "projectDirPath" : "",
+      "projectReferences" : [
+        {
+          "ProductGroup" : "E41D40FE13B3A0D800A75A5D",
+          "ProjectRef" : "E41D40FD13B3A0D800A75A5D"
+        }
+      ],
+      "projectRoot" : "",
+      "targets" : [
+        "1D6058900D05DD3D006BFB54"
+      ]
     },
-    "9969E7551C782C4500DEF0F6": {
-      "path": "System/Library/Frameworks/CoreMotion.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreMotion.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "29B97314FDCFA39411CA2CEA" : {
+      "children" : [
+        "9936F60E1BFA4DEE00891288",
+        "E4D8936A11527B74007E1F53",
+        "BB24E1F710DAA51900E9C588",
+        "BB16F26B0F2B646B00518274",
+        "BB16E9930F2B1E5900518274",
+        "19C28FACFE9D520D11CA2CBB",
+        "901808C02053638E004A7774"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "CustomTemplate",
+      "sourceTree" : "<group>"
     },
-    "29B97323FDCFA39411CA2CEA": {
-      "isa": "PBXGroup",
-      "name": "core frameworks",
-      "children": [
+    "29B97323FDCFA39411CA2CEA" : {
+      "children" : [
         "67DFA53419F92A5E003B3434",
         "901808BF2053636F004A7774",
         "BBE5EAB70F49AD8400F28951",
@@ -232,301 +230,193 @@
         "1DF5F4DF0D08C38300B7A737",
         "288765FC0DF74451002DB57D"
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXGroup",
+      "name" : "core frameworks",
+      "sourceTree" : "<group>"
     },
-    "E41D400713B39D2100A75A5D": {
-      "path": "System/Library/Frameworks/CoreMedia.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreMedia.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "32CA4F630368D1EE00C91783" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "path" : "ofxiOS_Prefix.pch",
+      "sourceTree" : "<group>"
     },
-    "9936F6101BFA4DEE00891288": {
-      "isa": "PBXBuildFile",
-      "fileRef": "9936F60F1BFA4DEE00891288"
+    "53F323EA10A20EDB00E0DAE4" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "OpenAL.framework",
+      "path" : "System\/Library\/Frameworks\/OpenAL.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "1DF5F4E00D08C38300B7A737": {
-      "isa": "PBXBuildFile",
-      "fileRef": "1DF5F4DF0D08C38300B7A737"
+    "53F323EB10A20EDB00E0DAE4" : {
+      "fileRef" : "53F323EA10A20EDB00E0DAE4",
+      "isa" : "PBXBuildFile"
     },
-    "BB16EBD10F2B2A9500518274": {
-      "path": "System/Library/Frameworks/OpenGLES.framework",
-      "isa": "PBXFileReference",
-      "name": "OpenGLES.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "67DFA53419F92A5E003B3434" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "Accelerate.framework",
+      "path" : "System\/Library\/Frameworks\/Accelerate.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "1D30AB110D05D00D00671497": {
-      "path": "System/Library/Frameworks/Foundation.framework",
-      "isa": "PBXFileReference",
-      "name": "Foundation.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "67DFA53619F92A69003B3434" : {
+      "fileRef" : "67DFA53419F92A5E003B3434",
+      "isa" : "PBXBuildFile"
     },
-    "5326AEA810A23A0500278DE6": {
-      "isa": "PBXBuildFile",
-      "fileRef": "5326AEA710A23A0500278DE6"
+    "5326AEA710A23A0500278DE6" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreLocation.framework",
+      "path" : "System\/Library\/Frameworks\/CoreLocation.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "1D60588F0D05DD3D006BFB54": {
-      "isa": "PBXFrameworksBuildPhase",
-      "buildActionMask": "2147483647",
-      "files": [
-        "9969E7561C782C4500DEF0F6",
-        "901808C12053638E004A7774",
-        "1D60589F0D05DD5A006BFB54",
-        "1DF5F4E00D08C38300B7A737",
-        "288765FD0DF74451002DB57D",
-        "BB16EBD20F2B2A9500518274",
-        "BB16EBD90F2B2AB500518274",
-        "BBE5EAB80F49AD8400F28951",
-        "53F323EB10A20EDB00E0DAE4",
-        "5326AEA810A23A0500278DE6",
-        "E41D400B13B39D2100A75A5D",
-        "E41D400C13B39D2100A75A5D",
-        "E41D400D13B39D2100A75A5D",
-        "E41D400E13B39D2100A75A5D",
-        "67DFA53619F92A69003B3434"
+    "5326AEA810A23A0500278DE6" : {
+      "fileRef" : "5326AEA710A23A0500278DE6",
+      "isa" : "PBXBuildFile"
+    },
+    "6948EE371B920CB800B5AC1A" : {
+      "children" : [
+
       ],
-      "runOnlyForDeploymentPostprocessing": "0"
+      "isa" : "PBXGroup",
+      "name" : "local_addons",
+      "sourceTree" : "<group>"
     },
-    "1D6058950D05DD3E006BFB54": {
-      "isa": "XCBuildConfiguration",
-      "buildSettings": {
-        "OTHER_LDFLAGS": [
-          "$(OF_CORE_LIBS)",
-          "$(OF_CORE_FRAMEWORKS)"
-        ],
-        "ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME": "",
-        "TARGETED_DEVICE_FAMILY": "1,2",
-        "INFOPLIST_FILE": "ofxiOS-Info.plist",
-        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": "NO",
-        "HEADER_SEARCH_PATHS": [
-          "$(OF_CORE_HEADERS)",
-          "src"
-        ],
-        "PRODUCT_NAME": "${TARGET_NAME}",
-        "VALID_ARCHS": "$(ARCHS_STANDARD)",
-        "FRAMEWORK_SEARCH_PATHS": [
-          "$(inherited)",
-          "$(PROJECT_DIR)"
-        ],
-        "GCC_PRECOMPILE_PREFIX_HEADER": "YES",
-        "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-        "GCC_PREFIX_HEADER": "ofxiOS_Prefix.pch"
-      },
-      "name": "Release"
-    },
-    "E4D8936E11527B74007E1F53": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E4D8936B11527B74007E1F53"
-    },
-    "E41D3ED613B38FB500A75A5D": {
-      "path": "Project.xcconfig",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "text.xcconfig",
-      "sourceTree": "<group>",
-      "fileEncoding": "4"
-    },
-    "9255DD331112741900D6945E": {
-      "inputPaths": [],
-      "shellPath": "/bin/sh",
-      "buildActionMask": "2147483647",
-      "isa": "PBXShellScriptBuildPhase",
-      "outputPaths": [],
-      "runOnlyForDeploymentPostprocessing": "0",
-      "shellScript": "rsync -avz --exclude='.DS_Store' \"${SRCROOT}/bin/data/\" \"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n",
-      "files": []
-    },
-    "32CA4F630368D1EE00C91783": {
-      "path": "ofxiOS_Prefix.pch",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "sourcecode.c.h",
-      "sourceTree": "<group>",
-      "fileEncoding": "4"
-    },
-    "E41D400E13B39D2100A75A5D": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E41D400913B39D2100A75A5D"
-    },
-    "901808C12053638E004A7774": {
-      "isa": "PBXBuildFile",
-      "fileRef": "901808BF2053636F004A7774"
-    },
-    "E4D8936B11527B74007E1F53": {
-      "path": "src/main.mm",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "sourcecode.cpp.objcpp",
-      "name": "main.mm",
-      "sourceTree": "SOURCE_ROOT",
-      "fileEncoding": "4"
-    },
-    "29B97314FDCFA39411CA2CEA": {
-      "isa": "PBXGroup",
-      "name": "CustomTemplate",
-      "children": [
-        "9936F60E1BFA4DEE00891288",
-        "E4D8936A11527B74007E1F53",
-        "BB24E1F710DAA51900E9C588",
-        "BB16F26B0F2B646B00518274",
-        "BB16E9930F2B1E5900518274",
-        "19C28FACFE9D520D11CA2CBB",
-        "901808C02053638E004A7774"
+    "9255DD331112741900D6945E" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
+
       ],
-      "sourceTree": "<group>"
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/bin\/sh",
+      "shellScript" : "rsync -avz --exclude='.DS_Store' \"${SRCROOT}\/bin\/data\/\" \"${TARGET_BUILD_DIR}\/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\n"
     },
-    "9969E7561C782C4500DEF0F6": {
-      "isa": "PBXBuildFile",
-      "fileRef": "9969E7551C782C4500DEF0F6"
-    },
-    "E41D410313B3A11300A75A5D": {
-      "isa": "PBXContainerItemProxy",
-      "containerPortal": "E41D40FD13B3A0D800A75A5D",
-      "remoteGlobalIDString": "BB24DE5C10DA7A3F00E9C588",
-      "remoteInfo": "iPhone+OF Static Library",
-      "proxyType": "1"
-    },
-    "E4A823A312561BE3002F86A2": {
-      "path": "System/Library/Frameworks/CoreGraphics.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreGraphics.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "9936F60E1BFA4DEE00891288": {
-      "path": "mediaAssets",
-      "isa": "PBXGroup",
-      "children": [
+    "9936F60E1BFA4DEE00891288" : {
+      "children" : [
         "9936F6111BFA65F100891288",
         "9936F60F1BFA4DEE00891288"
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXGroup",
+      "path" : "mediaAssets",
+      "sourceTree" : "<group>"
     },
-    "E41D400B13B39D2100A75A5D": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E41D400613B39D2100A75A5D"
+    "9936F60F1BFA4DEE00891288" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "folder.assetcatalog",
+      "path" : "Images.xcassets",
+      "sourceTree" : "<group>"
     },
-    "E41D400813B39D2100A75A5D": {
-      "path": "System/Library/Frameworks/CoreVideo.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreVideo.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "9936F6101BFA4DEE00891288" : {
+      "fileRef" : "9936F60F1BFA4DEE00891288",
+      "isa" : "PBXBuildFile"
     },
-    "BBE5E94E0F497BD800F28951": {
-      "isa": "PBXGroup",
-      "name": "core",
-      "children": [
-        "29B97323FDCFA39411CA2CEA"
+    "9936F6111BFA65F100891288" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "file.storyboard",
+      "path" : "LaunchScreen.storyboard",
+      "sourceTree" : "<group>"
+    },
+    "9936F6121BFA65F100891288" : {
+      "fileRef" : "9936F6111BFA65F100891288",
+      "isa" : "PBXBuildFile"
+    },
+    "9969E7551C782C4500DEF0F6" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreMotion.framework",
+      "path" : "System\/Library\/Frameworks\/CoreMotion.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "9969E7561C782C4500DEF0F6" : {
+      "fileRef" : "9969E7551C782C4500DEF0F6",
+      "isa" : "PBXBuildFile"
+    },
+    "288765FC0DF74451002DB57D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreGraphics.framework",
+      "path" : "System\/Library\/Frameworks\/CoreGraphics.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "288765FD0DF74451002DB57D" : {
+      "fileRef" : "288765FC0DF74451002DB57D",
+      "isa" : "PBXBuildFile"
+    },
+    "901808BF2053636F004A7774" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "GLKit.framework",
+      "path" : "System\/Library\/Frameworks\/GLKit.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "901808C02053638E004A7774" : {
+      "children" : [
+
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXGroup",
+      "name" : "Frameworks",
+      "sourceTree" : "<group>"
     },
-    "C01FCF5008A954540054247B": {
-      "baseConfigurationReference": "E41D3ED613B38FB500A75A5D",
-      "isa": "XCBuildConfiguration",
-      "buildSettings": {
-        "VALID_ARCHS": "$(ARCHS_STANDARD)",
-        "GCC_GENERATE_DEBUGGING_SYMBOLS": "NO",
-        "GCC_WARN_ABOUT_RETURN_TYPE": "YES",
-        "ONLY_ACTIVE_ARCH": "NO",
-        "GCC_SYMBOLS_PRIVATE_EXTERN": "NO",
-        "COMPRESS_PNG_FILES": "NO",
-        "GCC_OPTIMIZATION_LEVEL": "s",
-        "GCC_THUMB_SUPPORT": "NO",
-        "GCC_C_LANGUAGE_STANDARD": "c11",
-        "TARGETED_DEVICE_FAMILY": "1",
-        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]": "NO",
-        "ALWAYS_SEARCH_USER_PATHS": "YES",
-        "SDKROOT": "iphoneos",
-        "WARNING_LDFLAGS": "-no_arch_warnings",
-        "CODE_SIGN_IDENTITY": "",
-        "GCC_DYNAMIC_NO_PIC": "NO",
-        "CODE_SIGN_IDENTITY[sdk=iphoneos*]": "iPhone Developer",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "CODE_SIGN_IDENTITY[sdk=iphonesimulator*]": "",
-        "GCC_WARN_UNUSED_VARIABLE": "YES"
-      },
-      "name": "Release"
+    "901808C12053638E004A7774" : {
+      "fileRef" : "901808BF2053636F004A7774",
+      "isa" : "PBXBuildFile"
     },
-    "BB16EBD20F2B2A9500518274": {
-      "isa": "PBXBuildFile",
-      "fileRef": "BB16EBD10F2B2A9500518274"
-    },
-    "1D60589F0D05DD5A006BFB54": {
-      "isa": "PBXBuildFile",
-      "fileRef": "1D30AB110D05D00D00671497"
-    },
-    "1D6058960D05DD3E006BFB54": {
-      "isa": "XCConfigurationList",
-      "defaultConfigurationIsVisible": "0",
-      "defaultConfigurationName": "Release",
-      "buildConfigurations": [
-        "1D6058940D05DD3E006BFB54",
-        "1D6058950D05DD3E006BFB54"
-      ]
-    },
-    "E41D40FD13B3A0D800A75A5D": {
-      "path": "../../../libs/openFrameworksCompiled/project/ios/iOS+OFLib.xcodeproj",
-      "isa": "PBXFileReference",
-      "name": "iOS+OFLib.xcodeproj",
-      "lastKnownFileType": "wrapper.pb-project",
-      "sourceTree": "SOURCE_ROOT"
-    },
-    "BB16F26B0F2B646B00518274": {
-      "path": "../../../addons",
-      "isa": "PBXGroup",
-      "name": "addons",
-      "children": [],
-      "sourceTree": "SOURCE_ROOT"
-    },
-    "E4D8936F11527B74007E1F53": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E4D8936D11527B74007E1F53"
-    },
-    "1D60588D0D05DD3D006BFB54": {
-      "isa": "PBXResourcesBuildPhase",
-      "buildActionMask": "2147483647",
-      "files": [
-        "9936F6101BFA4DEE00891288",
-        "9936F6121BFA65F100891288"
+    "BB16E9930F2B1E5900518274" : {
+      "children" : [
+        "BBE5E94E0F497BD800F28951"
       ],
-      "runOnlyForDeploymentPostprocessing": "0"
+      "isa" : "PBXGroup",
+      "name" : "libs",
+      "sourceTree" : "<group>"
     },
-    "BBE5EAB70F49AD8400F28951": {
-      "path": "System/Library/Frameworks/AudioToolbox.framework",
-      "isa": "PBXFileReference",
-      "name": "AudioToolbox.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "BB16EBD10F2B2A9500518274" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "OpenGLES.framework",
+      "path" : "System\/Library\/Frameworks\/OpenGLES.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "BB16EBD80F2B2AB500518274": {
-      "path": "System/Library/Frameworks/QuartzCore.framework",
-      "isa": "PBXFileReference",
-      "name": "QuartzCore.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "BB16EBD20F2B2A9500518274" : {
+      "fileRef" : "BB16EBD10F2B2A9500518274",
+      "isa" : "PBXBuildFile"
     },
-    "1D6058900D05DD3D006BFB54": {
-      "buildConfigurationList": "1D6058960D05DD3E006BFB54",
-      "productReference": "1D6058910D05DD3D006BFB54",
-      "productType": "com.apple.product-type.application",
-      "productName": "iPhone",
-      "isa": "PBXNativeTarget",
-      "buildPhases": [
-        "1D60588D0D05DD3D006BFB54",
-        "1D60588E0D05DD3D006BFB54",
-        "1D60588F0D05DD3D006BFB54",
-        "9255DD331112741900D6945E"
+    "BB16EBD80F2B2AB500518274" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "QuartzCore.framework",
+      "path" : "System\/Library\/Frameworks\/QuartzCore.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "BB16EBD90F2B2AB500518274" : {
+      "fileRef" : "BB16EBD80F2B2AB500518274",
+      "isa" : "PBXBuildFile"
+    },
+    "BB16F26B0F2B646B00518274" : {
+      "children" : [
+
       ],
-      "dependencies": [
-        "E41D410413B3A11300A75A5D"
-      ],
-      "name": "emptyExample",
-      "buildRules": []
+      "isa" : "PBXGroup",
+      "name" : "addons",
+      "path" : "..\/..\/..\/addons",
+      "sourceTree" : "SOURCE_ROOT"
     },
-    "BB24E1F710DAA51900E9C588": {
-      "isa": "PBXGroup",
-      "name": "openFrameworks",
-      "children": [
+    "BB24DDC910DA781C00E9C588" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.plist.xml",
+      "path" : "ofxiOS-Info.plist",
+      "sourceTree" : "<group>"
+    },
+    "BB24E1F710DAA51900E9C588" : {
+      "children" : [
         "E41D40FD13B3A0D800A75A5D",
         "32CA4F630368D1EE00C91783",
         "BB24DDC910DA781C00E9C588",
@@ -534,112 +424,280 @@
         "6948EE371B920CB800B5AC1A",
         "E41D3ED613B38FB500A75A5D"
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXGroup",
+      "name" : "openFrameworks",
+      "sourceTree" : "<group>"
     },
-    "E41D410113B3A0D800A75A5D": {
-      "isa": "PBXContainerItemProxy",
-      "containerPortal": "E41D40FD13B3A0D800A75A5D",
-      "remoteGlobalIDString": "BB24DED610DA7A3F00E9C588",
-      "remoteInfo": "iPhone+OF Static Library",
-      "proxyType": "2"
+    "BBE5E94E0F497BD800F28951" : {
+      "children" : [
+        "29B97323FDCFA39411CA2CEA"
+      ],
+      "isa" : "PBXGroup",
+      "name" : "core",
+      "sourceTree" : "<group>"
     },
-    "288765FC0DF74451002DB57D": {
-      "path": "System/Library/Frameworks/CoreGraphics.framework",
-      "isa": "PBXFileReference",
-      "name": "CoreGraphics.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "BBE5EAB70F49AD8400F28951" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "AudioToolbox.framework",
+      "path" : "System\/Library\/Frameworks\/AudioToolbox.framework",
+      "sourceTree" : "SDKROOT"
     },
-    "E4D8936C11527B74007E1F53": {
-      "path": "src/ofApp.h",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "sourcecode.c.h",
-      "name": "ofApp.h",
-      "sourceTree": "SOURCE_ROOT",
-      "fileEncoding": "4"
+    "BBE5EAB80F49AD8400F28951" : {
+      "fileRef" : "BBE5EAB70F49AD8400F28951",
+      "isa" : "PBXBuildFile"
     },
-    "9936F6111BFA65F100891288": {
-      "path": "LaunchScreen.storyboard",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "file.storyboard",
-      "sourceTree": "<group>",
-      "fileEncoding": "4"
+    "BF1D97122D7552820033282F" : {
+      "alwaysOutOfDate" : "1",
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "inputFileListPaths" : [
+
+      ],
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "outputFileListPaths" : [
+
+      ],
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/bin\/sh",
+      "shellScript" : "# Type a script or drag a script file from your workspace to insert its path.\necho \"CONFIGURATION: ${CONFIGURATION}\"\necho \"LIB_OF: ${LIB_OF}\"\n",
+      "showEnvVarsInLog" : "0"
     },
-    "C01FCF4E08A954540054247B": {
-      "isa": "XCConfigurationList",
-      "defaultConfigurationIsVisible": "0",
-      "defaultConfigurationName": "Release",
-      "buildConfigurations": [
+    "BF46A0162D754E9E00E4F02F" : {
+      "alwaysOutOfDate" : "1",
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "inputFileListPaths" : [
+
+      ],
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "outputFileListPaths" : [
+
+      ],
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/bin\/sh",
+      "shellScript" : "#!\/bin\/sh\n\necho \"Running: Platform: $PLATFORM_NAME\"\nif [[ \"${PLATFORM_NAME}\" == \"iphonesimulator\" ]]; then\n    OF_CORE_SDK=\"iphonesimulator\"\n    if [[ \"$HOST_ARCH\" == \"arm64\" ]]; then\n        ARCHS=\"-arch arm64\"\n    elif [[ \"$HOST_ARCH\" == \"x86_64\" ]]; then\n        ARCHS=\"-arch x86_64 arm64\"\n    else\n        echo \"Warning: Unknown host architecture '$HOST_ARCH', defaulting to arm64 for simulator\"\n        ARCHS=\"-arch arm64\"\n    fi\nelse\n    OF_CORE_SDK=\"iphoneos\"\n    ARCHS=\"-arch arm64\"\nfi\n\nexport OF_CORE_BUILD_COMMAND=\"xcodebuild -project $OF_PATH\/libs\/openFrameworksCompiled\/project\/ios\/iOS+OFLib.xcodeproj \\\n-target openFrameworks -configuration ${CONFIGURATION} \\\nSDK=${OF_CORE_SDK} -sdk ${OF_CORE_SDK} ${ARCHS} \\\nCLANG_CXX_LANGUAGE_STANDARD=$CLANG_CXX_LANGUAGE_STANDARD \\\nIPHONEOS_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET \\\nGCC_PREPROCESSOR_DEFINITIONS=$USER_PREPROCESSOR_DEFINITIONS\"\n\necho \"Running: $OF_CORE_BUILD_COMMAND\"\n\n# Execute the build command\neval $OF_CORE_BUILD_COMMAND\n",
+      "showEnvVarsInLog" : "0"
+    },
+    "C01FCF4E08A954540054247B" : {
+      "buildConfigurations" : [
         "C01FCF4F08A954540054247B",
         "C01FCF5008A954540054247B"
-      ]
-    },
-    "9936F60F1BFA4DEE00891288": {
-      "path": "Images.xcassets",
-      "isa": "PBXFileReference",
-      "lastKnownFileType": "folder.assetcatalog",
-      "sourceTree": "<group>"
-    },
-    "E41D400C13B39D2100A75A5D": {
-      "isa": "PBXBuildFile",
-      "fileRef": "E41D400713B39D2100A75A5D"
-    },
-    "E41D400913B39D2100A75A5D": {
-      "path": "System/Library/Frameworks/MapKit.framework",
-      "isa": "PBXFileReference",
-      "name": "MapKit.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "1DF5F4DF0D08C38300B7A737": {
-      "path": "System/Library/Frameworks/UIKit.framework",
-      "isa": "PBXFileReference",
-      "name": "UIKit.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "53F323EA10A20EDB00E0DAE4": {
-      "path": "System/Library/Frameworks/OpenAL.framework",
-      "isa": "PBXFileReference",
-      "name": "OpenAL.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "67DFA53419F92A5E003B3434": {
-      "path": "System/Library/Frameworks/Accelerate.framework",
-      "isa": "PBXFileReference",
-      "name": "Accelerate.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
-    },
-    "E41D410413B3A11300A75A5D": {
-      "isa": "PBXTargetDependency",
-      "name": "iPhone+OF Static Library",
-      "targetProxy": "E41D410313B3A11300A75A5D"
-    },
-    "BB16E9930F2B1E5900518274": {
-      "isa": "PBXGroup",
-      "name": "libs",
-      "children": [
-        "BBE5E94E0F497BD800F28951"
       ],
-      "sourceTree": "<group>"
+      "defaultConfigurationIsVisible" : "0",
+      "defaultConfigurationName" : "Release",
+      "isa" : "XCConfigurationList"
     },
-    "E41D400613B39D2100A75A5D": {
-      "path": "System/Library/Frameworks/AVFoundation.framework",
-      "isa": "PBXFileReference",
-      "name": "AVFoundation.framework",
-      "lastKnownFileType": "wrapper.framework",
-      "sourceTree": "SDKROOT"
+    "C01FCF4F08A954540054247B" : {
+      "baseConfigurationReference" : "E41D3ED613B38FB500A75A5D",
+      "buildSettings" : {
+        "ALWAYS_SEARCH_USER_PATHS" : "YES",
+        "CLANG_CXX_LIBRARY" : "libc++",
+        "CODE_SIGN_IDENTITY" : "",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]" : "iPhone Developer",
+        "CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" : "",
+        "COMPRESS_PNG_FILES" : "NO",
+        "GCC_C_LANGUAGE_STANDARD" : "c17",
+        "GCC_OPTIMIZATION_LEVEL" : "0",
+        "GCC_SYMBOLS_PRIVATE_EXTERN" : "NO",
+        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" : "NO",
+        "GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO" : "NO",
+        "GCC_WARN_ABOUT_POINTER_SIGNEDNESS" : "NO",
+        "GCC_WARN_ABOUT_RETURN_TYPE" : "YES",
+        "GCC_WARN_ALLOW_INCOMPLETE_PROTOCOL" : "NO",
+        "GCC_WARN_PROTOTYPE_CONVERSION" : "NO",
+        "GCC_WARN_UNUSED_VARIABLE" : "YES",
+        "ONLY_ACTIVE_ARCH" : "YES",
+        "PROVISIONING_PROFILE[sdk=iphoneos*]" : "",
+        "SDKROOT" : "iphoneos",
+        "TARGETED_DEVICE_FAMILY" : "1",
+        "VALID_ARCHS" : "$(ARCHS_STANDARD)",
+        "WARNING_LDFLAGS" : "-no_arch_warnings"
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Debug"
     },
-    "E41D40FE13B3A0D800A75A5D": {
-      "isa": "PBXGroup",
-      "name": "Products",
-      "children": [
+    "C01FCF5008A954540054247B" : {
+      "baseConfigurationReference" : "E41D3ED613B38FB500A75A5D",
+      "buildSettings" : {
+        "ALWAYS_SEARCH_USER_PATHS" : "YES",
+        "CLANG_CXX_LIBRARY" : "libc++",
+        "CODE_SIGN_IDENTITY" : "",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]" : "iPhone Developer",
+        "CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" : "",
+        "COMPRESS_PNG_FILES" : "NO",
+        "GCC_C_LANGUAGE_STANDARD" : "c11",
+        "GCC_DYNAMIC_NO_PIC" : "NO",
+        "GCC_GENERATE_DEBUGGING_SYMBOLS" : "NO",
+        "GCC_OPTIMIZATION_LEVEL" : "s",
+        "GCC_SYMBOLS_PRIVATE_EXTERN" : "NO",
+        "GCC_THUMB_SUPPORT" : "NO",
+        "GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" : "NO",
+        "GCC_WARN_ABOUT_RETURN_TYPE" : "YES",
+        "GCC_WARN_UNUSED_VARIABLE" : "YES",
+        "ONLY_ACTIVE_ARCH" : "NO",
+        "SDKROOT" : "iphoneos",
+        "TARGETED_DEVICE_FAMILY" : "1",
+        "VALID_ARCHS" : "$(ARCHS_STANDARD)",
+        "WARNING_LDFLAGS" : "-no_arch_warnings"
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Release"
+    },
+    "E4A823A312561BE3002F86A2" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreGraphics.framework",
+      "path" : "System\/Library\/Frameworks\/CoreGraphics.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "E4D8936A11527B74007E1F53" : {
+      "children" : [
+        "E4D8936B11527B74007E1F53",
+        "E4D8936D11527B74007E1F53",
+        "E4D8936C11527B74007E1F53"
+      ],
+      "isa" : "PBXGroup",
+      "path" : "src",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4D8936B11527B74007E1F53" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.objcpp",
+      "name" : "main.mm",
+      "path" : "src\/main.mm",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4D8936C11527B74007E1F53" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "name" : "ofApp.h",
+      "path" : "src\/ofApp.h",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4D8936D11527B74007E1F53" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.objcpp",
+      "name" : "ofApp.mm",
+      "path" : "src\/ofApp.mm",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4D8936E11527B74007E1F53" : {
+      "fileRef" : "E4D8936B11527B74007E1F53",
+      "isa" : "PBXBuildFile"
+    },
+    "E4D8936F11527B74007E1F53" : {
+      "fileRef" : "E4D8936D11527B74007E1F53",
+      "isa" : "PBXBuildFile"
+    },
+    "E41D3ED613B38FB500A75A5D" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.xcconfig",
+      "path" : "Project.xcconfig",
+      "sourceTree" : "<group>"
+    },
+    "E41D3EE513B3906D00A75A5D" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.xcconfig",
+      "name" : "CoreOF.xcconfig",
+      "path" : "..\/..\/..\/libs\/openFrameworksCompiled\/project\/ios\/CoreOF.xcconfig",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E41D40FD13B3A0D800A75A5D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.pb-project",
+      "name" : "iOS+OFLib.xcodeproj",
+      "path" : "..\/..\/..\/libs\/openFrameworksCompiled\/project\/ios\/iOS+OFLib.xcodeproj",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E41D40FE13B3A0D800A75A5D" : {
+      "children" : [
         "E41D410213B3A0D800A75A5D"
       ],
-      "sourceTree": "<group>"
+      "isa" : "PBXGroup",
+      "name" : "Products",
+      "sourceTree" : "<group>"
+    },
+    "E41D400B13B39D2100A75A5D" : {
+      "fileRef" : "E41D400613B39D2100A75A5D",
+      "isa" : "PBXBuildFile"
+    },
+    "E41D400C13B39D2100A75A5D" : {
+      "fileRef" : "E41D400713B39D2100A75A5D",
+      "isa" : "PBXBuildFile"
+    },
+    "E41D400D13B39D2100A75A5D" : {
+      "fileRef" : "E41D400813B39D2100A75A5D",
+      "isa" : "PBXBuildFile"
+    },
+    "E41D400E13B39D2100A75A5D" : {
+      "fileRef" : "E41D400913B39D2100A75A5D",
+      "isa" : "PBXBuildFile"
+    },
+    "E41D400613B39D2100A75A5D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "AVFoundation.framework",
+      "path" : "System\/Library\/Frameworks\/AVFoundation.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "E41D400713B39D2100A75A5D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreMedia.framework",
+      "path" : "System\/Library\/Frameworks\/CoreMedia.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "E41D400813B39D2100A75A5D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "CoreVideo.framework",
+      "path" : "System\/Library\/Frameworks\/CoreVideo.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "E41D400913B39D2100A75A5D" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "wrapper.framework",
+      "name" : "MapKit.framework",
+      "path" : "System\/Library\/Frameworks\/MapKit.framework",
+      "sourceTree" : "SDKROOT"
+    },
+    "E41D410113B3A0D800A75A5D" : {
+      "containerPortal" : "E41D40FD13B3A0D800A75A5D",
+      "isa" : "PBXContainerItemProxy",
+      "proxyType" : "2",
+      "remoteGlobalIDString" : "BB24DED610DA7A3F00E9C588",
+      "remoteInfo" : "iPhone+OF Static Library"
+    },
+    "E41D410213B3A0D800A75A5D" : {
+      "fileType" : "archive.ar",
+      "isa" : "PBXReferenceProxy",
+      "path" : "openFrameworksiOSDebug.a",
+      "remoteRef" : "E41D410113B3A0D800A75A5D",
+      "sourceTree" : "BUILT_PRODUCTS_DIR"
     }
   },
-  "rootObject": "29B97313FDCFA39411CA2CEA"
+  "objectVersion" : "54",
+  "rootObject" : "29B97313FDCFA39411CA2CEA"
 }

--- a/scripts/templates/ios/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample.xcscheme
+++ b/scripts/templates/ios/emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample.xcscheme
@@ -23,12 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,17 +36,21 @@
             ReferencedContainer = "container:emptyExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
@@ -57,16 +59,15 @@
             ReferencedContainer = "container:emptyExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "1D6058900D05DD3D006BFB54"

--- a/scripts/templates/ios/ofxiOS-Info.plist
+++ b/scripts/templates/ios/ofxiOS-Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>This app needs to access the camera</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app makes use of your Location</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app needs to access the microphone</string>
 	<key>UIApplicationExitsOnSuspend</key>

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -1,311 +1,351 @@
 {
-	"classes": {},
-	"objectVersion": "54",
-	"archiveVersion": "1",
-	"objects": {
-		"E4B69E1C0A3A1BDC003C02F2": {
-			"path": "src",
-			"isa": "PBXGroup",
-			"children": [
-				"E4B69E1D0A3A1BDC003C02F2",
-				"E4B69E1E0A3A1BDC003C02F2",
-				"E4B69E1F0A3A1BDC003C02F2"
-			],
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"E4EB6923138AFD0F00A09F29": {
-			"path": "Project.xcconfig",
-			"isa": "PBXFileReference",
-			"sourceTree": "<group>",
-			"fileEncoding": "4",
-			"lastKnownFileType": "text.xcconfig"
-		},
-		"BF26640B2C634C16004360E2": {
-			"buildActionMask": "2147483647",
-			"runOnlyForDeploymentPostprocessing": "0",
-			"outputPaths": [],
-			"shellPath": "/usr/bin/env bash",
-			"inputFileListPaths": [],
-			"showEnvVarsInLog": "0",
-			"isa": "PBXShellScriptBuildPhase",
-			"shellScript": "#!/usr/bin/env bash\n\n# Determine the Xcode build directory\nTARGET_DIR=\"${BUILT_PRODUCTS_DIR:-$SRCROOT/bin}\"\n\n# Check if the directory exists\nif [ ! -d \"$TARGET_DIR\" ]; then\n  echo \"Error: Target directory $TARGET_DIR does not exist.\"\n  exit 1\nfi\n\n# Check and set the com.apple.xcode.CreatedByBuildSystem attribute\nATTRIBUTE_CHECK=$(xattr -p com.apple.xcode.CreatedByBuildSystem \"$TARGET_DIR\" 2>/dev/null)\nif [ -z \"$ATTRIBUTE_CHECK\" ]; then\n  xattr -w com.apple.xcode.CreatedByBuildSystem true \"$TARGET_DIR\"\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem set to true for $TARGET_DIR\"\nelse\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem already set for $TARGET_DIR\"\nfi\n",
-			"files": [],
-			"alwaysOutOfDate": "1",
-			"inputPaths": [],
-			"outputFileListPaths": []
-		},
-		"E4C2427710CC5ABF004149E2": {
-			"isa": "PBXCopyFilesBuildPhase",
-			"buildActionMask": "2147483647",
-			"dstPath": "",
-			"dstSubfolderSpec": "10",
-			"files": [],
-			"runOnlyForDeploymentPostprocessing": "0"
-		},
-		"E4A5B60F29BAAAE400C2D356": {
-			"isa": "PBXCopyFilesBuildPhase",
-			"buildActionMask": "2147483647",
-			"dstPath": "",
-			"dstSubfolderSpec": "6",
-			"files": [],
-			"runOnlyForDeploymentPostprocessing": "0"
-		},
-		"191EF70929D778A400F35F26": {
-			"path": "../../../libs/openFrameworks",
-			"isa": "PBXFileReference",
-			"name": "openFrameworks",
-			"lastKnownFileType": "folder",
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"191CD6FA2847E21E0085CBB6": {
-			"path": "of.entitlements",
-			"isa": "PBXFileReference",
-			"sourceTree": "<group>",
-			"fileEncoding": "4",
-			"lastKnownFileType": "text.plist.entitlements"
-		},
-		"E4B69B4C0A3A1720003C02F2": {
-			"buildConfigurationList": "E4B69B4D0A3A1720003C02F2",
-			"targets": [
-				"E4B69B5A0A3A1756003C02F2"
-			],
-			"developmentRegion": "en",
-			"knownRegions": [
-				"en",
-				"Base"
-			],
-			"isa": "PBXProject",
-			"compatibilityVersion": "Xcode 3.2",
-			"productRefGroup": "E4B69B4A0A3A1720003C02F2",
-			"projectDirPath": "",
-			"attributes": {
-				"LastUpgradeCheck": "1540",
-				"BuildIndependentTargetsInParallel": "YES"
-			},
-			"hasScannedForEncodings": "0",
-			"projectRoot": "",
-			"mainGroup": "E4B69B4A0A3A1720003C02F2"
-		},
-		"E4B69E1E0A3A1BDC003C02F2": {
-			"path": "src/ofApp.cpp",
-			"isa": "PBXFileReference",
-			"sourceTree": "SOURCE_ROOT",
-			"name": "ofApp.cpp",
-			"explicitFileType": "sourcecode.cpp.cpp",
-			"fileEncoding": "4"
-		},
-		"E4B69E1D0A3A1BDC003C02F2": {
-			"path": "src/main.cpp",
-			"isa": "PBXFileReference",
-			"sourceTree": "SOURCE_ROOT",
-			"name": "main.cpp",
-			"fileEncoding": "4",
-			"lastKnownFileType": "sourcecode.cpp.cpp"
-		},
-		"19B789C429E5AB4A0082E9B8": {
-			"buildActionMask": "2147483647",
-			"runOnlyForDeploymentPostprocessing": "0",
-			"outputPaths": [],
-			"shellPath": "/bin/sh",
-			"inputFileListPaths": [],
-			"showEnvVarsInLog": "0",
-			"isa": "PBXShellScriptBuildPhase",
-			"shellScript": "\"$OF_PATH/scripts/osx/xcode_project.sh\"\n",
-			"files": [],
-			"alwaysOutOfDate": "1",
-			"inputPaths": [],
-			"outputFileListPaths": []
-		},
-		"E42962A92163ECCD00A6A9E2": {
-			"alwaysOutOfDate": "1",
-			"inputPaths": [],
-			"buildActionMask": "2147483647",
-			"shellPath": "/bin/sh",
-			"showEnvVarsInLog": "0",
-			"outputPaths": [],
-			"isa": "PBXShellScriptBuildPhase",
-			"runOnlyForDeploymentPostprocessing": "0",
-			"shellScript": "$OF_CORE_BUILD_COMMAND\n",
-			"files": [],
-			"name": "Run Script — Compile OF"
-		},
-		"E4B69B4F0A3A1720003C02F2": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
-				"GCC_UNROLL_LOOPS": "YES",
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"GCC_OPTIMIZATION_LEVEL": "3",
-				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
-				"COPY_PHASE_STRIP": "YES"
-			},
-			"name": "Release"
-		},
-		"BB4B014C10F69532006C3DED": {
-			"path": "../../../addons",
-			"isa": "PBXGroup",
-			"name": "addons",
-			"children": [],
-			"sourceTree": "SOURCE_ROOT"
-		},
-		"E4B69B4A0A3A1720003C02F2": {
-			"isa": "PBXGroup",
-			"sourceTree": "<group>",
-			"children": [
-				"191CD6FA2847E21E0085CBB6",
-				"E4B6FCAD0C3E899E008CF71C",
-				"E4EB6923138AFD0F00A09F29",
-				"E4B69E1C0A3A1BDC003C02F2",
-				"191EF70929D778A400F35F26",
-				"BB4B014C10F69532006C3DED",
-				"E4B69B5B0A3A1756003C02F2"
-			]
-		},
-		"E4B69B580A3A1756003C02F2": {
-			"isa": "PBXSourcesBuildPhase",
-			"buildActionMask": "2147483647",
-			"files": [
-				"E4B69E200A3A1BDC003C02F2",
-				"E4B69E210A3A1BDC003C02F2"
-			],
-			"runOnlyForDeploymentPostprocessing": "0"
-		},
-		"E4B69B4E0A3A1720003C02F2": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"OTHER_CPLUSPLUSFLAGS": "-D__MACOSX_CORE__",
-				"CODE_SIGN_ENTITLEMENTS": "of.entitlements",
-				"COPY_PHASE_STRIP": "NO",
-				"GCC_OPTIMIZATION_LEVEL": "0",
-				"ENABLE_TESTABILITY": "YES",
-				"GCC_WARN_UNUSED_VARIABLE": "NO"
-			},
-			"name": "Debug"
-		},
-		"E4B69B600A3A1757003C02F2": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"GCC_DYNAMIC_NO_PIC": "NO",
-				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
-				"COPY_PHASE_STRIP": "NO",
-				"ARCHS": "$(ARCHS_STANDARD)",
-				"OTHER_LDFLAGS": [
-					"$(OF_CORE_LIBS)",
-					"$(OF_CORE_FRAMEWORKS)",
-					"$(LIB_OF_DEBUG)"
-				],
-				"LIBRARY_SEARCH_PATHS": "$(inherited)"
-			},
-			"name": "Debug"
-		},
-		"E4B69B590A3A1756003C02F2": {
-			"isa": "PBXFrameworksBuildPhase",
-			"buildActionMask": "2147483647",
-			"files": [],
-			"runOnlyForDeploymentPostprocessing": "0"
-		},
-		"E4B69B610A3A1757003C02F2": {
-			"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-			"isa": "XCBuildConfiguration",
-			"buildSettings": {
-				"HEADER_SEARCH_PATHS": [
-					"$(OF_CORE_HEADERS)",
-					"src"
-				],
-				"FRAMEWORK_SEARCH_PATHS": "$(inherited)",
-				"COPY_PHASE_STRIP": "YES",
-				"ARCHS": "$(ARCHS_STANDARD)",
-				"OTHER_LDFLAGS": [
-					"$(OF_CORE_LIBS)",
-					"$(OF_CORE_FRAMEWORKS)",
-					"$(LIB_OF)"
-				],
-				"baseConfigurationReference": "E4EB6923138AFD0F00A09F29",
-				"LIBRARY_SEARCH_PATHS": "$(inherited)"
-			},
-			"name": "Release"
-		},
-		"E4B69B4D0A3A1720003C02F2": {
-			"isa": "XCConfigurationList",
-			"defaultConfigurationIsVisible": "0",
-			"defaultConfigurationName": "Release",
-			"buildConfigurations": [
-				"E4B69B4E0A3A1720003C02F2",
-				"E4B69B4F0A3A1720003C02F2"
-			]
-		},
-		"E4B69E200A3A1BDC003C02F2": {
-			"isa": "PBXBuildFile",
-			"fileRef": "E4B69E1D0A3A1BDC003C02F2"
-		},
-		"E4B69E210A3A1BDC003C02F2": {
-			"isa": "PBXBuildFile",
-			"fileRef": "E4B69E1E0A3A1BDC003C02F2"
-		},
-		"E4B69B5A0A3A1756003C02F2": {
-			"buildConfigurationList": "E4B69B5F0A3A1757003C02F2",
-			"productReference": "E4B69B5B0A3A1756003C02F2",
-			"productType": "com.apple.product-type.application",
-			"productName": "myOFApp",
-			"isa": "PBXNativeTarget",
-			"buildPhases": [
-				"BF26640B2C634C16004360E2",
-				"E42962A92163ECCD00A6A9E2",
-				"E4B69B580A3A1756003C02F2",
-				"E4B69B590A3A1756003C02F2",
-				"E4C2427710CC5ABF004149E2",
-				"E4A5B60F29BAAAE400C2D356",
-				"19B789C429E5AB4A0082E9B8"
-			],
-			"dependencies": [],
-			"name": "emptyExample",
-			"buildRules": []
-		},
-		"E4B6FCAD0C3E899E008CF71C": {
-			"path": "openFrameworks-Info.plist",
-			"isa": "PBXFileReference",
-			"sourceTree": "<group>",
-			"fileEncoding": "4",
-			"lastKnownFileType": "text.plist.xml"
-		},
-		"E4B69B5F0A3A1757003C02F2": {
-			"isa": "XCConfigurationList",
-			"defaultConfigurationIsVisible": "0",
-			"defaultConfigurationName": "Release",
-			"buildConfigurations": [
-				"E4B69B600A3A1757003C02F2",
-				"E4B69B610A3A1757003C02F2"
-			]
-		},
-		"E4B69B5B0A3A1756003C02F2": {
-			"path": "emptyExampleDebug.app",
-			"isa": "PBXFileReference",
-			"includeInIndex": "0",
-			"explicitFileType": "wrapper.application",
-			"sourceTree": "BUILT_PRODUCTS_DIR"
-		},
-		"E4B69E1F0A3A1BDC003C02F2": {
-			"path": "src/ofApp.h",
-			"isa": "PBXFileReference",
-			"sourceTree": "SOURCE_ROOT",
-			"name": "ofApp.h",
-			"fileEncoding": "4",
-			"lastKnownFileType": "sourcecode.c.h"
-		}
-	},
-	"rootObject": "E4B69B4C0A3A1720003C02F2"
+  "archiveVersion" : "1",
+  "classes" : {
+
+  },
+  "objects" : {
+    "19B789C429E5AB4A0082E9B8" : {
+      "alwaysOutOfDate" : "1",
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "inputFileListPaths" : [
+
+      ],
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "outputFileListPaths" : [
+
+      ],
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/bin\/sh",
+      "shellScript" : "\"$OF_PATH\/scripts\/osx\/xcode_project.sh\"\n",
+      "showEnvVarsInLog" : "0"
+    },
+    "191CD6FA2847E21E0085CBB6" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.plist.entitlements",
+      "path" : "of.entitlements",
+      "sourceTree" : "<group>"
+    },
+    "191EF70929D778A400F35F26" : {
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "folder",
+      "name" : "openFrameworks",
+      "path" : "..\/..\/..\/libs\/openFrameworks",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "BB4B014C10F69532006C3DED" : {
+      "children" : [
+
+      ],
+      "isa" : "PBXGroup",
+      "name" : "addons",
+      "path" : "..\/..\/..\/addons",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "BF26640B2C634C16004360E2" : {
+      "alwaysOutOfDate" : "1",
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "inputFileListPaths" : [
+
+      ],
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "outputFileListPaths" : [
+
+      ],
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/usr\/bin\/env bash",
+      "shellScript" : "#!\/usr\/bin\/env bash\n\n# Determine the Xcode build directory\nTARGET_DIR=\"${BUILT_PRODUCTS_DIR:-$SRCROOT\/bin}\"\n\n# Check if the directory exists\nif [ ! -d \"$TARGET_DIR\" ]; then\n  echo \"Error: Target directory $TARGET_DIR does not exist.\"\n  exit 1\nfi\n\n# Check and set the com.apple.xcode.CreatedByBuildSystem attribute\nATTRIBUTE_CHECK=$(xattr -p com.apple.xcode.CreatedByBuildSystem \"$TARGET_DIR\" 2>\/dev\/null)\nif [ -z \"$ATTRIBUTE_CHECK\" ]; then\n  xattr -w com.apple.xcode.CreatedByBuildSystem true \"$TARGET_DIR\"\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem set to true for $TARGET_DIR\"\nelse\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem already set for $TARGET_DIR\"\nfi\n",
+      "showEnvVarsInLog" : "0"
+    },
+    "E4A5B60F29BAAAE400C2D356" : {
+      "buildActionMask" : "2147483647",
+      "dstPath" : "",
+      "dstSubfolderSpec" : "6",
+      "files" : [
+
+      ],
+      "isa" : "PBXCopyFilesBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
+    },
+    "E4B6FCAD0C3E899E008CF71C" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.plist.xml",
+      "path" : "openFrameworks-Info.plist",
+      "sourceTree" : "<group>"
+    },
+    "E4B69B4A0A3A1720003C02F2" : {
+      "children" : [
+        "191CD6FA2847E21E0085CBB6",
+        "E4B6FCAD0C3E899E008CF71C",
+        "E4EB6923138AFD0F00A09F29",
+        "E4B69E1C0A3A1BDC003C02F2",
+        "191EF70929D778A400F35F26",
+        "BB4B014C10F69532006C3DED",
+        "E4B69B5B0A3A1756003C02F2"
+      ],
+      "isa" : "PBXGroup",
+      "sourceTree" : "<group>"
+    },
+    "E4B69B4C0A3A1720003C02F2" : {
+      "attributes" : {
+        "BuildIndependentTargetsInParallel" : "YES",
+        "LastUpgradeCheck" : "1540"
+      },
+      "buildConfigurationList" : "E4B69B4D0A3A1720003C02F2",
+      "compatibilityVersion" : "Xcode 3.2",
+      "developmentRegion" : "en",
+      "hasScannedForEncodings" : "0",
+      "isa" : "PBXProject",
+      "knownRegions" : [
+        "en",
+        "Base"
+      ],
+      "mainGroup" : "E4B69B4A0A3A1720003C02F2",
+      "productRefGroup" : "E4B69B4A0A3A1720003C02F2",
+      "projectDirPath" : "",
+      "projectRoot" : "",
+      "targets" : [
+        "E4B69B5A0A3A1756003C02F2"
+      ]
+    },
+    "E4B69B4D0A3A1720003C02F2" : {
+      "buildConfigurations" : [
+        "E4B69B4E0A3A1720003C02F2",
+        "E4B69B4F0A3A1720003C02F2"
+      ],
+      "defaultConfigurationIsVisible" : "0",
+      "defaultConfigurationName" : "Release",
+      "isa" : "XCConfigurationList"
+    },
+    "E4B69B4E0A3A1720003C02F2" : {
+      "baseConfigurationReference" : "E4EB6923138AFD0F00A09F29",
+      "buildSettings" : {
+        "CODE_SIGN_ENTITLEMENTS" : "of.entitlements",
+        "COPY_PHASE_STRIP" : "NO",
+        "ENABLE_TESTABILITY" : "YES",
+        "GCC_OPTIMIZATION_LEVEL" : "0",
+        "GCC_WARN_UNUSED_VARIABLE" : "NO",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "OTHER_CPLUSPLUSFLAGS" : "-D__MACOSX_CORE__"
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Debug"
+    },
+    "E4B69B4F0A3A1720003C02F2" : {
+      "baseConfigurationReference" : "E4EB6923138AFD0F00A09F29",
+      "buildSettings" : {
+        "CODE_SIGN_ENTITLEMENTS" : "of.entitlements",
+        "COPY_PHASE_STRIP" : "YES",
+        "GCC_OPTIMIZATION_LEVEL" : "3",
+        "GCC_UNROLL_LOOPS" : "YES",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "OTHER_CPLUSPLUSFLAGS" : "-D__MACOSX_CORE__"
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Release"
+    },
+    "E4B69B5A0A3A1756003C02F2" : {
+      "buildConfigurationList" : "E4B69B5F0A3A1757003C02F2",
+      "buildPhases" : [
+        "BF26640B2C634C16004360E2",
+        "E42962A92163ECCD00A6A9E2",
+        "E4B69B580A3A1756003C02F2",
+        "E4B69B590A3A1756003C02F2",
+        "E4C2427710CC5ABF004149E2",
+        "E4A5B60F29BAAAE400C2D356",
+        "19B789C429E5AB4A0082E9B8"
+      ],
+      "buildRules" : [
+
+      ],
+      "dependencies" : [
+
+      ],
+      "isa" : "PBXNativeTarget",
+      "name" : "emptyExample",
+      "productName" : "myOFApp",
+      "productReference" : "E4B69B5B0A3A1756003C02F2",
+      "productType" : "com.apple.product-type.application"
+    },
+    "E4B69B5B0A3A1756003C02F2" : {
+      "explicitFileType" : "wrapper.application",
+      "includeInIndex" : "0",
+      "isa" : "PBXFileReference",
+      "path" : "emptyExampleDebug.app",
+      "sourceTree" : "BUILT_PRODUCTS_DIR"
+    },
+    "E4B69B5F0A3A1757003C02F2" : {
+      "buildConfigurations" : [
+        "E4B69B600A3A1757003C02F2",
+        "E4B69B610A3A1757003C02F2"
+      ],
+      "defaultConfigurationIsVisible" : "0",
+      "defaultConfigurationName" : "Release",
+      "isa" : "XCConfigurationList"
+    },
+    "E4B69B580A3A1756003C02F2" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
+        "E4B69E200A3A1BDC003C02F2",
+        "E4B69E210A3A1BDC003C02F2"
+      ],
+      "isa" : "PBXSourcesBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
+    },
+    "E4B69B590A3A1756003C02F2" : {
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "isa" : "PBXFrameworksBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
+    },
+    "E4B69B600A3A1757003C02F2" : {
+      "baseConfigurationReference" : "E4EB6923138AFD0F00A09F29",
+      "buildSettings" : {
+        "ARCHS" : "$(ARCHS_STANDARD)",
+        "COPY_PHASE_STRIP" : "NO",
+        "FRAMEWORK_SEARCH_PATHS" : "$(inherited)",
+        "GCC_DYNAMIC_NO_PIC" : "NO",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "LIBRARY_SEARCH_PATHS" : "$(inherited)",
+        "OTHER_LDFLAGS" : [
+          "$(OF_CORE_LIBS)",
+          "$(OF_CORE_FRAMEWORKS)",
+          "$(LIB_OF_DEBUG)"
+        ]
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Debug"
+    },
+    "E4B69B610A3A1757003C02F2" : {
+      "baseConfigurationReference" : "E4EB6923138AFD0F00A09F29",
+      "buildSettings" : {
+        "ARCHS" : "$(ARCHS_STANDARD)",
+        "baseConfigurationReference" : "E4EB6923138AFD0F00A09F29",
+        "COPY_PHASE_STRIP" : "YES",
+        "FRAMEWORK_SEARCH_PATHS" : "$(inherited)",
+        "HEADER_SEARCH_PATHS" : [
+          "$(OF_CORE_HEADERS)",
+          "src"
+        ],
+        "LIBRARY_SEARCH_PATHS" : "$(inherited)",
+        "OTHER_LDFLAGS" : [
+          "$(OF_CORE_LIBS)",
+          "$(OF_CORE_FRAMEWORKS)",
+          "$(LIB_OF_RELEASE)"
+        ]
+      },
+      "isa" : "XCBuildConfiguration",
+      "name" : "Release"
+    },
+    "E4B69E1C0A3A1BDC003C02F2" : {
+      "children" : [
+        "E4B69E1D0A3A1BDC003C02F2",
+        "E4B69E1E0A3A1BDC003C02F2",
+        "E4B69E1F0A3A1BDC003C02F2"
+      ],
+      "isa" : "PBXGroup",
+      "path" : "src",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4B69E1D0A3A1BDC003C02F2" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.cpp.cpp",
+      "name" : "main.cpp",
+      "path" : "src\/main.cpp",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4B69E1E0A3A1BDC003C02F2" : {
+      "explicitFileType" : "sourcecode.cpp.cpp",
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "name" : "ofApp.cpp",
+      "path" : "src\/ofApp.cpp",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4B69E1F0A3A1BDC003C02F2" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "sourcecode.c.h",
+      "name" : "ofApp.h",
+      "path" : "src\/ofApp.h",
+      "sourceTree" : "SOURCE_ROOT"
+    },
+    "E4B69E200A3A1BDC003C02F2" : {
+      "fileRef" : "E4B69E1D0A3A1BDC003C02F2",
+      "isa" : "PBXBuildFile"
+    },
+    "E4B69E210A3A1BDC003C02F2" : {
+      "fileRef" : "E4B69E1E0A3A1BDC003C02F2",
+      "isa" : "PBXBuildFile"
+    },
+    "E4C2427710CC5ABF004149E2" : {
+      "buildActionMask" : "2147483647",
+      "dstPath" : "",
+      "dstSubfolderSpec" : "10",
+      "files" : [
+
+      ],
+      "isa" : "PBXCopyFilesBuildPhase",
+      "runOnlyForDeploymentPostprocessing" : "0"
+    },
+    "E4EB6923138AFD0F00A09F29" : {
+      "fileEncoding" : "4",
+      "isa" : "PBXFileReference",
+      "lastKnownFileType" : "text.xcconfig",
+      "path" : "Project.xcconfig",
+      "sourceTree" : "<group>"
+    },
+    "E42962A92163ECCD00A6A9E2" : {
+      "alwaysOutOfDate" : "1",
+      "buildActionMask" : "2147483647",
+      "files" : [
+
+      ],
+      "inputPaths" : [
+
+      ],
+      "isa" : "PBXShellScriptBuildPhase",
+      "name" : "Run Script — Compile OF",
+      "outputPaths" : [
+
+      ],
+      "runOnlyForDeploymentPostprocessing" : "0",
+      "shellPath" : "\/bin\/sh",
+      "shellScript" : "$OF_CORE_BUILD_COMMAND\n",
+      "showEnvVarsInLog" : "0"
+    }
+  },
+  "objectVersion" : "54",
+  "rootObject" : "E4B69B4C0A3A1720003C02F2"
 }


### PR DESCRIPTION
# iOS and macOS fixes

- iOS Template Project Fixes for Target Configuration (Debug/Release)
- Also Target Device Simulator or Real -> **no more linking errors**
- core ios Project - targetname to just simple openFrameworks
- LIB_OF -> LIB_OF_RELEASE / LIB_OF_DEBUG
- Object-C enabled by default
- Fixes: https://github.com/openframeworks/openFrameworks/issues/8308
- plist add location permission https://github.com/openframeworks/openFrameworks/issues/8310
- Fix for ios ci script - add device target for later too 
- iOS Subproject removed and just using standard reference files of core code = clean

# osx
- fix for release
- added fmt Fixes https://github.com/openframeworks/openFrameworks/issues/8300