### PR TITLE
update alpha blend, smoothing, antialiasing and point sprites to be set with bool

### DIFF
--- a/addons/ofxGui/src/ofxGuiGroup.cpp
+++ b/addons/ofxGui/src/ofxGuiGroup.cpp
@@ -342,7 +342,7 @@ void ofxGuiGroup::render(){
 	}
 	ofBlendMode blendMode = ofGetStyle().blendingMode;
 	if(blendMode != OF_BLENDMODE_ALPHA){
-		ofEnableAlphaBlending();
+		ofSetAlphaBlending(true);
 	}
 	ofColor c = ofGetStyle().color;
 	if(bHeaderEnabled){

--- a/addons/ofxGui/src/ofxInputField.cpp
+++ b/addons/ofxGui/src/ofxInputField.cpp
@@ -688,7 +688,7 @@ void ofxInputField<Type>::render(){
 
 	ofBlendMode blendMode = ofGetStyle().blendingMode;
 	if(blendMode!=OF_BLENDMODE_ALPHA){
-		ofEnableAlphaBlending();
+		ofSetAlphaBlending(true);
 	}
 
 	bindFontTexture();

--- a/addons/ofxGui/src/ofxLabel.cpp
+++ b/addons/ofxGui/src/ofxLabel.cpp
@@ -58,7 +58,7 @@ void ofxLabel::render() {
 
 	ofBlendMode blendMode = ofGetStyle().blendingMode;
 	if(blendMode!=OF_BLENDMODE_ALPHA){
-		ofEnableAlphaBlending();
+		ofSetAlphaBlending(true);
 	}
     ofSetColor(textColor);
 

--- a/addons/ofxGui/src/ofxPanel.cpp
+++ b/addons/ofxGui/src/ofxPanel.cpp
@@ -70,7 +70,7 @@ void ofxPanel::render(){
 	if(bHeaderEnabled){
 		ofBlendMode blendMode = ofGetStyle().blendingMode;
 		if(blendMode!=OF_BLENDMODE_ALPHA){
-			ofEnableAlphaBlending();
+			ofSetAlphaBlending(true);
 		}
 		ofColor c = ofGetStyle().color;
 		ofSetColor(thisTextColor);

--- a/addons/ofxGui/src/ofxSlider.cpp
+++ b/addons/ofxGui/src/ofxSlider.cpp
@@ -282,7 +282,7 @@ void ofxSlider<Type>::render(){
 
 		ofBlendMode blendMode = ofGetStyle().blendingMode;
 		if(blendMode!=OF_BLENDMODE_ALPHA){
-			ofEnableAlphaBlending();
+			ofSetAlphaBlending(true);
 		}
 		ofSetColor(thisTextColor);
 

--- a/addons/ofxGui/src/ofxToggle.cpp
+++ b/addons/ofxGui/src/ofxToggle.cpp
@@ -121,7 +121,7 @@ void ofxToggle::render(){
 	ofColor c = ofGetStyle().color;
 	ofBlendMode blendMode = ofGetStyle().blendingMode;
 	if(blendMode!=OF_BLENDMODE_ALPHA){
-		ofEnableAlphaBlending();
+		ofSetAlphaBlending(true);
 	}
 	ofSetColor(thisTextColor);
 

--- a/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
+++ b/addons/ofxOpenCv/src/ofxCvHaarFinder.cpp
@@ -147,7 +147,7 @@ int ofxCvHaarFinder::findHaarObjects(const ofxCvGrayscaleImage&  input,
 
 void ofxCvHaarFinder::draw( float x, float y ) {
 	ofPushStyle();
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor( 255,0,200,100 );
 	ofPushMatrix();
 

--- a/examples/3d/advanced3dExample/src/ofApp.cpp
+++ b/examples/3d/advanced3dExample/src/ofApp.cpp
@@ -34,7 +34,7 @@ void ofApp::setup(){
 
 	ofSetVerticalSync(true);
 	ofBackground(70, 70, 70);
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	ofEnableDepthTest();
 
 

--- a/examples/3d/cameraLensOffsetExample/src/ofApp.cpp
+++ b/examples/3d/cameraLensOffsetExample/src/ofApp.cpp
@@ -2,7 +2,7 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	ofSetVerticalSync(true);
 
 	video.setup(320, 240);
@@ -137,7 +137,7 @@ void ofApp::drawScene(bool isPreview){
 	ofPopStyle();
 
 	ofPushStyle();
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	ofSetColor(255);
 	ofSetLineWidth(5.0f);
 	ofBeginShape();

--- a/examples/3d/normalsExample/src/ofApp.cpp
+++ b/examples/3d/normalsExample/src/ofApp.cpp
@@ -10,8 +10,8 @@ void ofApp::setup(){
 
 	ofSetVerticalSync(true);
 	ofEnableLighting();
-	ofEnableAlphaBlending();
-	ofEnableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(true);
 
 	mesh.addVertex(glm::vec3(0,0,0)); // add center vertex
 	mesh.addColor(ofColor(137,137,140,255)); // center is same as bg

--- a/examples/3d/quaternionLatLongExample/src/ofApp.cpp
+++ b/examples/3d/quaternionLatLongExample/src/ofApp.cpp
@@ -12,7 +12,7 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 //	ofNoFill();
 
 	camera.setFarClip(5000);

--- a/examples/android/androidAdvanced3DExample/src/ofApp.cpp
+++ b/examples/android/androidAdvanced3DExample/src/ofApp.cpp
@@ -42,7 +42,7 @@ void ofApp::setup(){
 	
 	ofSetVerticalSync(true);
 	ofBackground(70, 70, 70);
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	ofEnableDepthTest();
 	
 	

--- a/examples/android/androidAssimpExample/src/ofApp.cpp
+++ b/examples/android/androidAssimpExample/src/ofApp.cpp
@@ -18,7 +18,7 @@ void ofApp::setup(){
 	}
 
 	ofEnableBlendMode(OF_BLENDMODE_ALPHA);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	ofEnableDepthTest();
 

--- a/examples/android/androidCameraExample/src/ofApp.cpp
+++ b/examples/android/androidCameraExample/src/ofApp.cpp
@@ -6,7 +6,7 @@ void ofApp::setup(){
 
     ofBackground(255,255,255);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 
 	// List devices

--- a/examples/android/androidCompositeExample/src/ofApp.cpp
+++ b/examples/android/androidCompositeExample/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup(){
 
     ofBackground(255,255,255);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
     // ofSetOrientation(OF_ORIENTATION_90_LEFT);
 

--- a/examples/android/androidEmptyExample/src/ofApp.cpp
+++ b/examples/android/androidEmptyExample/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup(){
 
     ofBackground(255,255,255);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 }
 

--- a/examples/android/androidPolygonExample/src/ofApp.cpp
+++ b/examples/android/androidPolygonExample/src/ofApp.cpp
@@ -207,7 +207,7 @@ void ofApp::draw(){
 
 
 	// show a faint the non-curve version of the same polygon:
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofNoFill();
 		ofSetColor(0,0,0,40);
 		ofBeginShape();
@@ -223,7 +223,7 @@ void ofApp::draw(){
 			else ofNoFill();
 			ofCircle(curveVertices[i].x, curveVertices[i].y,4);
 		}
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	//-------------------------------------
 
 
@@ -255,14 +255,14 @@ void ofApp::draw(){
 	ofEndShape();
 
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofFill();
 		ofSetColor(0,0,0,40);
 		ofCircle(x0,y0,4);
 		ofCircle(x1,y1,4);
 		ofCircle(x2,y2,4);
 		ofCircle(x3,y3,4);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 
 

--- a/examples/android/androidShaderExample/src/ofApp.cpp
+++ b/examples/android/androidShaderExample/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup(){
 	ofSetLogLevel(OF_LOG_VERBOSE);
 	ofBackground(34, 34, 34);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 	//we load a font and tell OF to make outlines so we can draw it as GL shapes rather than textures
 	font.load("type/verdana.ttf", 80, true, false, true, 0.4, 72);

--- a/examples/android/androidVBOExample/src/ofApp.cpp
+++ b/examples/android/androidVBOExample/src/ofApp.cpp
@@ -86,7 +86,7 @@ void ofApp::draw() {
 
 
 	// the lines
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255, 255, 255);
 	//vbo.bind();
 	vbo.updateVertexData(pos, total);

--- a/examples/communication/firmataExample/src/ofApp.cpp
+++ b/examples/communication/firmataExample/src/ofApp.cpp
@@ -141,10 +141,10 @@ void ofApp::analogPinChanged(const int & pinNum) {
 void ofApp::draw(){
 	bgImage.draw(0,0);
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 127);
 	ofDrawRectangle(510, 15, 275, 150);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	ofSetColor(255, 255, 255);
 	if (!bSetupArduino){

--- a/examples/communication/networkUdpReceiverExample/src/ofApp.cpp
+++ b/examples/communication/networkUdpReceiverExample/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup(){
 	//we run at 60 fps!
 	ofSetVerticalSync(true);
 	ofSetFrameRate(60);
-	ofEnableAntiAliasing();
+	ofSetAntiAliasing(true);
 
 	//create the socket and bind to port 11999
 	ofxUDPSettings settings;

--- a/examples/communication/networkUdpSenderExample/src/ofApp.cpp
+++ b/examples/communication/networkUdpSenderExample/src/ofApp.cpp
@@ -7,7 +7,7 @@ void ofApp::setup(){
 	// we don't want to be running to fast
 	ofSetVerticalSync(true);
 	ofSetFrameRate(60);
-	ofEnableAntiAliasing();
+	ofSetAntiAliasing(true);
 
 	//create the socket and set to send to 127.0.0.1:11999
 	ofxUDPSettings settings;

--- a/examples/gl/billboardExample/src/ofApp.cpp
+++ b/examples/gl/billboardExample/src/ofApp.cpp
@@ -45,7 +45,7 @@ void ofApp::setup() {
 	// we need to disable ARB textures in order to use normalized texcoords
 	ofDisableArbTex();
 	texture.load("dot.png");
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 }
 
 //--------------------------------------------------------------
@@ -98,11 +98,11 @@ void ofApp::draw() {
 	// size of the points via the vert shader
 	billboardShader.begin();
 
-	ofEnablePointSprites(); // not needed for GL3/4
+	ofSetPointSprites(true); // not needed for GL3/4
 	texture.getTexture().bind();
 	billboards.draw();
 	texture.getTexture().unbind();
-	ofDisablePointSprites(); // not needed for GL3/4
+	ofSetPointSprites(false); // not needed for GL3/4
 
 	billboardShader.end();
 

--- a/examples/gl/billboardRotationExample/src/ofApp.cpp
+++ b/examples/gl/billboardRotationExample/src/ofApp.cpp
@@ -81,11 +81,11 @@ void ofApp::update() {
 
 //--------------------------------------------------------------
 void ofApp::draw() {
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255);
 	
 	shader.begin();
-	ofEnablePointSprites();
+	ofSetPointSprites(true);
 	
 	
 	texture.getTexture().bind();
@@ -98,7 +98,7 @@ void ofApp::draw() {
 	vbo.draw(GL_POINTS, 0, NUM_BILLBOARDS);
 	texture.getTexture().unbind();
 
-	ofDisablePointSprites();
+	ofSetPointSprites(false);
 	shader.end();
 }
 

--- a/examples/gl/fboTrailsExample/src/ofApp.cpp
+++ b/examples/gl/fboTrailsExample/src/ofApp.cpp
@@ -47,7 +47,7 @@ void ofApp::setup(){
 //--------------------------------------------------------------
 void ofApp::update(){
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 	//lets draw some graphics into our two fbos
 	rgbaFbo.begin();

--- a/examples/gl/geometryShaderExample/src/ofApp.cpp
+++ b/examples/gl/geometryShaderExample/src/ofApp.cpp
@@ -6,7 +6,7 @@ void ofApp::setup(){
 	ofSetLogLevel(OF_LOG_VERBOSE);
 	ofBackground(50, 50, 50);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 	shader.setGeometryInputType(GL_LINES);
 	shader.setGeometryOutputType(GL_TRIANGLE_STRIP);

--- a/examples/gl/materialPBRAdvancedExample/src/ofApp.cpp
+++ b/examples/gl/materialPBRAdvancedExample/src/ofApp.cpp
@@ -99,7 +99,7 @@ void ofApp::draw(){
 	ofDisableDepthTest();
 	
 	ofSetColor(255);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 #ifdef USE_LIGHT
 	for( auto& lp : lights ) {
 		lp->gui.draw();

--- a/examples/gl/multiTextureShaderExample/src/ofApp.cpp
+++ b/examples/gl/multiTextureShaderExample/src/ofApp.cpp
@@ -8,7 +8,7 @@ void ofApp::setup(){
 	// If ARB is left enabled, then it would be 0 -> tex width and 0 -> tex height
 	// opengl es only supports non arb textures where tex coords are 0 - 1
 	ofDisableArbTex();
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	int camWidth 		= 320;	// try to grab at this size.
 	int camHeight 		= 240;
 

--- a/examples/gl/pointsAsTexturesExample/src/ofApp.cpp
+++ b/examples/gl/pointsAsTexturesExample/src/ofApp.cpp
@@ -77,16 +77,16 @@ void ofApp::draw() {
 	
 	ofSetColor(255, 100, 90);
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	
 	// this makes everything look glowy :)
 	ofEnableBlendMode(OF_BLENDMODE_ADD);
-	ofEnablePointSprites();
+	ofSetPointSprites(true);
 
 	if (bSmoothing) {
-		ofEnableSmoothing();
+		ofSetSmoothing(true);
 	} else {
-		ofDisableSmoothing();
+		ofSetSmoothing(false);
 	}
 	
 	// determine if we should bind a texture for our points to draw
@@ -137,7 +137,7 @@ void ofApp::draw() {
 		
 	}
 
-	ofDisablePointSprites();
+	ofSetPointSprites(false);
 
 	camera.end();
 	
@@ -145,7 +145,7 @@ void ofApp::draw() {
 	
 	// check to see if the points are
 	// sizing to the right size
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	camera.begin();
 	for (unsigned int i=0; i<points.size(); i++) {
 		ofSetColor(255, 80);

--- a/examples/gl/shaderExample/src/ofApp.cpp
+++ b/examples/gl/shaderExample/src/ofApp.cpp
@@ -4,7 +4,7 @@
 void ofApp::setup(){
 	ofBackground(34, 34, 34);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		
 	//we load a font and tell OF to make outlines so we can draw it as GL shapes rather than textures
 	font.load("type/verdana.ttf", 100, true, false, true, 0.4, 72);

--- a/examples/gl/shadowsExample/src/ofApp.cpp
+++ b/examples/gl/shadowsExample/src/ofApp.cpp
@@ -213,7 +213,7 @@ void ofApp::draw(){
 	ofDrawBitmapStringHighlight(ss.str(), 20, 20 );
 	
 	ofSetColor(255);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	
 }
 // create a renderScene() function so the same drawing can happen in both ofApp::draw()

--- a/examples/gl/textureExample/src/ofApp.cpp
+++ b/examples/gl/textureExample/src/ofApp.cpp
@@ -66,9 +66,9 @@ void ofApp::draw(){
 	// 	blending had to be enabled 
 	// 	for transparency to work:
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	texColorAlpha.draw(250,200,w,h);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 }
 

--- a/examples/gl/transformFeedbackAnimatedExample/src/ofApp.cpp
+++ b/examples/gl/transformFeedbackAnimatedExample/src/ofApp.cpp
@@ -144,7 +144,7 @@ void ofApp::draw(){
 	ofDrawGridPlane(100, 10);
 	ofPopMatrix();
 	
-	ofEnablePointSprites();
+	ofSetPointSprites(true);
 	shaderRender.begin();
 	shaderRender.setUniformTexture("tex", dotTexture, 0);
 	shaderRender.setUniform1f("uElapsedTime", ofGetElapsedTimef() );
@@ -156,7 +156,7 @@ void ofApp::draw(){
 	
 	vbos[bufferIndex]->draw(GL_POINTS, 0, numVertices);
 	shaderRender.end();
-	ofDisablePointSprites();
+	ofSetPointSprites(false);
 	
 	cam.end();
 	// swap the buffer index

--- a/examples/gl/transformFeedbackExample/src/ofApp.cpp
+++ b/examples/gl/transformFeedbackExample/src/ofApp.cpp
@@ -61,11 +61,11 @@ void ofApp::update(){
 void ofApp::draw(){
 	ofEnableDepthTest();
 	cam.begin();
-	ofEnablePointSprites();
+	ofSetPointSprites(true);
 	renderShader.begin();
 	vbo.draw(GL_POINTS, 0, numVertices);
 	renderShader.end();
-	ofDisablePointSprites();
+	ofSetPointSprites(false);
 	cam.end();
 }
 

--- a/examples/gl/vboMeshDrawInstancedExample/src/ofApp.cpp
+++ b/examples/gl/vboMeshDrawInstancedExample/src/ofApp.cpp
@@ -88,7 +88,7 @@ void ofApp::draw(){
 	ofEnableDepthTest();
 	// we don't care about alpha blending in this example, and by default alpha blending is on in openFrameworks > 0.8.0
 	// so we de-activate it for now.
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 	ofBackgroundGradient(ofColor(18,33,54), ofColor(18,22,28));
 	
@@ -118,7 +118,7 @@ void ofApp::draw(){
 	ofSetColor(ofColor::white);
 	ofDrawBitmapString("Use mouse to move camera.\nPress 'f' to toggle fullscreen;\nSPACEBAR to reload shader.", 10, 20);
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	
 	
 }

--- a/examples/gl/viewportExample/src/ofApp.cpp
+++ b/examples/gl/viewportExample/src/ofApp.cpp
@@ -21,7 +21,7 @@
 void ofApp::setup(){
 	ofBackground(90);
 	randomizeViewports();
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 }
 
 //--------------------------------------------------------------

--- a/examples/gles/customEGLWindowSettingsExample/src/ofApp.cpp
+++ b/examples/gles/customEGLWindowSettingsExample/src/ofApp.cpp
@@ -30,9 +30,9 @@ void ofApp::draw() {
 	ofPushMatrix();
 	ofTranslate(ofGetWidth()/2.0f,ofGetHeight()/2.0f);
 	ofRotateZDeg(angle);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	rpiLogo.draw(-rpiLogo.getWidth()/2.0f,-rpiLogo.getHeight()/2.0f);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	ofPopMatrix();
 
 	// draw the mouse

--- a/examples/graphics/colorExample/src/ofApp.cpp
+++ b/examples/graphics/colorExample/src/ofApp.cpp
@@ -4,8 +4,8 @@
 //--------------------------------------------------------------
 void ofApp::setup(){
 	ofBackground(0,0,0);
-	ofEnableSmoothing();
-	ofEnableAlphaBlending();
+	ofSetSmoothing(true);
+	ofSetAlphaBlending(true);
 	ofSetWindowTitle("color example");
 
 	ofSetRectMode(OF_RECTMODE_CENTER);

--- a/examples/graphics/colorsExtendedExample/src/ofApp.cpp
+++ b/examples/graphics/colorsExtendedExample/src/ofApp.cpp
@@ -188,7 +188,7 @@ void ofApp::setup(){
 
 	ofSetVerticalSync(true);
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 
 	sortedType = 1; // by name, at the start

--- a/examples/graphics/graphicsExample/README.md
+++ b/examples/graphics/graphicsExample/README.md
@@ -11,7 +11,7 @@ In the code, pay attention to:
 * different commands for setting the active color, such as ```ofSetColor()``` and ```ofSetHexColor()```. These commands set the color for subsequent drawing operations, including lines and fills.
 * toggling transparency, with ```ofEnableAlphaBlending()``` and ```ofDisableAlphaBlending()```
 * toggling of shape fills, with ```ofFill()``` and ```ofNoFill()```
-* toggling the anti-aliasing of lines, with ```ofEnableAntiAliasing()``` and ```ofDisableAntiAliasing()```
+* toggling the anti-aliasing of lines, with ```ofSetAntiAliasing()```
 * rendering bitmap text to the screen, with ```ofDrawBitmapString()```.
 
 ### Expected Behavior

--- a/examples/graphics/graphicsExample/src/ofApp.cpp
+++ b/examples/graphics/graphicsExample/src/ofApp.cpp
@@ -57,12 +57,12 @@ void ofApp::draw(){
 	ofSetHexColor(0x00FF33);
 	ofDrawRectangle(400,350,100,100);
 	// alpha is usually turned off - for speed puposes.  let's turn it on!
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255,0,0,127);   // red, 50% transparent
 	ofDrawRectangle(450,430,100,33);
 	ofSetColor(255,0,0,(int)(counter * 10.0f) % 255);   // red, variable transparent
 	ofDrawRectangle(450,370,100,33);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("transparency", 410,500);
@@ -86,11 +86,7 @@ void ofApp::keyPressed  (int key){
 	// the key of s toggles antialiasing
 	if (key == 's'){
 		bSmooth = !bSmooth;
-		if (bSmooth){
-			ofEnableAntiAliasing(); 
-		}else{
-			ofDisableAntiAliasing(); 
-		}
+		ofSetAntiAliasing(bSmooth);
 	}
 }
 

--- a/examples/graphics/polygonExample/src/ofApp.cpp
+++ b/examples/graphics/polygonExample/src/ofApp.cpp
@@ -195,7 +195,7 @@ void ofApp::draw(){
 	
 	
 	// show a faint the non-curve version of the same polygon:
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofNoFill();
 		ofSetColor(0,0,0,40);
 		ofBeginShape();
@@ -211,7 +211,7 @@ void ofApp::draw(){
 			else ofNoFill();
 			ofDrawCircle(curveVertices[i].x, curveVertices[i].y,4);
 		}
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	//-------------------------------------
 	
 	
@@ -243,14 +243,14 @@ void ofApp::draw(){
 	ofEndShape();
 	
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofFill();
 		ofSetColor(0,0,0,40);
 		ofDrawCircle(x0,y0,4);
 		ofDrawCircle(x1,y1,4);
 		ofDrawCircle(x2,y2,4);
 		ofDrawCircle(x3,y3,4);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 	
 	

--- a/examples/graphics/rectangleAlignmentAndScalingExample/src/ofApp.cpp
+++ b/examples/graphics/rectangleAlignmentAndScalingExample/src/ofApp.cpp
@@ -21,7 +21,7 @@ void ofApp::setup(){
 	// aspect-ratio preservation modes.
 
 	ofSetFrameRate(30);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 	isScaling = false;
 	isAligning = true;

--- a/examples/gui/parameterGroupExample/src/ofApp.cpp
+++ b/examples/gui/parameterGroupExample/src/ofApp.cpp
@@ -16,7 +16,7 @@ void ofApp::setup(){
 	gui.loadFromFile("settings.xml");
 
 	font.load("frabk.ttf",9,true,true);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 }
 
 void ofApp::vSyncChanged(bool & vSync){

--- a/examples/input_output/imageLoaderExample/src/ofApp.cpp
+++ b/examples/input_output/imageLoaderExample/src/ofApp.cpp
@@ -32,10 +32,10 @@ void ofApp::draw(){
 	tdfSmall.draw(200, 300);
 	
 	ofSetColor(255);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	float wave = sin(ofGetElapsedTimef());
 	transparency.draw(500 + (wave * 100), 20);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 	// getting the ofColors from an image,
 	// using the brightness to draw circles

--- a/examples/input_output/xmlExample/src/ofApp.cpp
+++ b/examples/input_output/xmlExample/src/ofApp.cpp
@@ -111,10 +111,10 @@ void ofApp::draw(){
 	//--------
 	//we make a black area on the left
 	//which we can print the xml text on
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 200);
 	ofDrawRectangle(0, 0, 160, ofGetHeight());
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	//our text that shows how the <STROKE> data looks in the xml file
 	ofSetColor(240, 240, 240);
@@ -123,7 +123,7 @@ void ofApp::draw(){
 	ttf.drawString(drawString, 5, 10);
 
 	//the message bars at the top and bottom of the app
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 200);
 
 	ofDrawRectangle(160, 0, ofGetWidth()-160, 20);

--- a/examples/input_output/xmlSettingsExample/src/ofApp.cpp
+++ b/examples/input_output/xmlSettingsExample/src/ofApp.cpp
@@ -117,10 +117,10 @@ void ofApp::draw(){
 	//--------
 	//we make a black area on the left
 	//which we can print the xml text on
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 200);
 	ofDrawRectangle(0, 0, 160, ofGetHeight());
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	//our text that shows how the <STROKE> data looks in the xml file
 	ofSetColor(240, 240, 240);
@@ -131,7 +131,7 @@ void ofApp::draw(){
 
 	//the message bars at the top and bottom of the app
 	//ofSetHexColor(0xDDDDDD);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 200);
 
 	ofDrawRectangle(160, 0, ofGetWidth()-160, 20);

--- a/examples/ios/CoreLocationExample/src/ofApp.mm
+++ b/examples/ios/CoreLocationExample/src/ofApp.mm
@@ -28,7 +28,7 @@ void ofApp::draw(){
 	ofSetColor(54);
 	ofDrawBitmapString("Core Location Example", 8, 60);
 
-	ofEnableAlphaBlending();	
+	ofSetAlphaBlending(true);	
 	ofSetColor(255);
 		ofPushMatrix();
 		ofTranslate(160, 220, 0);

--- a/examples/ios/MapKitExample/src/ofApp.mm
+++ b/examples/ios/MapKitExample/src/ofApp.mm
@@ -16,7 +16,7 @@ void ofApp::setup(){
 	// dump lots of info to console (useful for debugging)
 	ofSetLogLevel(OF_LOG_VERBOSE);
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	
 	// load font for displaying info
 	font.load("verdana.ttf", 12);

--- a/examples/ios/advancedGraphicsExample/src/ofApp.mm
+++ b/examples/ios/advancedGraphicsExample/src/ofApp.mm
@@ -84,7 +84,7 @@ void ofApp::draw(){
 	}
 
 	//Lets stop the blending!
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	if(ofGetWidth() > 480){ // then we are running retina
 		ofScale(2, 2, 0);
@@ -104,7 +104,7 @@ void ofApp::draw(){
 	//enable blending!
 	//We are going to use a blend mode that adds
 	//all the colors to white.
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	glBlendFunc(GL_ONE, GL_ONE);
 
 	//---------------------------------
@@ -138,7 +138,7 @@ void ofApp::draw(){
 	//LISSAJOUS EXAMPLE
 	//http://en.wikipedia.org/wiki/Lissajous_curve
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 
 	float x = 0;
 	float y = 0;

--- a/examples/ios/graphicsExample/src/ofApp.mm
+++ b/examples/ios/graphicsExample/src/ofApp.mm
@@ -54,12 +54,12 @@ void ofApp::draw(){
 	ofSetHexColor(0x00FF33);
 	ofDrawRectangle(400,350,100,100);
 	// alpha is usually turned off - for speed puposes.  let's turn it on!
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255,0,0,127);   // red, 50% transparent
 	ofDrawRectangle(450,430,100,33);
 	ofSetColor(255,0,0,(int)(counter * 10.0f) % 255);   // red, variable transparent
 	ofDrawRectangle(450,370,100,33);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	ofSetHexColor(0x000000);
 	ofDrawBitmapString("transparency", 410,500);
@@ -68,7 +68,7 @@ void ofApp::draw(){
 	// a bunch of red lines, make them smooth if the flag is set
 
 	if (bSmooth){
-		ofEnableSmoothing();
+		ofSetSmoothing(true);
 	}
 
 	ofSetHexColor(0xFF0000);
@@ -77,7 +77,7 @@ void ofApp::draw(){
 	}
 
 	if (bSmooth){
-		ofDisableSmoothing();
+		ofSetSmoothing(false);
 	}
 
 	ofSetHexColor(0x000000);

--- a/examples/ios/imageLoaderExample/src/ofApp.mm
+++ b/examples/ios/imageLoaderExample/src/ofApp.mm
@@ -35,9 +35,9 @@ void ofApp::draw(){
 	tdfSmall.draw(200,300);
 	
 	ofSetHexColor(0xFFFFFF);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	transparency.draw(sin(ofGetElapsedTimeMillis()/1000.0f) * 100 + 500,20);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 	ofSetHexColor(0x000000);
 	

--- a/examples/ios/iosCoreMotionLegacyExample/src/ofApp.mm
+++ b/examples/ios/iosCoreMotionLegacyExample/src/ofApp.mm
@@ -40,7 +40,7 @@ void ofApp::draw() {
 
 	float angle = 180.0 - glm::degrees( atan2(accelerometerData.y, accelerometerData.x) );
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255);
 	ofPushMatrix();
 		ofTranslate(ofGetWidth()/2, ofGetHeight()/2, 0);

--- a/examples/ios/iosES2ShaderExample/src/ofApp.mm
+++ b/examples/ios/iosES2ShaderExample/src/ofApp.mm
@@ -4,7 +4,7 @@
 void ofApp::setup(){
 	ofBackground(40);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetLogLevel(OF_LOG_VERBOSE);
 	
 	shader.load("shaders/noise.vert", "shaders/noise.frag");

--- a/examples/ios/iosES3ShaderExample/src/ofApp.mm
+++ b/examples/ios/iosES3ShaderExample/src/ofApp.mm
@@ -4,7 +4,7 @@
 void ofApp::setup(){
 	ofBackground(80);
 	ofSetVerticalSync(false);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetLogLevel(OF_LOG_VERBOSE);
 	
 	shader.load("shaders/noise.vert", "shaders/noise.frag");

--- a/examples/ios/iosExternalDisplayExample/src/ofApp.mm
+++ b/examples/ios/iosExternalDisplayExample/src/ofApp.mm
@@ -36,7 +36,7 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
 
-	ofDisableSmoothing();
+	ofSetSmoothing(false);
 	ofSetLineWidth(2);
 
 	ofPoint p1;

--- a/examples/ios/opencvFaceExample/src/ofApp.mm
+++ b/examples/ios/opencvFaceExample/src/ofApp.mm
@@ -72,7 +72,7 @@ void ofApp::draw(){
 		}
 	ofPopStyle();
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(230, 0, 255, 200);
 	ofDrawRectangle(0, 0, ofGetWidth(), 16);
 	ofSetColor(255, 255, 255);

--- a/examples/ios/polygonExample/src/ofApp.mm
+++ b/examples/ios/polygonExample/src/ofApp.mm
@@ -207,7 +207,7 @@ void ofApp::draw(){
 	
 	
 	// show a faint the non-curve version of the same polygon:
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofNoFill();
 		ofSetColor(0,0,0,40);
 		ofBeginShape();
@@ -223,7 +223,7 @@ void ofApp::draw(){
 			else ofNoFill();
 			ofDrawCircle(curveVertices[i].x, curveVertices[i].y,4);
 		}
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	//-------------------------------------
 	
 	
@@ -255,14 +255,14 @@ void ofApp::draw(){
 	ofEndShape();
 	
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofFill();
 		ofSetColor(0,0,0,40);
 		ofDrawCircle(x0,y0,4);
 		ofDrawCircle(x1,y1,4);
 		ofDrawCircle(x2,y2,4);
 		ofDrawCircle(x3,y3,4);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 	
 	

--- a/examples/ios/textureExample/src/ofApp.mm
+++ b/examples/ios/textureExample/src/ofApp.mm
@@ -76,9 +76,9 @@ void ofApp::draw(){
 	// 	blending had to be enabled 
 	// 	for transparency to work:
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	texColorAlpha.draw(250,200,w,h);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 	
 }
 

--- a/examples/ios/vboExample/src/ofApp.mm
+++ b/examples/ios/vboExample/src/ofApp.mm
@@ -90,7 +90,7 @@ void ofApp::draw() {
 	
 	
 	// the lines
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(255, 255, 255);
 	vbo.bind();
 	vbo.updateVertexData(pos, total);

--- a/examples/ios/xmlSettingsExample/src/ofApp.mm
+++ b/examples/ios/xmlSettingsExample/src/ofApp.mm
@@ -109,7 +109,7 @@ void ofApp::draw(){
 
 	string drawString = "How the data is stored:\n\n";
 	if(xmlStructure.size() > 0){
-		ofEnableAlphaBlending();
+		ofSetAlphaBlending(true);
 		ofSetColor(255-red, 255-green, 255-blue, 180);
 		drawString += xmlStructure+"</STROKE>";
 		TTF.drawString(drawString, 5, 60);
@@ -129,7 +129,7 @@ void ofApp::draw(){
 
 	//the message bars at the top and bottom of the app
 	//ofSetHexColor(0xDDDDDD);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(0, 0, 0, 200);
 
 	ofDrawRectangle(0, 0, ofGetWidth(), 36);

--- a/examples/math/noise1dExample/src/ofApp.cpp
+++ b/examples/math/noise1dExample/src/ofApp.cpp
@@ -82,8 +82,8 @@ void ofApp::renderNoisyRobotArmDemo(){
 	float noisyG = ofNoise(t * 0.73); // guarantee that our color channels are
 	float noisyB = ofNoise(t * 0.81); // not all (apparently) synchronized.
 
-	ofEnableSmoothing();
-	ofEnableAlphaBlending();
+	ofSetSmoothing(true);
+	ofSetAlphaBlending(true);
 	ofSetCircleResolution(12);
 	ofSetLineWidth(1.0);
 
@@ -172,8 +172,8 @@ void ofApp::renderRadialSignedNoiseDemo (){
 	// the noise as radial displacements to a circle.
 	ofPushMatrix();
 	ofTranslate(centerX + radialNoiseDemoR,centerY,0);
-	ofEnableAlphaBlending();
-	ofEnableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(true);
 	ofNoFill();
 
 	// Draw a faint plain circle, so that we can better understand
@@ -206,7 +206,7 @@ void ofApp::renderRadialSignedNoiseDemo (){
 	}
 
 	// draw the "mesh" (line)
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	wigglyMeshLine.draw();
 
 	// draw a little ball at the end
@@ -225,8 +225,8 @@ void ofApp::renderLinearSignedNoiseDemo(){
 
 	float drawWiggleWidth = radialNoiseDemoR*glm::two_pi<float>();
 	ofTranslate (radialNoiseDemoX + radialNoiseDemoR - drawWiggleWidth, radialNoiseDemoY-radialNoiseDemoR,0);
-	ofEnableAlphaBlending();
-	ofEnableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(true);
 	ofNoFill();
 
 	// draw a "baseline"

--- a/examples/math/noise1dExample/src/ofxSimpleSlider.cpp
+++ b/examples/math/noise1dExample/src/ofxSimpleSlider.cpp
@@ -67,8 +67,8 @@ void ofxSimpleSlider::setLabelString (string str){
 //----------------------------------------------------
 void ofxSimpleSlider::draw(ofEventArgs& event){
 	
-	ofEnableAlphaBlending();
-	ofDisableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(false);
 	ofPushMatrix();
 	ofTranslate(x,y,0);
 	
@@ -123,7 +123,7 @@ void ofxSimpleSlider::draw(ofEventArgs& event){
 	
 	ofPopMatrix();
 	ofSetLineWidth(1.0);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 }
 
 //----------------------------------------------------

--- a/examples/math/noise1dOctaveExample/src/ofApp.cpp
+++ b/examples/math/noise1dOctaveExample/src/ofApp.cpp
@@ -164,8 +164,8 @@ void ofApp::renderMultibandNoiseDemo(){
 void ofApp::render1DNoiseStrip (float x, float y, float width, float height, float dt, float *data){
 	
 	ofPushMatrix();
-	ofDisableSmoothing();
-	ofEnableAlphaBlending();
+	ofSetSmoothing(false);
+	ofSetAlphaBlending(true);
 	ofTranslate(x, y, 0); 
 	
 	// Yes, this is a drop shadow
@@ -180,7 +180,7 @@ void ofApp::render1DNoiseStrip (float x, float y, float width, float height, flo
 	ofDrawRectangle(0,0, width, height); 
 	
 	// Draw a filled gray noise terrain.
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 	ofFill();
 	ofSetColor(190); 
 	ofBeginShape();
@@ -205,7 +205,7 @@ void ofApp::render1DNoiseStrip (float x, float y, float width, float height, flo
 	ofEndShape(false);
 	
 	// Draw a box outline on top, around everything
-	ofDisableSmoothing();
+	ofSetSmoothing(false);
 	ofNoFill();
 	ofSetColor(0,0,0); 
 	ofDrawRectangle(0,0, width, height);

--- a/examples/math/noise1dOctaveExample/src/ofxSimpleSlider.cpp
+++ b/examples/math/noise1dOctaveExample/src/ofxSimpleSlider.cpp
@@ -67,8 +67,8 @@ void ofxSimpleSlider::setLabelString (string str){
 //----------------------------------------------------
 void ofxSimpleSlider::draw(ofEventArgs& event){
 	
-	ofEnableAlphaBlending();
-	ofDisableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(false);
 	ofPushMatrix();
 	ofTranslate(x,y,0);
 	
@@ -123,7 +123,7 @@ void ofxSimpleSlider::draw(ofEventArgs& event){
 	
 	ofPopMatrix();
 	ofSetLineWidth(1.0);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 }
 
 //----------------------------------------------------

--- a/examples/math/noiseField2dExample/src/ofApp.cpp
+++ b/examples/math/noiseField2dExample/src/ofApp.cpp
@@ -41,7 +41,7 @@ glm::vec2 ofApp::getField(const glm::vec2& position) {
 //--------------------------------------------------------------
 void ofApp::setup() {
 	ofSetVerticalSync(true); // don't go too fast
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	
 	// randomly allocate the points across the screen
   points.resize(nPoints);

--- a/examples/math/periodicSignalsExample/src/ofApp.cpp
+++ b/examples/math/periodicSignalsExample/src/ofApp.cpp
@@ -23,7 +23,7 @@ void ofApp::setup(){
 	freq.setLabelString("frequency (hz)");
 	
 	ofSetVerticalSync(true);
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 	ofSetColor(20);
 	
 	preSpeed = speed.getValue();
@@ -93,12 +93,12 @@ void ofApp::draw(){
 	ofDrawLine(ofGetWidth()-rightMargin,0,ofGetWidth()-rightMargin,ofGetHeight());
 
 	for(int i=0;i<(int)trail.size();i++){
-		ofEnableSmoothing();
+		ofSetSmoothing(true);
 		ofDrawCircle(x,y[i],radius);
 		trail[i].draw();
 
 
-		ofDisableSmoothing();
+		ofSetSmoothing(false);
 		ofDrawLine(0,60*(i+2),ofGetWidth(),60*(i+2));
 
 		float rectY = 60*(i+2);

--- a/examples/math/periodicSignalsExample/src/ofxSimpleSlider.cpp
+++ b/examples/math/periodicSignalsExample/src/ofxSimpleSlider.cpp
@@ -68,8 +68,8 @@ void ofxSimpleSlider::setLabelString (string str){
 void ofxSimpleSlider::draw(ofEventArgs& event){
 	
 	ofPushStyle();
-	ofEnableAlphaBlending();
-	ofDisableSmoothing();
+	ofSetAlphaBlending(true);
+	ofSetSmoothing(false);
 	ofPushMatrix();
 	ofTranslate(x,y,0);
 	

--- a/examples/math/trigonometricMotionExample/src/ofApp.cpp
+++ b/examples/math/trigonometricMotionExample/src/ofApp.cpp
@@ -30,8 +30,8 @@ void ofApp::setup(){
 	bSelectedOscHor = false;
 	bSelectedOscVert = false;
 
-	ofEnableSmoothing();
-	ofEnableAlphaBlending();
+	ofSetSmoothing(true);
+	ofSetAlphaBlending(true);
 	ofSetVerticalSync(true);
 }
 
@@ -69,7 +69,7 @@ void ofApp::draw(){
 
 
 
-	ofEnableSmoothing();
+	ofSetSmoothing(true);
 
 	//This are just the reference lines draw in the screen.
 	ofSetColor(0, 0, 0, 150);

--- a/examples/sound/soundPlayerFFTExample/src/ofApp.cpp
+++ b/examples/sound/soundPlayerFFTExample/src/ofApp.cpp
@@ -76,10 +76,10 @@ void ofApp::update(){
 void ofApp::draw(){
 
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofSetColor(255,255,255,100);
 		ofDrawRectangle(100,ofGetHeight()-300,5*128,200);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	// draw the fft resutls:
 	ofSetColor(255,255,255,255);
@@ -93,10 +93,10 @@ void ofApp::draw(){
 
 	// finally draw the playing circle:
 
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 		ofSetColor(255,255,255,20);
 		ofDrawCircle(px, py,50);
-	ofDisableAlphaBlending();
+	ofSetAlphaBlending(false);
 
 	ofSetHexColor(0xffffff);
 	ofDrawCircle(px, py,8);

--- a/examples/video/asciiVideoExample/src/ofApp.cpp
+++ b/examples/video/asciiVideoExample/src/ofApp.cpp
@@ -18,7 +18,7 @@ void ofApp::setup(){
 	// changed order slightly to work better for mapping
 	asciiCharacters =  string("  ..,,,'''``--_:;^^**""=+<>iv%&xclrs)/){}I?!][1taeo7zjLunT#@JCwfy325Fp6mqSghVd4EgXPGZbYkOA8U$KHDBWNMR0Q");
 	
-	ofEnableAlphaBlending();
+	ofSetAlphaBlending(true);
 }
 
 

--- a/examples/video/slitscanRadialClockExample/src/ofApp.cpp
+++ b/examples/video/slitscanRadialClockExample/src/ofApp.cpp
@@ -55,7 +55,7 @@ void ofApp::setup(){
     videoTexture.allocate(videoPixels);
     
     ofSetBackgroundColor(0, 0, 0); // set the background colour to dark black
-    ofDisableSmoothing();
+    ofSetSmoothing(false);
     
     // set start time from system time
     seconds = ofGetSeconds();

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -637,16 +637,15 @@ void ofEnableBlendMode(ofBlendMode blendMode){
 }
 
 //----------------------------------------------------------
-void ofEnablePointSprites() {
+void ofSetPointSprites(bool pointSprites) {
 	if (ofGetCurrentRenderer()->getType() == "GL" || ofGetCurrentRenderer()->getType() == "ProgrammableGL") {
-		static_cast<ofBaseGLRenderer *>(ofGetCurrentRenderer().get())->enablePointSprites();
-	}
-}
-
-//----------------------------------------------------------
-void ofDisablePointSprites() {
-	if (ofGetCurrentRenderer()->getType() == "GL" || ofGetCurrentRenderer()->getType() == "ProgrammableGL") {
-		static_cast<ofBaseGLRenderer *>(ofGetCurrentRenderer().get())->disablePointSprites();
+		auto renderer = static_cast<ofBaseGLRenderer *>(ofGetCurrentRenderer().get());
+		if (pointSprites) {
+			renderer->enablePointSprites();
+		}
+		else {
+			renderer->disablePointSprites();
+		}
 	}
 }
 
@@ -656,25 +655,15 @@ void ofDisableBlendMode() {
 }
 
 //----------------------------------------------------------
-void ofEnableAlphaBlending() {
-	ofEnableBlendMode(OF_BLENDMODE_ALPHA);
+void ofSetAlphaBlending(bool blending) {
+	blending ? ofEnableBlendMode(OF_BLENDMODE_ALPHA) : ofDisableBlendMode();
 }
 
 //----------------------------------------------------------
-void ofDisableAlphaBlending() {
-	ofDisableBlendMode();
-}
-
-//----------------------------------------------------------
-void ofEnableSmoothing() {
+void ofSetSmoothing(bool smoothing) {
 	// please see:
 	// http://www.opengl.org/resources/faq/technical/rasterization.htm
-	ofGetCurrentRenderer()->setLineSmoothing(true);
-}
-
-//----------------------------------------------------------
-void ofDisableSmoothing() {
-	ofGetCurrentRenderer()->setLineSmoothing(false);
+	ofGetCurrentRenderer()->setLineSmoothing(smoothing);
 }
 
 //----------------------------------------------------------
@@ -683,13 +672,9 @@ void ofSetPolyMode(ofPolyWindingMode mode) {
 }
 
 //----------------------------------------
-void ofEnableAntiAliasing() {
-	ofGetCurrentRenderer()->enableAntiAliasing();
-}
-
-//----------------------------------------
-void ofDisableAntiAliasing() {
-	ofGetCurrentRenderer()->disableAntiAliasing();
+void ofSetAntiAliasing(bool antialiasing) {
+	auto renderer = ofGetCurrentRenderer();
+	antialiasing ? renderer->enableAntiAliasing() : renderer->disableAntiAliasing();
 }
 
 //----------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphics.h
+++ b/libs/openFrameworks/graphics/ofGraphics.h
@@ -44,10 +44,10 @@ void ofSetColor(int r, int g, int b);
 ///
 /// ~~~~{.cpp}
 /// void ofApp::draw(){
-///     ofEnableAlphaBlending();    // turn on alpha blending
+///     ofSetAlphaBlending(true);    // turn on alpha blending
 ///     ofSetColor(255,0,0,127);    // red, 50% transparent
 ///     ofDrawRectangle(20,20,100,100);
-///     ofDisableAlphaBlending();   // turn it back off, if you don't need it
+///     ofSetAlphaBlending(false);   // turn it back off, if you don't need it
 /// }
 /// ~~~~
 void ofSetColor(int r, int g, int b, int a);
@@ -846,57 +846,35 @@ void ofEnableBlendMode(ofBlendMode blendMode);
 /// \brief Disable the current blend mode.
 void ofDisableBlendMode();
 
-/// \brief Turn on point sprite.
+/// \brief Set point sprite.
 ///
 /// Textures can be mapped onto points. By default, point size is 1pt. So
 /// texture is not shown correctly. You can change point size by
-/// `glPointSize(GLfloat size).
-void ofEnablePointSprites();
+/// `glPointSize(GLfloat size)`.
+void ofSetPointSprites(bool pointSprites);
 
-/// \brief Turn off point sprites
-void ofDisablePointSprites();
-
-/// \brief Turns on alpha blending (which is on by default since OF version 0.8.0).
+/// \brief Sets whether or not to use alpha blending (which is on by default since OF version 0.8.0).
 /// It simply wraps opengl commands that enable blending, and turn on a common
 /// blend mode.
 ///
 /// ~~~~{.cpp}
 /// void ofApp::draw(){
-///     ofEnableAlphaBlending();    // turn on alpha blending
+///     ofSetAlphaBlending(true);    // turn on alpha blending
 ///     ofSetColor(255,0,0,127);    // red, 50% transparent
 ///     ofDrawRectangle(20,20,100,100);      // draws the rect with alpha
-///     ofDisableAlphaBlending();   // turn off alpha
+///     ofSetAlphaBlending(false);   // turn off alpha
 ///     ofDrawRectangle(120,20,100,100);     // draws the rect without alpha
 /// }
 /// ~~~~
-void ofEnableAlphaBlending(); // this just turns on and off opengl blending, the common mode
+void ofSetAlphaBlending(bool blending); // this just turns on and off opengl blending, the common mode
 
-/// \brief Turn off alpha blending.
-/// ~~~~{.cpp}
-/// void ofApp::draw(){
-///     ofEnableAlphaBlending();    // turn on alpha blending
-///     ofSetColor(255,0,0,127);    // red, 50% transparent
-///     ofDrawRectangle(20,20,100,100);      // draws the rect with alpha
-///     ofDisableAlphaBlending();   // turn off alpha
-///     ofDrawRectangle(120,20,100,100); // draws the rect without alpha
-/// }
-/// ~~~~
-///
-/// \sa ofEnableAlphaBlending()
-void ofDisableAlphaBlending();
-
-void ofEnableSmoothing();
-
-/// \brief Turn off smoothing. Currently, this only works for lines. You can draw a
+/// \brief Set whether or not to do smoothing. Currently, this only works for lines. You can draw a
 /// filled object, and then draw the outline with smoothing enabled to get
 /// smoothing effects on filled shapes.
-void ofDisableSmoothing();
+void ofSetSmoothing(bool smoothing);
 
-/// Enables anti-aliasing (smoothing) for lines.
-void ofEnableAntiAliasing();
-
-/// \brief Turns off anti-aliasing (smoothing).
-void ofDisableAntiAliasing();
+/// Set anti-aliasing (smoothing) for lines.
+void ofSetAntiAliasing(bool antialiasing);
 
 // drawing style - combines color, fill, blending and smoothing
 ofStyle ofGetStyle();


### PR DESCRIPTION
Previously these were set with `ofEnable[property]` or `ofDisable[property]`. I have changed that so they're now set with a bool, which I feel most users will prefer. All the examples have also been updated, and this code has been tested.
Failed to mention in the commit message but point sprites have also been changed to a bool set function