### PR TITLE
ofURLFileLoader bugfix for sending POST

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -354,23 +354,6 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 	if (headers) {
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPHEADER, headers);
 	}
-	std::string body = request.body;
-	if (!request.body.empty()) {
-		if (request.method == ofHttpRequest::PUT || request.body.size() > MAX_POSTFIELDS_SIZE) { // If request is an upload (e.g., file upload)
-			curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 1L);
-			curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, readBody_cb);
-			curl_easy_setopt(curl.get(), CURLOPT_READDATA, &body);
-			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, 0L);
-		} else { // If request is a normal POST
-			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, request.body.size());
-			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS, request.body.c_str());
-		}
-	} else {
-		curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, 0L);
-		curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS, "");
-		curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, nullptr);
-		curl_easy_setopt(curl.get(), CURLOPT_READDATA, nullptr);
-	}
 	if (request.method == ofHttpRequest::GET) {
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 1L);
 		curl_easy_setopt(curl.get(), CURLOPT_POST, 0L);
@@ -385,6 +368,25 @@ ofHttpResponse ofURLFileLoaderImpl::handleRequest(const ofHttpRequest & request)
 		curl_easy_setopt(curl.get(), CURLOPT_POST, 1L);
 		curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 0L);
 		curl_easy_setopt(curl.get(), CURLOPT_HTTPGET, 0L);
+	}
+	if (request.method != ofHttpRequest::GET) {
+		std::string body = request.body;
+		if (!request.body.empty()) {
+			if (request.method == ofHttpRequest::PUT || request.body.size() > MAX_POSTFIELDS_SIZE) { // If request is an upload (e.g., file upload)
+				curl_easy_setopt(curl.get(), CURLOPT_UPLOAD, 1L);
+				curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, readBody_cb);
+				curl_easy_setopt(curl.get(), CURLOPT_READDATA, &body);
+				curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, 0L);
+			} else { // If request is a normal POST
+				curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, request.body.size());
+				curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS, request.body.c_str());
+			}
+		} else {
+			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDSIZE, 0L);
+			curl_easy_setopt(curl.get(), CURLOPT_POSTFIELDS, "");
+			curl_easy_setopt(curl.get(), CURLOPT_READFUNCTION, nullptr);
+			curl_easy_setopt(curl.get(), CURLOPT_READDATA, nullptr);
+		}
 	}
 
 	if (request.timeoutSeconds > 0) {


### PR DESCRIPTION
So I am a little lazy and decided to use ofURLFileLoader for *basic* REST stuff to a local ollama server instead of bothering with ofxHTTP. It's just a thin wrapper for HTTP and it's built into the core anyway...

I noticed that GETs work fine however trying to POST a body with stringified JSON resulted in a 405 METHOD NOT ALLOWED error. Enabling verbose in the request showed that, in my case, the actual request type being made was a GET even though I set the request method to POST.

I was able to fix this by making sure the libcurl method opts are set *before* dealing with the request body / POST data handling. This broke GET so only setting the POST handling stuff if not doing a GET was the fix. If the request is a GET, the request body should be ignored anyway, I believe. I think libcurl is making some assumptions in the background when setting some of these options, so order might be important, ie. setting POSTFIELDS (even disabling) might trigger it to change the request type.

---

My original tests are big made using ofxLua and the `of_v20250330_osx_release` build:

```lua
of.setLogLevel("ofURLFileLoader", of.LOG_VERBOSE)

-- http get
-- check with: curl -X GET "http://httpbin.org/get
local http = of.URLFileLoader()
local res = http:get("http://httpbin.org/get")
print("http get: "..res.status)
if res.data ~= "" then
  print(res.data:getText())
end

-- http post
-- check with: curl -X POST -d '{"foo":"bar","baz":123}' "http://httpbin.org/post"
local req = of.HttpRequest("http://httpbin.org/post", "test")
req.body = '{"foo":"bar","baz":123}'
req.contentType = "application/json"
req.method = of.HttpRequest_POST
req.verbose = true
res = http:handleRequest(req)
print("http post: "..res.status)
if res.data ~= "" then
  print(res.data:getText())
end
```

The equivalent C++ should be something like:
```cpp
ofSetLogLevel("ofURLFileLoader", OF_LOG_VERBOSE);

// http get
// check with: curl -X GET "http://httpbin.org/get
auto http = ofURLFileLoader();
auto res = http.get("http://httpbin.org/get");
ofLog() << "http get: " << res.status << std::endl;
if(res.data != "") {
  ofLog() << res.data.getText() << std::endl;
}

// http post
// check with: curl -X POST -d '{"foo":"bar","baz":123}' "http://httpbin.org/post"
auto req = ofHttpRequest("http://httpbin.org/post", "test");
req.body = "{\"foo\":\"bar\",\"baz\":123}";
req.contentType = "application/json";
req.method = ofHttpRequest::POST;
req.verbose = true;
res = http.handleRequest(req);
ofLog() << "http post: " << res.status << std::endl;
if(res.data != "") {
  ofLog() << res.data.getText() << std::endl;
}
```

The output in my simple test is:
```
http get: 200.0
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "br,gzip", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-68002ab3-08e2be1606af68f4570a815b"
  }, 
  "origin": "#.#.#.#", 
  "url": "http://httpbin.org/get"
}

* Host httpbin.org:80 was resolved.
* IPv6: (none)
* IPv4: 35.172.19.140, 34.238.6.191, 54.152.142.77, 3.224.7.64
*   Trying 35.172.19.140:80...
* Connected to httpbin.org (35.172.19.140) port 80
* using HTTP/1.x
> POST /post HTTP/1.1
Host: httpbin.org
User-Agent: curl/8.11.0
Accept: */*
Content-Type: application/json
Connection: close
Accept-Encoding: br
Accept-Encoding: gzip
Content-Length: 23

* upload completely sent off: 23 bytes
< HTTP/1.1 200 OK
< Date: Wed, 16 Apr 2025 22:09:56 GMT
< Content-Type: application/json
< Content-Length: 487
< Connection: close
< Server: gunicorn/19.9.0
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< 
* shutting down connection #0
http post: 200.0
{
  "args": {}, 
  "data": "{\"foo\":\"bar\",\"baz\":123}", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept": "*/*", 
    "Accept-Encoding": "br,gzip", 
    "Content-Length": "23", 
    "Content-Type": "application/json", 
    "Host": "httpbin.org", 
    "User-Agent": "curl/8.11.0", 
    "X-Amzn-Trace-Id": "Root=1-68002ab3-2f095ad9038b7121062c154c"
  }, 
  "json": {
    "baz": 123, 
    "foo": "bar"
  }, 
  "origin": "#.#.#.#", 
  "url": "http://httpbin.org/post"
}
```

I also tested imageLoaderWebExample which works fine.
