### PR TITLE
cURL / OpenSSL core api fixes

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -442,9 +442,7 @@ void ofURLFileLoaderImpl::update(ofEventArgs & args) {
 			std::lock_guard<std::mutex> lock(responseMutex);
 			if (response.request.done) {
 				response.request.done(response);
-			} else {
-				ofLogWarning("ofURLFileLoader") << "No callback set for request: " << response.request.url;
-			}
+			} 
 		} catch (...) {
 		}
 

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -129,82 +129,104 @@ void ofURLFileLoaderImpl::stop() {
 }
 
 #if !defined(NO_OPENSSL)
-bool ofURLFileLoaderImpl::checkValidCertifcate(const std::string& cert_file) {
-	FILE *fp = fopen(cert_file.c_str(), "r");
-	if (!fp) return false;
-	X509 *cert = PEM_read_X509(fp, NULL, NULL, NULL);
-	fclose(fp);
-	if (!cert) return false;
-	time_t current_time = time(NULL);
-	int notBefore = X509_cmp_time(X509_get0_notBefore(cert), &current_time);
-	int notAfter = X509_cmp_time(X509_get0_notAfter(cert), &current_time);
-	X509_free(cert);
-	return (notBefore <= 0 && notAfter >= 0);
+bool ofURLFileLoaderImpl::checkValidCertifcate(const std::string & cert_file) {
+	try {
+		FILE * fp = fopen(cert_file.c_str(), "r");
+		if (!fp) return false;
+		X509 * cert = PEM_read_X509(fp, NULL, NULL, NULL);
+		fclose(fp);
+		if (!cert) return false;
+		time_t current_time = time(NULL);
+		int notBefore = X509_cmp_time(X509_get0_notBefore(cert), &current_time);
+		int notAfter = X509_cmp_time(X509_get0_notAfter(cert), &current_time);
+		X509_free(cert);
+		return (notBefore <= 0 && notAfter >= 0);
+	} catch (const std::exception & e) {
+		ofLogError("ofURLFileLoader") << "Exception in checkValidCertifcate: " << e.what();
+		return false;
+	} catch (...) {
+		ofLogError("ofURLFileLoader") << "Unknown error occurred in checkValidCertifcate.";
+		return false;
+	}
 }
 
+
 void ofURLFileLoaderImpl::createSSLCertificate() {
-	EVP_PKEY *pkey = nullptr;
-	X509 *x509 = nullptr;
-	EVP_PKEY_CTX *pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
-	if (!pkey_ctx) {
-		ofLogError("ofURLFileLoader") << "Error initializing key generation context";
-		return;
-	}
-	if (EVP_PKEY_keygen_init(pkey_ctx) <= 0 ||
-		EVP_PKEY_CTX_set_rsa_keygen_bits(pkey_ctx, 2048) <= 0 ||
-		EVP_PKEY_keygen(pkey_ctx, &pkey) <= 0) {
-		ofLogError("ofURLFileLoader") << "Error generating RSA key";
+	try {
+		EVP_PKEY * pkey = nullptr;
+		X509 * x509 = nullptr;
+		EVP_PKEY_CTX * pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
+		if (!pkey_ctx) {
+			throw std::runtime_error("Error initializing key generation context");
+		}
+		if (EVP_PKEY_keygen_init(pkey_ctx) <= 0 || EVP_PKEY_CTX_set_rsa_keygen_bits(pkey_ctx, 2048) <= 0 || EVP_PKEY_keygen(pkey_ctx, &pkey) <= 0) {
+			EVP_PKEY_CTX_free(pkey_ctx);
+			throw std::runtime_error("Error generating RSA key");
+		}
 		EVP_PKEY_CTX_free(pkey_ctx);
-		return;
-	}
-	EVP_PKEY_CTX_free(pkey_ctx);
-	x509 = X509_new();
-	ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
-	X509_gmtime_adj(X509_get_notBefore(x509), 0);
-	X509_gmtime_adj(X509_get_notAfter(x509), 31536000L); // 1 year == 31536000L
-	X509_set_pubkey(x509, pkey);
-	X509_NAME *name = X509_get_subject_name(x509);
-	X509_NAME_add_entry_by_txt(name, "C",  MBSTRING_ASC, (unsigned char *)"US", -1, -1, 0);
-	X509_NAME_add_entry_by_txt(name, "O",  MBSTRING_ASC, (unsigned char *)"Local Machine", -1, -1, 0);
-	X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)"Local Root CA", -1, -1, 0);
-	X509_set_issuer_name(x509, name);
-	if (X509_sign(x509, pkey, EVP_sha256()) == 0) {
-		ofLogError("ofURLFileLoader") << "Error signing the certificate";
+		x509 = X509_new();
+		if (!x509) {
+			EVP_PKEY_free(pkey);
+			throw std::runtime_error("Failed to create new X509 certificate");
+		}
+		ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
+		X509_gmtime_adj(X509_get_notBefore(x509), 0);
+		X509_gmtime_adj(X509_get_notAfter(x509), 31536000L); // 1 year
+		X509_set_pubkey(x509, pkey);
+		X509_NAME * name = X509_get_subject_name(x509);
+		if (!name) {
+			X509_free(x509);
+			EVP_PKEY_free(pkey);
+			throw std::runtime_error("Failed to get subject name from X509 certificate");
+		}
+		X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, (unsigned char *)"US", -1, -1, 0);
+		X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char *)"Local Machine", -1, -1, 0);
+		X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char *)"Local Root CA", -1, -1, 0);
+		X509_set_issuer_name(x509, name);
+		if (X509_sign(x509, pkey, EVP_sha256()) == 0) {
+			X509_free(x509);
+			EVP_PKEY_free(pkey);
+			throw std::runtime_error("Error signing the certificate");
+		}
+		BIO * keyBio = BIO_new(BIO_s_mem());
+		BIO * certBio = BIO_new(BIO_s_mem());
+		if (!keyBio || !certBio) {
+			if (keyBio) BIO_free(keyBio);
+			if (certBio) BIO_free(certBio);
+			X509_free(x509);
+			EVP_PKEY_free(pkey);
+			throw std::runtime_error("Failed to create BIO objects for key/cert storage");
+		}
+		PEM_write_bio_PrivateKey(keyBio, pkey, nullptr, nullptr, 0, nullptr, nullptr);
+		PEM_write_bio_X509(certBio, x509);
+		char * keyData = nullptr;
+		long keyLen = BIO_get_mem_data(keyBio, &keyData);
+		std::string keyStr(keyData, keyLen);
+		char * certData = nullptr;
+		long certLen = BIO_get_mem_data(certBio, &certData);
+		std::string certStr(certData, certLen);
+		ofBuffer keyBuffer, certBuffer;
+		keyBuffer.set(keyStr.c_str(), keyLen);
+		certBuffer.set(certStr.c_str(), certLen);
+		if (!ofDirectory::createDirectory("ssl")) {
+			ofLogWarning("ofURLFileLoader") << "Could not create ssl directory";
+		}
+		if (!ofBufferToFile(ofToDataPath(PRIVATE_KEY_FILE), keyBuffer)) {
+			throw std::runtime_error("Failed to save private key to file");
+		}
+		if (!ofBufferToFile(ofToDataPath(CERTIFICATE_FILE), certBuffer)) {
+			throw std::runtime_error("Failed to save certificate to file");
+		}
+		BIO_free(keyBio);
+		BIO_free(certBio);
 		EVP_PKEY_free(pkey);
 		X509_free(x509);
-		return;
+		ofLogNotice("ofURLFileLoader") << "Root certificate and private key generated and saved";
+	} catch (const std::exception & e) {
+		ofLogError("ofURLFileLoader") << "Exception in createSSLCertificate: " << e.what();
+	} catch (...) {
+		ofLogError("ofURLFileLoader") << "Unknown error occurred in createSSLCertificate.";
 	}
-	BIO *keyBio = BIO_new(BIO_s_mem());
-	BIO *certBio = BIO_new(BIO_s_mem());
-	PEM_write_bio_PrivateKey(keyBio, pkey, nullptr, nullptr, 0, nullptr, nullptr);
-	PEM_write_bio_X509(certBio, x509);
-	char *keyData = nullptr;
-	long keyLen = BIO_get_mem_data(keyBio, &keyData);
-	std::string keyStr(keyData, keyLen);
-	char *certData = nullptr;
-	long certLen = BIO_get_mem_data(certBio, &certData);
-	std::string certStr(certData, certLen);
-	ofBuffer keyBuffer;
-	ofBuffer certBuffer;
-	keyBuffer.set(keyStr.c_str(), keyLen);
-	certBuffer.set(certStr.c_str(), certLen);
-	
-	if(!ofDirectory::createDirectory( "ssl" )) {
-		ofLogWarning("ofURLFileLoader") << "ssl dir could not create";
-	}
-	if(!ofBufferToFile(ofToDataPath(PRIVATE_KEY_FILE), keyBuffer)) {
-		ofLogError("ofURLFileLoader") << "createSSLCertificate. could not save keyBuffer";
-	}
-	if(!ofBufferToFile(ofToDataPath(CERTIFICATE_FILE), certBuffer)) {
-		ofLogError("ofURLFileLoader") << "createSSLCertificate. could not save certBuffer";
-	}
-
-	BIO_free(keyBio);
-	BIO_free(certBio);
-	EVP_PKEY_free(pkey);
-	X509_free(x509);
-	
-	ofLogNotice("ofURLFileLoader") << "Root certificate and private key generated and saved";
 }
 #endif
 

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -145,7 +145,7 @@ bool ofURLFileLoaderImpl::checkValidCertifcate(const std::string& cert_file) {
 void ofURLFileLoaderImpl::createSSLCertificate() {
 	EVP_PKEY *pkey = nullptr;
 	X509 *x509 = nullptr;
-	EVP_PKEY_CTX *pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, NULL);
+	EVP_PKEY_CTX *pkey_ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
 	if (!pkey_ctx) {
 		ofLogError("ofURLFileLoader") << "Error initializing key generation context";
 		return;
@@ -274,6 +274,9 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 	curl_version_info_data *version = curl_version_info( CURLVERSION_NOW );
 	if(request.verbose) {
 		CURLcode ret = curl_easy_setopt(curl.get(), CURLOPT_VERBOSE, 1L);
+		if (ret != CURLE_OK) {
+			ofLogWarning() << "cURL error: " << curl_easy_strerror(ret);
+		}
 		if (version) {
 			std::string userAgent = std::string("curl/") + version->version;
 			curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, userAgent.c_str());
@@ -338,18 +341,16 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 	if (request.method == ofHttpRequest::GET) {
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 1);
 		curl_easy_setopt(curl.get(), CURLOPT_POST, 0);
-		curl_easy_setopt(curl.get(), CURLOPT_PUT, 0);
+		curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 0);
 	}
 	else if (request.method == ofHttpRequest::PUT) {
 		curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 1);
-		curl_easy_setopt(curl.get(), CURLOPT_PUT, 1);
 		curl_easy_setopt(curl.get(), CURLOPT_POST, 0);
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 0);
 	}
 	else if (request.method == ofHttpRequest::POST) {
-	} else {
 		curl_easy_setopt(curl.get(), CURLOPT_POST, 1);
-		curl_easy_setopt(curl.get(), CURLOPT_PUT, 0);
+		curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 0);
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 0);
 	}
 

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -387,12 +387,20 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 		ofFile saveTo(request.name, ofFile::WriteOnly, true);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &saveTo);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, saveToFile_cb);
-		err = curl_easy_perform(curl.get());
 	} else {
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &response);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, saveToMemory_cb);
-		err = curl_easy_perform(curl.get());
 	}
+	try {
+		err = curl_easy_perform(curl.get());
+	} catch (const std::exception & e) {
+		ofLogError("ofURLFileLoader") << "Exception: " << e.what();
+		return ofHttpResponse(request, -1, e.what());
+	} catch (...) {
+		ofLogError("ofURLFileLoader") << "Unknown exception caught!";
+		return ofHttpResponse(request, -1, "Unknown exception");
+	}
+
 	if (err == CURLE_OK) {
 		long http_code = 0;
 		curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -399,20 +399,12 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 		ofFile saveTo(request.name, ofFile::WriteOnly, true);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &saveTo);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, saveToFile_cb);
+		err = curl_easy_perform(curl.get());
 	} else {
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, &response);
 		curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, saveToMemory_cb);
-	}
-	try {
 		err = curl_easy_perform(curl.get());
-	} catch (const std::exception & e) {
-		ofLogError("ofURLFileLoader") << "Exception: " << e.what();
-		return ofHttpResponse(request, -1, e.what());
-	} catch (...) {
-		ofLogError("ofURLFileLoader") << "Unknown exception caught!";
-		return ofHttpResponse(request, -1, "Unknown exception");
 	}
-
 	if (err == CURLE_OK) {
 		long http_code = 0;
 		curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -24,6 +24,7 @@ public:
 	std::string contentType; ///< POST data mime type
 	std::function<void(const ofHttpResponse &)> done;
 	size_t timeoutSeconds = 0;
+	bool headerOnly = false;
 
 	/// \return the unique id for this request
 	int getId() const;


### PR DESCRIPTION
## ofURLFileLoader
- fix missing POST (broken by else statement)
- Fix issue for Async threads  throwing exceptions (and randomly failing to complete directive)

## cURL 
- minor update api of deprecated ```PUT``` changed to ```UPLOAD```
```
C/C++: /home/runner/work/openFrameworks/openFrameworks/libs/openFrameworks/utils/ofURLFileLoader.cpp:341:32: 
warning: 'CURLOPT_PUT' is deprecated: since 7.12.1. Use CURLOPT_UPLOAD [-Wdeprecated-declarations]
C/C++:   341 |                 curl_easy_setopt(curl.get(), CURLOPT_PUT, 0);
C/C++:       |                                              ^
C/C++: /home/runner/work/openFrameworks/openFrameworks/libs/openFrameworksCompiled/project/android/openframeworksAndroid/../../../../../libs/curl/include/curl/curl.h:1294:3: note:
 'CURLOPT_PUT' has been explicitly marked deprecated here
C/C++:  1294 |   CURLOPTDEPRECATED(CURLOPT_PUT, CURLOPTTYPE_LONG, 54,
C/C++:       |   ^
C/C++: /home/runner/work/openFrameworks/openFrameworks/libs/openFrameworksCompiled/project/android/openframeworksAndroid/../../../../../libs/curl/include/curl/curl.h:1090:43: note: expanded from macro 'CURLOPTDEPRECATED'
C/C++:  1090 | #define CURLOPTDEPRECATED(na,t,nu,v,m) na CURL_DEPRECATED(v,m) = t + nu
C/C++:       |                                           ^
```

## OpenSSL
- Update createSSL cert from 1.1 style deprecated to 3  ```EVP_PKEY_CTX_new_from_name```
