### PR TITLE
Handle returned value when OPENSSL is disable in checkValidCertificate

### DIFF
--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -151,6 +151,8 @@ bool ofURLFileLoaderImpl::checkValidCertifcate(const std::string & cert_file) {
 		ofLogError("ofURLFileLoader") << "Unknown error occurred in checkValidCertifcate.";
 		return false;
 	}
+#else
+	return false;
 #endif
 }
 


### PR DESCRIPTION
Disabling OPENSSL currently prevents ofURLFileLoaderImpl::checkValidCertificate() from compiling because the function provides no return value when OPENSSL support is not available.

This change introduces a default return value (false) for builds where OPENSSL is disabled, ensuring consistent behavior and successful compilation across all configurations.