### PR TITLE
of script updates

### DIFF
--- a/scripts/of.sh
+++ b/scripts/of.sh
@@ -30,8 +30,8 @@ autoDetectOS() {
                 ;;
         esac
     else
-    	export OF_OS=$(${OF_PLATFORM} | tr '[:upper:]' '[:lower:]')
-    	export OF_ARCH=""
+        export OF_OS=$(${OF_PLATFORM} | tr '[:upper:]' '[:lower:]')
+        export OF_ARCH=""
     fi
 }
 
@@ -74,14 +74,14 @@ runCommand() {
             ;;
         update)
             echo "openFrameworks update"
-            SCRIPT="${OF_SCRIPT_PATH}/download_libs.sh"
+            SCRIPT="${OF_CORE_SCRIPT_DIR}/${OF_PLATFORM}/download_libs.sh"
             ;;
         upgrade)
             echo "openFrameworks upgrade"
             case "$SUBCMD" in
                 addons)
                     echo "Upgrading addons"
-                    SCRIPT="${OF_SCRIPT_PATH}/dev/upgrade.sh"
+                    SCRIPT="${OF_CORE_SCRIPT_DIR}/dev/upgrade.sh"
                     ;;
                 apps)
                     echo "Upgrading apps"
@@ -91,7 +91,7 @@ runCommand() {
                         echo "Upgrade cancelled. No changes were made."
                         exit 0
                     fi
-                    SCRIPT="${OF_SCRIPT_PATH}/dev/upgrade.sh"
+                    SCRIPT="${OF_CORE_SCRIPT_DIR}/dev/upgrade.sh"
                     ;;
                 *)
                     echo "Unknown upgrade action: $SUBCMD"

--- a/scripts/of.sh
+++ b/scripts/of.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # pipe commands to core openFrameworks scripts
-OF_SCRIPT_VERSION=0.1.1
+OF_SCRIPT_VERSION=0.2.0
 # Dan Rosser 2025
 OF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 OF_DIR="$(realpath "$OF_DIR/../")"
@@ -13,7 +13,7 @@ autoDetectOS() {
         export OF_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         case "$OF_OS" in
             darwin | Dawin)
-                export OF_PLATFORM="macos"
+                export OF_PLATFORM="osx"
                 export OF_ARCH=$(uname -m)
                 ;;
             linux | Linux)
@@ -47,7 +47,7 @@ coreScriptPath() {
                     ;;
             esac
             ;;
-        macos | vs | emscripten | msys2 | android)
+        macos | osx | vs | emscripten | msys2 | android)
             export OF_SCRIPT_PATH="${OF_CORE_SCRIPT_DIR}/${OF_PLATFORM}"
             ;;
         *)
@@ -62,25 +62,116 @@ echo " platfrom:[$OF_PLATFORM] arch:[$OF_ARCH]"
 coreScriptPath
 echo " coreScriptPath: [$OF_SCRIPT_PATH]"
 
+printHelp() {
+    cat << EOF
+Usage: $0 <command> [subcommand] [options]
+
+Commands:
+  setup                  Setup openFrameworks (TODO)
+  update [subcommand]    Update openFrameworks components
+    libs                 Download openFrameworks libraries (default)
+    pg | projectgenerator  Download Project Generator
+
+  version [subcommand]   Show version information
+    of                   Show openFrameworks version (default)
+    pg | projectgenerator Show Project Generator version
+
+  upgrade [subcommand]   Upgrade openFrameworks components
+    addons               Upgrade addons (backup recommended)
+    apps                 Upgrade apps (backup recommended)
+
+Options:
+  -h, --help             Show this help message
+
+Examples:
+  $0 setup
+  $0 update              # Updates libraries
+  $0 update pg           # Updates Project Generator
+  $0 version             # Shows openFrameworks version
+  $0 version pg          # Shows Project Generator version
+  $0 upgrade addons      # Upgrades addons
+  $0 upgrade apps        # Upgrades apps
+EOF
+}
+
 runCommand() {
     local CMD=$1
     local SUBCMD=$2
+    local SUBCMD2=$3
     local SCRIPT
+    local PLATFORM_DIR="${SUBCMD2:-$OF_PLATFORM}"  # Use SUBCMD2 if provided, otherwise default to OF_PLATFORM
+    local EXTRA_ARGS=$2
 
     case "$CMD" in
+        help|--help)
+            printHelp
+            exit 0
+            ;;
         setup)
-            echo "openFrameworks setup"
+            echo "openFrameworks setup - TODO"
             SCRIPT="${OF_SCRIPT_PATH}/setup.sh"
             ;;
         update)
             echo "openFrameworks update"
-            SCRIPT="${OF_CORE_SCRIPT_DIR}/${OF_PLATFORM}/download_libs.sh"
+            EXTRA_ARGS=""
+            case "$SUBCMD" in
+                ""|libs)
+                    SCRIPT="${OF_CORE_SCRIPT_DIR}/${PLATFORM_DIR}/download_libs.sh"
+                    ;;
+                pg|projectgenerator)  # Calls download_projectGenerator.sh
+                    SCRIPT="${OF_CORE_SCRIPT_DIR}/${PLATFORM_DIR}/download_projectGenerator.sh"
+                    ;;
+                *)
+                    SCRIPT="${OF_CORE_SCRIPT_DIR}/${PLATFORM_DIR}/download_libs.sh" ""
+                    exit 1
+                    ;;
+            esac
+            ;;
+        version)
+            EXTRA_ARGS=""
+            case "$SUBCMD" in
+                ""|of)  # Default: Show openFrameworks version
+                    OF_CONSTANTS_H="${OF_DIR}/libs/openFrameworks/utils/ofConstants.h"
+                    SCRIPT="NO"
+                    if [[ -f "$OF_CONSTANTS_H" ]]; then
+                        OF_VERSION_MAJOR=$(grep "#define OF_VERSION_MAJOR" "$OF_CONSTANTS_H" | awk '{print $3}')
+                        OF_VERSION_MINOR=$(grep "#define OF_VERSION_MINOR" "$OF_CONSTANTS_H" | awk '{print $3}')
+                        OF_VERSION_PATCH=$(grep "#define OF_VERSION_PATCH" "$OF_CONSTANTS_H" | awk '{print $3}')
+                        OF_VERSION_PRE_RELEASE=$(grep "#define OF_VERSION_PRE_RELEASE" "$OF_CONSTANTS_H" | awk '{print $3}' | tr -d '"')
+
+                        OF_VERSION="${OF_VERSION_MAJOR}.${OF_VERSION_MINOR}.${OF_VERSION_PATCH}"
+                        if [[ -n "$OF_VERSION_PRE_RELEASE" && "$OF_VERSION_PRE_RELEASE" != "0" ]]; then
+                            OF_VERSION+="-${OF_VERSION_PRE_RELEASE}"
+                        fi
+
+                        echo "openFrameworks version: [$OF_VERSION]"
+                    else
+                        echo "Error: $OF_CONSTANTS_H not found."
+                        exit 1
+                    fi
+                    ;;
+                pg|projectgenerator)  # Show Project Generator version
+                    SCRIPT="${OF_DIR}/projectGenerator/projectGenerator"
+                    EXTRA_ARGS="--version"
+                    ;;
+                *)
+                    echo "Unknown version action: $SUBCMD"
+                    echo "Valid version actions: [of (default), pg, projectgenerator]"
+                    exit 1
+                    ;;
+            esac
             ;;
         upgrade)
             echo "openFrameworks upgrade"
             case "$SUBCMD" in
                 addons)
                     echo "Upgrading addons"
+                    echo "Warning: This script will modify files in the addons folder. Stop and back up the folder. Commit all to local repos before proceeding."
+                    read -p "Do you want to continue? (Y/n): " CONFIRM
+                    if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+                        echo "Upgrade cancelled. No changes were made."
+                        exit 0
+                    fi
                     SCRIPT="${OF_CORE_SCRIPT_DIR}/dev/upgrade.sh"
                     ;;
                 apps)
@@ -107,11 +198,17 @@ runCommand() {
             ;;
     esac
 
+    if [[ "$SCRIPT" == "NO" ]]; then
+        exit 0
+    fi
     if [[ -x "$SCRIPT" ]]; then
         echo "runCommand: [$SCRIPT]"
-        "$SCRIPT" "${@:2}"
+        "$SCRIPT" "$EXTRA_ARGS"
+    elif [[ -f "$SCRIPT" ]]; then
+        echo "Error: Script for ['$CMD'] exists but is not executable at: [$SCRIPT]"
+        exit 1
     else
-        echo "Error: Script for ['$CMD'] not found or not executable at: [$SCRIPT]"
+        echo "Error: Command ['$CMD'] not implemented yet. [$SCRIPT]"
         exit 1
     fi
 }

--- a/scripts/of.sh
+++ b/scripts/of.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 # pipe commands to core openFrameworks scripts
-OF_SCRIPT_VERSION=0.2.0
+OF_SCRIPT_VERSION=0.2.1
 # Dan Rosser 2025
 OF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 OF_DIR="$(realpath "$OF_DIR/../")"
 OF_CORE_SCRIPT_DIR="$(realpath "$OF_DIR/scripts")"
 OF_CORE_CI_SCRIPT_DIR="$(realpath "$OF_DIR/scripts/ci")"
 OF_PG_INSTALLED_DIR="$(realpath "$OF_DIR/projectGenerator")"
-echo "$(date): [openFrameworks: $@]"
+VERBOSE=${VERBOSE:-0}
+echoVerbose() {
+    if [[ -n "$VERBOSE" ]]; then
+        echo "$@"
+    fi
+}
+echoVerbose "$(date): [openFrameworks: $@]"
 autoDetectOS() {
     if [[ -z "$PLATFORM" ]]; then
         export OF_OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -58,16 +64,15 @@ coreScriptPath() {
 }
 
 autoDetectOS
-echo " platfrom:[$OF_PLATFORM] arch:[$OF_ARCH]"
+echoVerbose " platfrom:[$OF_PLATFORM] arch:[$OF_ARCH]"
 coreScriptPath
-echo " coreScriptPath: [$OF_SCRIPT_PATH]"
+echoVerbose " coreScriptPath: [$OF_SCRIPT_PATH]"
 
 printHelp() {
     cat << EOF
 Usage: $0 <command> [subcommand] [options]
 
 Commands:
-  setup                  Setup openFrameworks (TODO)
   update [subcommand]    Update openFrameworks components
     libs                 Download openFrameworks libraries (default)
     pg | projectgenerator  Download Project Generator
@@ -84,7 +89,6 @@ Options:
   -h, --help             Show this help message
 
 Examples:
-  $0 setup
   $0 update              # Updates libraries
   $0 update pg           # Updates Project Generator
   $0 version             # Shows openFrameworks version
@@ -107,10 +111,10 @@ runCommand() {
             printHelp
             exit 0
             ;;
-        setup)
-            echo "openFrameworks setup - TODO"
-            SCRIPT="${OF_SCRIPT_PATH}/setup.sh"
-            ;;
+        # setup)
+        #     echo "openFrameworks setup - TODO"
+        #     SCRIPT="${OF_SCRIPT_PATH}/setup.sh"
+        #     ;;
         update)
             echo "openFrameworks update"
             EXTRA_ARGS=""


### PR DESCRIPTION
Since this is Developer useful in this Release window this will aide 

# of.sh
- oF script 0.1.0 -> 0.2.0 - fixed subcommands
- update now supports pg/projectgenerator / libs
-  fixed passing values to subscripts when not needed
- added version query for library and pg

# download_libs
- added variable for HOST_URL -u --url - default to github/openframeworks/apothecary 

<img width="777" alt="image" src="https://github.com/user-attachments/assets/9eacbe3c-ea96-4e1e-9840-eb75422d5273" />
<img width="464" alt="image" src="https://github.com/user-attachments/assets/484f6c87-382b-4579-a3cf-eebf5bc9fcd8" />
<img width="693" alt="image" src="https://github.com/user-attachments/assets/45d02c1c-96e3-4df5-816d-bcd8a9fff42e" />
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b2c04c55-84bd-43ba-8b2a-f85345bc6039" />

```
one@One4Sevens-MBP openFrameworksiOSTIPS % ./of help     
Wed  5 Mar 2025 13:15:17 AEDT: [openFrameworks: help]
Usage: ./of <command> [subcommand] [options]

Commands:
  update [subcommand]    Update openFrameworks components
    libs                 Download openFrameworks libraries (default)
    pg | projectgenerator  Download Project Generator

  version [subcommand]   Show version information
    of                   Show openFrameworks version (default)
    pg | projectgenerator Show Project Generator version

  upgrade [subcommand]   Upgrade openFrameworks components
    addons               Upgrade addons (backup recommended)
    apps                 Upgrade apps (backup recommended)

Options:
  -h, --help             Show this help message

Examples:
  ./of update              # Updates libraries
  ./of update pg           # Updates Project Generator
  ./of version             # Shows openFrameworks version
  ./of version pg          # Shows Project Generator version
  ./of upgrade addons      # Upgrades addons
  ./of upgrade apps        # Upgrades apps
  ```
