### PR TITLE
fix(GSTPlayer): prevent multiple speed change requests within a frame

### DIFF
--- a/libs/openFrameworks/video/ofGstUtils.cpp
+++ b/libs/openFrameworks/video/ofGstUtils.cpp
@@ -507,6 +507,12 @@ void ofGstUtils::setLoopState(ofLoopType state){
 void ofGstUtils::setSpeed(float _speed){
 	if(_speed == speed) return;
 
+	if (updated_in_frame) {
+		ofLogVerbose("ofGstUtils") << "setSpeed(): prevented multiple changes within a frame";
+		return;
+	}
+	updated_in_frame = true;
+
 	GstFormat format = GST_FORMAT_TIME;
 	GstSeekFlags flags = (GstSeekFlags) (GST_SEEK_FLAG_ACCURATE | GST_SEEK_FLAG_FLUSH);
 
@@ -910,6 +916,7 @@ ofTexture * ofGstVideoUtils::getTexture(){
 
 void ofGstVideoUtils::update(){
 	if (isLoaded()){
+		updated_in_frame = false;
 		if(!isFrameByFrame()){
 			std::unique_lock<std::mutex> lock(mutex);
 			bHavePixelsChanged = bBackPixelsChanged;

--- a/libs/openFrameworks/video/ofGstUtils.h
+++ b/libs/openFrameworks/video/ofGstUtils.h
@@ -73,6 +73,8 @@ public:
 
 	void setSinkListener(ofGstAppSink * appsink);
 
+	bool updated_in_frame { false };
+
 	// callbacks to get called from gstreamer
 #if GST_VERSION_MAJOR==0
 	virtual GstFlowReturn preroll_cb(std::shared_ptr<GstBuffer> buffer);
@@ -111,6 +113,7 @@ private:
 	std::condition_variable		eosCondition;
 	std::mutex			eosMutex;
 	guint				busWatchID;
+
 
 	class ofGstMainLoopThread: public ofThread{
 	public:


### PR DESCRIPTION
2 speed calls within a video frame tends to freeze the video player (confirmed on multiple setups with GST >= 1.20). behavior seems related to changes between GST 1.12 and 1.20. this implements a simple guard that gets reset at the beginning of update().