### PR TITLE
Nightly - Android - Linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,14 +1,26 @@
 name: nightly-linux64
 
 on:
- schedule:
-  - cron: "0 6 * * *"
- workflow_dispatch:
-    inputs:
-      release:
-        description: 'release'     
-        required: true
-        default: 'latest'
+  push:
+    if: github.event_name == 'push' && github.event.pull_request == null
+    paths-ignore:
+      - "**/*.md"
+      - "examples/**"
+  pull_request:
+    if: github.event_name == 'pull_request' && github.repository == 'openframeworks/openFrameworks'
+    paths-ignore:
+      - "**/*.md"
+      - "examples/**"
+
+# on:
+#  schedule:
+#   - cron: "0 6 * * *"
+#  workflow_dispatch:
+#     inputs:
+#       release:
+#         description: 'release'
+#         required: true
+#         default: 'latest'
 env:
   ccache: ccache
   RELEASE: latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build-nightly-ok:
     runs-on: ubuntu-24.04
-    if: github.repository == 'openframeworks/openFrameworks' && github.ref == 'refs/heads/master'
+    # if: github.repository == 'openframeworks/openFrameworks' && github.ref == 'refs/heads/master'
     strategy:
       matrix:
         cfg:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,12 +2,10 @@ name: nightly-linux64
 
 on:
   push:
-    if: github.event_name == 'push' && github.event.pull_request == null
     paths-ignore:
       - "**/*.md"
       - "examples/**"
   pull_request:
-    if: github.event_name == 'pull_request' && github.repository == 'openframeworks/openFrameworks'
     paths-ignore:
       - "**/*.md"
       - "examples/**"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,12 +59,10 @@ jobs:
       id: createpackage
     - name: List output directory
       run: ls -lah out/
-    - name: Update Release
-      uses: IsaacShelton/update-existing-release@v1.3.4
+
+    - name: Upload to GitHub Release
+      uses: softprops/action-gh-release@v2.1.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag: nightly
-        release: nightly
-        prerelease: false
-        replace: true
+        tag_name: "nightly"
         files: ${{ steps.createpackage.outputs.FILES_OUT }}

--- a/scripts/ci/package_builds.sh
+++ b/scripts/ci/package_builds.sh
@@ -22,6 +22,12 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 fi
 echo "##[endgroup]"
 
+echo "##[group]submodule update and pull"
+git submodule update --init --recursive
+git submodule update --recursive --remote
+cd apps/projectGenerator
+git pull origin master
+
 echo "##[group]ls"
 echo "Where is ROOT: $ROOT"
 cd $ROOT

--- a/scripts/ci/package_builds.sh
+++ b/scripts/ci/package_builds.sh
@@ -26,8 +26,6 @@ echo "##[group]ls"
 echo "Where is ROOT: $ROOT"
 cd $ROOT
 ls
-
-
 OUTPUT_FOLDER=$ROOT/out
 mkdir -p $OUTPUT_FOLDER
 
@@ -39,33 +37,58 @@ lastversion=$(date +%Y%m%d)
 # fi
 echo "##[endgroup]"
 
-echo "##[group]submodule update and pull"
-git submodule update --init --recursive
-git submodule update --recursive --remote
-cd apps/projectGenerator
-git pull origin master
 echo "##[endgroup]"
-
-echo "##[group]create package"
 cd $OUTPUT_FOLDER
 pwd
-if [[ "$(uname -s)" == "Linux" ]]; then
-	$ROOT/scripts/dev/create_package.sh linux64 $lastversion master gcc6
-	$ROOT/scripts/dev/create_package.sh linuxarmv6l $lastversion master
-	$ROOT/scripts/dev/create_package.sh linuxaarch64 $lastversion master
-	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master mingw64
-	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master clang64
-	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master ucrt64
-	$ROOT/scripts/dev/create_package.sh vs $lastversion master
-	$ROOT/scripts/dev/create_package.sh vs $lastversion master 64
-    $ROOT/scripts/dev/create_package.sh android $lastversion master windows
-    $ROOT/scripts/dev/create_package.sh android $lastversion master macos
-fi
-$ROOT/scripts/dev/create_package.sh osx $lastversion master
-$ROOT/scripts/dev/create_package.sh ios $lastversion master
-echo "##[endgroup]"
+PACKAGES=(
+  "linux64 $lastversion master gcc6"
+  "linuxarmv6l $lastversion master"
+  "linuxaarch64 $lastversion master"
+  "msys2 $lastversion master mingw64"
+  "msys2 $lastversion master clang64"
+  "msys2 $lastversion master ucrt64"
+  "vs $lastversion master"
+  "vs $lastversion master 64"
+  "android $lastversion master windows"
+  "android $lastversion master macos"
+  "osx $lastversion master"
+  "ios $lastversion master"
+)
 
-# $ROOT/scripts/dev/create_package.sh macos $lastversion master
+FAILED_PACKAGES=()
+
+echo "##[group]Create packages"
+for pkg in "${PACKAGES[@]}"; do
+    echo "Creating package with arguments: $pkg"
+    # Use "|| true" to prevent immediate exit on error.
+    $ROOT/scripts/dev/create_package.sh $pkg || FAILED_PACKAGES+=("$pkg")
+done
+
+
+
+echo "# Package Build Summary" > package_summary.md
+echo "" >> package_summary.md
+echo "| Configuration | Status |" >> package_summary.md
+echo "|---------------|--------|" >> package_summary.md
+
+for pkg in "${PACKAGES[@]}"; do
+    status="SUCCESS"
+    for fail in "${FAILED_PACKAGES[@]}"; do
+        if [ "$fail" = "$pkg" ]; then
+            status="FAILED"
+            break
+        fi
+    done
+    echo "| $pkg | $status |" >> package_summary.md
+done
+
+if [ "${GITHUB_ACTIONS}" == "true" ]; then
+    echo "## Package Build Summary" >> "$GITHUB_STEP_SUMMARY"
+    cat package_summary.md >> "$GITHUB_STEP_SUMMARY"
+else
+    echo "Package Build Summary:"
+    cat package_summary.md
+fi
 
 ls -la
 cd $ROOT

--- a/scripts/ci/package_builds.sh
+++ b/scripts/ci/package_builds.sh
@@ -58,7 +58,8 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 	$ROOT/scripts/dev/create_package.sh msys2 $lastversion master ucrt64
 	$ROOT/scripts/dev/create_package.sh vs $lastversion master
 	$ROOT/scripts/dev/create_package.sh vs $lastversion master 64
-	# $ROOT/scripts/dev/create_package.sh vs2019 $lastversion master 64
+    $ROOT/scripts/dev/create_package.sh android $lastversion master windows
+    $ROOT/scripts/dev/create_package.sh android $lastversion master macos
 fi
 $ROOT/scripts/dev/create_package.sh osx $lastversion master
 $ROOT/scripts/dev/create_package.sh ios $lastversion master

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -458,7 +458,6 @@ function createPackage {
         downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-linux-gui.gz 2> /dev/null
         gunzip projectGenerator-linux-gui.gz
         mv projectGenerator-linux-gui projectGenerator
-        rm projectGenerator-linux-gui.gz
         rm -rf apps/projectGenerator
     fi
 
@@ -479,7 +478,6 @@ function createPackage {
             downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-linux-gui.gz 2> /dev/null
             gunzip projectGenerator-linux-gui.gz
             mv projectGenerator-linux-gui projectGenerator
-            rm projectGenerator-linux-gui.gz
             rm -rf apps/projectGenerator
         fi
 

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -22,9 +22,9 @@ else
 fi
 
 if [ $# -ge 4 ]; then
-    libs_abi=$4
+    LIBS_ABI=$4
 else
-    libs_abi=""
+    LIBS_ABI=""
 fi
 
 REPO=https://github.com/openframeworks/openFrameworks.git
@@ -44,8 +44,8 @@ if [[ ! -d "$SCRIPT_DIR" ]]; then SCRIPT_DIR="$PWD"; fi
 
 isRunning(){
     if [ “$hostArch” == “Linux” ]; then
-		if [ -d /proc/$1 ]; then
-	    	return 0
+        if [ -d /proc/$1 ]; then
+            return 0
         else
             return 1
         fi
@@ -101,7 +101,7 @@ echo
 echo
 echo
 echo --------------------------------------------------------------------------
-echo "Creating package $version for $platform $libs_abi"
+echo "Creating package $version for $platform $LIBS_ABI"
 echo --------------------------------------------------------------------------
 echo
 
@@ -193,11 +193,11 @@ function createProjectFiles {
         else
             pg_platform="$pkg_platform,vscode"
         fi
-        
+
 
         if [ -f "${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator" ]; then
             echo "projectGenerator exists..."
-            
+
             echo "##[group]PG building example projects"
             # ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples > /dev/null
             ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples
@@ -205,11 +205,11 @@ function createProjectFiles {
 
         else
             echo "projectGenerator does not exist. Continue."
-	    ls ${main_ofroot}/apps/projectGenerator/commandLine/bin/
-	    exit 1
+        ls ${main_ofroot}/apps/projectGenerator/commandLine/bin/
+        exit 1
         fi
 
-        
+
         #fix config.make because the project generator is putting in the full path to the OF_ROOT as it is designed to do.
         #in this case we actually don't want to set it as the default of ../../../ is fine.
         find $pkg_ofroot/examples -name "config.make" -type f -exec sed -i 's/^OF_ROOT =.*/# OF_ROOT = ..\/..\/..\//' {} \;
@@ -241,34 +241,34 @@ function createPackage {
 
     #remove previously created package
     cd $pkg_ofroot/..
-	rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}.*
-	rm -Rf of_v${pkg_version}_${pkg_platform}${libs_abi}_*
+    rm -Rf of_v${pkg_version}_${pkg_platform}${LIBS_ABI}.*
+    rm -Rf of_v${pkg_version}_${pkg_platform}${LIBS_ABI}_*
     echo "Creating package $pkg_platform $version in $pkg_ofroot"
 
     #remove devApps folder
     rm -r $pkg_ofroot/apps/devApps
 
-	cd $pkg_ofroot/examples
+    cd $pkg_ofroot/examples
 
-	#delete ios examples in other platforms
-	if [ "$pkg_platform" != "ios" ]; then
-		rm -Rf ios
-		rm -Rf tvOS
-	fi
+    #delete ios examples in other platforms
+    if [ "$pkg_platform" != "ios" ]; then
+        rm -Rf ios
+        rm -Rf tvOS
+    fi
 
-	#delete android examples in other platforms
-	if [ "$pkg_platform" != "android" ]; then
-		rm -Rf android
-	fi
+    #delete android examples in other platforms
+    if [ "$pkg_platform" != "android" ]; then
+        rm -Rf android
+    fi
 
 
     if [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ]; then
-		rm -Rf events/rpiTouchExample
-	fi
+        rm -Rf events/rpiTouchExample
+    fi
 
-	#delete desktop examples in mobile packages
-	if [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then
-		rm -Rf computer_vision/kinectExample
+    #delete desktop examples in mobile packages
+    if [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then
+        rm -Rf computer_vision/kinectExample
         rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
         rm -Rf gl/billboardExample
@@ -296,15 +296,15 @@ function createPackage {
         rm -Rf sound
         rm -Rf threads
         rm -Rf windowing
-	fi
+    fi
 
-	if [ "$pkg_platform" == "linux" ] || [ "$pkg_platform" == "linux64" ]; then
-	    rm -Rf gles
-	fi
+    if [ "$pkg_platform" == "linux" ] || [ "$pkg_platform" == "linux64" ]; then
+        rm -Rf gles
+    fi
 
-	if [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ] || [ "$pkg_platform" == "linuxaarch64" ]; then
+    if [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ] || [ "$pkg_platform" == "linuxaarch64" ]; then
 
-	rm -Rf gl/glInfoExample
+    rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
         rm -Rf gl/billboardExample
         rm -Rf gl/billboardRotationExample
@@ -335,7 +335,7 @@ function createPackage {
     fi
 
     if [ "$pkg_platform" == "osx" ] || [ "$pkg_platform" == "macos" ]; then
-        
+
         rm -Rf gl/computeShaderParticlesExample
         rm -Rf gl/computeShaderTextureExample
     fi
@@ -352,7 +352,7 @@ function createPackage {
         scripts/osx/download_libs.sh -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     elif [ "$pkg_platform" = "linux64" ]; then
-        scripts/linux/download_libs.sh -a 64$libs_abi
+        scripts/linux/download_libs.sh -a 64$LIBS_ABI
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     elif [ "$pkg_platform" = "linuxarmv6l" ]; then
         scripts/linux/download_libs.sh -a armv6l -t $RELEASE
@@ -361,16 +361,16 @@ function createPackage {
     elif [ "$pkg_platform" = "linuxaarch64" ]; then
         scripts/linux/download_libs.sh -a aarch64 -t $RELEASE
     elif [ "$pkg_platform" = "msys2" ]; then
-        scripts/msys2/download_libs.sh -a $libs_abi -t $RELEASE
+        scripts/msys2/download_libs.sh -a $LIBS_ABI -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     elif [ "$pkg_platform" = "vs2019" ]; then
-        scripts/vs/download_libs.sh -a $libs_abi -t $RELEASE
+        scripts/vs/download_libs.sh -a $LIBS_ABI -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     elif [ "$pkg_platform" = "vs" ]; then
-        if [ "$libs_abi" = "" ]; then
+        if [ "$LIBS_ABI" = "" ]; then
             scripts/vs/download_libs_2019_x64.sh -t $RELEASE
         else
-            scripts/vs/download_libs.sh -a $libs_abi -t $RELEASE
+            scripts/vs/download_libs.sh -a $LIBS_ABI -t $RELEASE
         fi
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     elif [ "$pkg_platform" = "android" ]; then
@@ -426,10 +426,10 @@ function createPackage {
         exit 1
     fi
 
-	#download and uncompress PG
-	echo "Creating projectGenerator"
-	mkdir -p $HOME/.tmp
-	export TMPDIR=$HOME/.tmp
+    #download and uncompress PG
+    echo "Creating projectGenerator"
+    mkdir -p $HOME/.tmp
+    export TMPDIR=$HOME/.tmp
 
     # FIXME: Temporary fix for latest projectGenerator
     # there is no "latest" release so we use nightly. feel free to remove this when PG/Apothecary releases are in sync
@@ -437,103 +437,99 @@ function createPackage {
         RELEASE="nightly"
     fi
 
- 
+
     if [ "$pkg_platform" = "vs" ] || [ "$pkg_platform" = "vs2019" ] || [ "$pkg_platform" = "msys2" ]; then
         downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-vs-gui.zip 2> /dev/null
         mkdir -p projectGenerator
         unzip -q projectGenerator-vs-gui.zip -d "projectGenerator" 2> /dev/null
-		rm projectGenerator-vs-gui.zip
-		rm -rf apps/projectGenerator
-	fi
+        rm projectGenerator-vs-gui.zip
+        rm -rf apps/projectGenerator
+    fi
 
     if [ "$pkg_platform" = "osx" ] || [ "$pkg_platform" = "ios" ] || [ "$pkg_platform" = "macos" ]; then
-	downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-osx.zip 2> /dev/null
+        downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-osx.zip 2> /dev/null
         unzip -q projectGenerator-osx.zip
         mv projectGenerator-osx/ projectGenerator
         rm projectGenerator-osx.zip
-		rm -rf apps/projectGenerator
-	fi
+        rm -rf apps/projectGenerator
+    fi
 
-	if [ "$pkg_platform" = "linux" ]; then
-		cd ${pkg_ofroot}/apps/projectGenerator/frontend
-		npm install > /dev/null
-		npm run build:linux32 > /dev/null
-		mv dist/projectGenerator-linux-ia32 ${pkg_ofroot}/projectGenerator-linux
-		cd ${pkg_ofroot}
-	fi
-
-	if [ "$pkg_platform" = "linux64" ]; then
-		cd ${pkg_ofroot}/apps/projectGenerator/frontend
-		npm install > /dev/null
-		npm run build:linux64 > /dev/null
-		mv dist/projectGenerator-linux-x64 ${pkg_ofroot}/projectGenerator-linux64
-		cd ${pkg_ofroot}
-		chmod +x projectGenerator-linux64/projectGenerator
-	fi
+    if [ "$pkg_platform" = "linux64" ]; then
+        downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-linux-gui.gz 2> /dev/null
+        gunzip projectGenerator-linux-gui.gz
+        mv projectGenerator-linux-gui projectGenerator
+        rm projectGenerator-linux-gui.gz
+        rm -rf apps/projectGenerator
+    fi
 
     if [ "$pkg_platform" = "android" ]; then
-		# cd ${pkg_ofroot}/apps/projectGenerator/frontend
-		# npm install > /dev/null
-		# npm run build:vs > /dev/null
-		# mv dist/projectGenerator-win32-ia32 ${pkg_ofroot}/projectGenerator-windows
-		# cd ${pkg_ofroot}/projectGenerator-windows/resources/app/app/
-		downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-vs-gui.zip 2> /dev/null
-		unzip -q -d "projectGenerator" projectGenerator-vs-gui.zip 2> /dev/null
-		rm projectGenerator-vs-gui.zip
-		cd ${pkg_ofroot}
 
-		# cd ${pkg_ofroot}/apps/projectGenerator/frontend
-		# npm install > /dev/null
-		# npm run build:linux64 > /dev/null
-		# mv dist/projectGenerator-linux-x64 ${pkg_ofroot}/projectGenerator-linux64
-		# cd ${pkg_ofroot}
-	fi
+        if [ "${LIBS_ABI}" == "windows" ]; then
+            downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-vs-gui.zip 2> /dev/null
+            unzip -q -d "projectGenerator" projectGenerator-vs-gui.zip 2> /dev/null
+            rm projectGenerator-vs-gui.zip
+            cd ${pkg_ofroot}
+        elif [ "${LIBS_ABI}" == "macos" ]; then
+            downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-osx.zip 2> /dev/null
+            unzip -q projectGenerator-osx.zip
+            mv projectGenerator-osx/ projectGenerator
+            rm projectGenerator-osx.zip
+            rm -rf apps/projectGenerator
+        elif [ "${LIBS_ABI}" == "linux64" ]; then
+            downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-linux-gui.gz 2> /dev/null
+            gunzip projectGenerator-linux-gui.gz
+            mv projectGenerator-linux-gui projectGenerator
+            rm projectGenerator-linux-gui.gz
+            rm -rf apps/projectGenerator
+        fi
 
-	# linux remove other platform projects from PG source and copy ofxGui
-	if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ] || [ "$pkg_platform" = "linuxarmv7l" ] || [ "$pkg_platform" = "android" ]; then
-	    cd ${pkg_ofroot}
-		mv apps/projectGenerator/commandLine .
-		rm -rf apps/projectGenerator
-		mkdir apps/projectGenerator
-		mv commandLine apps/projectGenerator/
-		cd apps/projectGenerator/commandLine
-		deleteCodeblocks
-		deleteVS
-		deleteXcode
-	fi
+    fi
 
-	#delete ofxAndroid in non android
-	if [ "$pkg_platform" != "android" ]; then
-		rm -Rf ofxAndroid
-		rm -Rf ofxUnitTests
-	fi
-	#delete ofxiPhone in non ios
-	if [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ] && [ "$pkg_platform" != "osx" ]; then
-		rm -Rf ofxiPhone
-		rm -Rf ofxiOS
-		rm -Rf ofxUnitTests
-	fi
+    # linux remove other platform projects from PG source and copy ofxGui
+    if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ] || [ "$pkg_platform" = "linuxarmv7l" ] || [ "$pkg_platform" = "android" ]; then
+        cd ${pkg_ofroot}
+        mv apps/projectGenerator/commandLine .
+        rm -rf apps/projectGenerator
+        mkdir apps/projectGenerator
+        mv commandLine apps/projectGenerator/
+        cd apps/projectGenerator/commandLine
+        deleteCodeblocks
+        deleteVS
+        deleteXcode
+    fi
 
-	#delete ofxMultiTouch in non mobile
-	if [ "$pkg_platform" != "android" ] && [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ]; then
-		rm -Rf ofxMultiTouch
-		rm -Rf ofxAccelerometer
-		rm -Rf ofxUnitTests
-	fi
+    #delete ofxAndroid in non android
+    if [ "$pkg_platform" != "android" ]; then
+        rm -Rf ofxAndroid
+        rm -Rf ofxUnitTests
+    fi
+    #delete ofxiPhone in non ios
+    if [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ] && [ "$pkg_platform" != "osx" ]; then
+        rm -Rf ofxiPhone
+        rm -Rf ofxiOS
+        rm -Rf ofxUnitTests
+    fi
 
-	if [ "$pkg_platform" == "ios" ] || [ "$pkg_platform" == "android" ]; then
-	    rm -Rf ofxVectorGraphics
-   	    rm -Rf ofxKinect
-		rm -Rf ofxUnitTests
-	fi
+    #delete ofxMultiTouch in non mobile
+    if [ "$pkg_platform" != "android" ] && [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ]; then
+        rm -Rf ofxMultiTouch
+        rm -Rf ofxAccelerometer
+        rm -Rf ofxUnitTests
+    fi
 
-	#delete unit tests by now
-	rm -Rf ${pkg_ofroot}/tests
+    if [ "$pkg_platform" == "ios" ] || [ "$pkg_platform" == "android" ]; then
+        rm -Rf ofxVectorGraphics
+        rm -Rf ofxKinect
+        rm -Rf ofxUnitTests
+    fi
 
-	#android, move paths.default.make to paths.make
-	if [ "$pkg_platform" == "android" ]; then
-	    cd ${pkg_ofroot}
-	fi
+    #delete unit tests by now
+    rm -Rf ${pkg_ofroot}/tests
+
+    #android, move paths.default.make to paths.make
+    if [ "$pkg_platform" == "android" ]; then
+        cd ${pkg_ofroot}
+    fi
 
     #delete other platforms OF project files
     cd ${pkg_ofroot}/libs/openFrameworksCompiled/lib
@@ -558,12 +554,12 @@ function createPackage {
         echo "Warning: dev/init_submodules.sh does not exist. Skipping copy."
     fi
 
-	if [ "$pkg_platform" != "linux" ] && [ "$pkg_platform" != "linux64" ] && [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ]; then
-    	rm -Rf $otherplatforms
+    if [ "$pkg_platform" != "linux" ] && [ "$pkg_platform" != "linux64" ] && [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ]; then
+        rm -Rf $otherplatforms
         rm -Rf ci dev apothecary
-	else
-    	rm -Rf msys2 vs vs2019 osx ios android ci dev apothecary
-	fi
+    else
+        rm -Rf msys2 vs vs2019 osx ios android ci dev apothecary
+    fi
 
     if [ "$pkg_platform" = "android" ] || [ "$pkg_platform" = "ios" ]; then
         rm -Rf qtcreator emscripten
@@ -574,9 +570,9 @@ function createPackage {
 #    fi
 
     #delete omap4 scripts for non armv7l
-	if [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ]; then
-	    rm -Rf linux/ubuntu-omap4
-	fi
+    if [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ]; then
+        rm -Rf linux/ubuntu-omap4
+    fi
 
 
     #delete .svn dirs
@@ -599,11 +595,11 @@ function createPackage {
     # make sure any remaining dev scripts are executable
     find . -type f -name "*.sh" -exec chmod +x {} +
 
-	#delete xcode templates in other platforms
-	cd $pkg_ofroot
-	if [ "$pkg_platform" != "osx" ] && [ "$pkg_platform" != "ios" ] && [ "$platform" != "macos" ]; then
-		rm -Rf "xcode templates"
-	fi
+    #delete xcode templates in other platforms
+    cd $pkg_ofroot
+    if [ "$pkg_platform" != "osx" ] && [ "$pkg_platform" != "ios" ] && [ "$platform" != "macos" ]; then
+        rm -Rf "xcode templates"
+    fi
     echo ----------------------------------------------------------------------
     echo
     echo
@@ -617,7 +613,7 @@ function createPackage {
     rm -Rf .travis.yml
     rm -Rf .gitmodules
     rm -Rf .gitattributes
-    
+
 
     if [ "$platform" = "linux" ] || [ "$platform" = "linux64" ] || [ "$platform" = "linuxarmv6l" ] || [ "$platform" = "linuxarmv7l" ] || [ "$platform" = "linuxaarch64" ]; then
         cp docs/linux.md INSTALL.md
@@ -636,7 +632,6 @@ function createPackage {
     fi
 
     if [ "$platform" = "android" ]; then
-        # cp docs/android_eclipse.md INSTALL_ECLIPSE.md
         cp docs/android_studio.md INSTALL_ANDROID_STUDIO.md
     fi
 
@@ -660,31 +655,31 @@ function createPackage {
 
     #create compressed package
    if [[ "$pkg_platform" =~ ^(linux|linux64|android|linuxarmv6l|linuxarmv7l|linuxaarch64|macos|ios|osx)$ ]]; then
-        if [ "$libs_abi" = "" ]; then
-            pkg_name=of_v${pkg_version}_${pkg_platform}_release
+        if [ "$LIBS_ABI" = "" ]; then
+            PKG_NAME=of_v${pkg_version}_${pkg_platform}_release
         else
-            pkg_name=of_v${pkg_version}_${pkg_platform}_${libs_abi}_release
-        fi 
-        echo "compressing package to of_v${pkg_version}_${pkg_platform}${libs_abi}_release.tar.gz"
+            PKG_NAME=of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release
+        fi
+        echo "compressing package to of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release.tar.gz"
         cd $pkg_ofroot/..
-        mkdir ${pkg_name}
-        mv ${pkgfolder}/* ${pkg_name}
-        mv ${pkgfolder}/.* ${pkg_name} 2>/dev/null || true # add hidden files 
-        COPYFILE_DISABLE=true tar czf ${pkg_name}.tar.gz ${pkg_name}
-        rm -Rf ${pkg_name}
+        mkdir ${PKG_NAME}
+        mv ${pkgfolder}/* ${PKG_NAME}
+        mv ${pkgfolder}/.* ${PKG_NAME} 2>/dev/null || true # add hidden files
+        COPYFILE_DISABLE=true tar czf ${PKG_NAME}.tar.gz ${PKG_NAME}
+        rm -Rf ${PKG_NAME}
     else
-        if [ "$libs_abi" = "" ]; then
-            pkg_name=of_v${pkg_version}_${pkg_platform}_release
+        if [ "$LIBS_ABI" = "" ]; then
+            PKG_NAME=of_v${pkg_version}_${pkg_platform}_release
         else
-            pkg_name=of_v${pkg_version}_${pkg_platform}_${libs_abi}_release
+            PKG_NAME=of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release
         fi 
-        echo "compressing package to ${pkg_name}.zip"
+        echo "compressing package to ${PKG_NAME}.zip"
         cd $pkg_ofroot/..
-        mkdir ${pkg_name}
-        mv ${pkgfolder}/* ${pkg_name}
-        mv ${pkgfolder}/.* ${pkg_name} 2>/dev/null || true # add hidden files 
-        zip --symlinks -r ${pkg_name}.zip ${pkg_name} > /dev/null
-        rm -Rf ${pkg_name}
+        mkdir ${PKG_NAME}
+        mv ${pkgfolder}/* ${PKG_NAME}
+        mv ${pkgfolder}/.* ${PKG_NAME} 2>/dev/null || true # add hidden files
+        zip --symlinks -r ${PKG_NAME}.zip ${PKG_NAME} > /dev/null
+        rm -Rf ${PKG_NAME}
     fi
 }
 

--- a/scripts/dev/create_package.sh
+++ b/scripts/dev/create_package.sh
@@ -173,9 +173,9 @@ function deleteEclipse {
 
 
 function createProjectFiles {
-    if [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ] ; then
-        mkdir -p ${main_ofroot}/libs/openFrameworksCompiled/lib/linux64/
-        cd ${main_ofroot}/apps/projectGenerator/commandLine
+    if [ "$PKG_PLATFORM" != "linuxarmv6l" ] && [ "$PKG_PLATFORM" != "linuxarmv7l" ] && [ "$PKG_PLATFORM" != "linuxaarch64" ] && [ "$PKG_PLATFORM" != "android" ] ; then
+        mkdir -p ${MAIN_OFROOT}/libs/openFrameworksCompiled/lib/linux64/
+        cd ${MAIN_OFROOT}/apps/projectGenerator/commandLine
         echo "Recompiling command line PG"
         if [ -d ~/logs ]; then
             PROJECT_OPTIMIZATION_CFLAGS_RELEASE="-O0 -g0" CXXFLAGS=-ftrack-macro-expansion=0 make Release > ~/logs/compilePG.log 2>&1 &
@@ -186,44 +186,44 @@ function createProjectFiles {
             PROJECT_OPTIMIZATION_CFLAGS_RELEASE="-O0 -g0" CXXFLAGS=-ftrack-macro-expansion=0 make Release
         fi
 
-        cd ${pkg_ofroot}
-        echo "Creating project files for $pkg_platform"
-        if [ "$pkg_platform" == "vs" ] || [ "$pkg_platform" == "vs2019" ] || [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then
-            pg_platform=$pkg_platform
+        cd ${PKG_OFROOT}
+        echo "Creating project files for $PKG_PLATFORM"
+        if [ "$PKG_PLATFORM" == "vs" ] || [ "$PKG_PLATFORM" == "vs2019" ] || [ "$PKG_PLATFORM" == "android" ] || [ "$PKG_PLATFORM" == "ios" ]; then
+            PG_PLATFORM=$PKG_PLATFORM
         else
-            pg_platform="$pkg_platform,vscode"
+            PG_PLATFORM="$PKG_PLATFORM,vscode"
         fi
 
 
-        if [ -f "${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator" ]; then
+        if [ -f "${MAIN_OFROOT}/apps/projectGenerator/commandLine/bin/projectGenerator" ]; then
             echo "projectGenerator exists..."
 
             echo "##[group]PG building example projects"
-            # ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples > /dev/null
-            ${main_ofroot}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${pg_platform} -o$pkg_ofroot $pkg_ofroot/examples
+            # ${MAIN_OFROOT}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${PG_PLATFORM} -o$PKG_OFROOT $PKG_OFROOT/examples > /dev/null
+            ${MAIN_OFROOT}/apps/projectGenerator/commandLine/bin/projectGenerator --recursive -p${PG_PLATFORM} -o$PKG_OFROOT $PKG_OFROOT/examples
             echo "##[endgroup]"
 
         else
             echo "projectGenerator does not exist. Continue."
-        ls ${main_ofroot}/apps/projectGenerator/commandLine/bin/
-        exit 1
+            ls ${MAIN_OFROOT}/apps/projectGenerator/commandLine/bin/
+            exit 1
         fi
 
 
         #fix config.make because the project generator is putting in the full path to the OF_ROOT as it is designed to do.
         #in this case we actually don't want to set it as the default of ../../../ is fine.
-        find $pkg_ofroot/examples -name "config.make" -type f -exec sed -i 's/^OF_ROOT =.*/# OF_ROOT = ..\/..\/..\//' {} \;
-    elif [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ] || [ "$pkg_platform" == "linuxaarch64" ]; then
-        for example_group in $pkg_ofroot/examples/*; do
+        find $PKG_OFROOT/examples -name "config.make" -type f -exec sed -i 's/^OF_ROOT =.*/# OF_ROOT = ..\/..\/..\//' {} \;
+    elif [ "$PKG_PLATFORM" == "linuxarmv6l" ] || [ "$PKG_PLATFORM" == "linuxarmv7l" ] || [ "$PKG_PLATFORM" == "linuxaarch64" ]; then
+        for example_group in $PKG_OFROOT/examples/*; do
             for example in $example_group/*; do
                 if [ -d $example ]; then
-                    cp $pkg_ofroot/scripts/templates/linux/Makefile $example/
-                    cp $pkg_ofroot/scripts/templates/linux/config.make $example/
+                    cp $PKG_OFROOT/scripts/templates/linux/Makefile $example/
+                    cp $PKG_OFROOT/scripts/templates/linux/config.make $example/
                 fi
             done
         done
     fi
-    cd ${pkg_ofroot}
+    cd ${PKG_OFROOT}
 }
 
 
@@ -234,40 +234,40 @@ remove_current_platform() {
 }
 
 function createPackage {
-    pkg_platform=$1
-    pkg_version=$2
-    pkg_ofroot=$3
-    main_ofroot=$4
+    PKG_PLATFORM=$1
+    PKG_VERSION=$2
+    PKG_OFROOT=$3
+    MAIN_OFROOT=$4
 
     #remove previously created package
-    cd $pkg_ofroot/..
-    rm -Rf of_v${pkg_version}_${pkg_platform}${LIBS_ABI}.*
-    rm -Rf of_v${pkg_version}_${pkg_platform}${LIBS_ABI}_*
-    echo "Creating package $pkg_platform $version in $pkg_ofroot"
+    cd $PKG_OFROOT/..
+    rm -Rf of_v${PKG_VERSION}_${PKG_PLATFORM}${LIBS_ABI}.*
+    rm -Rf of_v${PKG_VERSION}_${PKG_PLATFORM}${LIBS_ABI}_*
+    echo "Creating package $PKG_PLATFORM $version in $PKG_OFROOT"
 
     #remove devApps folder
-    rm -r $pkg_ofroot/apps/devApps
+    rm -r $PKG_OFROOT/apps/devApps
 
-    cd $pkg_ofroot/examples
+    cd $PKG_OFROOT/examples
 
     #delete ios examples in other platforms
-    if [ "$pkg_platform" != "ios" ]; then
+    if [ "$PKG_PLATFORM" != "ios" ]; then
         rm -Rf ios
         rm -Rf tvOS
     fi
 
     #delete android examples in other platforms
-    if [ "$pkg_platform" != "android" ]; then
+    if [ "$PKG_PLATFORM" != "android" ]; then
         rm -Rf android
     fi
 
 
-    if [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ]; then
+    if [ "$PKG_PLATFORM" != "linuxarmv6l" ] && [ "$PKG_PLATFORM" != "linuxarmv7l" ] && [ "$PKG_PLATFORM" != "linuxaarch64" ]; then
         rm -Rf events/rpiTouchExample
     fi
 
     #delete desktop examples in mobile packages
-    if [ "$pkg_platform" == "android" ] || [ "$pkg_platform" == "ios" ]; then
+    if [ "$PKG_PLATFORM" == "android" ] || [ "$PKG_PLATFORM" == "ios" ]; then
         rm -Rf computer_vision/kinectExample
         rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
@@ -298,11 +298,11 @@ function createPackage {
         rm -Rf windowing
     fi
 
-    if [ "$pkg_platform" == "linux" ] || [ "$pkg_platform" == "linux64" ]; then
+    if [ "$PKG_PLATFORM" == "linux" ] || [ "$PKG_PLATFORM" == "linux64" ]; then
         rm -Rf gles
     fi
 
-    if [ "$pkg_platform" == "linuxarmv6l" ] || [ "$pkg_platform" == "linuxarmv7l" ] || [ "$pkg_platform" == "linuxaarch64" ]; then
+    if [ "$PKG_PLATFORM" == "linuxarmv6l" ] || [ "$PKG_PLATFORM" == "linuxarmv7l" ] || [ "$PKG_PLATFORM" == "linuxaarch64" ]; then
 
     rm -Rf gl/glInfoExample
         rm -Rf gl/alphaMaskingShaderExample
@@ -328,101 +328,100 @@ function createPackage {
         rm -Rf windowing
     fi
 
-    if [ "$pkg_platform" == "msys2" ] || [ "$pkg_platform" == "vs2019" ] || [ "$pkg_platform" == "vs" ]; then
+    if [ "$PKG_PLATFORM" == "msys2" ] || [ "$PKG_PLATFORM" == "vs2019" ] || [ "$PKG_PLATFORM" == "vs" ]; then
         rm -Rf video/osxHighPerformanceVideoPlayerExample
         rm -Rf video/osxVideoRecorderExample
         rm -Rf gles
     fi
 
-    if [ "$pkg_platform" == "osx" ] || [ "$pkg_platform" == "macos" ]; then
+    if [ "$PKG_PLATFORM" == "osx" ] || [ "$PKG_PLATFORM" == "macos" ]; then
 
         rm -Rf gl/computeShaderParticlesExample
         rm -Rf gl/computeShaderTextureExample
     fi
 
     #delete tutorials by now
-    rm -Rf $pkg_ofroot/tutorials
+    rm -Rf $PKG_OFROOT/tutorials
 
     RELEASE="${RELEASE:-latest}"
 
-    #download external dependencies
-    cd $pkg_ofroot/
-    echo " Location: {$pkg_ofroot}"
-    if [ "$pkg_platform" = "osx" ]; then
+    cd $PKG_OFROOT/
+    echo " Location: {$PKG_OFROOT}"
+    if [ "$PKG_PLATFORM" = "osx" ]; then
         scripts/osx/download_libs.sh -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "linux64" ]; then
+    elif [ "$PKG_PLATFORM" = "linux64" ]; then
         scripts/linux/download_libs.sh -a 64$LIBS_ABI
         scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "linuxarmv6l" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxarmv6l" ]; then
         scripts/linux/download_libs.sh -a armv6l -t $RELEASE
-    elif [ "$pkg_platform" = "linuxarmv7l" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxarmv7l" ]; then
         scripts/linux/download_libs.sh -a armv7l -t $RELEASE
-    elif [ "$pkg_platform" = "linuxaarch64" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxaarch64" ]; then
         scripts/linux/download_libs.sh -a aarch64 -t $RELEASE
-    elif [ "$pkg_platform" = "msys2" ]; then
+    elif [ "$PKG_PLATFORM" = "msys2" ]; then
         scripts/msys2/download_libs.sh -a $LIBS_ABI -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "vs2019" ]; then
+    elif [ "$PKG_PLATFORM" = "vs2019" ]; then
         scripts/vs/download_libs.sh -a $LIBS_ABI -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "vs" ]; then
+    elif [ "$PKG_PLATFORM" = "vs" ]; then
         if [ "$LIBS_ABI" = "" ]; then
             scripts/vs/download_libs_2019_x64.sh -t $RELEASE
         else
             scripts/vs/download_libs.sh -a $LIBS_ABI -t $RELEASE
         fi
         scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "android" ]; then
+    elif [ "$PKG_PLATFORM" = "android" ]; then
         scripts/android/download_libs.sh -t $RELEASE
-    elif [ "$pkg_platform" = "ios" ]; then
+    elif [ "$PKG_PLATFORM" = "ios" ]; then
         scripts/macos/download_libs.sh -t $RELEASE
-     elif [ "$pkg_platform" = "emscripten" ]; then
+     elif [ "$PKG_PLATFORM" = "emscripten" ]; then
        scripts/emscripten/download_libs.sh -n -t $RELEASE
-    elif [ "$pkg_platform" = "macos" ]; then
+    elif [ "$PKG_PLATFORM" = "macos" ]; then
         scripts/osx/download_libs.sh -t $RELEASE
         scripts/macos/download_libs.sh -t $RELEASE
         scripts/emscripten/download_libs.sh -n -t $RELEASE
     fi
 
-    createProjectFiles $pkg_platform $pkg_ofroot
+    createProjectFiles $PKG_PLATFORM $PKG_OFROOT
 
-    if [ "$pkg_platform" = "linux" ]; then
+    if [ "$PKG_PLATFORM" = "linux" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "linux")
-    elif [ "$pkg_platform" = "linux64" ]; then
+    elif [ "$PKG_PLATFORM" = "linux64" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "emscripten")
         otherplatforms=$(remove_current_platform "$otherplatforms" "linux64")
-    elif [ "$pkg_platform" = "linuxarmv6l" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxarmv6l" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "linuxarmv6l")
-    elif [ "$pkg_platform" = "linuxarmv7l" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxarmv7l" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "linuxarmv7l")
-    elif [ "$pkg_platform" = "linuxaarch64" ]; then
+    elif [ "$PKG_PLATFORM" = "linuxaarch64" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "linuxaarch64")
-    elif [ "$pkg_platform" = "osx" ]; then
+    elif [ "$PKG_PLATFORM" = "osx" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "osx")
         otherplatforms=$(remove_current_platform "$otherplatforms" "emscripten")
-    elif [ "$pkg_platform" = "msys2" ]; then
+    elif [ "$PKG_PLATFORM" = "msys2" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "msys2")
-    elif [ "$pkg_platform" = "vs" ] || [ "$pkg_platform" = "vs2019" ]; then
+    elif [ "$PKG_PLATFORM" = "vs" ] || [ "$PKG_PLATFORM" = "vs2019" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "vs")
         otherplatforms=$(remove_current_platform "$otherplatforms" "emscripten")
-    elif [ "$pkg_platform" = "ios" ]; then
+    elif [ "$PKG_PLATFORM" = "ios" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "ios")
         otherplatforms=$(remove_current_platform "$otherplatforms" "osx")
         otherplatforms=$(remove_current_platform "$otherplatforms" "tvos")
         otherplatforms=$(remove_current_platform "$otherplatforms" "macos")
-    elif [ "$pkg_platform" = "macos" ]; then
+    elif [ "$PKG_PLATFORM" = "macos" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "macos")
         otherplatforms=$(remove_current_platform "$otherplatforms" "ios")
         otherplatforms=$(remove_current_platform "$otherplatforms" "osx")
         otherplatforms=$(remove_current_platform "$otherplatforms" "tvos")
         otherplatforms=$(remove_current_platform "$otherplatforms" "emscripten")
-    elif [ "$pkg_platform" = "emscripten" ]; then
+    elif [ "$PKG_PLATFORM" = "emscripten" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "emscripten")
-    elif [ "$pkg_platform" = "android" ]; then
+    elif [ "$PKG_PLATFORM" = "android" ]; then
         otherplatforms=$(remove_current_platform "$all_platforms" "android")
     else
-        echo "Unknown platform: $pkg_platform"
+        echo "Unknown platform: $PKG_PLATFORM"
         exit 1
     fi
 
@@ -438,7 +437,7 @@ function createPackage {
     fi
 
 
-    if [ "$pkg_platform" = "vs" ] || [ "$pkg_platform" = "vs2019" ] || [ "$pkg_platform" = "msys2" ]; then
+    if [ "$PKG_PLATFORM" = "vs" ] || [ "$PKG_PLATFORM" = "vs2019" ] || [ "$PKG_PLATFORM" = "msys2" ]; then
         downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-vs-gui.zip 2> /dev/null
         mkdir -p projectGenerator
         unzip -q projectGenerator-vs-gui.zip -d "projectGenerator" 2> /dev/null
@@ -446,7 +445,7 @@ function createPackage {
         rm -rf apps/projectGenerator
     fi
 
-    if [ "$pkg_platform" = "osx" ] || [ "$pkg_platform" = "ios" ] || [ "$pkg_platform" = "macos" ]; then
+    if [ "$PKG_PLATFORM" = "osx" ] || [ "$PKG_PLATFORM" = "ios" ] || [ "$PKG_PLATFORM" = "macos" ]; then
         downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-osx.zip 2> /dev/null
         unzip -q projectGenerator-osx.zip
         mv projectGenerator-osx/ projectGenerator
@@ -454,20 +453,20 @@ function createPackage {
         rm -rf apps/projectGenerator
     fi
 
-    if [ "$pkg_platform" = "linux64" ]; then
+    if [ "$PKG_PLATFORM" = "linux64" ]; then
         downloader https://github.com/openframeworks/projectGenerator/releases/download/nightly/projectGenerator-linux-gui.gz 2> /dev/null
         gunzip projectGenerator-linux-gui.gz
         mv projectGenerator-linux-gui projectGenerator
         rm -rf apps/projectGenerator
     fi
 
-    if [ "$pkg_platform" = "android" ]; then
+    if [ "$PKG_PLATFORM" = "android" ]; then
 
         if [ "${LIBS_ABI}" == "windows" ]; then
             downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-vs-gui.zip 2> /dev/null
             unzip -q -d "projectGenerator" projectGenerator-vs-gui.zip 2> /dev/null
             rm projectGenerator-vs-gui.zip
-            cd ${pkg_ofroot}
+            cd ${PKG_OFROOT}
         elif [ "${LIBS_ABI}" == "macos" ]; then
             downloader https://github.com/openframeworks/projectGenerator/releases/download/$RELEASE/projectGenerator-osx.zip 2> /dev/null
             unzip -q projectGenerator-osx.zip
@@ -484,8 +483,8 @@ function createPackage {
     fi
 
     # linux remove other platform projects from PG source and copy ofxGui
-    if [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ] || [ "$pkg_platform" = "linuxarmv7l" ] || [ "$pkg_platform" = "android" ]; then
-        cd ${pkg_ofroot}
+    if [ "$PKG_PLATFORM" = "linux" ] || [ "$PKG_PLATFORM" = "linux64" ] || [ "$PKG_PLATFORM" = "linuxarmv6l" ] || [ "$PKG_PLATFORM" = "linuxaarch64" ] || [ "$PKG_PLATFORM" = "linuxarmv7l" ] || [ "$PKG_PLATFORM" = "android" ]; then
+        cd ${PKG_OFROOT}
         mv apps/projectGenerator/commandLine .
         rm -rf apps/projectGenerator
         mkdir apps/projectGenerator
@@ -497,49 +496,49 @@ function createPackage {
     fi
 
     #delete ofxAndroid in non android
-    if [ "$pkg_platform" != "android" ]; then
+    if [ "$PKG_PLATFORM" != "android" ]; then
         rm -Rf ofxAndroid
         rm -Rf ofxUnitTests
     fi
     #delete ofxiPhone in non ios
-    if [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ] && [ "$pkg_platform" != "osx" ]; then
+    if [ "$PKG_PLATFORM" != "ios" ] && [ "$PKG_PLATFORM" != "macos" ] && [ "$PKG_PLATFORM" != "osx" ]; then
         rm -Rf ofxiPhone
         rm -Rf ofxiOS
         rm -Rf ofxUnitTests
     fi
 
     #delete ofxMultiTouch in non mobile
-    if [ "$pkg_platform" != "android" ] && [ "$pkg_platform" != "ios" ] && [ "$pkg_platform" != "macos" ]; then
+    if [ "$PKG_PLATFORM" != "android" ] && [ "$PKG_PLATFORM" != "ios" ] && [ "$PKG_PLATFORM" != "macos" ]; then
         rm -Rf ofxMultiTouch
         rm -Rf ofxAccelerometer
         rm -Rf ofxUnitTests
     fi
 
-    if [ "$pkg_platform" == "ios" ] || [ "$pkg_platform" == "android" ]; then
+    if [ "$PKG_PLATFORM" == "ios" ] || [ "$PKG_PLATFORM" == "android" ]; then
         rm -Rf ofxVectorGraphics
         rm -Rf ofxKinect
         rm -Rf ofxUnitTests
     fi
 
     #delete unit tests by now
-    rm -Rf ${pkg_ofroot}/tests
+    rm -Rf ${PKG_OFROOT}/tests
 
     #android, move paths.default.make to paths.make
-    if [ "$pkg_platform" == "android" ]; then
-        cd ${pkg_ofroot}
+    if [ "$PKG_PLATFORM" == "android" ]; then
+        cd ${PKG_OFROOT}
     fi
 
     #delete other platforms OF project files
-    cd ${pkg_ofroot}/libs/openFrameworksCompiled/lib
+    cd ${PKG_OFROOT}/libs/openFrameworksCompiled/lib
     rm -Rf $otherplatforms
-    cd ${pkg_ofroot}/libs/openFrameworksCompiled/project
+    cd ${PKG_OFROOT}/libs/openFrameworksCompiled/project
     rm -Rf $otherplatforms
 
-    cd ${pkg_ofroot}/libs/
+    cd ${PKG_OFROOT}/libs/
     rm -Rf download
 
     #delete scripts
-    cd $pkg_ofroot/scripts
+    cd $PKG_OFROOT/scripts
 
     mkdir -p developer
     # Copy the specified scripts to the new folder
@@ -552,38 +551,38 @@ function createPackage {
         echo "Warning: dev/init_submodules.sh does not exist. Skipping copy."
     fi
 
-    if [ "$pkg_platform" != "linux" ] && [ "$pkg_platform" != "linux64" ] && [ "$pkg_platform" != "linuxarmv6l" ] && [ "$pkg_platform" != "linuxarmv7l" ] && [ "$pkg_platform" != "linuxaarch64" ]; then
+    if [ "$PKG_PLATFORM" != "linux" ] && [ "$PKG_PLATFORM" != "linux64" ] && [ "$PKG_PLATFORM" != "linuxarmv6l" ] && [ "$PKG_PLATFORM" != "linuxarmv7l" ] && [ "$PKG_PLATFORM" != "linuxaarch64" ]; then
         rm -Rf $otherplatforms
         rm -Rf ci dev apothecary
     else
         rm -Rf msys2 vs vs2019 osx ios android ci dev apothecary
     fi
 
-    if [ "$pkg_platform" = "android" ] || [ "$pkg_platform" = "ios" ]; then
+    if [ "$PKG_PLATFORM" = "android" ] || [ "$PKG_PLATFORM" = "ios" ]; then
         rm -Rf qtcreator emscripten
     fi
 
-#    if [ "$pkg_platform" = "msys2" ]; then
+#    if [ "$PKG_PLATFORM" = "msys2" ]; then
 #        rm -Rf emscripten
 #    fi
 
     #delete omap4 scripts for non armv7l
-    if [ "$pkg_platform" = "linux64" ] || [ "$pkg_platform" = "linux" ] || [ "$pkg_platform" = "linuxarmv6l" ] || [ "$pkg_platform" = "linuxaarch64" ]; then
+    if [ "$PKG_PLATFORM" = "linux64" ] || [ "$PKG_PLATFORM" = "linux" ] || [ "$PKG_PLATFORM" = "linuxarmv6l" ] || [ "$PKG_PLATFORM" = "linuxaarch64" ]; then
         rm -Rf linux/ubuntu-omap4
     fi
 
 
     #delete .svn dirs
-    cd $pkg_ofroot
+    cd $PKG_OFROOT
     rm -Rf $(find . -type d -name .svn)
 
     #delete .gitignore
-    cd $pkg_ofroot
+    cd $PKG_OFROOT
     # rm -Rf $(find . -name .gitignore -not -path "scripts/templates/*")
-    find $pkg_ofroot -type f -name .gitignore -not -path "scripts/templates/*" -exec rm {} +
+    find $PKG_OFROOT -type f -name .gitignore -not -path "scripts/templates/*" -exec rm {} +
 
     #delete dev folders
-    cd ${pkg_ofroot}/scripts
+    cd ${PKG_OFROOT}/scripts
     rm -Rf dev
     # rm */download_libs.sh
 
@@ -594,8 +593,8 @@ function createPackage {
     find . -type f -name "*.sh" -exec chmod +x {} +
 
     #delete xcode templates in other platforms
-    cd $pkg_ofroot
-    if [ "$pkg_platform" != "osx" ] && [ "$pkg_platform" != "ios" ] && [ "$platform" != "macos" ]; then
+    cd $PKG_OFROOT
+    if [ "$PKG_PLATFORM" != "osx" ] && [ "$PKG_PLATFORM" != "ios" ] && [ "$platform" != "macos" ]; then
         rm -Rf "xcode templates"
     fi
     echo ----------------------------------------------------------------------
@@ -603,7 +602,7 @@ function createPackage {
     echo
 
     #choose readme
-    cd $pkg_ofroot
+    cd $PKG_OFROOT
 
     rm -Rf .github/
     rm -Rf .git/
@@ -636,30 +635,30 @@ function createPackage {
     rm CONTRIBUTING.md
 
     #copy empty example
-    cd $pkg_ofroot
+    cd $PKG_OFROOT
 
     cd examples
     find . -type f -name '*.dll' -delete
 
-    cd $pkg_ofroot
+    cd $PKG_OFROOT
     mkdir -p apps/myApps
-    if [ "$pkg_platform" = "android" ]; then
+    if [ "$PKG_PLATFORM" = "android" ]; then
         cp -r examples/android/androidEmptyExample apps/myApps/
-    elif [ "$pkg_platform" = "ios" ]; then
+    elif [ "$PKG_PLATFORM" = "ios" ]; then
         cp -r examples/ios/emptyExample apps/myApps/
     else
         cp -r examples/templates/emptyExample apps/myApps/
     fi
 
     #create compressed package
-   if [[ "$pkg_platform" =~ ^(linux|linux64|android|linuxarmv6l|linuxarmv7l|linuxaarch64|macos|ios|osx)$ ]]; then
+   if [[ "$PKG_PLATFORM" =~ ^(linux|linux64|android|linuxarmv6l|linuxarmv7l|linuxaarch64|macos|ios|osx)$ ]]; then
         if [ "$LIBS_ABI" = "" ]; then
-            PKG_NAME=of_v${pkg_version}_${pkg_platform}_release
+            PKG_NAME=of_v${PKG_VERSION}_${PKG_PLATFORM}_release
         else
-            PKG_NAME=of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release
+            PKG_NAME=of_v${PKG_VERSION}_${PKG_PLATFORM}_${LIBS_ABI}_release
         fi
-        echo "compressing package to of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release.tar.gz"
-        cd $pkg_ofroot/..
+        echo "compressing package to of_v${PKG_VERSION}_${PKG_PLATFORM}_${LIBS_ABI}_release.tar.gz"
+        cd $PKG_OFROOT/..
         mkdir ${PKG_NAME}
         mv ${pkgfolder}/* ${PKG_NAME}
         mv ${pkgfolder}/.* ${PKG_NAME} 2>/dev/null || true # add hidden files
@@ -667,12 +666,12 @@ function createPackage {
         rm -Rf ${PKG_NAME}
     else
         if [ "$LIBS_ABI" = "" ]; then
-            PKG_NAME=of_v${pkg_version}_${pkg_platform}_release
+            PKG_NAME=of_v${PKG_VERSION}_${PKG_PLATFORM}_release
         else
-            PKG_NAME=of_v${pkg_version}_${pkg_platform}_${LIBS_ABI}_release
+            PKG_NAME=of_v${PKG_VERSION}_${PKG_PLATFORM}_${LIBS_ABI}_release
         fi 
         echo "compressing package to ${PKG_NAME}.zip"
-        cd $pkg_ofroot/..
+        cd $PKG_OFROOT/..
         mkdir ${PKG_NAME}
         mv ${pkgfolder}/* ${PKG_NAME}
         mv ${pkgfolder}/.* ${PKG_NAME} 2>/dev/null || true # add hidden files

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -8,7 +8,7 @@ LEGACY=0
 SILENT_ARGS=""
 NO_SSL=""
 BLEEDING_EDGE=0
-DL_VERSION=2.6.6
+DL_VERSION=2.6.7
 TAG=""
 
 printHelp(){
@@ -392,9 +392,9 @@ for PKG in $PKGS; do
 
         if [ "$PLATFORM" == "linux" ] && { [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "armv7l" ] || [ "$ARCH" == "armv6l" ]; }; then
             echo "tar xjfv download/$PKG  --strip-components=1"
-            tar xjf download/$PKG --strip-components=1 > /dev/null 2>&1
+            tar xf download/$PKG --strip-components=1 > /dev/null 2>&1
         else
-            tar xjf download/$PKG > /dev/null 2>&1
+            tar xf download/$PKG > /dev/null 2>&1
         fi
         # rm -r download/$PKG
     fi
@@ -407,7 +407,7 @@ if [ "$PLATFORM" == "osx" ]; then
         info_plist_path="${libs[i]}/lib/macos/${libs[i]}.xcframework/Info.plist"
         if [ -e "${info_plist_path}.bak" ]; then
             #echo "  Restoring: [${info_plist_path}.bak] to [${info_plist_path}]"
-            mv "${info_plist_path}.bak" "$info_plist_path"
+            mv "${info_plist_path}.bak" "$info_plist_path" 2>/dev/null
         fi
     done
 fi
@@ -501,7 +501,7 @@ if [ "$PLATFORM" == "osx" ]; then
         if [ -e ${addonslibs[i]} ] ; then
             info_plist_path="../addons/${addons[i]}/libs/${addonslibs[i]}/lib/macos/${addonslibs[i]}.xcframework/Info.plist"
             if [ -e "${info_plist_path}.bak" ]; then
-                mv "${info_plist_path}.bak" "$info_plist_path"
+                mv "${info_plist_path}.bak" "$info_plist_path" 2>/dev/null
             fi
         fi
     done

--- a/scripts/dev/download_libs.sh
+++ b/scripts/dev/download_libs.sh
@@ -8,7 +8,7 @@ LEGACY=0
 SILENT_ARGS=""
 NO_SSL=""
 BLEEDING_EDGE=0
-DL_VERSION=2.6.5
+DL_VERSION=2.6.6
 TAG=""
 
 printHelp(){
@@ -392,9 +392,9 @@ for PKG in $PKGS; do
 
         if [ "$PLATFORM" == "linux" ] && { [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "armv7l" ] || [ "$ARCH" == "armv6l" ]; }; then
             echo "tar xjfv download/$PKG  --strip-components=1"
-            tar xjf download/$PKG --strip-components=1
+            tar xjf download/$PKG --strip-components=1 > /dev/null 2>&1
         else
-            tar xjfv download/$PKG
+            tar xjf download/$PKG > /dev/null 2>&1
         fi
         # rm -r download/$PKG
     fi


### PR DESCRIPTION
Changes to nightly create package 
- Add Android Release - Windows / macOS 
- Linux create package to use built project generator rather than build 
- non verbose on extraction libs from download_libs
- disabled build android examples PG until fixed
- Allowed for nightly failure on one target to not break others.
- export build summary now found on action (click it) with table of success
