### PR TITLE
ofxAssimp Naming Convention

### DIFF
--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
@@ -1,8 +1,3 @@
-//
-//  ofxAssimpSrcAnimKeyCollection.cpp
-//  Created by Nick Hardeman on 11/1/23.
-//
-
 #include "ofxAssimpSrcAnimKeyCollection.h"
 #include "ofxAssimpUtils.h"
 

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
@@ -6,7 +6,7 @@
 #include "ofxAssimpSrcAnimKeyCollection.h"
 #include "ofxAssimpUtils.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //--------------------------------------------------------------
 void SrcAnimKeyCollection::setup( aiNodeAnim* aNodeAnim, float aDurationInTicks ) {
@@ -21,7 +21,7 @@ bool  SrcAnimKeyCollection::hasKeys() {
 
 
 //--------------------------------------------------------------
-glm::vec3 SrcAnimKeyCollection::getVec3ForTime( const float& atime, const std::vector<ofx::assimp::AnimVectorKey>& akeys ) {
+glm::vec3 SrcAnimKeyCollection::getVec3ForTime( const float& atime, const std::vector<ofxAssimp::AnimVectorKey>& akeys ) {
 	size_t numKeys = akeys.size();
 	for( size_t i = 0; i < numKeys; i++ ) {
 		if( akeys[i].time == atime ) {

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.cpp
@@ -108,7 +108,7 @@ std::vector<AnimVectorKey> SrcAnimKeyCollection::getAnimVectorKeysForTime(const 
 	if(aNumKeys == 1) {
 		AnimVectorKey vkey;
 		vkey.time = aStartTime;
-		vkey.value = aiVecToOfVec(aAiKeys[0].mValue);
+		vkey.value = ofxAssimp::Utils::aiVecToOfVec(aAiKeys[0].mValue);
 		vkey.valueAi = aAiKeys[0].mValue;
 		rkeys.push_back( vkey );
 		return rkeys;
@@ -117,7 +117,7 @@ std::vector<AnimVectorKey> SrcAnimKeyCollection::getAnimVectorKeysForTime(const 
 	double currTime = aStartTime;
 	for( unsigned int i = 0; i < aNumKeys; i++ ) {
 		auto& key1 = aAiKeys[i];
-		auto v1 = aiVecToOfVec(key1.mValue);
+		auto v1 = ofxAssimp::Utils::aiVecToOfVec(key1.mValue);
 		AnimVectorKey vkey;
 		vkey.time = key1.mTime;
 		vkey.value = v1;
@@ -138,7 +138,7 @@ std::vector<AnimRotationKey> SrcAnimKeyCollection::getAnimRotationKeysForTime(co
 	if(aNumKeys == 1) {
 		AnimRotationKey vkey;
 		vkey.time = aStartTime;
-		vkey.value = aiQuatToOfQuat(aAiKeys[0].mValue);
+		vkey.value = ofxAssimp::Utils::aiQuatToOfQuat(aAiKeys[0].mValue);
 		vkey.valueAi = aAiKeys[0].mValue;
 		rkeys.push_back( vkey );
 		return rkeys;
@@ -146,7 +146,7 @@ std::vector<AnimRotationKey> SrcAnimKeyCollection::getAnimRotationKeysForTime(co
 	double currTime = aStartTime;
 	for( unsigned int i = 0; i < aNumKeys; i++ ) {
 		auto& key1 = aAiKeys[i];
-		auto v1 = aiQuatToOfQuat(key1.mValue);
+		auto v1 = ofxAssimp::Utils::aiQuatToOfQuat(key1.mValue);
 		AnimRotationKey vkey;
 		vkey.time = key1.mTime;
 		vkey.value = v1;

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcAnimKeyCollection.h
@@ -8,7 +8,7 @@
 #include "ofNode.h"
 
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 
 struct AnimVectorKey {
 	float time = 0.0;
@@ -26,9 +26,9 @@ class SrcAnimKeyCollection {
 public:
 	unsigned int uId = 0;
 	std::string name = "";
-	std::vector<ofx::assimp::AnimVectorKey> positionKeys;
-	std::vector<ofx::assimp::AnimRotationKey> rotationKeys;
-	std::vector<ofx::assimp::AnimVectorKey> scaleKeys;
+	std::vector<ofxAssimp::AnimVectorKey> positionKeys;
+	std::vector<ofxAssimp::AnimRotationKey> rotationKeys;
+	std::vector<ofxAssimp::AnimVectorKey> scaleKeys;
 	
 	void clear() {
 		positionKeys.clear();
@@ -39,7 +39,7 @@ public:
 	void setup( aiNodeAnim* aNodeAnim, float aDurationInTicks );
 	bool hasKeys();
 	
-	glm::vec3 getVec3ForTime( const float& atime, const std::vector<ofx::assimp::AnimVectorKey>& akeys );
+	glm::vec3 getVec3ForTime( const float& atime, const std::vector<ofxAssimp::AnimVectorKey>& akeys );
 	
 	glm::vec3 getPosition( const float& atime );
 	glm::vec3 getScale( const float& atime );

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.cpp
@@ -4,7 +4,7 @@
 #include "of3dUtils.h"
 #include "ofxAssimpUtils.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //--------------------------------------------------------------
 void SrcBone::setAiBone(aiBone* aAiBone, aiNode* aAiNode) {
@@ -118,8 +118,8 @@ void SrcBone::setAiBone(aiBone* aAiBone, aiNode* aAiNode) {
 //}
 
 //--------------------------------------------------------------
-std::shared_ptr<ofx::assimp::SrcBone> SrcBone::getBone( aiNode* aAiNode ) {
-	std::shared_ptr<ofx::assimp::SrcBone> tbone;
+std::shared_ptr<ofxAssimp::SrcBone> SrcBone::getBone( aiNode* aAiNode ) {
+	std::shared_ptr<ofxAssimp::SrcBone> tbone;
 	findBoneRecursive( aAiNode, tbone );
 	if( tbone ) {
 		return tbone;

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.h
@@ -6,15 +6,15 @@
 #pragma once
 #include "ofxAssimpSrcNode.h"
 
-namespace ofx::assimp {
-class SrcBone : public ofx::assimp::SrcNode {
+namespace ofxAssimp {
+class SrcBone : public ofxAssimp::SrcNode {
 public:
 	virtual NodeType getType() override { return OFX_ASSIMP_BONE; }
 	
 	void setAiBone(aiBone* aAiBone, aiNode* aAiNode);
 //	void update();
 	
-	std::shared_ptr<ofx::assimp::SrcBone> getBone( aiNode* aAiNode );
+	std::shared_ptr<ofxAssimp::SrcBone> getBone( aiNode* aAiNode );
 	void findBoneRecursive( aiNode* aAiNode, std::shared_ptr<SrcBone>& returnBone );
 	
 	std::string getAsString( unsigned int aLevel=0 );
@@ -29,7 +29,7 @@ public:
 //	aiMatrix4x4& getAiMatrixGlobal() { return mAiMatrixGlobal; }
 	aiMatrix4x4& getAiOffsetMatrix() { return mOffsetMatrix;}
 	
-	std::vector< std::shared_ptr<ofx::assimp::SrcBone> > childBones;
+	std::vector< std::shared_ptr<ofxAssimp::SrcBone> > childBones;
 	
 protected:
 	aiBone* mAiBone = nullptr;

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
@@ -1,10 +1,3 @@
-//
-//  ofxAssimpSrcMesh.cpp
-//  ofxAssimpExample
-//
-//  Created by Nick Hardeman on 10/24/23.
-//
-
 #include "ofxAssimpSrcMesh.h"
 #include "ofxAssimpUtils.h"
 #include "of3dGraphics.h"

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
@@ -132,9 +132,9 @@ void SrcMesh::setAiMesh( aiMesh* amesh, aiNode* aAiNode ) {
 void SrcMesh::setupVbo( std::shared_ptr<ofVbo> avbo ) {
 	ofMesh tempMesh;
 	if( hasTexture() ) {
-		aiMeshToOfMesh(mAiMesh, tempMesh, !bConvertedToLeftHand, &getTexture() );
+		ofxAssimp::Utils::aiMeshToOfMesh(mAiMesh, tempMesh, !bConvertedToLeftHand, &getTexture() );
 	} else {
-		aiMeshToOfMesh(mAiMesh, tempMesh, !bConvertedToLeftHand, nullptr);
+		ofxAssimp::Utils::aiMeshToOfMesh(mAiMesh, tempMesh, !bConvertedToLeftHand, nullptr);
 	}
 		
 	avbo->setVertexData(&mAiMesh->mVertices[0].x,3,mAiMesh->mNumVertices,usage,sizeof(aiVector3D));
@@ -164,9 +164,9 @@ void SrcMesh::setupVbo( std::shared_ptr<ofVbo> avbo ) {
 void SrcMesh::setMeshFromAiMesh( ofMesh& amesh ) {
 	if( mAiMesh != NULL && amesh.getNumVertices() < 1 ) {
 		if( hasTexture() ) {
-			aiMeshToOfMesh(mAiMesh, amesh, !bConvertedToLeftHand, &getTexture());
+			ofxAssimp::Utils::aiMeshToOfMesh(mAiMesh, amesh, !bConvertedToLeftHand, &getTexture());
 		} else {
-			aiMeshToOfMesh(mAiMesh, amesh, !bConvertedToLeftHand, nullptr);
+			ofxAssimp::Utils::aiMeshToOfMesh(mAiMesh, amesh, !bConvertedToLeftHand, nullptr);
 		}
 	}
 }

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.cpp
@@ -13,23 +13,23 @@
 using std::make_shared;
 using std::shared_ptr;
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 static unsigned int sUniqueMeshCounter = 0;
 ofTexture SrcMesh::sDummyTex;
 
 //-------------------------------------------
-void SrcMesh::addTexture( std::shared_ptr<ofx::assimp::Texture> aAssimpTex){
+void SrcMesh::addTexture( std::shared_ptr<ofxAssimp::Texture> aAssimpTex){
 	
 	if(!material) {
 		material = std::make_shared<ofMaterial>();
 	}
 	
 	auto tAiType = aAssimpTex->getAiTextureType();
-	auto tofType = ofx::assimp::Texture::ofTextureTypeForAiType(tAiType);
+	auto tofType = ofxAssimp::Texture::ofTextureTypeForAiType(tAiType);
 	
 	if(tofType == OF_MATERIAL_TEXTURE_NONE ) {
-		ofLogError("ofx::assimp::Mesh::addTexture") << aAssimpTex->getAiTextureTypeAsString();
+		ofLogError("ofxAssimp::Mesh::addTexture") << aAssimpTex->getAiTextureTypeAsString();
 		return;
 	}
 	
@@ -70,7 +70,7 @@ bool SrcMesh::hasTexture(aiTextureType aTexType){
 
 //-------------------------------------------
 bool SrcMesh::hasTexture(ofMaterialTextureType aType){
-	return hasTexture( ofx::assimp::Texture::aiTextureTypeForOfType(aType));
+	return hasTexture( ofxAssimp::Texture::aiTextureTypeForOfType(aType));
 }
 
 //-------------------------------------------
@@ -80,13 +80,13 @@ std::size_t SrcMesh::getNumTextures() {
 
 //-------------------------------------------
 ofTexture& SrcMesh::getTexture() {
-	for( auto iter = ofx::assimp::Texture::sAiTexTypeToOfTexTypeMap.begin(); iter != ofx::assimp::Texture::sAiTexTypeToOfTexTypeMap.end(); iter++ ) {
+	for( auto iter = ofxAssimp::Texture::sAiTexTypeToOfTexTypeMap.begin(); iter != ofxAssimp::Texture::sAiTexTypeToOfTexTypeMap.end(); iter++ ) {
 		if( hasTexture((aiTextureType)iter->first) ) {
 			return getTexture((aiTextureType)iter->first);
 		}
 	}
 	
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << " unable to find any allocated texture";
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << " unable to find any allocated texture";
 	return sDummyTex;
 }
 
@@ -97,13 +97,13 @@ ofTexture& SrcMesh::getTexture(aiTextureType aTexType){
 			return tex->getTextureRef();
 		}
 	}
-	ofLogWarning("ofx::assimp::SrcMesh::getTexture : unable to find texture ref for ") << aTexType;
+	ofLogWarning("ofxAssimp::SrcMesh::getTexture : unable to find texture ref for ") << aTexType;
 	return sDummyTex;
 }
 
 //-------------------------------------------
 ofTexture& SrcMesh::getTexture(ofMaterialTextureType aType){
-	return getTexture( ofx::assimp::Texture::aiTextureTypeForOfType(aType) );
+	return getTexture( ofxAssimp::Texture::aiTextureTypeForOfType(aType) );
 }
 
 //-------------------------------------------

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.h
@@ -12,13 +12,13 @@
 #include "ofVbo.h"
 #include "ofxAssimpBounds.h"
 
-namespace ofx::assimp {
-class SrcMesh : public ofx::assimp::SrcNode {
+namespace ofxAssimp {
+class SrcMesh : public ofxAssimp::SrcNode {
 public:
 	static ofTexture sDummyTex;
 	virtual NodeType getType() override { return OFX_ASSIMP_MESH; }
 	
-	void addTexture(std::shared_ptr<ofx::assimp::Texture> aAssimpTex);
+	void addTexture(std::shared_ptr<ofxAssimp::Texture> aAssimpTex);
 	bool hasTexture();
 	bool hasTexture(aiTextureType aTexType);
 	bool hasTexture( ofMaterialTextureType aType );
@@ -27,7 +27,7 @@ public:
 	ofTexture& getTexture();
 	ofTexture& getTexture(aiTextureType aTexType);
 	ofTexture& getTexture(ofMaterialTextureType aType);
-	std::vector<std::shared_ptr<ofx::assimp::Texture>> & getAllMeshTextures(){ return meshTextures; }
+	std::vector<std::shared_ptr<ofxAssimp::Texture>> & getAllMeshTextures(){ return meshTextures; }
 	
 	void setAiMesh(aiMesh* amesh, aiNode* aAiNode);
 	aiMesh* getAiMesh() { return mAiMesh; }
@@ -51,6 +51,6 @@ public:
 protected:
 	aiMesh* mAiMesh = nullptr; // pointer to the aiMesh we represent.
 	Bounds mLocalBounds;
-	std::vector<std::shared_ptr<ofx::assimp::Texture>> meshTextures;
+	std::vector<std::shared_ptr<ofxAssimp::Texture>> meshTextures;
 };
 }

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcMesh.h
@@ -1,6 +1,5 @@
 //
 //  ofxAssimpSrcMesh.h
-//  ofxAssimpExample
 //
 //  Created by Nick Hardeman on 10/24/23.
 //

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcNode.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcNode.cpp
@@ -2,7 +2,7 @@
 
 static unsigned int sUniqueIdCounter = 0;
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //--------------------------------------------------------------
 std::string SrcNode::sGetNodeTypeAsString( const NodeType& atype ) {
@@ -12,8 +12,8 @@ std::string SrcNode::sGetNodeTypeAsString( const NodeType& atype ) {
 		return "OFX_ASSIMP_BONE";
 	} else if(atype == OFX_ASSIMP_SKELETON ) {
 		return "OFX_ASSIMP_SKELETON";
-	} else if(atype == OFX_ASSIMP_MODEL ) {
-		return "OFX_ASSIMP_MODEL";
+	} else if(atype == OFX_ASSIMP_SCENE ) {
+		return "OFX_ASSIMP_SCENE";
 	}
 	return "OFX_ASSIMP_NODE";
 }
@@ -26,8 +26,8 @@ std::string SrcNode::sGetNodeTypeShortAsString( const NodeType& atype ) {
 		return "BONE";
 	} else if(atype == OFX_ASSIMP_SKELETON ) {
 		return "SKELETON";
-	} else if(atype == OFX_ASSIMP_MODEL ) {
-		return "MODEL";
+	} else if(atype == OFX_ASSIMP_SCENE ) {
+		return "SCENE";
 	}
 	return "NODE";
 }
@@ -53,8 +53,8 @@ std::string SrcNode::getName() {
 }
 
 //----------------------------------------
-std::shared_ptr<ofx::assimp::SrcNode> SrcNode::getNode( aiNode* aAiNode ) {
-	std::shared_ptr<ofx::assimp::SrcNode> tnode;
+std::shared_ptr<ofxAssimp::SrcNode> SrcNode::getNode( aiNode* aAiNode ) {
+	std::shared_ptr<ofxAssimp::SrcNode> tnode;
 	findNodeRecursive( aAiNode, tnode );
 	return tnode;
 }
@@ -73,8 +73,8 @@ void SrcNode::findNodeRecursive( aiNode* aAiNode, std::shared_ptr<SrcNode>& aRet
 }
 
 //----------------------------------------
-std::shared_ptr<ofx::assimp::SrcNode> SrcNode::getNode( const std::string& aAiNodeName ) {
-	std::shared_ptr<ofx::assimp::SrcNode> tnode;
+std::shared_ptr<ofxAssimp::SrcNode> SrcNode::getNode( const std::string& aAiNodeName ) {
+	std::shared_ptr<ofxAssimp::SrcNode> tnode;
 	findNodeRecursive( aAiNodeName, tnode );
 	return tnode;
 }
@@ -151,7 +151,7 @@ std::string SrcNode::getAsString( int aLevel ) {
 
 // animation functions
 //--------------------------------------------------------------
-ofx::assimp::SrcAnimKeyCollection& SrcNode::getKeyCollection(unsigned int aAnimUId){
+ofxAssimp::SrcAnimKeyCollection& SrcNode::getKeyCollection(unsigned int aAnimUId){
 	if( mKeyCollections.count(aAnimUId) < 1 ) {
 		SrcAnimKeyCollection temp;
 		temp.uId = aAnimUId;

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcNode.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcNode.h
@@ -8,13 +8,13 @@
 #include <assimp/scene.h>
 #include <unordered_map>
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 enum NodeType {
 	OFX_ASSIMP_MESH=0,
 	OFX_ASSIMP_BONE,
 	OFX_ASSIMP_SKELETON,
 	OFX_ASSIMP_NODE,
-	OFX_ASSIMP_MODEL
+	OFX_ASSIMP_SCENE
 };
 
 class SrcNode {
@@ -31,27 +31,27 @@ public:
 	
 	aiNode* getAiNode() { return mAiNode; }
 	
-	std::shared_ptr<ofx::assimp::SrcNode> getNode( aiNode* aAiNode );
+	std::shared_ptr<ofxAssimp::SrcNode> getNode( aiNode* aAiNode );
 	void findNodeRecursive( aiNode* aAiNode, std::shared_ptr<SrcNode>& aReturnNode );
 	
-	std::shared_ptr<ofx::assimp::SrcNode> getNode( const std::string& aAiNodeName );
+	std::shared_ptr<ofxAssimp::SrcNode> getNode( const std::string& aAiNodeName );
 	void findNodeRecursive( const std::string& aAiNodeName, std::shared_ptr<SrcNode>& aReturnNode );
 	
 	void clearChildren();
-	void addChild( std::shared_ptr<ofx::assimp::SrcNode> akiddo );
+	void addChild( std::shared_ptr<ofxAssimp::SrcNode> akiddo );
 	unsigned int getNumChildren();
-	std::vector< std::shared_ptr<ofx::assimp::SrcNode> >& getChildren();
+	std::vector< std::shared_ptr<ofxAssimp::SrcNode> >& getChildren();
 	
 	virtual std::string getAsString( int aLevel=0 );
 	
 	// animation functions
-	ofx::assimp::SrcAnimKeyCollection& getKeyCollection( unsigned int aAnimUId );
+	ofxAssimp::SrcAnimKeyCollection& getKeyCollection( unsigned int aAnimUId );
 	
 protected:
 	aiNode* mAiNode = nullptr;
 	std::string mName = "";
-	std::vector< std::shared_ptr<ofx::assimp::SrcNode> > mKids;
+	std::vector< std::shared_ptr<ofxAssimp::SrcNode> > mKids;
 	
-	std::unordered_map<unsigned int, ofx::assimp::SrcAnimKeyCollection> mKeyCollections;
+	std::unordered_map<unsigned int, ofxAssimp::SrcAnimKeyCollection> mKeyCollections;
 };
 }

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
@@ -102,11 +102,15 @@ bool SrcScene::load( const ImportSettings& asettings ) {
 }
 
 unsigned int SrcScene::initImportProperties(int assimpOptimizeFlags, const ImportSettings& asettings ) {
-	store.reset(aiCreatePropertyStore(), aiReleasePropertyStore);
+//	store.reset(aiCreatePropertyStore(), aiReleasePropertyStore);
 	
 	// only ever give us triangles.
-	aiSetImportPropertyInteger(store.get(), AI_CONFIG_PP_SBP_REMOVE, aiPrimitiveType_LINE | aiPrimitiveType_POINT );
-	aiSetImportPropertyInteger(store.get(), AI_CONFIG_PP_PTV_NORMALIZE, true);
+//	aiSetImportPropertyInteger(store.get(), AI_CONFIG_PP_SBP_REMOVE, aiPrimitiveType_LINE | aiPrimitiveType_POINT );
+//	aiSetImportPropertyInteger(store.get(), AI_CONFIG_PP_PTV_NORMALIZE, true);
+	
+	// only ever give us triangles; newer c++ api
+	importer.SetPropertyInteger(AI_CONFIG_PP_SBP_REMOVE, aiPrimitiveType_LINE | aiPrimitiveType_POINT );
+	importer.SetPropertyBool(AI_CONFIG_PP_PTV_NORMALIZE, true);
 	
 	unsigned int flags = assimpOptimizeFlags;
 	
@@ -157,9 +161,12 @@ unsigned int SrcScene::initImportProperties(int assimpOptimizeFlags, const Impor
 //-------------------------------------------
 void SrcScene::optimizeScene(){
 	if( scene ) {
-		aiApplyPostProcessing(scene.get(),aiProcess_ImproveCacheLocality | aiProcess_OptimizeGraph |
-							  aiProcess_OptimizeMeshes | aiProcess_JoinIdenticalVertices |
-							  aiProcess_RemoveRedundantMaterials);
+//		aiApplyPostProcessing(scene.get(),aiProcess_ImproveCacheLocality | aiProcess_OptimizeGraph |
+//							  aiProcess_OptimizeMeshes | aiProcess_JoinIdenticalVertices |
+//							  aiProcess_RemoveRedundantMaterials);
+		importer.ApplyPostProcessing(aiProcess_ImproveCacheLocality | aiProcess_OptimizeGraph |
+									 aiProcess_OptimizeMeshes | aiProcess_JoinIdenticalVertices |
+									 aiProcess_RemoveRedundantMaterials);
 	}
 }
 
@@ -200,7 +207,7 @@ bool SrcScene::processScene(const ImportSettings& asettings) {
 		
 		return true;
 	}else{
-		ofLogError("ofxAssimp::SrcScene") << "load(): " + (string) aiGetErrorString();
+		ofLogError("ofxAssimp::SrcScene") << "load(): " + (std::string)importer.GetErrorString();
 		clear();
 		return false;
 	}
@@ -410,46 +417,8 @@ aiBone* SrcScene::getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::s
 		return aBoneMap[bstr];
 	}
 	return nullptr;
-	
-//	for (unsigned int i = 0; i < scene->mNumMeshes; ++i){
-//		ofLogVerbose("ofxAssimp::SrcScene") << "getAiBoneForAiNode(): loading mesh " << i;
-//		// current mesh we are introspecting
-//		aiMesh* mesh = scene->mMeshes[i];
-//		if( mesh == nullptr ) {
-//			continue;
-//		}
-//		for(unsigned int a = 0; a < mesh->mNumBones; ++a) {
-//			aiBone* bone = mesh->mBones[a];
-//			if( bone != nullptr ) {
-//				if( aAiNode->mName == bone->mName ) {
-////				if( bone->mNode == aAiNode) {
-//					return bone;
-//				}
-//			}
-//		}
-//	}
-//	return nullptr;
-}
 
-//-------------------------------------------
-//void SrcScene::recursiveAddSrcBones( std::shared_ptr<ofxAssimp::SrcBone> abone ) {
-//	for( unsigned int i = 0; i < abone->getAiNode()->mNumChildren; i++ ) {
-//		// aiNode, now we need to get the associated bone
-//		auto boneNode = abone->getAiNode()->mChildren[i];
-//		if( boneNode ) {
-//			auto tbone = getAiBoneForAiNode( boneNode );
-//			if( tbone ) {
-//				auto nSrcBone = std::make_shared<ofxAssimp::SrcBone>();
-//				nSrcBone->setAiBone(tbone, boneNode);
-//				abone->childBones.push_back(nSrcBone);
-//			}
-//		}
-//	}
-//	
-//	for( auto iter : abone->childBones ) {
-//		recursiveAddSrcBones(iter);
-//	}
-//}
+}
 
 //-------------------------------------------
 std::shared_ptr<ofxAssimp::SrcNode> SrcScene::getSrcNodeForAiNodeName( const std::string& aAiNodeName ) {

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
@@ -473,15 +473,15 @@ void SrcScene::processLights(){
 		mLights[i].enable();
 		if(scene->mLights[i]->mType==aiLightSource_DIRECTIONAL){
 			mLights[i].setDirectional();
-			mLights[i].setOrientation(aiVecToOfVec(scene->mLights[i]->mDirection));
+			mLights[i].setOrientation(ofxAssimp::Utils::aiVecToOfVec(scene->mLights[i]->mDirection));
 		}
 		if(scene->mLights[i]->mType!=aiLightSource_POINT){
 			mLights[i].setSpotlight();
-			mLights[i].setPosition(aiVecToOfVec(scene->mLights[i]->mPosition));
+			mLights[i].setPosition(ofxAssimp::Utils::aiVecToOfVec(scene->mLights[i]->mPosition));
 		}
-		mLights[i].setAmbientColor(aiColorToOfColor(scene->mLights[i]->mColorAmbient));
-		mLights[i].setDiffuseColor(aiColorToOfColor(scene->mLights[i]->mColorDiffuse));
-		mLights[i].setSpecularColor(aiColorToOfColor(scene->mLights[i]->mColorSpecular));
+		mLights[i].setAmbientColor(ofxAssimp::Utils::aiColorToOfColor(scene->mLights[i]->mColorAmbient));
+		mLights[i].setDiffuseColor(ofxAssimp::Utils::aiColorToOfColor(scene->mLights[i]->mColorDiffuse));
+		mLights[i].setSpecularColor(ofxAssimp::Utils::aiColorToOfColor(scene->mLights[i]->mColorSpecular));
 	}
 }
 
@@ -583,22 +583,22 @@ void SrcScene::loadGLResources(std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh, aiM
 		aiColor4D tcolor;
 		if( mSettings.importMaterials ) {
 			if(AI_SUCCESS == aiGetMaterialColor(mtl, AI_MATKEY_COLOR_DIFFUSE, &tcolor)){
-				auto col = aiColorToOfColor(tcolor);
+				auto col = ofxAssimp::Utils::aiColorToOfColor(tcolor);
 				aSrcMesh->material->setDiffuseColor(col);
 			}
 			
 			if(AI_SUCCESS == aiGetMaterialColor(mtl, AI_MATKEY_COLOR_SPECULAR, &tcolor)){
-				auto col = aiColorToOfColor(tcolor);
+				auto col = ofxAssimp::Utils::aiColorToOfColor(tcolor);
 				aSrcMesh->material->setSpecularColor(col);
 			}
 			
 			if(AI_SUCCESS == aiGetMaterialColor(mtl, AI_MATKEY_COLOR_AMBIENT, &tcolor)){
-				auto col = aiColorToOfColor(tcolor);
+				auto col = ofxAssimp::Utils::aiColorToOfColor(tcolor);
 				aSrcMesh->material->setAmbientColor(col);
 			}
 			
 			if(AI_SUCCESS == aiGetMaterialColor(mtl, AI_MATKEY_COLOR_EMISSIVE, &tcolor)){
-				auto col = aiColorToOfColor(tcolor);
+				auto col = ofxAssimp::Utils::aiColorToOfColor(tcolor);
 				aSrcMesh->material->setEmissiveColor(col);
 			}
 			
@@ -776,9 +776,9 @@ void SrcScene::loadGLResources(std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh, aiM
 		
 		ofMesh tempMesh;
 		if( aSrcMesh->hasTexture() ) {
-			aiMeshToOfMesh(amesh, tempMesh, !mSettings.convertToLeftHanded, &aSrcMesh->getTexture() );
+			ofxAssimp::Utils::aiMeshToOfMesh(amesh, tempMesh, !mSettings.convertToLeftHanded, &aSrcMesh->getTexture() );
 		} else {
-			aiMeshToOfMesh(amesh, tempMesh, !mSettings.convertToLeftHanded, nullptr);
+			ofxAssimp::Utils::aiMeshToOfMesh(amesh, tempMesh, !mSettings.convertToLeftHanded, nullptr);
 		}
 		
 		aSrcMesh->calculateLocalBounds(tempMesh);

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
@@ -6,11 +6,8 @@
 #include "ofGraphics.h"
 #include "ofConstants.h"
 
-#include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
-#include <assimp/config.h>
-#include <assimp/DefaultLogger.hpp>
 
 //--------------------------------------------------------------
 using std::shared_ptr;
@@ -91,6 +88,11 @@ bool SrcScene::load( const ImportSettings& asettings ) {
 	// loads scene from file
 	std::string path = mFile.getAbsolutePath();
 	const aiScene * scenePtr = importer.ReadFile(path.c_str(), flags);
+	
+	if(!scenePtr || scenePtr->mFlags & AI_SCENE_FLAGS_INCOMPLETE ) {
+		ofLogError("ofxAssimp::SrcScene") << "load: " << importer.GetErrorString();
+		return false;
+	}
 	
 	//this is funky but the scenePtr is managed by assimp and so we can't put it in our shared_ptr without disabling the deleter with: [](const aiScene*){}
 	scene = shared_ptr<const aiScene>(scenePtr,[](const aiScene*){});

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.cpp
@@ -16,7 +16,7 @@
 using std::shared_ptr;
 using std::vector;
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //------------------------------------------
 SrcScene::SrcScene(){
@@ -39,7 +39,7 @@ bool SrcScene::load(std::string aPathToFile, int assimpOptimizeFlags){
 //------------------------------------------
 bool SrcScene::load(ofBuffer & buffer, int assimpOptimizeFlags, const char * extension){
 	
-	ofLogVerbose("ofx::assimp::SrcScene") << "load(): loading from memory buffer \"." << extension << "\"";
+	ofLogVerbose("ofxAssimp::SrcScene") << "load(): loading from memory buffer \"." << extension << "\"";
 	
 	if(scene.get() != nullptr){
 		clear();
@@ -73,11 +73,11 @@ bool SrcScene::load(ofBuffer & buffer, int assimpOptimizeFlags, const char * ext
 bool SrcScene::load( const ImportSettings& asettings ) {
 	mFile.open(asettings.filePath, ofFile::ReadOnly, true); // Since it may be a binary file we should read it in binary -Ed
 	if(!mFile.exists()) {
-		ofLogVerbose("ofx::assimp::SrcScene") << "load(): model does not exist: \"" << asettings.filePath << "\"";
+		ofLogVerbose("ofxAssimp::SrcScene") << "load(): model does not exist: \"" << asettings.filePath << "\"";
 		return false;
 	}
 	
-	ofLogVerbose("ofx::assimp::SrcScene") << "load(): loading \"" << mFile.getFileName() << "\" from \"" << mFile.getEnclosingDirectory() << "\"";
+	ofLogVerbose("ofxAssimp::SrcScene") << "load(): loading \"" << mFile.getFileName() << "\" from \"" << mFile.getEnclosingDirectory() << "\"";
 	
 	if(scene.get() != nullptr){
 		clear();
@@ -168,7 +168,7 @@ void SrcScene::clear(){
 		importer.FreeScene();
 	}
 	
-	ofLogVerbose("ofx::assimp::SrcScene") << "clear(): deleting GL resources";
+	ofLogVerbose("ofxAssimp::SrcScene") << "clear(): deleting GL resources";
 	
 	// clear out everything.
 	mSrcMeshes.clear();
@@ -191,14 +191,14 @@ bool SrcScene::processScene(const ImportSettings& asettings) {
 		processAnimations();
 		
 		if(mAnimations.size() > 0)
-			ofLogVerbose("ofx::assimp::SrcScene") << "load(): scene has " << mAnimations.size() << "animations";
+			ofLogVerbose("ofxAssimp::SrcScene") << "load(): scene has " << mAnimations.size() << "animations";
 		else {
-			ofLogVerbose("ofx::assimp::SrcScene") << "load(): no animations";
+			ofLogVerbose("ofxAssimp::SrcScene") << "load(): no animations";
 		}
 		
 		return true;
 	}else{
-		ofLogError("ofx::assimp::SrcScene") << "load(): " + (string) aiGetErrorString();
+		ofLogError("ofxAssimp::SrcScene") << "load(): " + (string) aiGetErrorString();
 		clear();
 		return false;
 	}
@@ -237,12 +237,12 @@ void SrcScene::printAllNodeNames( aiNode* anode, int alevel ) {
 void SrcScene::processNodes() {
 	// lets load in the node hierarchy here //
 	mSrcMeshes.clear();
-	mSrcMeshes.assign( scene->mNumMeshes, shared_ptr<ofx::assimp::SrcMesh>() );
+	mSrcMeshes.assign( scene->mNumMeshes, shared_ptr<ofxAssimp::SrcMesh>() );
 	processMeshes(scene->mRootNode, shared_ptr<SrcNode>());
 	
 	std::unordered_map<std::string, aiBone*> boneMap;
 	for (unsigned int i = 0; i < scene->mNumMeshes; ++i){
-		ofLogVerbose("ofx::assimp::SrcScene") << "getAiBoneForAiNode(): loading mesh " << i;
+		ofLogVerbose("ofxAssimp::SrcScene") << "getAiBoneForAiNode(): loading mesh " << i;
 		// current mesh we are introspecting
 		aiMesh* mesh = scene->mMeshes[i];
 		if( mesh == nullptr ) {
@@ -270,7 +270,7 @@ void SrcScene::processNodesRecursive(aiNode* anode, std::shared_ptr<SrcNode> aPa
 	if( isBone(anode, aBoneMap) || isArmature(anode, aBoneMap) ) {
 //	if( aiBone* tAiBone = getAiBoneForAiNode(anode) ) {
 		aiBone* tAiBone = getAiBoneForAiNode(anode, aBoneMap);
-		auto sBone = std::make_shared<ofx::assimp::SrcBone>();
+		auto sBone = std::make_shared<ofxAssimp::SrcBone>();
 		sBone->setAiBone(tAiBone, anode);
 		sBone->bRoot = isRootBone(anode, aBoneMap) || !isBone(anode, aBoneMap);
 //		sBone->bRoot = isArmature(anode);
@@ -289,7 +289,7 @@ void SrcScene::processNodesRecursive(aiNode* anode, std::shared_ptr<SrcNode> aPa
 			}
 		}
 		if(!bExclude) {
-			sNode = std::make_shared<ofx::assimp::SrcNode>();
+			sNode = std::make_shared<ofxAssimp::SrcNode>();
 			sNode->setAiNode(anode);
 		}
 	}
@@ -323,7 +323,7 @@ void SrcScene::processMeshes(aiNode* anode, std::shared_ptr<SrcNode> aSrcNode) {
 		} else {
 			ofLogNotice("SrcScene::processNodesRecursive") << " going to process mesh: " << scene->mMeshes[meshIndex]->mName.data << " from node: " << anode->mName.data << " num scene meshes: " << scene->mNumMeshes;
 			// ok, open slot for a src mesh //
-			auto srcMesh = std::make_shared<ofx::assimp::SrcMesh>();
+			auto srcMesh = std::make_shared<ofxAssimp::SrcMesh>();
 			srcMesh->setAiMesh(scene->mMeshes[meshIndex], anode );
 			loadGLResources(srcMesh, srcMesh->getAiMesh());
 			mSrcMeshes.push_back(srcMesh);
@@ -410,7 +410,7 @@ aiBone* SrcScene::getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::s
 	return nullptr;
 	
 //	for (unsigned int i = 0; i < scene->mNumMeshes; ++i){
-//		ofLogVerbose("ofx::assimp::SrcScene") << "getAiBoneForAiNode(): loading mesh " << i;
+//		ofLogVerbose("ofxAssimp::SrcScene") << "getAiBoneForAiNode(): loading mesh " << i;
 //		// current mesh we are introspecting
 //		aiMesh* mesh = scene->mMeshes[i];
 //		if( mesh == nullptr ) {
@@ -430,14 +430,14 @@ aiBone* SrcScene::getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::s
 }
 
 //-------------------------------------------
-//void SrcScene::recursiveAddSrcBones( std::shared_ptr<ofx::assimp::SrcBone> abone ) {
+//void SrcScene::recursiveAddSrcBones( std::shared_ptr<ofxAssimp::SrcBone> abone ) {
 //	for( unsigned int i = 0; i < abone->getAiNode()->mNumChildren; i++ ) {
 //		// aiNode, now we need to get the associated bone
 //		auto boneNode = abone->getAiNode()->mChildren[i];
 //		if( boneNode ) {
 //			auto tbone = getAiBoneForAiNode( boneNode );
 //			if( tbone ) {
-//				auto nSrcBone = std::make_shared<ofx::assimp::SrcBone>();
+//				auto nSrcBone = std::make_shared<ofxAssimp::SrcBone>();
 //				nSrcBone->setAiBone(tbone, boneNode);
 //				abone->childBones.push_back(nSrcBone);
 //			}
@@ -450,8 +450,8 @@ aiBone* SrcScene::getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::s
 //}
 
 //-------------------------------------------
-std::shared_ptr<ofx::assimp::SrcNode> SrcScene::getSrcNodeForAiNodeName( const std::string& aAiNodeName ) {
-	std::shared_ptr<ofx::assimp::SrcNode> rnode;
+std::shared_ptr<ofxAssimp::SrcNode> SrcScene::getSrcNodeForAiNodeName( const std::string& aAiNodeName ) {
+	std::shared_ptr<ofxAssimp::SrcNode> rnode;
 	for( auto tnode : mSrcNodes ) {
 		if( tnode->getName() == aAiNodeName ) {
 			rnode = tnode;
@@ -506,7 +506,7 @@ void SrcScene::processAnimations() {
 			// the nodeAnim contains the name of the node it affects,
 			// according to the docs, it must exist and the name must be unique
 			std::string nodeName = nodeAnim->mNodeName.data;
-			if(std::shared_ptr<ofx::assimp::SrcNode> snode = getSrcNodeForAiNodeName( nodeName )) {
+			if(std::shared_ptr<ofxAssimp::SrcNode> snode = getSrcNodeForAiNodeName( nodeName )) {
 				// SrcNode contains a pointer to the aiNode
 				processKeyframes(snode, nodeAnim, i);
 			} else {
@@ -517,12 +517,12 @@ void SrcScene::processAnimations() {
 }
 
 //-------------------------------------------
-void SrcScene::processKeyframes(std::shared_ptr<ofx::assimp::SrcNode> aSrcNode, aiNodeAnim* aNodeAnim, unsigned int aAnimIndex) {
+void SrcScene::processKeyframes(std::shared_ptr<ofxAssimp::SrcNode> aSrcNode, aiNodeAnim* aNodeAnim, unsigned int aAnimIndex) {
 	if(!aSrcNode || !aNodeAnim) {
 		return;
 	}
 	auto& anim = mAnimations[aAnimIndex];
-	ofx::assimp::SrcAnimKeyCollection& keyCollection = aSrcNode->getKeyCollection(aAnimIndex);
+	ofxAssimp::SrcAnimKeyCollection& keyCollection = aSrcNode->getKeyCollection(aAnimIndex);
 	keyCollection.clear();
 	keyCollection.setup( aNodeAnim, anim.getDurationInTicks() );
 	
@@ -555,18 +555,18 @@ static GLint getGLFormatFromAiFormat(const char * aiFormat){
 				return GL_RGB;
 			}
 		}else{
-			ofLogError("ofx::assimp::SrcScene : getGLFormatFromAiFormat") << " can't parse format " << formatStr;
+			ofLogError("ofxAssimp::SrcScene : getGLFormatFromAiFormat") << " can't parse format " << formatStr;
 		}
 	}
 	
-	ofLogWarning("ofx::assimp::SrcScene : getGLFormatFromAiFormat") << " can't parse format " << formatStr << " returning GL_RGB";
+	ofLogWarning("ofxAssimp::SrcScene : getGLFormatFromAiFormat") << " can't parse format " << formatStr << " returning GL_RGB";
 	return GL_RGB;
 }
 
 //-------------------------------------------
-void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, aiMesh* amesh){
+void SrcScene::loadGLResources(std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh, aiMesh* amesh){
 	
-	ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResources(): starting";
+	ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResources(): starting";
 	
 	// we do this as we have textures and vbos and in mesh and we don't want to copy them
 	// create OpenGL buffers and populate them based on each meshes pertinant info.
@@ -622,10 +622,10 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 		int two_sided=0;
 		if((AI_SUCCESS == aiGetMaterialIntegerArray(mtl, AI_MATKEY_TWOSIDED, &two_sided, &max)) && two_sided){
 			aSrcMesh->twoSided = true;
-			ofLogVerbose("ofx::assimp::SrcScene") <<" loadGLResources: mesh is two sided";
+			ofLogVerbose("ofxAssimp::SrcScene") <<" loadGLResources: mesh is two sided";
 		}else{
 			aSrcMesh->twoSided = false;
-			ofLogVerbose("ofx::assimp::SrcScene") <<" loadGLResources: mesh is one sided";
+			ofLogVerbose("ofxAssimp::SrcScene") <<" loadGLResources: mesh is one sided";
 		}
 		
 		// Load Textures
@@ -646,7 +646,7 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 					
 					//this is a solution to support older versions of assimp. see the weak defination above
 					if( aiTextureTypeToString ){
-						ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource(): loading " <<  aiTextureTypeToString((aiTextureType)d) << " image from \"" << texPath.data << "\"";
+						ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource(): loading " <<  aiTextureTypeToString((aiTextureType)d) << " image from \"" << texPath.data << "\"";
 					}
 					
 					bool bWrap = (texMapMode[0]==aiTextureMapMode_Wrap);
@@ -678,9 +678,9 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 						auto embeddedTexture = scene->GetEmbeddedTexture(ogPath.c_str());
 						if( embeddedTexture ){
 							bHasEmbeddedTexture = true;
-							ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource() texture " << realPath.filename() << " is embedded ";
+							ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource() texture " << realPath.filename() << " is embedded ";
 						}else{
-							ofLogError("ofx::assimp::SrcScene") << "loadGLResource(): texture doesn't exist: \""
+							ofLogError("ofxAssimp::SrcScene") << "loadGLResource(): texture doesn't exist: \""
 							<< mFile.getFileName() + "\" in \"" << realPath.string() << "\"";
 						}
 					}
@@ -698,11 +698,11 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 						auto assimpTexture = mAssimpTextures[realPath];
 						aSrcMesh->addTexture(assimpTexture);
 						
-						ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource(): texture already loaded: \""
+						ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource(): texture already loaded: \""
 						<< mFile.getFileName() + "\" from \"" << realPath.string() << "\"" << " adding texture as " << assimpTexture->getAiTextureTypeAsString() ;
 					} else {
 //						shared_ptr<ofTexture> texture = std::make_shared<ofTexture>();
-						auto assimpTexture = std::make_shared<ofx::assimp::Texture>();
+						auto assimpTexture = std::make_shared<ofxAssimp::Texture>();
 						
 						if( bHasEmbeddedTexture ){
 							
@@ -718,7 +718,7 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 								tmp.setUseTexture(false);
 								tmp.load(buffer);
 								
-								ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource() texture size is " << tmp.getWidth() << "x" << tmp.getHeight();
+								ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource() texture size is " << tmp.getWidth() << "x" << tmp.getHeight();
 								
 								assimpTexture->getTextureRef().loadData(tmp.getPixels());
 							}else{
@@ -738,13 +738,13 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 							assimpTexture->setup( realPath, bWrap );
 							assimpTexture->setAiTextureType((aiTextureType)d);
 							mAssimpTextures[realPath] = assimpTexture;
-							ofLogNotice( "ofx::assimp::SrcScene") << " assimpTexture type: " << assimpTexture->getAiTextureTypeAsString() << " path: " << assimpTexture->getTexturePath();
+							ofLogNotice( "ofxAssimp::SrcScene") << " assimpTexture type: " << assimpTexture->getAiTextureTypeAsString() << " path: " << assimpTexture->getTexturePath();
 //							tmpTex.setTextureType((aiTextureType)d);
 							aSrcMesh->addTexture( assimpTexture );
 							
-							ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource(): texture " << assimpTexture->getAiTextureTypeAsString() << " loaded, dimensions: " << assimpTexture->getTextureRef().getWidth() << "x" << assimpTexture->getTextureRef().getHeight();
+							ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource(): texture " << assimpTexture->getAiTextureTypeAsString() << " loaded, dimensions: " << assimpTexture->getTextureRef().getWidth() << "x" << assimpTexture->getTextureRef().getHeight();
 						}else{
-							ofLogError("ofx::assimp::SrcScene") << "loadGLResource(): couldn't load texture: \""
+							ofLogError("ofxAssimp::SrcScene") << "loadGLResource(): couldn't load texture: \""
 							<< mFile.getFileName() + "\" from \"" << realPath.string() << "\"";
 						}
 					}
@@ -803,5 +803,5 @@ void SrcScene::loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, a
 		}
 		aSrcMesh->vbo->setIndexData(&aSrcMesh->indices[0],aSrcMesh->indices.size(),GL_STATIC_DRAW);
 	}
-	ofLogVerbose("ofx::assimp::SrcScene") << "loadGLResource(): finished";
+	ofLogVerbose("ofxAssimp::SrcScene") << "loadGLResource(): finished";
 }

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
@@ -22,7 +22,7 @@ struct aiNode;
 // This class loads and stores all of the resources used by a ofxAssimpModel
 // It is not intended for rendering
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 //to pass into the load function use this syntax: ofxAssimpModelLoader::OPTIMIZE_DEFAULT
 //Note these are negative as we want to let users pass in assimp flags directly if they want to
 enum ImportFlags{
@@ -60,9 +60,9 @@ public:
 	void optimizeScene();
 	void clear();
 	
-	std::vector< std::shared_ptr<ofx::assimp::SrcNode> > getRootNodes() { return mSrcNodes; }
+	std::vector< std::shared_ptr<ofxAssimp::SrcNode> > getRootNodes() { return mSrcNodes; }
 	
-	std::vector< ofx::assimp::Animation >& getAnimations() {return mAnimations;}
+	std::vector< ofxAssimp::Animation >& getAnimations() {return mAnimations;}
 	
 	ImportSettings getImportSettings() { return mSettings; }
 	
@@ -84,26 +84,26 @@ protected:
 	bool isArmature( aiNode* aAiNode, const std::unordered_map<std::string, aiBone*>& aBoneMap );
 	bool isRootBone( aiNode* aAiNode, std::unordered_map<std::string, aiBone*>& aBoneMap );
 	aiBone* getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::string, aiBone*>& aBoneMap );
-//	void recursiveAddSrcBones( std::shared_ptr<ofx::assimp::SrcBone> abone );
+//	void recursiveAddSrcBones( std::shared_ptr<ofxAssimp::SrcBone> abone );
 	
-	std::shared_ptr<ofx::assimp::SrcNode> getSrcNodeForAiNodeName( const std::string& aAiNodeName );
+	std::shared_ptr<ofxAssimp::SrcNode> getSrcNodeForAiNodeName( const std::string& aAiNodeName );
 	
 	void processLights();
 	
 	void processAnimations();
-	void processKeyframes( std::shared_ptr<ofx::assimp::SrcNode> aSrcNode, aiNodeAnim* aNodeAnim, unsigned int aAnimIndex );
+	void processKeyframes( std::shared_ptr<ofxAssimp::SrcNode> aSrcNode, aiNodeAnim* aNodeAnim, unsigned int aAnimIndex );
 	
 	// Initial VBO creation, etc
-	void loadGLResources(std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh, aiMesh* amesh);
+	void loadGLResources(std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh, aiMesh* amesh);
 	
 	ofFile mFile;
 	
 	std::vector<ofLight> mLights;
-	std::map<of::filesystem::path, std::shared_ptr<ofx::assimp::Texture> > mAssimpTextures;
-	std::vector< ofx::assimp::Animation > mAnimations;
+	std::map<of::filesystem::path, std::shared_ptr<ofxAssimp::Texture> > mAssimpTextures;
+	std::vector< ofxAssimp::Animation > mAnimations;
 	
-	std::vector< std::shared_ptr<ofx::assimp::SrcMesh> > mSrcMeshes;
-	std::vector< std::shared_ptr<ofx::assimp::SrcNode> > mSrcNodes;
+	std::vector< std::shared_ptr<ofxAssimp::SrcMesh> > mSrcMeshes;
+	std::vector< std::shared_ptr<ofxAssimp::SrcNode> > mSrcNodes;
 	
 	ImportSettings mSettings;
 	
@@ -114,7 +114,7 @@ protected:
 	std::shared_ptr<const aiScene> scene;
 	std::shared_ptr<aiPropertyStore> store;
 	
-//	ofx::assimp::Bounds mSceneBoundsLocal;
+//	ofxAssimp::Bounds mSceneBoundsLocal;
 	
 };
 }

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
@@ -84,7 +84,6 @@ protected:
 	bool isArmature( aiNode* aAiNode, const std::unordered_map<std::string, aiBone*>& aBoneMap );
 	bool isRootBone( aiNode* aAiNode, std::unordered_map<std::string, aiBone*>& aBoneMap );
 	aiBone* getAiBoneForAiNode( aiNode* aAiNode, std::unordered_map<std::string, aiBone*>& aBoneMap );
-//	void recursiveAddSrcBones( std::shared_ptr<ofxAssimp::SrcBone> abone );
 	
 	std::shared_ptr<ofxAssimp::SrcNode> getSrcNodeForAiNodeName( const std::string& aAiNodeName );
 	
@@ -112,9 +111,7 @@ protected:
 	
 	// the main Asset Import scene that does the magic.
 	std::shared_ptr<const aiScene> scene;
-	std::shared_ptr<aiPropertyStore> store;
-	
-//	ofxAssimp::Bounds mSceneBoundsLocal;
+//	std::shared_ptr<aiPropertyStore> store;
 	
 };
 }

--- a/addons/ofxAssimp/src/ofxAssimp.h
+++ b/addons/ofxAssimp/src/ofxAssimp.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "ofxAssimpScene.h"

--- a/addons/ofxAssimp/src/ofxAssimpAnimation.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpAnimation.cpp
@@ -7,7 +7,7 @@
 #include "ofAppRunner.h"
 #include "ofUtils.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //-------------------------------------------
 Animation::Animation() {

--- a/addons/ofxAssimp/src/ofxAssimpAnimation.h
+++ b/addons/ofxAssimp/src/ofxAssimpAnimation.h
@@ -5,7 +5,6 @@
 
 #pragma once
 #include "ofVideoBaseTypes.h"
-#include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 

--- a/addons/ofxAssimp/src/ofxAssimpAnimation.h
+++ b/addons/ofxAssimp/src/ofxAssimpAnimation.h
@@ -9,7 +9,7 @@
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 
 class Animation {
 public:

--- a/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
@@ -7,7 +7,7 @@
 #include "ofLog.h"
 #include "ofUtils.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //--------------------------------------------------------------
 bool AnimationClip::shouldRemove( const AnimationClip& ac ) {
@@ -22,7 +22,7 @@ std::size_t AnimationMixer::getNumAnimationClips() {
 //--------------------------------------------------------------
 AnimationClip& AnimationMixer::getAnimationClip(int aindex) {
 	if( getNumAnimationClips() < 1 ) {
-		ofLogWarning("ofx::assimp::AnimationMixer::getAnimationClip") << "there are no animation clips.";
+		ofLogWarning("ofxAssimp::AnimationMixer::getAnimationClip") << "there are no animation clips.";
 		return dummy;
 	}
 	aindex = ofClamp( aindex, 0, getNumAnimationClips()-1);
@@ -32,7 +32,7 @@ AnimationClip& AnimationMixer::getAnimationClip(int aindex) {
 //--------------------------------------------------------------
 AnimationClip& AnimationMixer::getAnimationClip(const std::string& aname) {
 	if( getNumAnimationClips() < 1 ) {
-		ofLogWarning("ofx::assimp::AnimationMixer::getAnimationClip") << "there are no animation clips.";
+		ofLogWarning("ofxAssimp::AnimationMixer::getAnimationClip") << "there are no animation clips.";
 		return dummy;
 	}
 	for( auto& anim : mAnimationClips ) {
@@ -40,7 +40,7 @@ AnimationClip& AnimationMixer::getAnimationClip(const std::string& aname) {
 			return anim;
 		}
 	}
-	ofLogWarning("ofx::assimp::AnimationMixer::getAnimationClip") << " could not find clip " << aname;
+	ofLogWarning("ofxAssimp::AnimationMixer::getAnimationClip") << " could not find clip " << aname;
 	return dummy;
 }
 

--- a/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
@@ -1,8 +1,3 @@
-//
-//  ofxAssimpAnimationMixer.cpp
-//  Created by Nick Hardeman on 11/3/23.
-//
-
 #include "ofxAssimpAnimationMixer.h"
 #include "ofLog.h"
 #include "ofUtils.h"

--- a/addons/ofxAssimp/src/ofxAssimpAnimationMixer.h
+++ b/addons/ofxAssimp/src/ofxAssimpAnimationMixer.h
@@ -6,7 +6,7 @@
 #pragma once
 #include "ofxAssimpAnimation.h"
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 class AnimationClip {
 public:
 	static bool shouldRemove( const AnimationClip& ac );

--- a/addons/ofxAssimp/src/ofxAssimpBone.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpBone.cpp
@@ -24,9 +24,9 @@ void Bone::setSrcBone( std::shared_ptr<ofxAssimp::SrcBone> aSrcBone ) {
 	mSrcBone = aSrcBone;
 	mOffsetMatrix = mSrcBone->getAiOffsetMatrix();
 	
-	mGlmOffsetMat = aiMatrix4x4ToGlmMatrix(mOffsetMatrix);
+	mGlmOffsetMat = ofxAssimp::Utils::aiMatrix4x4ToGlmMatrix(mOffsetMatrix);
 	
-	setOfNodeFromAiMatrix( mSrcBone->getAiMatrix(), this );
+	ofxAssimp::Utils::setOfNodeFromAiMatrix( mSrcBone->getAiMatrix(), this );
 }
 
 ////--------------------------------------------------------------
@@ -67,7 +67,7 @@ void Bone::cacheGlobalBoneMat(glm::mat4& aInvMat) {
 //	aiMatrix4x4 posTrafo = gBoneMat * sbone->getAiOffsetMatrix();
 	mCachedGlobalBoneMat = aInvMat * getGlobalTransformMatrix();
 	mCachedGlobalBoneMat = mCachedGlobalBoneMat * mGlmOffsetMat;
-	mAiCachedGlobalBoneMat = glmMat4ToAiMatrix4x4(mCachedGlobalBoneMat);
+	mAiCachedGlobalBoneMat = ofxAssimp::Utils::glmMat4ToAiMatrix4x4(mCachedGlobalBoneMat);
 }
 
 //--------------------------------------------------------------

--- a/addons/ofxAssimp/src/ofxAssimpBone.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpBone.cpp
@@ -1,10 +1,3 @@
-//
-//  ofxAssimpBone.cpp
-//  ofxAssimpExample
-//
-//  Created by Nick Hardeman on 10/24/23.
-//
-
 #include "ofxAssimpBone.h"
 #include "ofGraphics.h"
 #include "of3dGraphics.h"
@@ -28,38 +21,6 @@ void Bone::setSrcBone( std::shared_ptr<ofxAssimp::SrcBone> aSrcBone ) {
 	
 	ofxAssimp::Utils::setOfNodeFromAiMatrix( mSrcBone->getAiMatrix(), this );
 }
-
-////--------------------------------------------------------------
-//void Bone::updateFromSrcBone() {
-//	if( mSrcBone ) {
-//
-//		aiVector3t<float> tAiScale;
-//		aiQuaterniont<float> tAiRotation;
-//		aiVector3t<float> tAiPosition;
-//
-//		// TODO: These will get update via the animation keyframes
-//		// SO there won't be a decompose every frame
-////		mAiMatrixGlobal = mSrcBone->getAiMatrixGlobal();
-//		mAiMatrix = mSrcBone->getAiMatrix();
-//		// this is the local matrix
-//		mSrcBone->getAiMatrix().Decompose( tAiScale, tAiRotation, tAiPosition );
-//
-//		glm::vec3 tpos = glm::vec3( tAiPosition.x, tAiPosition.y, tAiPosition.z );
-//		glm::quat tquat = glm::quat(tAiRotation.w, tAiRotation.x, tAiRotation.y, tAiRotation.z);
-//	//	glm::quat tquat = glm::quat(tAiRotation.x, tAiRotation.y, tAiRotation.z, tAiRotation.w);
-//		glm::vec3 tscale = glm::vec3( tAiScale.x, tAiScale.y, tAiScale.z );
-//
-//		setPositionOrientationScale( tpos, tquat, tscale );
-//
-////		mOffsetMatrix.Decompose(tAiScale, tAiRotation, tAiPosition);
-//
-////		mOffsetOrientation = glm::quat(tAiRotation.w, tAiRotation.x, tAiRotation.y, tAiRotation.z);
-//
-////		setPosition( mSrcBone->getPosition() );
-////		setOrientation( mSrcBone->getOrientationQuat() );
-////		setScale( mSrcBone->getScale() );
-//	}
-//}
 
 //--------------------------------------------------------------
 void Bone::cacheGlobalBoneMat(glm::mat4& aInvMat) {

--- a/addons/ofxAssimp/src/ofxAssimpBone.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpBone.cpp
@@ -12,7 +12,7 @@
 #include "ofxAssimpUtils.h"
 #include "ofVboMesh.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 using std::shared_ptr;
 using std::make_shared;
 
@@ -20,7 +20,7 @@ using std::make_shared;
 std::unordered_map< int, std::shared_ptr<ofVboMesh> > Bone::sRenderMeshes;
 
 //--------------------------------------------------------------
-void Bone::setSrcBone( std::shared_ptr<ofx::assimp::SrcBone> aSrcBone ) {
+void Bone::setSrcBone( std::shared_ptr<ofxAssimp::SrcBone> aSrcBone ) {
 	mSrcBone = aSrcBone;
 	mOffsetMatrix = mSrcBone->getAiOffsetMatrix();
 	

--- a/addons/ofxAssimp/src/ofxAssimpBone.h
+++ b/addons/ofxAssimp/src/ofxAssimpBone.h
@@ -11,21 +11,21 @@
 
 class ofVboMesh;
 
-namespace ofx::assimp {
-class Bone : public ofx::assimp::Node {
+namespace ofxAssimp {
+class Bone : public ofxAssimp::Node {
 public:
 	
 	virtual NodeType getType() override { return OFX_ASSIMP_BONE; }
 	
-	void setSrcBone( std::shared_ptr<ofx::assimp::SrcBone> aSrcBone );
+	void setSrcBone( std::shared_ptr<ofxAssimp::SrcBone> aSrcBone );
 	
 //	virtual void updateFromSrcBone();
 	void cacheGlobalBoneMat(glm::mat4& aInvMat);
 	virtual void draw(float aAxisSize=30.0f);
 	
-	std::shared_ptr<ofx::assimp::SrcBone> getSrcBone() { return mSrcBone; }
+	std::shared_ptr<ofxAssimp::SrcBone> getSrcBone() { return mSrcBone; }
 	
-//	std::shared_ptr<ofx::assimp::Bone> getBone( const std::string& aName );
+//	std::shared_ptr<ofxAssimp::Bone> getBone( const std::string& aName );
 //	void findBoneRecursive( const std::string& aName, std::shared_ptr<Bone>& returnBone );
 	
 //	aiMatrix4x4& getAiMatrix() { return mAiMatrix; }
@@ -35,8 +35,8 @@ public:
 	const aiMatrix4x4& getAiCachedGlobalBoneMat() { return mAiCachedGlobalBoneMat; }
 	
 protected:
-	std::vector< std::shared_ptr<ofx::assimp::Bone> > mChildBones;
-	std::shared_ptr<ofx::assimp::SrcBone> mSrcBone;
+	std::vector< std::shared_ptr<ofxAssimp::Bone> > mChildBones;
+	std::shared_ptr<ofxAssimp::SrcBone> mSrcBone;
 	
 	void _initRenderMesh();
 	

--- a/addons/ofxAssimp/src/ofxAssimpBone.h
+++ b/addons/ofxAssimp/src/ofxAssimpBone.h
@@ -1,6 +1,5 @@
 //
 //  ofxAssimpBone.h
-//  ofxAssimpExample
 //
 //  Created by Nick Hardeman on 10/24/23.
 //
@@ -19,17 +18,11 @@ public:
 	
 	void setSrcBone( std::shared_ptr<ofxAssimp::SrcBone> aSrcBone );
 	
-//	virtual void updateFromSrcBone();
 	void cacheGlobalBoneMat(glm::mat4& aInvMat);
 	virtual void draw(float aAxisSize=30.0f);
 	
 	std::shared_ptr<ofxAssimp::SrcBone> getSrcBone() { return mSrcBone; }
 	
-//	std::shared_ptr<ofxAssimp::Bone> getBone( const std::string& aName );
-//	void findBoneRecursive( const std::string& aName, std::shared_ptr<Bone>& returnBone );
-	
-//	aiMatrix4x4& getAiMatrix() { return mAiMatrix; }
-//	aiMatrix4x4& getAiMatrixGlobal() { return mAiMatrixGlobal; }
 	aiMatrix4x4& getAiOffsetMatrix() { return mOffsetMatrix;}
 	const glm::mat4& getCachedGlobalBoneMat() { return mCachedGlobalBoneMat; }
 	const aiMatrix4x4& getAiCachedGlobalBoneMat() { return mAiCachedGlobalBoneMat; }
@@ -41,10 +34,8 @@ protected:
 	void _initRenderMesh();
 	
 	glm::mat4 mCachedGlobalBoneMat = glm::mat4(1.0f);
-//	glm::quat mOffsetOrientation;
 	
 	aiMatrix4x4 mAiMatrix, mAiCachedGlobalBoneMat;
-//	aiMatrix4x4 mAiMatrixGlobal;
 	aiMatrix4x4 mOffsetMatrix;
 	glm::mat4 mGlmOffsetMat;
 	
@@ -56,6 +47,5 @@ protected:
 	// 5: -z
 	int mAlignAxis = -1;
 	static std::unordered_map< int, std::shared_ptr<ofVboMesh> > sRenderMeshes;
-//	static std::shared_ptr<ofVboMesh> sRenderMesh;
 };
 }

--- a/addons/ofxAssimp/src/ofxAssimpBounds.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpBounds.cpp
@@ -8,7 +8,7 @@
 #include "ofGraphics.h"
 
 //--------------------------------------------------------------
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 ofMesh Bounds::mLinesMesh;
 
@@ -291,7 +291,7 @@ Bounds& Bounds::operator*=( const glm::vec3& ascale ) {
 }
 
 //----------------------------------------------------------
-std::ostream& operator<<(std::ostream& os, const ofx::assimp::Bounds& ab){
+std::ostream& operator<<(std::ostream& os, const ofxAssimp::Bounds& ab){
 	os << " min: " << ab.min << ", max: " << ab.max << ", center: " << ab.radius;
 	return os;
 }

--- a/addons/ofxAssimp/src/ofxAssimpBounds.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpBounds.cpp
@@ -1,9 +1,3 @@
-//
-//  ofxAssimpBounds.cpp
-//
-//  Created by Nick Hardeman on 10/18/23.
-//
-
 #include "ofxAssimpBounds.h"
 #include "ofGraphics.h"
 

--- a/addons/ofxAssimp/src/ofxAssimpBounds.h
+++ b/addons/ofxAssimp/src/ofxAssimpBounds.h
@@ -11,7 +11,7 @@
 #include <assimp/postprocess.h>
 #include "ofNode.h"
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 
 class Bounds {
 protected:
@@ -78,4 +78,4 @@ protected:
 };
 }
 
-std::ostream& operator<<(std::ostream& os, const ofx::assimp::Bounds& ab);
+std::ostream& operator<<(std::ostream& os, const ofxAssimp::Bounds& ab);

--- a/addons/ofxAssimp/src/ofxAssimpBounds.h
+++ b/addons/ofxAssimp/src/ofxAssimpBounds.h
@@ -1,6 +1,5 @@
 //
 //  ofxAssimpBounds.h
-//  AssimpModelLoaderGlow
 //
 //  Created by Nick Hardeman on 10/18/23.
 //

--- a/addons/ofxAssimp/src/ofxAssimpMesh.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpMesh.cpp
@@ -11,14 +11,14 @@
 using std::make_shared;
 using std::shared_ptr;
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 //-------------------------------------------
 bool Mesh::hasTexture() {
 	if(mSrcMesh) {
 		return mSrcMesh->hasTexture();
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
 	return false;
 }
 
@@ -27,7 +27,7 @@ bool Mesh::hasTexture(ofMaterialTextureType aType){
 	if(mSrcMesh) {
 		return mSrcMesh->hasTexture(aType);
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
 	return false;
 }
 
@@ -36,7 +36,7 @@ std::size_t Mesh::getNumTextures() {
 	if(mSrcMesh) {
 		return mSrcMesh->getNumTextures();
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
 	return 0;
 }
 
@@ -45,8 +45,8 @@ ofTexture& Mesh::getTexture() {
 	if(mSrcMesh) {
 		return mSrcMesh->getTexture();
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
-	return ofx::assimp::SrcMesh::sDummyTex;
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
+	return ofxAssimp::SrcMesh::sDummyTex;
 }
 
 //-------------------------------------------
@@ -54,20 +54,20 @@ ofTexture& Mesh::getTexture(ofMaterialTextureType aType){
 	if(mSrcMesh) {
 		return mSrcMesh->getTexture( aType );
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
-	return ofx::assimp::SrcMesh::sDummyTex;
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
+	return ofxAssimp::SrcMesh::sDummyTex;
 }
 
 //-------------------------------------------
-std::shared_ptr<ofx::assimp::Texture> Mesh::getTexture( unsigned int aindex ) {
+std::shared_ptr<ofxAssimp::Texture> Mesh::getTexture( unsigned int aindex ) {
 	if(mSrcMesh) {
 		if( aindex < 0 || aindex >= getNumTextures() ) {
-			ofLogWarning("ofx::assimp::Mesh::getTexture") << "out of bounds: " << aindex << " - " << getNumTextures();
+			ofLogWarning("ofxAssimp::Mesh::getTexture") << "out of bounds: " << aindex << " - " << getNumTextures();
 		}
 		return mSrcMesh->getAllMeshTextures()[aindex];
 	}
-	ofLogWarning("ofx::assimp::Mesh::getTexture") << "SrcMesh is not set.";
-	return std::shared_ptr<ofx::assimp::Texture>();
+	ofLogWarning("ofxAssimp::Mesh::getTexture") << "SrcMesh is not set.";
+	return std::shared_ptr<ofxAssimp::Texture>();
 }
 
 //-------------------------------------------
@@ -103,7 +103,7 @@ std::size_t Mesh::getNumIndices() {
 }
 
 //-------------------------------------------
-void Mesh::setSrcMesh( std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh ) {
+void Mesh::setSrcMesh( std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh ) {
 	mSrcMesh = aSrcMesh;
 	
 	// if we have bones, no offset, since we are controlled by the bones //

--- a/addons/ofxAssimp/src/ofxAssimpMesh.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpMesh.cpp
@@ -130,9 +130,9 @@ void Mesh::setSrcMesh( std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh ) {
 ofMesh& Mesh::getStaticMesh() {
 	if( mSrcMesh && mSrcMesh->getAiMesh() && mMesh.getNumVertices() < 1 ) {
 		if( hasTexture() ) {
-			aiMeshToOfMesh(mSrcMesh->getAiMesh(), mMesh, !bConvertedToLeftHand, &getTexture() );
+			ofxAssimp::Utils::aiMeshToOfMesh(mSrcMesh->getAiMesh(), mMesh, !bConvertedToLeftHand, &getTexture() );
 		} else {
-			aiMeshToOfMesh(mSrcMesh->getAiMesh(), mMesh, !bConvertedToLeftHand, nullptr);
+			ofxAssimp::Utils::aiMeshToOfMesh(mSrcMesh->getAiMesh(), mMesh, !bConvertedToLeftHand, nullptr);
 		}
 	}
 	return mMesh;
@@ -146,19 +146,19 @@ ofMesh& Mesh::getMesh() {
 				mBInitedAnimatedMesh=true;
 				if(mSrcMesh && mSrcMesh->getAiMesh()) {
 					if( hasTexture() ) {
-						aiMeshToOfMesh(mSrcMesh->getAiMesh(), mAnimatedMesh, !bConvertedToLeftHand, &getTexture() );
+						ofxAssimp::Utils::aiMeshToOfMesh(mSrcMesh->getAiMesh(), mAnimatedMesh, !bConvertedToLeftHand, &getTexture() );
 					} else {
-						aiMeshToOfMesh(mSrcMesh->getAiMesh(), mAnimatedMesh, !bConvertedToLeftHand, nullptr);
+						ofxAssimp::Utils::aiMeshToOfMesh(mSrcMesh->getAiMesh(), mAnimatedMesh, !bConvertedToLeftHand, nullptr);
 					}
 				}
 			}
 			
 			mAnimatedMesh.clearVertices();
 			mAnimatedMesh.clearNormals();
-			mAnimatedMesh.addVertices(aiVecVecToOfVecVec(animatedVertices));
+			mAnimatedMesh.addVertices(ofxAssimp::Utils::aiVecVecToOfVecVec(animatedVertices));
 //			mAnimatedMesh.addVertices(animatedVertices);
 			if(animatedNormals.size() == animatedVertices.size() ) {
-				mAnimatedMesh.addNormals(aiVecVecToOfVecVec(animatedNormals));
+				mAnimatedMesh.addNormals(ofxAssimp::Utils::aiVecVecToOfVecVec(animatedNormals));
 //				mAnimatedMesh.addNormals(animatedNormals);
 			}
 			validCache = true;

--- a/addons/ofxAssimp/src/ofxAssimpMesh.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpMesh.cpp
@@ -117,9 +117,6 @@ void Mesh::setSrcMesh( std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh ) {
 		blendMode = mSrcMesh->blendMode;
 		vbo = make_shared<ofVbo>();
 		mSrcMesh->setupVbo(vbo);
-//		ofVbo temp = *mSrcMesh->vbo;
-//		vbo = std::make_shared<ofVbo>(temp);
-//		vbo = make_shared<ofVbo>();
 		
 		mLocalBounds = mSrcMesh->getLocalBounds();
 		bConvertedToLeftHand = mSrcMesh->bConvertedToLeftHand;

--- a/addons/ofxAssimp/src/ofxAssimpMesh.h
+++ b/addons/ofxAssimp/src/ofxAssimpMesh.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "ofMaterial.h"
-#include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include "ofxAssimpTexture.h"

--- a/addons/ofxAssimp/src/ofxAssimpMesh.h
+++ b/addons/ofxAssimp/src/ofxAssimpMesh.h
@@ -19,9 +19,9 @@
 #include "ofxAssimpSrcMesh.h"
 
 struct aiMesh;
-namespace ofx::assimp {
+namespace ofxAssimp {
 
-class Mesh : public ofx::assimp::Node {
+class Mesh : public ofxAssimp::Node {
 public:
 	
 	virtual NodeType getType() override { return OFX_ASSIMP_MESH; }
@@ -32,14 +32,14 @@ public:
 	std::size_t getNumTextures();
 	ofTexture& getTexture();
 	ofTexture& getTexture(ofMaterialTextureType aType);
-	std::shared_ptr<ofx::assimp::Texture> getTexture( unsigned int aindex );
+	std::shared_ptr<ofxAssimp::Texture> getTexture( unsigned int aindex );
 	
 	std::size_t getNumVertices();
 	bool hasNormals();
 	aiMesh* getAiMesh();
 	std::size_t getNumIndices();
 	
-	void setSrcMesh( std::shared_ptr<ofx::assimp::SrcMesh> aSrcMesh );
+	void setSrcMesh( std::shared_ptr<ofxAssimp::SrcMesh> aSrcMesh );
 	
 	ofMesh& getStaticMesh();
 	ofMesh& getMesh();
@@ -66,16 +66,16 @@ public:
 	std::vector<aiVector3D> animatedVertices;
 	std::vector<aiVector3D> animatedNormals;
 	
-	std::vector< std::shared_ptr<ofx::assimp::Bone> > mBones;
+	std::vector< std::shared_ptr<ofxAssimp::Bone> > mBones;
 	
-	std::shared_ptr<ofx::assimp::SrcMesh> getSrcMesh() { return mSrcMesh; }
+	std::shared_ptr<ofxAssimp::SrcMesh> getSrcMesh() { return mSrcMesh; }
 	
 protected:
 	virtual void onPositionChanged() override;
 	virtual void onOrientationChanged() override;
 	virtual void onScaleChanged() override;
 	
-	std::shared_ptr<ofx::assimp::SrcMesh> mSrcMesh;
+	std::shared_ptr<ofxAssimp::SrcMesh> mSrcMesh;
 	
 	// calculate the local bounds for all of the vertices
 	// has no position, scale or rotations applied

--- a/addons/ofxAssimp/src/ofxAssimpNode.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpNode.cpp
@@ -7,14 +7,14 @@
 #include "ofxAssimpUtils.h"
 #include "of3dGraphics.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
 using std::shared_ptr;
 using std::string;
 using std::cout;
 
 //--------------------------------------------------------------
-void Node::setSrcNode( std::shared_ptr<ofx::assimp::SrcNode> aSrcNode ) {
+void Node::setSrcNode( std::shared_ptr<ofxAssimp::SrcNode> aSrcNode ) {
 	mSrcNode = aSrcNode;
 	if( getType() == OFX_ASSIMP_BONE ) {
 //		setOfNodeFromAiMatrix(mSrcNode->getAiNode()->mTransformation, this );
@@ -30,8 +30,8 @@ std::string Node::getName() {
 }
 
 //--------------------------------------------------------------
-void Node::update( const std::shared_ptr<ofx::assimp::AnimationMixer>& aAnimMixer ) {
-	std::shared_ptr<ofx::assimp::AnimationMixer> mixer;
+void Node::update( const std::shared_ptr<ofxAssimp::AnimationMixer>& aAnimMixer ) {
+	std::shared_ptr<ofxAssimp::AnimationMixer> mixer;
 	if( hasAnimationMixer() && areAnimationsEnabled() ) {
 		mixer = mAnimMixer;
 	} else {
@@ -39,7 +39,7 @@ void Node::update( const std::shared_ptr<ofx::assimp::AnimationMixer>& aAnimMixe
 	}
 
 	if( !mixer ) {
-		ofLogError("ofx::assimp::Node:update") << "not a valid AnimationMixer!";
+		ofLogError("ofxAssimp::Node:update") << "not a valid AnimationMixer!";
 		return;
 	}
 	
@@ -142,7 +142,7 @@ void Node::setEnabled( bool aBEnable, bool aBRecursively) {
 }
 
 //----------------------------------------
-void Node::setParentNode( shared_ptr<ofx::assimp::Node> anode ) {
+void Node::setParentNode( shared_ptr<ofxAssimp::Node> anode ) {
 	mParentNode = anode;
 }
 
@@ -153,7 +153,7 @@ bool Node::hasParentNode() {
 }
 
 //----------------------------------------
-shared_ptr<ofx::assimp::Node> Node::getParentNode() {
+shared_ptr<ofxAssimp::Node> Node::getParentNode() {
 	return mParentNode;
 }
 
@@ -178,22 +178,22 @@ std::vector< std::shared_ptr<Node> >& Node::getChildren() {
 }
 
 //--------------------------------------------------------------
-std::shared_ptr<ofx::assimp::Node> Node::getNode( const string& aPath, bool bStrict ) {
+std::shared_ptr<ofxAssimp::Node> Node::getNode( const string& aPath, bool bStrict ) {
 	std::vector< std::string > tsearches;
 	if( ofIsStringInString( aPath, ":" ) ) {
 		tsearches = ofSplitString( aPath, ":" );
 	} else {
 		tsearches.push_back( aPath );
 	}
-	std::shared_ptr<ofx::assimp::Node> temp;
+	std::shared_ptr<ofxAssimp::Node> temp;
 	_getNodeForNameRecursive( tsearches, temp, mKids, bStrict );
 	return temp;
 }
 
 //--------------------------------------------------------------
 void Node::_getNodeForNameRecursive(std::vector<std::string>& aNamesToFind,
-									std::shared_ptr<ofx::assimp::Node>& aTarget,
-									std::vector< std::shared_ptr<ofx::assimp::Node> >& aElements, bool bStrict ) {
+									std::shared_ptr<ofxAssimp::Node>& aTarget,
+									std::vector< std::shared_ptr<ofxAssimp::Node> >& aElements, bool bStrict ) {
 	if( aNamesToFind.size() < 1 ) {
 		return;
 	}
@@ -248,8 +248,8 @@ void Node::_getNodeForNameRecursive(std::vector<std::string>& aNamesToFind,
 
 //--------------------------------------------------------------
 void Node::_getNodesForTypeRecursive( int atype, const std::string& aNameToContain,
-									std::vector< std::shared_ptr<ofx::assimp::Node> >& aFoundElements,
-									std::vector< std::shared_ptr<ofx::assimp::Node> >& aElements ) {
+									std::vector< std::shared_ptr<ofxAssimp::Node> >& aFoundElements,
+									std::vector< std::shared_ptr<ofxAssimp::Node> >& aElements ) {
 	
 	for( size_t i = 0; i < aElements.size(); i++ ) {
 		if( aElements[i]->getType() == atype ) {
@@ -286,7 +286,7 @@ std::string Node::getAsString( int aLevel ) {
 	} else {
 		oStr << "- ";
 	}
-	oStr << ofx::assimp::SrcNode::sGetNodeTypeShortAsString( getType() );
+	oStr << ofxAssimp::SrcNode::sGetNodeTypeShortAsString( getType() );
 	oStr << ": " << getName();
 	oStr << std::endl;
 	

--- a/addons/ofxAssimp/src/ofxAssimpNode.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpNode.cpp
@@ -1,8 +1,3 @@
-//
-//  ofxAssimpNode.cpp
-//  Created by Nick Hardeman on 10/24/23.
-//
-
 #include "ofxAssimpNode.h"
 #include "ofxAssimpUtils.h"
 #include "of3dGraphics.h"

--- a/addons/ofxAssimp/src/ofxAssimpNode.h
+++ b/addons/ofxAssimp/src/ofxAssimpNode.h
@@ -9,16 +9,16 @@
 #include "ofxAssimpSrcNode.h"
 #include <assimp/scene.h>
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 class Node : public ofNode {
 public:
-	void setSrcNode( std::shared_ptr<ofx::assimp::SrcNode> aSrcNode );
+	void setSrcNode( std::shared_ptr<ofxAssimp::SrcNode> aSrcNode );
 	virtual std::string getName();
 	
 	virtual NodeType getType() { return OFX_ASSIMP_NODE; }
 	
 	virtual void update() {};
-	virtual void update( const std::shared_ptr<ofx::assimp::AnimationMixer>& aAnimMixer );
+	virtual void update( const std::shared_ptr<ofxAssimp::AnimationMixer>& aAnimMixer );
 	
 	virtual void drawNodes();
 	
@@ -30,7 +30,7 @@ public:
 	void removeAnimationMixer();
 	/// \brief Get the animation mixer on the node.
 	/// \return AnimationMixer as a shared ptr.
-	std::shared_ptr<ofx::assimp::AnimationMixer> getAnimationMixer() {return mAnimMixer;}
+	std::shared_ptr<ofxAssimp::AnimationMixer> getAnimationMixer() {return mAnimMixer;}
 	
 	bool areAnimationsEnabled() const;
 	void setAnimationsEnabled(bool aBEnable, bool aBRecursively=true);
@@ -38,26 +38,26 @@ public:
 	bool isEnabled() const;
 	void setEnabled( bool aBEnable, bool aBRecursively=true);
 	
-	void setParentNode( std::shared_ptr<ofx::assimp::Node> anode );
+	void setParentNode( std::shared_ptr<ofxAssimp::Node> anode );
 	bool hasParentNode();
-	std::shared_ptr<ofx::assimp::Node> getParentNode();
+	std::shared_ptr<ofxAssimp::Node> getParentNode();
 	
 	void clearChildren();
-	void addChild( std::shared_ptr<ofx::assimp::Node> akiddo );
+	void addChild( std::shared_ptr<ofxAssimp::Node> akiddo );
 	int getNumChildren();
-	std::vector< std::shared_ptr<ofx::assimp::Node> >& getChildren();
+	std::vector< std::shared_ptr<ofxAssimp::Node> >& getChildren();
 	
 	virtual std::string getAsString( int aLevel=0 );
 	/// \brief Get a node for path.
 	/// \param aPath path in heirarchy to the desired node.\nUse direct path, ie. 'root:someNode:myNode' or recursively using asterik ie. '*:myNode'.
 	/// \param bStrict if true, name must match. If not, apath search name is contained in node string.
-	/// \return ofx::assimp::Node as shared_ptr. Valid ptr if found.
-	std::shared_ptr<ofx::assimp::Node> getNode( const std::string& aPath, bool bStrict );
+	/// \return ofxAssimp::Node as shared_ptr. Valid ptr if found.
+	std::shared_ptr<ofxAssimp::Node> getNode( const std::string& aPath, bool bStrict );
 		
-	/// \brief Get a node cast as template type. ie. getNodeAsType<ofx::assimp::Bone>('root:someNode:myNode', true);
+	/// \brief Get a node cast as template type. ie. getNodeAsType<ofxAssimp::Bone>('root:someNode:myNode', true);
 	/// \param aPath path in heirarchy to the desired node.\nUse direct path, ie. 'root:someNode:myNode' or recursively using asterik ie. '*:myNode'.
 	/// \param bStrict if true, name must match. If not, apath search name is contained in node string.
-	/// \return ofx::assimp::Node cast to ofxAssimpNodeType as shared_ptr. Valid ptr if found.
+	/// \return ofxAssimp::Node cast to ofxAssimpNodeType as shared_ptr. Valid ptr if found.
 	template<typename ofxAssimpNodeType>
 	std::shared_ptr<ofxAssimpNodeType> getNodeAsType( const std::string& aPath, bool bStrict = false ) {
 		auto stemp = getNode( aPath, bStrict );
@@ -66,14 +66,14 @@ public:
 			if(stemp->getType() == sType) {
 				return std::dynamic_pointer_cast<ofxAssimpNodeType>( stemp );
 			} else {
-				ofLogWarning("ofx::assimp::Node") << getName() << " found node with path: " << aPath << ", but WRONG type!";
+				ofLogWarning("ofxAssimp::Node") << getName() << " found node with path: " << aPath << ", but WRONG type!";
 			}
 		}
 		return std::shared_ptr<ofxAssimpNodeType>();
 	}
-	/// \brief Get child nodes for template type ie. getNodesForType<ofx::assimp::Bone>(); (non-recursive).
+	/// \brief Get child nodes for template type ie. getNodesForType<ofxAssimp::Bone>(); (non-recursive).
 	/// \param aNameToContain To be returned, name of node must contain this string.\nDefault is return all nodes for type.
-	/// \return vector of shared_ptrs of ofx::assimp::Node cast to ofxAssimpNodeType.
+	/// \return vector of shared_ptrs of ofxAssimp::Node cast to ofxAssimpNodeType.
 	template<typename ofxAssimpNodeType>
 	std::vector< std::shared_ptr<ofxAssimpNodeType> > getNodesForType( const std::string& aNameToContain="" ) {
 		int sType = std::make_shared<ofxAssimpNodeType>()->getType();
@@ -87,13 +87,13 @@ public:
 		}
 		return telements;
 	}
-	/// \brief Get nodes for template type ie. getNodesForType<ofx::assimp::Bone>(); (recursive).
+	/// \brief Get nodes for template type ie. getNodesForType<ofxAssimp::Bone>(); (recursive).
 	/// \param aNameToContain To be returned, name of node must contain this string.\nDefault is return all nodes for type.
-	/// \return vector of shared_ptrs of ofx::assimp::Node cast to ofxAssimpNodeType.
+	/// \return vector of shared_ptrs of ofxAssimp::Node cast to ofxAssimpNodeType.
 	template<typename ofxAssimpNodeType>
 	std::vector< std::shared_ptr<ofxAssimpNodeType> > getAllNodesForType( const std::string& aNameToContain="" ) {
 		int sType = std::make_shared<ofxAssimpNodeType>()->getType();
-		std::vector< std::shared_ptr<ofx::assimp::Node> > tFoundNodes;
+		std::vector< std::shared_ptr<ofxAssimp::Node> > tFoundNodes;
 		_getNodesForTypeRecursive( sType, aNameToContain, tFoundNodes, mKids );
 		std::vector< std::shared_ptr<ofxAssimpNodeType> > tReturnNodes;
 		for( auto tfn : tFoundNodes ) {
@@ -104,18 +104,18 @@ public:
 	
 protected:
 	void _getNodeForNameRecursive( std::vector<std::string>& aNamesToFind,
-								   std::shared_ptr<ofx::assimp::Node>& aTarget,
-								  std::vector< std::shared_ptr<ofx::assimp::Node> >& aElements, bool bStrict );
+								   std::shared_ptr<ofxAssimp::Node>& aTarget,
+								  std::vector< std::shared_ptr<ofxAssimp::Node> >& aElements, bool bStrict );
 	void _getNodesForTypeRecursive( int atype, const std::string& aNameToContain,
-								  std::vector< std::shared_ptr<ofx::assimp::Node> >& aFoundElements,
-								  std::vector< std::shared_ptr<ofx::assimp::Node> >& aElements );
+								  std::vector< std::shared_ptr<ofxAssimp::Node> >& aFoundElements,
+								  std::vector< std::shared_ptr<ofxAssimp::Node> >& aElements );
 	
 	std::string mName = "";
-	std::shared_ptr<ofx::assimp::SrcNode> mSrcNode;
-	std::vector< std::shared_ptr<ofx::assimp::Node> > mKids;
-	std::shared_ptr<ofx::assimp::Node> mParentNode;
+	std::shared_ptr<ofxAssimp::SrcNode> mSrcNode;
+	std::vector< std::shared_ptr<ofxAssimp::Node> > mKids;
+	std::shared_ptr<ofxAssimp::Node> mParentNode;
 	
-	std::shared_ptr<ofx::assimp::AnimationMixer> mAnimMixer;
+	std::shared_ptr<ofxAssimp::AnimationMixer> mAnimMixer;
 	
 	bool mBAnimationsEnabled = true;
 	bool mBEnabled = true;

--- a/addons/ofxAssimp/src/ofxAssimpScene.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpScene.cpp
@@ -6,11 +6,6 @@
 #include "ofGraphics.h"
 #include "ofConstants.h"
 
-#include <assimp/scene.h>
-#include <assimp/postprocess.h>
-#include <assimp/config.h>
-#include <assimp/DefaultLogger.hpp>
-
 using std::shared_ptr;
 using std::vector;
 using std::make_shared;
@@ -1004,11 +999,6 @@ std::shared_ptr<ofxAssimp::SrcScene> Scene::getSrcScene() {
 float Scene::getNormalizedScale(){
 	return normalizedScale;
 }
-
-////-------------------------------------------
-//const aiScene* Scene::getAssimpScene(){
-//	return scene.get();
-//}
 
 //--------------------------------------------------------------
 void Scene::enableTextures(){

--- a/addons/ofxAssimp/src/ofxAssimpScene.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpScene.cpp
@@ -6,7 +6,6 @@
 #include "ofGraphics.h"
 #include "ofConstants.h"
 
-#include <assimp/cimport.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include <assimp/config.h>

--- a/addons/ofxAssimp/src/ofxAssimpScene.h
+++ b/addons/ofxAssimp/src/ofxAssimpScene.h
@@ -7,6 +7,7 @@
 // Kyle McDonald and Arturo Castro for C++ nuances
 // Lukasz Karluk additions Dec 2012.
 
+// ofxAssimp by Nick Hardeman
 
 #include "ofxAssimpMesh.h"
 #include "ofxAssimpSrcScene.h"
@@ -15,15 +16,15 @@
 struct aiScene;
 struct aiNode;
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 
-class Model : public ofx::assimp::Node {
+class Scene : public ofxAssimp::Node {
 public:
 	
-	~Model();
-	Model();
+	~Scene();
+	Scene();
 	
-	virtual NodeType getType() { return OFX_ASSIMP_MODEL; }
+	virtual NodeType getType() { return OFX_ASSIMP_SCENE; }
 	
 	//use the default OF selected flags ( from the options above ) or pass in the exact assimp flags you want
 	//note: you will probably want to |= aiProcess_ConvertToLeftHanded to anything you pass in
@@ -45,7 +46,7 @@ public:
 	/// \brief Setup a model from a SrcScene.
 	/// \param ascene shared ptr of a SrcScene setup model with.
 	/// \return True if the scene is processed successfully.
-	bool setup( std::shared_ptr<ofx::assimp::SrcScene> ascene );
+	bool setup( std::shared_ptr<ofxAssimp::SrcScene> ascene );
 	
 	/// \brief Check to see if the scene is valid and loaded.
 	/// \return If the scene has been loaded or setup successfully.
@@ -81,7 +82,7 @@ public:
 	unsigned int getCurrentAnimationIndex();
 	/// \brief The current active animation that is influencing the bones / meshes.
 	/// \return The current animation.
-	ofx::assimp::Animation& getCurrentAnimation();
+	ofxAssimp::Animation& getCurrentAnimation();
 	/// \brief Immediately sets the current active animation that is influencing the bones / meshes.
 	/// \param aindex vector index of the desired animation.
 	/// \return True if the current index is not the same as aindex and there is at least 1 animation.
@@ -111,11 +112,11 @@ public:
 	/// \brief Get an animation by vector index.
 	/// \param aindex vector index of animation to retrieve.
 	/// \return Animation if found, dummy animation if no animations.
-	ofx::assimp::Animation& getAnimation(int aindex);
+	ofxAssimp::Animation& getAnimation(int aindex);
 	/// \brief Get an animation by aname.
 	/// \param aname name of the animation to retrieve.
 	/// \return Animation if found, dummy animation if no animations.
-	ofx::assimp::Animation& getAnimation(const std::string& aname);
+	ofxAssimp::Animation& getAnimation(const std::string& aname);
 	/// \brief Add a new animation based on an existing animation.
 	/// \param aSrcAnimIndex name of the animation to copy.
 	/// \param aNewAnimName name of the new animation.
@@ -155,15 +156,15 @@ public:
 	std::vector<std::string> getMeshNames();
 	/// \brief Get a mesh based on index. Clamps to valid index range.
 	/// \param meshIndex vector index of the desired mesh.
-	/// \return ofx::assimp::Mesh as a shared_ptr. Valid ptr if at least one mesh.
-	std::shared_ptr<ofx::assimp::Mesh> getMesh(int meshIndex);
+	/// \return ofxAssimp::Mesh as a shared_ptr. Valid ptr if at least one mesh.
+	std::shared_ptr<ofxAssimp::Mesh> getMesh(int meshIndex);
 	/// \brief Get a mesh based on name.
 	/// \param aname name of the desired mesh.
-	/// \return ofx::assimp::Mesh as a shared_ptr. Valid ptr if mesh was found by name.
-	std::shared_ptr<ofx::assimp::Mesh> getMesh(const std::string& aname);
+	/// \return ofxAssimp::Mesh as a shared_ptr. Valid ptr if mesh was found by name.
+	std::shared_ptr<ofxAssimp::Mesh> getMesh(const std::string& aname);
 	/// \brief Get all the meshes in the model.
-	/// \return vector of ofx::assimp::Mesh as shared_ptr.
-	std::vector< std::shared_ptr<ofx::assimp::Mesh> > getMeshes() {return mMeshes;}
+	/// \return vector of ofxAssimp::Mesh as shared_ptr.
+	std::vector< std::shared_ptr<ofxAssimp::Mesh> > getMeshes() {return mMeshes;}
 	/// \brief Get an OF mesh based on name of assimp mesh.
 	/// \param aname name of the desired assimp mesh.
 	/// \return ofMesh that is not transformed.
@@ -207,15 +208,15 @@ public:
 	size_t getNumSkeletons();
 	/// \brief Get a skeleton based on index. Clamps to valid index range.
 	/// \param aindex vector index of the desired skeleton.
-	/// \return ofx::assimp::Skeleton as a shared_ptr. Valid ptr if at least one skeleton.
-	std::shared_ptr<ofx::assimp::Skeleton> getSkeleton( const unsigned int& aindex );
+	/// \return ofxAssimp::Skeleton as a shared_ptr. Valid ptr if at least one skeleton.
+	std::shared_ptr<ofxAssimp::Skeleton> getSkeleton( const unsigned int& aindex );
 	/// \brief Get a skeleton based on aname.
 	/// \param aname name of the desired skeleton.
-	/// \return ofx::assimp::Skeleton as a shared_ptr. Valid ptr if skeleton was found by name.
-	std::shared_ptr<ofx::assimp::Skeleton> getSkeleton( const std::string& aname );
+	/// \return ofxAssimp::Skeleton as a shared_ptr. Valid ptr if skeleton was found by name.
+	std::shared_ptr<ofxAssimp::Skeleton> getSkeleton( const std::string& aname );
 	/// \brief Get all the skeletons in the model.
-	/// \return vector of ofx::assimp::Skeleton as shared_ptr.
-	std::vector< std::shared_ptr<ofx::assimp::Skeleton> > getSkeletons();
+	/// \return vector of ofxAssimp::Skeleton as shared_ptr.
+	std::vector< std::shared_ptr<ofxAssimp::Skeleton> > getSkeletons();
 	/// \brief Total number of bones in the model.
 	/// \return The number of bones.
 	unsigned int getNumBones();
@@ -228,8 +229,8 @@ public:
 	void drawFaces();
 	void drawVertices();
 	
-	void _drawMesh(const std::shared_ptr<ofx::assimp::Mesh>& amesh, ofPolyRenderMode aRenderType, bool bSetRenderType );
-	void drawMesh(const std::shared_ptr<ofx::assimp::Mesh>& amesh, ofPolyRenderMode aRenderType=OF_MESH_FILL );
+	void _drawMesh(const std::shared_ptr<ofxAssimp::Mesh>& amesh, ofPolyRenderMode aRenderType, bool bSetRenderType );
+	void drawMesh(const std::shared_ptr<ofxAssimp::Mesh>& amesh, ofPolyRenderMode aRenderType=OF_MESH_FILL );
 	void drawMesh(int aMeshIndex, ofPolyRenderMode aRenderType=OF_MESH_FILL );
 	void drawMesh(const std::string& aMeshName, ofPolyRenderMode aRenderType=OF_MESH_FILL );
 	
@@ -265,9 +266,9 @@ public:
 	
 	
 	// -- bounds ---------------------------------------
-	ofx::assimp::Bounds getSceneBounds();
-	ofx::assimp::Bounds getSceneBoundsLocal();
-	std::shared_ptr<ofx::assimp::SrcScene> getSrcScene();
+	ofxAssimp::Bounds getSceneBounds();
+	ofxAssimp::Bounds getSceneBoundsLocal();
+	std::shared_ptr<ofxAssimp::SrcScene> getSrcScene();
 	void calculateDimensions();
 	
 	
@@ -276,7 +277,7 @@ protected:
 	void updateMeshesFromBones();
 	
 	bool processScene();
-	void processSceneNodesRecursive( std::shared_ptr<ofx::assimp::SrcNode> aSrcNode, std::shared_ptr<ofx::assimp::Node> aParentNode );
+	void processSceneNodesRecursive( std::shared_ptr<ofxAssimp::SrcNode> aSrcNode, std::shared_ptr<ofxAssimp::Node> aParentNode );
 	
 	// updates the *actual GL resources* for the current animation
 	void updateGLResources();
@@ -284,14 +285,14 @@ protected:
 	double normalizedScale = 1.0;
 	
 	// stores all of the resources
-	std::shared_ptr<ofx::assimp::SrcScene> mSrcScene;
+	std::shared_ptr<ofxAssimp::SrcScene> mSrcScene;
 	
-	std::vector< std::shared_ptr<ofx::assimp::Mesh> > mMeshes;
-	std::vector< std::shared_ptr<ofx::assimp::Bone> > mBones;
+	std::vector< std::shared_ptr<ofxAssimp::Mesh> > mMeshes;
+	std::vector< std::shared_ptr<ofxAssimp::Bone> > mBones;
 	// the skeletons are the root bones
-	std::vector< std::shared_ptr<ofx::assimp::Skeleton> > mSkeletons;
-	std::vector< std::shared_ptr<ofx::assimp::Node> > mNullNodes;
-	std::vector<ofx::assimp::Animation> mAnimations;
+	std::vector< std::shared_ptr<ofxAssimp::Skeleton> > mSkeletons;
+	std::vector< std::shared_ptr<ofxAssimp::Node> > mNullNodes;
+	std::vector<ofxAssimp::Animation> mAnimations;
 	
 	int mAnimationIndex = 0;
 	
@@ -309,11 +310,11 @@ protected:
 	bool bProcessedSceneSuccessfully = false;
 	
 	bool mBSceneBoundsDirty=true;
-	ofx::assimp::Bounds mSceneBoundsGlobal;
-	ofx::assimp::Bounds mSceneBoundsLocal;
+	ofxAssimp::Bounds mSceneBoundsGlobal;
+	ofxAssimp::Bounds mSceneBoundsLocal;
 	
 	ofMesh dummyMesh;
-	ofx::assimp::Animation dummyAnimation;
+	ofxAssimp::Animation dummyAnimation;
 	ofTexture dummyTexture;
 };
 }

--- a/addons/ofxAssimp/src/ofxAssimpSkeleton.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpSkeleton.cpp
@@ -1,10 +1,3 @@
-//
-//  ofxAssimpSkeleton.cpp
-//  ofxAssimpExample
-//
-//  Created by Nick Hardeman on 10/25/23.
-//
-
 #include "ofxAssimpSkeleton.h"
 
 //--------------------------------------------------------------

--- a/addons/ofxAssimp/src/ofxAssimpSkeleton.h
+++ b/addons/ofxAssimp/src/ofxAssimpSkeleton.h
@@ -1,6 +1,5 @@
 //
 //  ofxAssimpSkeleton.h
-//  ofxAssimpExample
 //
 //  Created by Nick Hardeman on 10/25/23.
 //

--- a/addons/ofxAssimp/src/ofxAssimpSkeleton.h
+++ b/addons/ofxAssimp/src/ofxAssimpSkeleton.h
@@ -8,8 +8,8 @@
 #pragma once
 #include "ofxAssimpBone.h"
 
-namespace ofx::assimp {
-class Skeleton : public ofx::assimp::Bone {
+namespace ofxAssimp {
+class Skeleton : public ofxAssimp::Bone {
 public:
 	virtual NodeType getType() override { return OFX_ASSIMP_SKELETON; }
 	

--- a/addons/ofxAssimp/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpTexture.cpp
@@ -9,12 +9,12 @@
 #include "ofLog.h"
 #include "ofUtils.h"
 
-using namespace ofx::assimp;
+using namespace ofxAssimp;
 
-std::unordered_map< int, ofMaterialTextureType > ofx::assimp::Texture::sAiTexTypeToOfTexTypeMap;
+std::unordered_map< int, ofMaterialTextureType > ofxAssimp::Texture::sAiTexTypeToOfTexTypeMap;
 
 //-------------------------------------------
-void ofx::assimp::Texture::setup(const of::filesystem::path & texturePath, bool bTexRepeat) {
+void ofxAssimp::Texture::setup(const of::filesystem::path & texturePath, bool bTexRepeat) {
 //	this->texture = texture;
 	if( bTexRepeat ){
 		this->texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
@@ -30,7 +30,7 @@ const char *aiTextureTypeToString(enum aiTextureType in)__attribute__((weak));
 #endif
 
 //-------------------------------------------
-void ofx::assimp::Texture::setAiTextureType(aiTextureType aTexType){
+void ofxAssimp::Texture::setAiTextureType(aiTextureType aTexType){
 	textureType = aTexType;
 
 	if( textureType >= 0 && textureType < AI_TEXTURE_TYPE_MAX){

--- a/addons/ofxAssimp/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimp/src/ofxAssimpTexture.h
@@ -10,7 +10,7 @@
 #include <assimp/material.h>
 #include "ofMaterial.h"
 
-namespace ofx::assimp {
+namespace ofxAssimp {
 class Texture {
 public:
 	static std::unordered_map< int, ofMaterialTextureType > sAiTexTypeToOfTexTypeMap;

--- a/addons/ofxAssimp/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimp/src/ofxAssimpUtils.h
@@ -13,154 +13,158 @@ using std::string;
 using std::vector;
 
 namespace ofxAssimp {
-//--------------------------------------------------------------
-inline ofFloatColor aiColorToOfColor(const aiColor4D& c){
-	return ofFloatColor(c.r,c.g,c.b,c.a);
-}
 
-//--------------------------------------------------------------
-inline ofFloatColor aiColorToOfColor(const aiColor3D& c){
-	return ofFloatColor(c.r,c.g,c.b,1);
-}
-
-//--------------------------------------------------------------
-inline ofDefaultVec3 aiVecToOfVec(const aiVector3D& v){
-	return ofDefaultVec3(v.x,v.y,v.z);
-}
-
-//--------------------------------------------------------------
-inline void aiVecToOfVec(const aiVector3D& v, glm::vec3& fv){
-	fv = glm::vec3(v.x,v.y,v.z);
-}
-
-//--------------------------------------------------------------
-inline glm::quat aiQuatToOfQuat( const aiQuaternion& aq ) {
-	return glm::quat(aq.w, aq.x, aq.y, aq.z);
-}
-
-//--------------------------------------------------------------
-inline vector<ofDefaultVec3> aiVecVecToOfVecVec(const vector<aiVector3D>& v){
-	vector<ofDefaultVec3> ofv(v.size());
-	memcpy(ofv.data(),v.data(),v.size()*sizeof(ofDefaultVec3));
-	return ofv;
-}
-
-inline static aiMatrix4x4 glmMat4ToAiMatrix4x4(const glm::mat4& aMat4) {
-	// hmm, this didn't work, so I guess it's the other way :)
-	//	aiMatrix4x4 aMat4(gMat[0][0], aMat4[0][1], aMat4[0][2], aMat4[0][3],
-	//								 aMat4[1][0], aMat4[1][1], aMat4[1][2], aMat4[1][3],
-	//								 aMat4[2][0], aMat4[2][1], aMat4[2][2], aMat4[2][3],
-	//								 aMat4[3][0], aMat4[3][1], aMat4[3][2], aMat4[3][3]
-	//								 );
-	
-	return aiMatrix4x4(aMat4[0][0], aMat4[1][0], aMat4[2][0], aMat4[3][0],
-					   aMat4[0][1], aMat4[1][1], aMat4[2][1], aMat4[3][1],
-					   aMat4[0][2], aMat4[1][2], aMat4[2][2], aMat4[3][2],
-					   aMat4[0][3], aMat4[1][3], aMat4[2][3], aMat4[3][3]
-					   );
-}
-
-inline static glm::mat4 aiMatrix4x4ToGlmMatrix(const aiMatrix4x4& amat ) {
-	//	glm::mat4 tmatrix(amat.a1, amat.a2, amat.a3, amat.a4,
-	//					   amat.b1, amat.b2, amat.b3, amat.b4,
-	//					   amat.c1, amat.c2, amat.c3, amat.c4,
-	//					   amat.d1, amat.d2, amat.d3, amat.d4);
-	glm::mat4 tmatrix(amat.a1, amat.b1, amat.c1, amat.d1,
-					  amat.a2, amat.b2, amat.c2, amat.d2,
-					  amat.a3, amat.b3, amat.c3, amat.d3,
-					  amat.a4, amat.b4, amat.c4, amat.d4);
-	return tmatrix;
-}
-
-inline void getPositionOrientationScaleFromAiMatrix(aiMatrix4x4& aMat, glm::vec3& apos, glm::quat& aq, glm::vec3& ascale ) {
-	aiVector3t<float> tAiScale;
-	aiQuaterniont<float> tAiRotation;
-	aiVector3t<float> tAiPosition;
-	
-	aMat.Decompose( tAiScale, tAiRotation, tAiPosition );
-	
-	apos = glm::vec3( tAiPosition.x, tAiPosition.y, tAiPosition.z );
-	aq = glm::quat(tAiRotation.w, tAiRotation.x, tAiRotation.y, tAiRotation.z);
-	ascale = glm::vec3( tAiScale.x, tAiScale.y, tAiScale.z );
-}
-
-inline void setOfNodeFromAiMatrix(aiMatrix4x4& aMat, ofNode* anode) {
-	glm::vec3 tpos, tscale;
-	glm::quat tquat;
-	getPositionOrientationScaleFromAiMatrix(aMat, tpos, tquat, tscale );
-	anode->setPositionOrientationScale( tpos, tquat, tscale );
-}
-
-//--------------------------------------------------------------
-inline void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord, ofTexture* aTex=nullptr){
-	
-	// default to triangle mode
-	ofm.clear();
-	ofm.setMode(OF_PRIMITIVE_TRIANGLES);
-	
-	// copy vertices
-	for (unsigned int i=0; i < aim->mNumVertices;i++){
-		ofm.addVertex(glm::vec3(aim->mVertices[i].x,aim->mVertices[i].y,aim->mVertices[i].z));
+class Utils {
+public:
+	//--------------------------------------------------------------
+	static ofFloatColor aiColorToOfColor(const aiColor4D& c){
+		return ofFloatColor(c.r,c.g,c.b,c.a);
 	}
 	
-	if(aim->HasNormals()){
+	//--------------------------------------------------------------
+	static ofFloatColor aiColorToOfColor(const aiColor3D& c){
+		return ofFloatColor(c.r,c.g,c.b,1);
+	}
+	
+	//--------------------------------------------------------------
+	static ofDefaultVec3 aiVecToOfVec(const aiVector3D& v){
+		return ofDefaultVec3(v.x,v.y,v.z);
+	}
+	
+	//--------------------------------------------------------------
+	static void aiVecToOfVec(const aiVector3D& v, glm::vec3& fv){
+		fv = glm::vec3(v.x,v.y,v.z);
+	}
+	
+	//--------------------------------------------------------------
+	static glm::quat aiQuatToOfQuat( const aiQuaternion& aq ) {
+		return glm::quat(aq.w, aq.x, aq.y, aq.z);
+	}
+	
+	//--------------------------------------------------------------
+	static vector<ofDefaultVec3> aiVecVecToOfVecVec(const vector<aiVector3D>& v){
+		vector<ofDefaultVec3> ofv(v.size());
+		memcpy(ofv.data(),v.data(),v.size()*sizeof(ofDefaultVec3));
+		return ofv;
+	}
+	
+	static aiMatrix4x4 glmMat4ToAiMatrix4x4(const glm::mat4& aMat4) {
+		// hmm, this didn't work, so I guess it's the other way :)
+		//	aiMatrix4x4 aMat4(gMat[0][0], aMat4[0][1], aMat4[0][2], aMat4[0][3],
+		//								 aMat4[1][0], aMat4[1][1], aMat4[1][2], aMat4[1][3],
+		//								 aMat4[2][0], aMat4[2][1], aMat4[2][2], aMat4[2][3],
+		//								 aMat4[3][0], aMat4[3][1], aMat4[3][2], aMat4[3][3]
+		//								 );
+		
+		return aiMatrix4x4(aMat4[0][0], aMat4[1][0], aMat4[2][0], aMat4[3][0],
+						   aMat4[0][1], aMat4[1][1], aMat4[2][1], aMat4[3][1],
+						   aMat4[0][2], aMat4[1][2], aMat4[2][2], aMat4[3][2],
+						   aMat4[0][3], aMat4[1][3], aMat4[2][3], aMat4[3][3]
+						   );
+	}
+	
+	static glm::mat4 aiMatrix4x4ToGlmMatrix(const aiMatrix4x4& amat ) {
+		//	glm::mat4 tmatrix(amat.a1, amat.a2, amat.a3, amat.a4,
+		//					   amat.b1, amat.b2, amat.b3, amat.b4,
+		//					   amat.c1, amat.c2, amat.c3, amat.c4,
+		//					   amat.d1, amat.d2, amat.d3, amat.d4);
+		glm::mat4 tmatrix(amat.a1, amat.b1, amat.c1, amat.d1,
+						  amat.a2, amat.b2, amat.c2, amat.d2,
+						  amat.a3, amat.b3, amat.c3, amat.d3,
+						  amat.a4, amat.b4, amat.c4, amat.d4);
+		return tmatrix;
+	}
+	
+	static void getPositionOrientationScaleFromAiMatrix(aiMatrix4x4& aMat, glm::vec3& apos, glm::quat& aq, glm::vec3& ascale ) {
+		aiVector3t<float> tAiScale;
+		aiQuaterniont<float> tAiRotation;
+		aiVector3t<float> tAiPosition;
+		
+		aMat.Decompose( tAiScale, tAiRotation, tAiPosition );
+		
+		apos = glm::vec3( tAiPosition.x, tAiPosition.y, tAiPosition.z );
+		aq = glm::quat(tAiRotation.w, tAiRotation.x, tAiRotation.y, tAiRotation.z);
+		ascale = glm::vec3( tAiScale.x, tAiScale.y, tAiScale.z );
+	}
+	
+	static void setOfNodeFromAiMatrix(aiMatrix4x4& aMat, ofNode* anode) {
+		glm::vec3 tpos, tscale;
+		glm::quat tquat;
+		getPositionOrientationScaleFromAiMatrix(aMat, tpos, tquat, tscale );
+		anode->setPositionOrientationScale( tpos, tquat, tscale );
+	}
+	
+	//--------------------------------------------------------------
+	static void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord, ofTexture* aTex=nullptr){
+		
+		// default to triangle mode
+		ofm.clear();
+		ofm.setMode(OF_PRIMITIVE_TRIANGLES);
+		
+		// copy vertices
 		for (unsigned int i=0; i < aim->mNumVertices;i++){
-			ofm.addNormal(glm::vec3(aim->mNormals[i].x,aim->mNormals[i].y,aim->mNormals[i].z));
+			ofm.addVertex(glm::vec3(aim->mVertices[i].x,aim->mVertices[i].y,aim->mVertices[i].z));
 		}
-	}
-	
-	// aiVector3D * 	mTextureCoords [AI_MAX_NUMBER_OF_TEXTURECOORDS]
-	// just one for now
-	if(aim->GetNumUVChannels()>0){
-		for (unsigned int i=0; i < aim->mNumVertices;i++){
-			//			if(helper && helper->hasTexture()){
-			if( aTex && aTex->isAllocated() ) {
-				//				ofTexture& tex = helper->getTexture();
-				glm::vec2 texCoord = aTex->getCoordFromPercent(aim->mTextureCoords[0][i].x, aim->mTextureCoords[0][i].y);
-				if(bInvertYTexCoord) {
-					texCoord.y = aTex->getCoordFromPercent(0.0f, 1.0f).y - texCoord.y;
-				}
-				ofm.addTexCoord(texCoord);
-			}else{
-				glm::vec2 texCoord(aim->mTextureCoords[0][i].x, aim->mTextureCoords[0][i].y);
-				ofm.addTexCoord(texCoord);
+		
+		if(aim->HasNormals()){
+			for (unsigned int i=0; i < aim->mNumVertices;i++){
+				ofm.addNormal(glm::vec3(aim->mNormals[i].x,aim->mNormals[i].y,aim->mNormals[i].z));
 			}
 		}
-	}
-	
-	//aiColor4D * 	mColors [AI_MAX_NUMBER_OF_COLOR_SETS]
-	// just one for now
-	if(aim->GetNumColorChannels()>0){
-		for (unsigned int i=0; i < aim->mNumVertices;i++){
-			ofm.addColor(aiColorToOfColor(aim->mColors[0][i]));
+		
+		// aiVector3D * 	mTextureCoords [AI_MAX_NUMBER_OF_TEXTURECOORDS]
+		// just one for now
+		if(aim->GetNumUVChannels()>0){
+			for (unsigned int i=0; i < aim->mNumVertices;i++){
+				//			if(helper && helper->hasTexture()){
+				if( aTex && aTex->isAllocated() ) {
+					//				ofTexture& tex = helper->getTexture();
+					glm::vec2 texCoord = aTex->getCoordFromPercent(aim->mTextureCoords[0][i].x, aim->mTextureCoords[0][i].y);
+					if(bInvertYTexCoord) {
+						texCoord.y = aTex->getCoordFromPercent(0.0f, 1.0f).y - texCoord.y;
+					}
+					ofm.addTexCoord(texCoord);
+				}else{
+					glm::vec2 texCoord(aim->mTextureCoords[0][i].x, aim->mTextureCoords[0][i].y);
+					ofm.addTexCoord(texCoord);
+				}
+			}
 		}
-	}
-	
-	//	meshHelper->indices.resize(mesh->mNumFaces * 3);
-	//	int j=0;
-	//	for (unsigned int x = 0; x < mesh->mNumFaces; ++x){
-	//		for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a){
-	//			meshHelper->indices[j++]=mesh->mFaces[x].mIndices[a];
-	//		}
-	//	}
-	
-	int j=0;
-	auto& indices = ofm.getIndices();
-	indices.resize(aim->mNumFaces * 3);
-	for (unsigned int x = 0; x < aim->mNumFaces; ++x){
-		for (unsigned int a = 0; a < aim->mFaces[x].mNumIndices; ++a){
-			indices[j++] = aim->mFaces[x].mIndices[a];
+		
+		//aiColor4D * 	mColors [AI_MAX_NUMBER_OF_COLOR_SETS]
+		// just one for now
+		if(aim->GetNumColorChannels()>0){
+			for (unsigned int i=0; i < aim->mNumVertices;i++){
+				ofm.addColor(aiColorToOfColor(aim->mColors[0][i]));
+			}
 		}
+		
+		//	meshHelper->indices.resize(mesh->mNumFaces * 3);
+		//	int j=0;
+		//	for (unsigned int x = 0; x < mesh->mNumFaces; ++x){
+		//		for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a){
+		//			meshHelper->indices[j++]=mesh->mFaces[x].mIndices[a];
+		//		}
+		//	}
+		
+		int j=0;
+		auto& indices = ofm.getIndices();
+		indices.resize(aim->mNumFaces * 3);
+		for (unsigned int x = 0; x < aim->mNumFaces; ++x){
+			for (unsigned int a = 0; a < aim->mFaces[x].mNumIndices; ++a){
+				indices[j++] = aim->mFaces[x].mIndices[a];
+			}
+		}
+		
+		//	for (unsigned int i=0; i < aim->mNumFaces;i++){
+		//		if(aim->mFaces[i].mNumIndices>3){
+		//			ofLogWarning("ofxAssimpUtils") << "aiMeshToOfMesh(): non triangular face found: model face " << i;
+		//		}
+		//		for (unsigned int j=0; j < aim->mFaces[i].mNumIndices; j++){
+		//			ofm.addIndex(aim->mFaces[i].mIndices[j]);
+		//		}
+		//	}
 	}
 	
-	//	for (unsigned int i=0; i < aim->mNumFaces;i++){
-	//		if(aim->mFaces[i].mNumIndices>3){
-	//			ofLogWarning("ofxAssimpUtils") << "aiMeshToOfMesh(): non triangular face found: model face " << i;
-	//		}
-	//		for (unsigned int j=0; j < aim->mFaces[i].mNumIndices; j++){
-	//			ofm.addIndex(aim->mFaces[i].mIndices[j]);
-	//		}
-	//	}
-}
-
+};
 }

--- a/addons/ofxAssimp/src/ofxAssimpUtils.h
+++ b/addons/ofxAssimp/src/ofxAssimpUtils.h
@@ -7,13 +7,12 @@
 #pragma once
 
 #include "ofxAssimpMesh.h"
-#include <assimp/scene.h>
-#include <assimp/postprocess.h>
 #include "ofNode.h"
 
 using std::string;
 using std::vector;
 
+namespace ofxAssimp {
 //--------------------------------------------------------------
 inline ofFloatColor aiColorToOfColor(const aiColor4D& c){
 	return ofFloatColor(c.r,c.g,c.b,c.a);
@@ -48,11 +47,11 @@ inline vector<ofDefaultVec3> aiVecVecToOfVecVec(const vector<aiVector3D>& v){
 
 inline static aiMatrix4x4 glmMat4ToAiMatrix4x4(const glm::mat4& aMat4) {
 	// hmm, this didn't work, so I guess it's the other way :)
-//	aiMatrix4x4 aMat4(gMat[0][0], aMat4[0][1], aMat4[0][2], aMat4[0][3],
-//								 aMat4[1][0], aMat4[1][1], aMat4[1][2], aMat4[1][3],
-//								 aMat4[2][0], aMat4[2][1], aMat4[2][2], aMat4[2][3],
-//								 aMat4[3][0], aMat4[3][1], aMat4[3][2], aMat4[3][3]
-//								 );
+	//	aiMatrix4x4 aMat4(gMat[0][0], aMat4[0][1], aMat4[0][2], aMat4[0][3],
+	//								 aMat4[1][0], aMat4[1][1], aMat4[1][2], aMat4[1][3],
+	//								 aMat4[2][0], aMat4[2][1], aMat4[2][2], aMat4[2][3],
+	//								 aMat4[3][0], aMat4[3][1], aMat4[3][2], aMat4[3][3]
+	//								 );
 	
 	return aiMatrix4x4(aMat4[0][0], aMat4[1][0], aMat4[2][0], aMat4[3][0],
 					   aMat4[0][1], aMat4[1][1], aMat4[2][1], aMat4[3][1],
@@ -62,10 +61,10 @@ inline static aiMatrix4x4 glmMat4ToAiMatrix4x4(const glm::mat4& aMat4) {
 }
 
 inline static glm::mat4 aiMatrix4x4ToGlmMatrix(const aiMatrix4x4& amat ) {
-//	glm::mat4 tmatrix(amat.a1, amat.a2, amat.a3, amat.a4,
-//					   amat.b1, amat.b2, amat.b3, amat.b4,
-//					   amat.c1, amat.c2, amat.c3, amat.c4,
-//					   amat.d1, amat.d2, amat.d3, amat.d4);
+	//	glm::mat4 tmatrix(amat.a1, amat.a2, amat.a3, amat.a4,
+	//					   amat.b1, amat.b2, amat.b3, amat.b4,
+	//					   amat.c1, amat.c2, amat.c3, amat.c4,
+	//					   amat.d1, amat.d2, amat.d3, amat.d4);
 	glm::mat4 tmatrix(amat.a1, amat.b1, amat.c1, amat.d1,
 					  amat.a2, amat.b2, amat.c2, amat.d2,
 					  amat.a3, amat.b3, amat.c3, amat.d3,
@@ -94,29 +93,29 @@ inline void setOfNodeFromAiMatrix(aiMatrix4x4& aMat, ofNode* anode) {
 
 //--------------------------------------------------------------
 inline void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord, ofTexture* aTex=nullptr){
-
+	
 	// default to triangle mode
 	ofm.clear();
 	ofm.setMode(OF_PRIMITIVE_TRIANGLES);
-
+	
 	// copy vertices
 	for (unsigned int i=0; i < aim->mNumVertices;i++){
 		ofm.addVertex(glm::vec3(aim->mVertices[i].x,aim->mVertices[i].y,aim->mVertices[i].z));
 	}
-
+	
 	if(aim->HasNormals()){
 		for (unsigned int i=0; i < aim->mNumVertices;i++){
 			ofm.addNormal(glm::vec3(aim->mNormals[i].x,aim->mNormals[i].y,aim->mNormals[i].z));
 		}
 	}
-
+	
 	// aiVector3D * 	mTextureCoords [AI_MAX_NUMBER_OF_TEXTURECOORDS]
 	// just one for now
 	if(aim->GetNumUVChannels()>0){
 		for (unsigned int i=0; i < aim->mNumVertices;i++){
-//			if(helper && helper->hasTexture()){
+			//			if(helper && helper->hasTexture()){
 			if( aTex && aTex->isAllocated() ) {
-//				ofTexture& tex = helper->getTexture();
+				//				ofTexture& tex = helper->getTexture();
 				glm::vec2 texCoord = aTex->getCoordFromPercent(aim->mTextureCoords[0][i].x, aim->mTextureCoords[0][i].y);
 				if(bInvertYTexCoord) {
 					texCoord.y = aTex->getCoordFromPercent(0.0f, 1.0f).y - texCoord.y;
@@ -128,7 +127,7 @@ inline void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord
 			}
 		}
 	}
-
+	
 	//aiColor4D * 	mColors [AI_MAX_NUMBER_OF_COLOR_SETS]
 	// just one for now
 	if(aim->GetNumColorChannels()>0){
@@ -137,13 +136,13 @@ inline void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord
 		}
 	}
 	
-//	meshHelper->indices.resize(mesh->mNumFaces * 3);
-//	int j=0;
-//	for (unsigned int x = 0; x < mesh->mNumFaces; ++x){
-//		for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a){
-//			meshHelper->indices[j++]=mesh->mFaces[x].mIndices[a];
-//		}
-//	}
+	//	meshHelper->indices.resize(mesh->mNumFaces * 3);
+	//	int j=0;
+	//	for (unsigned int x = 0; x < mesh->mNumFaces; ++x){
+	//		for (unsigned int a = 0; a < mesh->mFaces[x].mNumIndices; ++a){
+	//			meshHelper->indices[j++]=mesh->mFaces[x].mIndices[a];
+	//		}
+	//	}
 	
 	int j=0;
 	auto& indices = ofm.getIndices();
@@ -153,13 +152,15 @@ inline void aiMeshToOfMesh(const aiMesh* aim, ofMesh& ofm, bool bInvertYTexCoord
 			indices[j++] = aim->mFaces[x].mIndices[a];
 		}
 	}
+	
+	//	for (unsigned int i=0; i < aim->mNumFaces;i++){
+	//		if(aim->mFaces[i].mNumIndices>3){
+	//			ofLogWarning("ofxAssimpUtils") << "aiMeshToOfMesh(): non triangular face found: model face " << i;
+	//		}
+	//		for (unsigned int j=0; j < aim->mFaces[i].mNumIndices; j++){
+	//			ofm.addIndex(aim->mFaces[i].mIndices[j]);
+	//		}
+	//	}
+}
 
-//	for (unsigned int i=0; i < aim->mNumFaces;i++){
-//		if(aim->mFaces[i].mNumIndices>3){
-//			ofLogWarning("ofxAssimpUtils") << "aiMeshToOfMesh(): non triangular face found: model face " << i;
-//		}
-//		for (unsigned int j=0; j < aim->mFaces[i].mNumIndices; j++){
-//			ofm.addIndex(aim->mFaces[i].mIndices[j]);
-//		}
-//	}
 }

--- a/examples/3d/ofxAssimpAdvancedExample/src/ofApp.cpp
+++ b/examples/3d/ofxAssimpAdvancedExample/src/ofApp.cpp
@@ -18,7 +18,7 @@ void ofApp::setup(){
 	gui.add(cubeMapExposure.set("CubeMapExposure", 0.25, 0.0, 1.0));
 	gui.add(mBDrawCubeMap.set("DrawCubeMap", false ));
 	
-	ofx::assimp::ImportSettings tsettings;
+	ofxAssimp::ImportSettings tsettings;
 	tsettings.filePath = "ofLogoHollow.fbx";
 	// we don't have any animations in this model
 	tsettings.importAnimations = false;
@@ -56,12 +56,12 @@ void ofApp::setup(){
 	tsettings.importAnimations = true;
 	tsettings.excludeNodesContainingStrings = {"_Goal"};
 	tsettings.convertToLeftHanded = false;
-	srcFoxModel = make_shared<ofx::assimp::Model>();
-	if( srcFoxModel->load(tsettings) ) {
+	srcFoxScene = make_shared<ofxAssimp::Scene>();
+	if( srcFoxScene->load(tsettings) ) {
 		int numFoxes = 16;
 		for( int i = 0; i < numFoxes; i++ ) {
-			auto fox = make_shared<ofx::assimp::Model>();
-			if( fox->setup(srcFoxModel->getSrcScene())) {
+			auto fox = make_shared<ofxAssimp::Scene>();
+			if( fox->setup(srcFoxScene->getSrcScene())) {
 				fox->addAnimation( 0, "idle", 2, 300, OF_LOOP_NORMAL );
 				fox->addAnimation( 0, "idleBark", 310, 350 );
 				fox->addAnimation( 0, "jump", 852, 890 );
@@ -173,7 +173,7 @@ void ofApp::update(){
 		fox->setPosition( fx-80.0, 20.0, 320.0f + sinf(glm::pi<float>() * fpct) * 100.0f  );
 	}
 	
-	auto wizardLeftHand = wizardModel.getNodeAsType<ofx::assimp::Bone>("*:hand right");
+	auto wizardLeftHand = wizardModel.getNodeAsType<ofxAssimp::Bone>("*:hand right");
 	if(wizardLeftHand) {
 		auto lpos = wizardLeftHand->getGlobalOrientation() * wizardHandOffset.get();
 		light.setPosition(wizardLeftHand->getGlobalPosition()+lpos);

--- a/examples/3d/ofxAssimpAdvancedExample/src/ofApp.h
+++ b/examples/3d/ofxAssimpAdvancedExample/src/ofApp.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ofMain.h"
-#include "ofxAssimpModel.h"
+#include "ofxAssimp.h"
 #include "ofxGui.h"
 
 class ofApp : public ofBaseApp{
@@ -27,11 +27,11 @@ class ofApp : public ofBaseApp{
 	
 	ofEasyCam cam;
 	ofLight	light;
-	ofx::assimp::Model wizardModel;
+	ofxAssimp::Scene wizardModel;
 	
-	ofx::assimp::Model logoModel;
-	shared_ptr<ofx::assimp::Model> srcFoxModel;
-	vector< shared_ptr<ofx::assimp::Model> > foxes;
+	ofxAssimp::Scene logoModel;
+	shared_ptr<ofxAssimp::Scene> srcFoxScene;
+	vector< shared_ptr<ofxAssimp::Scene> > foxes;
 	
 	shared_ptr<ofMaterial> logoMaterial;
 	

--- a/examples/3d/ofxAssimpBoneControlExample/src/ofApp.cpp
+++ b/examples/3d/ofxAssimpBoneControlExample/src/ofApp.cpp
@@ -15,7 +15,7 @@ void ofApp::setup(){
 //--------------------------------------------------------------
 void ofApp::loadModel(string filename){
 	
-	ofx::assimp::ImportSettings tsettings;
+	ofxAssimp::ImportSettings tsettings;
 	tsettings.filePath = filename;
 //	tsettings.importTextures = false;
 //	tsettings.importAnimations = false;
@@ -41,7 +41,7 @@ void ofApp::loadModel(string filename){
 		mSceneString += model.getHierarchyAsString();
 		cout << mSceneString << endl;
 		
-		auto neckBone = model.getNodeAsType<ofx::assimp::Bone>("*:neck_control");
+		auto neckBone = model.getNodeAsType<ofxAssimp::Bone>("*:neck_control");
 		if( neckBone ) {
 			mLocalQuat = neckBone->getOrientationQuat();
 		}
@@ -55,7 +55,7 @@ void ofApp::loadModel(string filename){
 		
 		model.getAnimation("eat").setLoopType( OF_LOOP_NORMAL );
 		
-		auto tailBone = model.getNodeAsType<ofx::assimp::Bone>("*:tail_top");
+		auto tailBone = model.getNodeAsType<ofxAssimp::Bone>("*:tail_top");
 		if( tailBone ) {
 //			tailBone->setAnimationsEnabled(false);
 		}
@@ -106,7 +106,7 @@ void ofApp::update(){
 	
 	if( lookStrength > 0.0f ) {
 		// try to grab the neck bone
-		auto neckBone = model.getNodeAsType<ofx::assimp::Bone>("*:neck_control");
+		auto neckBone = model.getNodeAsType<ofxAssimp::Bone>("*:neck_control");
 		if( neckBone ) {
 			
 			glm::vec3 relPosition = neckBone->getGlobalPosition() - mLookAtPos;

--- a/examples/3d/ofxAssimpBoneControlExample/src/ofApp.h
+++ b/examples/3d/ofxAssimpBoneControlExample/src/ofApp.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofMain.h"
-#include "ofxAssimpModel.h"
+#include "ofxAssimp.h"
 #include "ofVboMesh.h"
 
 class ofApp : public ofBaseApp{
@@ -26,7 +26,7 @@ class ofApp : public ofBaseApp{
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
 
-		ofx::assimp::Model model;
+		ofxAssimp::Scene model;
 
 		bool bHelpText = false;
 		bool bDrawBones = false;

--- a/examples/3d/ofxAssimpExample/src/ofApp.cpp
+++ b/examples/3d/ofxAssimpExample/src/ofApp.cpp
@@ -68,7 +68,7 @@ void ofApp::setup(){
 //--------------------------------------------------------------
 void ofApp::loadModel(string filename){
 	
-	ofx::assimp::ImportSettings tsettings;
+	ofxAssimp::ImportSettings tsettings;
 	tsettings.filePath = filename;
 	// we don't have any animations in this model
 	tsettings.importAnimations = false;
@@ -76,15 +76,15 @@ void ofApp::loadModel(string filename){
 	// the z-axis is flipped and the text on the camera body appears backwards
 	tsettings.convertToLeftHanded = false;
     
-	if( model.load(tsettings)) {
-		model.centerAndScaleToWindow();
+	if( scene.load(tsettings)) {
+		scene.centerAndScaleToWindow();
 		cout << endl << endl << endl << endl;
 		stringstream ss;
-		ss << "Num Meshes: " << model.getNumMeshes() << endl;
-		ss << "Num Vertices: " << model.getNumVertices() << endl;
+		ss << "Num Meshes: " << scene.getNumMeshes() << endl;
+		ss << "Num Vertices: " << scene.getNumVertices() << endl;
 		ss << endl;
 		mSceneString = ss.str();
-		mSceneString += model.getHierarchyAsString();
+		mSceneString += scene.getHierarchyAsString();
 		cout << mSceneString << endl;
 		
     } else {
@@ -116,16 +116,16 @@ void ofApp::update(){
 	ofShadow::setAllShadowNormalBias(shadowNormalBias);
 	
 	
-	model.calculateDimensions();
+	scene.calculateDimensions();
 
-	auto meshMountNode = model.getNode("security_camera_02_mount", true);
+	auto meshMountNode = scene.getNode("security_camera_02_mount", true);
 	if( meshMountNode ) {
 		auto tpos = meshMountNode->getPosition();
 		meshMountNode->setPosition( tpos.x, bottomOffsetY, bottomOffsetZ+cameraOffsetZ );
 	}
 	// Notice that we pass true for the second argument which strictly searches for the string
 	// because the string security_camera_02 is also contained in security_camera_02_mount
-	auto meshCameraNode = model.getNode("security_camera_02", true);
+	auto meshCameraNode = scene.getNode("security_camera_02", true);
 	if( meshCameraNode ) {
 		auto tpos = meshCameraNode->getPosition();
 		meshCameraNode->setPosition( tpos.x, tpos.y, cameraOffsetZ );
@@ -134,8 +134,8 @@ void ofApp::update(){
 		meshCameraNode->tiltDeg( tiltDeg );
 	}
 	
-	if( model.getNumMeshes() > 1 ) {
-		auto camMesh = model.getMesh(1);
+	if( scene.getNumMeshes() > 1 ) {
+		auto camMesh = scene.getMesh(1);
 		auto camBounds = camMesh->getLocalBounds();
 		// local bounds do not have transforms applied
 		// this will provide us with a more accurate size of the mesh
@@ -192,7 +192,7 @@ void ofApp::draw(){
 	renderScene();
 	
 	if( bDebug && bDrawBounds ) {
-		for( auto& mesh : model.getMeshes() ) {
+		for( auto& mesh : scene.getMeshes() ) {
 			mesh->getGlobalBounds().draw();
 		}
 	}
@@ -215,8 +215,8 @@ void ofApp::draw(){
 	float texWidth = (mTextRect.getWidth() - texPadding*3.0f) * 0.5;
 	// now lets grab the textures from the meshes //
 	ofRectangle meshTexRect( mTextRect.x + texPadding, 150.0f, texWidth, texWidth );
-	if( model.getNumMeshes() > 0 ) {
-		auto mesh = model.getMesh(0);
+	if( scene.getNumMeshes() > 0 ) {
+		auto mesh = scene.getMesh(0);
 		if( mesh->getNumTextures() > 0 ) {
 			for( unsigned int i = 0; i < mesh->getNumTextures(); i++ ) {
 				auto texture = mesh->getTexture(i);
@@ -255,9 +255,9 @@ void ofApp::renderScene() {
 	wallMaterial.end();
 	if( bDrawMeshes) {
 		if( bDrawWireframe ) {
-			model.drawWireframe();
+			scene.drawWireframe();
 		} else {
-			model.drawFaces();
+			scene.drawFaces();
 		}
 	}
 }

--- a/examples/3d/ofxAssimpExample/src/ofApp.h
+++ b/examples/3d/ofxAssimpExample/src/ofApp.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofMain.h"
-#include "ofxAssimpModel.h"
+#include "ofxAssimp.h"
 #include "ofVboMesh.h"
 #include "ofxGui.h"
 
@@ -29,7 +29,7 @@ class ofApp : public ofBaseApp{
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
 
-		ofx::assimp::Model model;
+		ofxAssimp::Scene scene;
 
 		bool bDrawWireframe = false;
 		bool bDrawMeshes = true;


### PR DESCRIPTION
- Reduce naming complexity from `ofx::assimp` to `ofxAssimp`.
- Changed `ofx::assimp::Model `to `ofxAssimp::Scene` for better representation of functionality and more closely aligned to the underlying assimp scene.
- Updated legacy c import api calls to newer c++ importer.
- Added `ofxAssimp.h` file for importing the `ofxAssimpScene` file.
- Updated ofxAssimp examples to reflect changes.

Further discussion here: #8354
