### PR TITLE
Restore target build dir behavior for Xcode. Closes #8321

### DIFF
--- a/scripts/osx/xcode_project.sh
+++ b/scripts/osx/xcode_project.sh
@@ -46,13 +46,13 @@ bundle_data_folder() {
 
     if [ -z "$OF_BUNDLE_DATA_FOLDER" ]; then
         msg 'Bundle data folder disabled \ncan be enabled with OF_BUNDLE_DATA_FOLDER=1 in Project.xcconfig ';
-        if [ "$ARCHIVING" = 0 ]; then
-            if [ -d "${SRCROOT}/bin/data/" ]; then
-                rsync -avz --delete --exclude='.DS_Store' "${SRCROOT}/bin/data/" "${TARGET_BUILD_DIR}/data/"
-            else
-                echo "Source directory ${SRCROOT}/bin/data/ does not exist."
-            fi
-        fi
+#        if [ "$ARCHIVING" = 0 ]; then
+#            if [ -d "${SRCROOT}/bin/data/" ]; then
+#                rsync -avz --delete --exclude='.DS_Store' "${SRCROOT}/bin/data/" "${TARGET_BUILD_DIR}/data/"
+#            else
+#                echo "Source directory ${SRCROOT}/bin/data/ does not exist."
+#            fi
+#        fi
     else
         # Copy bin/data into App/Resources
         msg 'Bundle data folder enabled - will copy bin/data to App Package'
@@ -279,7 +279,7 @@ copy_resources
 bundle_data_folder
 code_sign
 bundle_dylibs
-copy_binary
+#copy_binary
 
 divider
 

--- a/scripts/templates/osx/Project.xcconfig
+++ b/scripts/templates/osx/Project.xcconfig
@@ -78,6 +78,10 @@ OTHER_CFLAGS = $(OF_CORE_CFLAGS)
 OTHER_LDFLAGS = $(OF_CORE_LIBS) $(OF_CORE_FRAMEWORKS)
 HEADER_SEARCH_PATHS = $(OF_CORE_HEADERS)
 
+//THIS MAKES SURE THE APP BUILDS INSIDE THE BIN FOLDER
+//If you comment this line out the app will be run from DerrivedData and your data/ files won't be accessible unless you uncomment OF_BUNDLE_DATA_FOLDER = 1 above
+CONFIGURATION_BUILD_DIR = ${SRCROOT}/bin
+
 //OF_CORE_BUILD_COMMAND = echo \"💾 Compiling openFrameworks\"\nxcodebuild -project \"$OF_PATH/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj\" -target openFrameworks -configuration \"${CONFIGURATION}\"  CLANG_CXX_LANGUAGE_STANDARD=$CLANG_CXX_LANGUAGE_STANDARD MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET GCC_PREPROCESSOR_DEFINITIONS='$USER_PREPROCESSOR_DEFINITIONS'
 
 

--- a/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
+++ b/scripts/templates/osx/emptyExample.xcodeproj/project.pbxproj
@@ -51,30 +51,6 @@
       "path" : "..\/..\/..\/addons",
       "sourceTree" : "SOURCE_ROOT"
     },
-    "BF26640B2C634C16004360E2" : {
-      "alwaysOutOfDate" : "1",
-      "buildActionMask" : "2147483647",
-      "files" : [
-
-      ],
-      "inputFileListPaths" : [
-
-      ],
-      "inputPaths" : [
-
-      ],
-      "isa" : "PBXShellScriptBuildPhase",
-      "outputFileListPaths" : [
-
-      ],
-      "outputPaths" : [
-
-      ],
-      "runOnlyForDeploymentPostprocessing" : "0",
-      "shellPath" : "\/usr\/bin\/env bash",
-      "shellScript" : "#!\/usr\/bin\/env bash\n\n# Determine the Xcode build directory\nTARGET_DIR=\"${BUILT_PRODUCTS_DIR:-$SRCROOT\/bin}\"\n\n# Check if the directory exists\nif [ ! -d \"$TARGET_DIR\" ]; then\n  echo \"Error: Target directory $TARGET_DIR does not exist.\"\n  exit 1\nfi\n\n# Check and set the com.apple.xcode.CreatedByBuildSystem attribute\nATTRIBUTE_CHECK=$(xattr -p com.apple.xcode.CreatedByBuildSystem \"$TARGET_DIR\" 2>\/dev\/null)\nif [ -z \"$ATTRIBUTE_CHECK\" ]; then\n  xattr -w com.apple.xcode.CreatedByBuildSystem true \"$TARGET_DIR\"\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem set to true for $TARGET_DIR\"\nelse\n  echo \"Attribute com.apple.xcode.CreatedByBuildSystem already set for $TARGET_DIR\"\nfi\n",
-      "showEnvVarsInLog" : "0"
-    },
     "E4A5B60F29BAAAE400C2D356" : {
       "buildActionMask" : "2147483647",
       "dstPath" : "",
@@ -172,7 +148,6 @@
     "E4B69B5A0A3A1756003C02F2" : {
       "buildConfigurationList" : "E4B69B5F0A3A1757003C02F2",
       "buildPhases" : [
-        "BF26640B2C634C16004360E2",
         "E42962A92163ECCD00A6A9E2",
         "E4B69B580A3A1756003C02F2",
         "E4B69B590A3A1756003C02F2",


### PR DESCRIPTION
Narrowly scoped just for osx/ template. 
Might be needed for macOS/ template too, but that is not currently being used by PG. 
I believe iOS and tvOS is not needed as they deploy to the device. 

Move the setting to Project.xcconfig with a comment, to give people the option to easily override it if they want. 

Closes #8321