### PR TITLE
[bugfix] linux64 linker

### DIFF
--- a/libs/openFrameworksCompiled/project/linux64/config.linux64.default.mk
+++ b/libs/openFrameworksCompiled/project/linux64/config.linux64.default.mk
@@ -27,4 +27,8 @@
 
 include $(OF_SHARED_MAKEFILES_PATH)/config.linux.common.mk
 
-PLATFORM_LDFLAGS += -fuse-ld=gold
+ifneq (, $(shell command -v mold))
+ PLATFORM_LDFLAGS += -fuse-ld=mold
+else ifneq (, $(shell command -v gold))
+ PLATFORM_LDFLAGS += -fuse-ld=gold
+endif

--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/helpers.js
@@ -116,6 +116,12 @@ function pkgExists(pkg){
     return pkgconfig.exitCode() === 0;
 }
 
+function commandExists(command) {
+    var commandProcess = new Process();
+    commandProcess.exec('command', ['-v', command]);
+    return commandProcess.exitCode() === 0;
+}
+
 function findLibsRecursive(dir, platform, exclude){
     var ret = []
     if(!File.exists(dir)){

--- a/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
+++ b/libs/openFrameworksCompiled/project/qtcreator/modules/of/of.qbs
@@ -210,7 +210,9 @@ Module{
                 ldflags = Helpers.pkgconfig(configs, ["--libs-only-L"]);
                 if(platform === "msys2"){
                     ldflags.push("-L"+FileInfo.joinPaths(Helpers.msys2root(),"mingw32/lib"));
-                }else{
+                }else if (Helpers.commandExists("mold")) {
+                    ldflags.push("-fuse-ld=mold");
+                }else if (Helpers.commandExists("gold")) {
                     ldflags.push("-fuse-ld=gold");
                 }
             }else{


### PR DESCRIPTION
The gold linker is slowly fading out of existence on some Linux distros (e.g. Void linux).
Compilation therefore fails (unnecessarily).

[This is very likely gonna happen for any modern Linux distro.](https://www.phoronix.com/news/GNU-Gold-Linker-Deprecated)

But even apart from this, I think a better approach would be to only add `-fuse-ld=gold` if `gold` exists.

And while we're at it.. use `mold`, if `mold` exists.