### PR TITLE
fix(random_distributions): enforce real for expon lambda

### DIFF
--- a/examples/math/randomExample/src/ofApp.cpp
+++ b/examples/math/randomExample/src/ofApp.cpp
@@ -131,11 +131,10 @@ void ofApp::perform() {
 		ofLogNotice("gaussian aka normal<vec3>(10,2)") << gaussian<vec3>(10, 2);
 		ofLogNotice("gaussian aka normal<vec3>({10,20,30},{2,1,.5})") << gaussian<vec3>({ 10, 20, 30 }, { 2, 1, .5 });
 
-		// exponential requires 1 args (no defaults)
+		// exponential requires 1 args (no defaults) which must be real (not int)
 
 		ofLogNotice("exponential(2.5)") << of::random::exponential(2.5);
 		ofLogNotice("exponential<double>(2.5)") << exponential<double>(2.5);
-		ofLogNotice("exponential<int>(2.5)") << exponential<int>(2.5);
 		ofLogNotice("exponential<vec2>(2.5)") << exponential<vec2>(2.5);
 		ofLogNotice("exponential<vec4>(2.5)") << exponential<vec4>(2.5);
 		ofLogNotice("exponential<vec2>({2.5, 10})") << exponential<vec2>({ 2.5, 10 });
@@ -145,7 +144,6 @@ void ofApp::perform() {
 
 		ofLogNotice("ofRandomExponential(2.5)") << ofRandomExponential(2.5);
 		ofLogNotice("ofRandomExponential<double>(2.5)") << ofRandomExponential<double>(2.5);
-		ofLogNotice("ofRandomExponential<int>(2.5)") << ofRandomExponential<int>(2.5);
 		ofLogNotice("ofRandomExponential<vec2>(2.5)") << ofRandomExponential<vec2>(2.5);
 		ofLogNotice("ofRandomExponential<vec2>({2.5, 10})") << ofRandomExponential<vec2>({ 2.5, 10 });
 		ofLogNotice("ofRandomExponential<vec3>(2.5, 10, 0.1") << ofRandomExponential<vec3>(2.5);

--- a/libs/openFrameworks/utils/ofRandomDistributions.h
+++ b/libs/openFrameworks/utils/ofRandomDistributions.h
@@ -494,7 +494,7 @@ poisson(T mean, G & g = of::random::gen()) {
 /// \param g the random engine (default: OF internal of::random::gen())
 /// \return an exponential random value ot type T
 template <typename T = float, typename G = decltype(of::random::gen()), typename = std::enable_if_t<is_random_engine_v<G>>>
-std::enable_if_t<std::is_arithmetic_v<T>, T>
+std::enable_if_t<std::is_floating_point_v<T>, T>
 exponential(T lambda, G & g = of::random::gen()) {
 	return std::exponential_distribution<T>{lambda}(g);
 }


### PR DESCRIPTION
exponential distribution requires a real value for lambda; enforce it at the OF interface.