### PR TITLE
Forward addon -std=* from ADDON_CFLAGS into CXXFLAGS

### DIFF
--- a/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.project.mk
@@ -365,7 +365,16 @@ OF_PROJECT_CFLAGS += $(PROJECT_CFLAGS)
 OF_PROJECT_CFLAGS += $(PROJECT_ADDONS_CFLAGS)
 OF_PROJECT_CFLAGS += $(USER_CFLAGS) # legacy
 OF_PROJECT_CFLAGS += $(OF_PROJECT_DEFINES_CFLAGS)
-OF_PROJECT_CXXFLAGS = $(OF_CORE_BASE_CXXFLAGS)
+_addon_std_flags := $(filter -std=%,$(PROJECT_ADDONS_CFLAGS))
+ifneq ($(_addon_std_flags),)
+	# Forward addon -std=* into CXXFLAGS (ADDON_CFLAGS only land in CFLAGS today).
+	OF_PROJECT_CFLAGS := $(filter-out -std=%,$(OF_PROJECT_CFLAGS))
+	OF_PROJECT_CFLAGS += $(lastword $(_addon_std_flags))
+	OF_PROJECT_CXXFLAGS := $(filter-out -std=%,$(OF_CORE_BASE_CXXFLAGS))
+	OF_PROJECT_CXXFLAGS += $(lastword $(_addon_std_flags))
+else
+	OF_PROJECT_CXXFLAGS = $(OF_CORE_BASE_CXXFLAGS)
+endif
 
 
 ################################################################################


### PR DESCRIPTION
Forward addon -std=* from ADDON_CFLAGS into CXXFLAGS
ADDON_CFLAGS are merged into OF_PROJECT_CFLAGS only, so addon
-std=gnu++20 (etc.) never reached C++ builds. Extract -std flags
from PROJECT_ADDONS_CFLAGS, dedupe against core flags, and apply
the last addon value to both CFLAGS and CXXFLAGS.