### PR TITLE
Don't load non-existent JSON settings file when saving a new file

### DIFF
--- a/addons/ofxGui/src/ofxBaseGui.cpp
+++ b/addons/ofxGui/src/ofxBaseGui.cpp
@@ -239,7 +239,7 @@ void ofxBaseGui::saveToFile(const of::filesystem::path & filename){
 		xml.save(filename);
     }else
     if(extension == ".json"){
-        ofJson json = ofLoadJson(filename);
+        ofJson json;
 		saveTo(json);
         ofSavePrettyJson(filename, json);
 	}else{


### PR DESCRIPTION
Prevent this error when a new JSON settings is saved:
```
[ error ] ofLoadJson: Error loading json from "/Users/steve/Documents/MarkSynth/settings/synth1/settings-4.json": file doesn't exist
```

I'm also suspicious of L235-237 for the same reason, but there's no error message when loading a non-existent XML so not sure.