### PR TITLE
ofxAssimp: Convert animation mixer animation clip references to weak_ptrs

### DIFF
--- a/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpAnimationMixer.cpp
@@ -6,7 +6,7 @@ using namespace ofxAssimp;
 
 //--------------------------------------------------------------
 bool AnimationClip::shouldRemove( const AnimationClip& ac ) {
-	return ac.bRemove;
+	return (ac.animationWeak.expired() || ac.bRemove);
 }
 
 //--------------------------------------------------------------
@@ -31,8 +31,11 @@ AnimationClip& AnimationMixer::getAnimationClip(const std::string& aname) {
 		return dummy;
 	}
 	for( auto& anim : mAnimationClips ) {
-		if( anim.animation.getName() == aname ) {
-			return anim;
+		if(anim.animationWeak.expired()) {continue;}
+		if( auto alock = anim.animationWeak.lock() ) {
+			if( alock->getName() == aname ) {
+				return anim;
+			}
 		}
 	}
 	ofLogWarning("ofxAssimp::AnimationMixer::getAnimationClip") << " could not find clip " << aname;
@@ -57,9 +60,12 @@ bool AnimationMixer::remove( int aindex ) {
 bool AnimationMixer::remove( const std::string& aname ) {
 	int tindex = -1;
 	for(int i = 0; i < (int)mAnimationClips.size(); i++) {
-		if( mAnimationClips[i].animation.getName() == aname ) {
-			tindex = i;
-			break;
+		if(mAnimationClips[i].animationWeak.expired()) {continue;}
+		if( auto alock = mAnimationClips[i].animationWeak.lock() ) {
+			if( alock->getName() == aname ) {
+				tindex = i;
+				break;
+			}
 		}
 	}
 	if( tindex > -1 ) {
@@ -76,14 +82,20 @@ void AnimationMixer::removeAll() {
 //--------------------------------------------------------------
 void AnimationMixer::playAll() {
 	for( auto& anim : mAnimationClips ) {
-		anim.animation.play();
+		if(anim.animationWeak.expired()) {continue;}
+		if( auto alock = anim.animationWeak.lock() ) {
+			alock->play();
+		}
 	}
 }
 
 //--------------------------------------------------------------
 void AnimationMixer::stopAll() {
 	for( auto& anim : mAnimationClips ) {
-		anim.animation.stop();
+		if(anim.animationWeak.expired()) {continue;}
+		if( auto alock = anim.animationWeak.lock() ) {
+			alock->stop();
+		}
 	}
 }
 
@@ -91,7 +103,10 @@ void AnimationMixer::stopAll() {
 void AnimationMixer::update(float aElapsedTimef) {
 	for(auto& anim : mAnimationClips ) {
 //		std::cout << "AnimationMixer :: update : " << anim.animation.getName() << " position: " << anim.animation.getPositionInSeconds() << std::endl;
-		anim.animation.update();
+		if(anim.animationWeak.expired()) {continue;}
+		if( auto alock = anim.animationWeak.lock() ) {
+			alock->update();
+		}
 	}
 	
 	float tdelta = std::max( std::min(aElapsedTimef-mLastUpdateTime, 10.f), ai_epsilon);
@@ -166,9 +181,13 @@ void AnimationMixer::transition( const std::string& aname, float aduration, bool
 	// first get the targeted animation //
 	int animIndex = -1;
 	for( int i = 0; i < (int)mAnimationClips.size(); i++ ) {
-		if( mAnimationClips[i].animation.getName() == aname ) {
-			animIndex = i;
-			break;
+//		if( mAnimationClips[i].animation.getName() == aname ) {
+		if(mAnimationClips[i].animationWeak.expired()) {continue;}
+		if( auto alock = mAnimationClips[i].animationWeak.lock() ) {
+			if( alock->getName() == aname ) {
+				animIndex = i;
+				break;
+			}
 		}
 	}
 	if( animIndex < 0 ) {

--- a/addons/ofxAssimp/src/ofxAssimpAnimationMixer.h
+++ b/addons/ofxAssimp/src/ofxAssimpAnimationMixer.h
@@ -12,8 +12,8 @@ public:
 	static bool shouldRemove( const AnimationClip& ac );
 	
 	AnimationClip() {}
-	AnimationClip(Animation anim, float aweight) {
-		animation = anim;
+	AnimationClip(std::shared_ptr<Animation> anim, float aweight) {
+		animationWeak = anim;
 		weight = aweight;
 	}
 //	AnimationClip(const Animation& anim, float aweight, bool abOneShot) {
@@ -39,8 +39,15 @@ public:
 	
 	void tagForRemoval() {bRemove=true;}
 	
+	void resetAnimation() {
+		if( auto alock = animationWeak.lock() ) {
+			alock->reset();
+		}
+	}
+	
 	float weight = 1.0f;
-	Animation animation;
+//	Animation animation;
+	std::weak_ptr<Animation> animationWeak;
 	
 //protected:
 	float mTargetWeight = -1.f;

--- a/addons/ofxAssimp/src/ofxAssimpNode.cpp
+++ b/addons/ofxAssimp/src/ofxAssimpNode.cpp
@@ -50,10 +50,14 @@ void Node::update( const std::shared_ptr<ofxAssimp::AnimationMixer>& aAnimMixer 
 			bool bHasSomeKeys = false;
 			int clipWithKeysIndex = 0;
 			for( auto& animClip : mixer->getAnimationClips() ) {
-				auto& keyCollection = mSrcNode->getKeyCollection(animClip.animation.getUid());
+				
+				auto animation = animClip.animationWeak.lock();
+				if( !animation ) {continue;}
+				
+				auto& keyCollection = mSrcNode->getKeyCollection(animation->getUid());
 				
 				if( keyCollection.hasKeys() ) {
-					auto animTime = animClip.animation.getPositionInTicks() + animClip.animation.getStartTick();
+					auto animTime = animation->getPositionInTicks() + animation->getStartTick();
 					tempPos += animClip.weight * keyCollection.getPosition( animTime );
 					tempScale += animClip.weight * keyCollection.getScale( animTime );
 					// TODO: Keep an eye on this :O

--- a/addons/ofxAssimp/src/ofxAssimpScene.h
+++ b/addons/ofxAssimp/src/ofxAssimpScene.h
@@ -273,6 +273,7 @@ public:
 	
 	
 protected:
+	std::shared_ptr<AnimationMixer> _getAnimationMixer();
 	void updateAnimations();
 	void updateMeshesFromBones();
 	
@@ -292,7 +293,8 @@ protected:
 	// the skeletons are the root bones
 	std::vector< std::shared_ptr<ofxAssimp::Skeleton> > mSkeletons;
 	std::vector< std::shared_ptr<ofxAssimp::Node> > mNullNodes;
-	std::vector<ofxAssimp::Animation> mAnimations;
+//	std::vector<ofxAssimp::Animation> mAnimations;
+	std::vector< std::shared_ptr<ofxAssimp::Animation> > mAnimations;
 	
 	int mAnimationIndex = 0;
 	


### PR DESCRIPTION
updating from scene will take effect on changing animation parameters.

Before this PR, the following would have no effect, and calling `setAnimation(0)` to try and update the animation mixer would fail since it was the same index.
```
model.getAnimation(0).setLoopType(OF_LOOP_NORMAL);
model.getAnimation(0).play();
```

Now both the above works in addition to 
```
model.getCurrentAnimation().setLoopType(OF_LOOP_NORMAL);
model.getCurrentAnimation().play();
```

As mentioned in this issue:
https://github.com/openframeworks/openFrameworks/issues/8387