### PR TITLE
ofxAssimp: Fix for incorrectly over writing textures.

### DIFF
--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.cpp
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcBone.cpp
@@ -24,99 +24,6 @@ void SrcBone::setAiBone(aiBone* aAiBone, aiNode* aAiNode) {
 	mAiMatrix = mAiNode->mTransformation;
 }
 
-////--------------------------------------------------------------
-//void SrcBone::update() {
-//	if( mAiNode == nullptr ) {
-//		ofLogWarning("SrcBone::update mAiNode nullptr!!!");
-//		return;
-//	}
-//
-////	if( mAiBone == nullptr ) {
-////		ofLogWarning("SrcBone::update mAiBone nullptr!!!");
-////		return;
-////	}
-//
-////	if( bRoot ) {
-////		std::cout << "Bone: " << getName() << " has parent: " << (getParent() != nullptr) << " | " << ofGetFrameNum() << std::endl;
-////	}
-//	// update //
-////	mAiMatrix = mAiBone->mOffsetMatrix;
-//	mAiMatrix = mAiNode->mTransformation;
-//
-////	mAiMatrixGlobal = mAiNode->mTransformation;
-////	mBoneLocalTransform = glmMat4ToAiMatrix4x4(mAiMatrix);
-//	// and now append all node transformations down the parent chain until we're back at mesh coordinates again
-////	if( bRoot ) {
-////		const aiNode* tempNode = mAiNode;
-////		aiNode* node = scene->mRootNode->FindNode(mAiBone->mName);
-////		const aiNode* tempNode = mAiNode->mParent;
-////		while(tempNode) {
-//////			aiMatrix4x4 m = tempNode->mTransformation;
-//////			m.Transpose();
-////		// check your matrix multiplication order here!!!
-//////			mAiMatrix = m * mAiMatrix;//boneMatrices[a];
-//////			ofLogNotice("SrcBone name: ") << getName() << " parent: " << tempNode->mName.data;
-//////			mAiMatrixGlobal = tempNode->mTransformation * mAiMatrixGlobal;
-////			mAiMatrixGlobal = tempNode->mTransformation * mAiMatrixGlobal;
-////														 // boneMatrices[a] = boneMatrices[a] * tempNode->mTransformation;
-//////			mAiMatrix = tempNode->mTransformation * mAiMatrix;
-//////			mAiMatrix = mAiMatrix * tempNode->mTransformation;
-////			tempNode = tempNode->mParent;
-////		}
-////		mAiMatrix = aGlobalInv * mAiMatrix;
-////	} else {
-////		mAiMatrix = mAiNode->mTransformation * mAiMatrix;
-////		mAiMatrix = mAiMatrix * mAiNode->mTransformation;
-////	}
-//	if( bRoot) {
-////		mAiMatrix = mAiMatrixGlobal;
-//	}
-//
-////	mAiMatrix *= (mOffsetMatrix);
-//
-////	aiVector3t<float> tAiScale;
-////	aiQuaterniont<float> tAiRotation;
-////	aiVector3t<float> tAiPosition;
-////
-////	// this is the local matrix
-////	mAiMatrix.Decompose( tAiScale, tAiRotation, tAiPosition );
-////
-////	glm::vec3 tpos = glm::vec3( tAiPosition.x, tAiPosition.y, tAiPosition.z );
-////	glm::quat tquat = glm::quat(tAiRotation.w, tAiRotation.x, tAiRotation.y, tAiRotation.z);
-//////	glm::quat tquat = glm::quat(tAiRotation.x, tAiRotation.y, tAiRotation.z, tAiRotation.w);
-////	glm::vec3 tscale = glm::vec3( tAiScale.x, tAiScale.y, tAiScale.z );
-////
-//////	if( bRoot ) {
-//////		std::cout << "Bone: " << getName() << " tscale: " << tscale << " | " << ofGetFrameNum() << std::endl;
-//////	}
-////
-//////	if(bRoot) {
-//////		setGlobalPosition( tpos );
-//////		setGlobalOrientation( tquat );
-//////		setScale( tscale );
-//////	} else {
-////		setPositionOrientationScale( tpos, tquat, tscale );
-////	setPosition(tpos);
-////	setOrientation(tquat);
-////	setScale(tscale);
-//
-////	setGlobalPosition(tpos);
-////	setGlobalOrientation(tquat);
-////	setScale(tscale);
-//
-////	mPos = getGlobalPosition();
-////	}
-//
-////	for(auto it = childBones.begin(); it != childBones.end(); ++it ) {
-////		it->second->update();
-////	}
-////	for( auto& kid : childBones ) {
-////		kid->update();
-////	}
-//
-////	getGlobalTransformMatrix();
-//}
-
 //--------------------------------------------------------------
 std::shared_ptr<ofxAssimp::SrcBone> SrcBone::getBone( aiNode* aAiNode ) {
 	std::shared_ptr<ofxAssimp::SrcBone> tbone;
@@ -130,13 +37,6 @@ std::shared_ptr<ofxAssimp::SrcBone> SrcBone::getBone( aiNode* aAiNode ) {
 //--------------------------------------------------------------
 void SrcBone::findBoneRecursive( aiNode* aAiNode, std::shared_ptr<SrcBone>& returnBone ) {
 	if( !returnBone ) {
-//		for(auto it = childBones.begin(); it != childBones.end(); ++it ) {
-//			if( it->second->getAiNode() == aAiNode ) {
-//				returnBone = (it->second);
-//				break;
-//			}
-//			it->second->findBoneRecursive( aAiNode, returnBone );
-//		}
 		for(auto& kid : childBones ) {
 			if( kid->getAiNode() == aAiNode ) {
 				returnBone = kid;//(it->second);
@@ -150,9 +50,6 @@ void SrcBone::findBoneRecursive( aiNode* aAiNode, std::shared_ptr<SrcBone>& retu
 //--------------------------------------------------------------
 unsigned int SrcBone::getNumBones() {
 	unsigned int ttotal = childBones.size();
-//	for(auto it = childBones.begin(); it != childBones.end(); ++it ) {
-//		ttotal += it->second->getNumBones();
-//	}
 	for(auto& kid : childBones ) {
 		ttotal += kid->getNumBones();
 	}

--- a/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
+++ b/addons/ofxAssimp/src/Source/ofxAssimpSrcScene.h
@@ -41,7 +41,7 @@ struct ImportSettings {
 	bool fixInfacingNormals = false; // aiProcess_FixInfacingNormals
 //	bool importLights = false;
 	bool convertToLeftHanded = true; // aiProcess_ConvertToLeftHanded
-	
+	bool transformRootNode = true; // orient based on src scene root node, helps with correct orientation
 	std::vector<std::string> excludeNodesContainingStrings;
 	unsigned int aiFlags = 0; // ai process flags, ie. aiProcess_FixInfacingNormals
 };
@@ -98,7 +98,10 @@ protected:
 	ofFile mFile;
 	
 	std::vector<ofLight> mLights;
-	std::map<of::filesystem::path, std::shared_ptr<ofxAssimp::Texture> > mAssimpTextures;
+//	std::map<of::filesystem::path, std::shared_ptr<ofxAssimp::Texture> > mAssimpTextures;
+	std::map<std::string, std::shared_ptr<ofxAssimp::Texture> > mAssimpTextures;
+	std::map<of::filesystem::path, std::shared_ptr<ofTexture> > mTextureCacheMap;
+	
 	std::vector< ofxAssimp::Animation > mAnimations;
 	
 	std::vector< std::shared_ptr<ofxAssimp::SrcMesh> > mSrcMeshes;

--- a/addons/ofxAssimp/src/ofxAssimpTexture.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpTexture.cpp
@@ -14,12 +14,22 @@ using namespace ofxAssimp;
 std::unordered_map< int, ofMaterialTextureType > ofxAssimp::Texture::sAiTexTypeToOfTexTypeMap;
 
 //-------------------------------------------
+void ofxAssimp::Texture::setTexture( std::shared_ptr<ofTexture> atexture ) {
+	if( texture ) {
+		texture.reset();
+	}
+	texture = atexture;
+}
+
+//-------------------------------------------
 void ofxAssimp::Texture::setup(const of::filesystem::path & texturePath, bool bTexRepeat) {
 //	this->texture = texture;
-	if( bTexRepeat ){
-		this->texture.setTextureWrap(GL_REPEAT, GL_REPEAT);
-	}else{
-		this->texture.setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
+	if(texture && texture->isAllocated()) {
+		if( bTexRepeat ){
+			texture->setTextureWrap(GL_REPEAT, GL_REPEAT);
+		}else{
+			texture->setTextureWrap(GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE);
+		}
 	}
 	this->texturePath = texturePath;
 }
@@ -46,8 +56,11 @@ void ofxAssimp::Texture::setAiTextureType(aiTextureType aTexType){
 }
 
 //-------------------------------------------
-ofTexture & Texture::getTextureRef() {
-	return texture;
+ofTexture& Texture::getTextureRef() {
+	if( !texture ) {
+		texture = std::make_shared<ofTexture>();
+	}
+	return *texture;
 }
 
 //-------------------------------------------
@@ -57,7 +70,7 @@ of::filesystem::path Texture::getTexturePath() {
 
 //-------------------------------------------
 bool Texture::hasTexture() {
-	return texture.isAllocated();
+	return (texture && texture->isAllocated());
 }
 
 //-------------------------------------------

--- a/addons/ofxAssimp/src/ofxAssimpTexture.h
+++ b/addons/ofxAssimp/src/ofxAssimpTexture.h
@@ -16,6 +16,7 @@ public:
 	static std::unordered_map< int, ofMaterialTextureType > sAiTexTypeToOfTexTypeMap;
 	
 	//	void setup(const ofTexture & texture, const of::filesystem::path & texturePath, bool bTexRepeat = true);
+	void setTexture( std::shared_ptr<ofTexture> atexture );
 	void setup(const of::filesystem::path & texturePath, bool bTexRepeat = true);
 	
 	ofTexture & getTextureRef();
@@ -35,7 +36,8 @@ public:
 private:
 	static void _initTextureTypeMap();
 	
-	ofTexture texture;
+	std::shared_ptr<ofTexture> texture;
+//	ofTexture texture;
 	of::filesystem::path texturePath;
 	aiTextureType textureType = aiTextureType_NONE;
 	std::string mTexTypeStr;


### PR DESCRIPTION
Material set metalness, roughness and clear coat values. Somewhat related: #8267
Clean up of commented code.
Recalculate scene bounds per request, instead of cache and requiring calling recalculate bounds per mesh.