### PR TITLE
Fix native iOS view controller startup

### DIFF
--- a/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSEAGLView.mm
@@ -99,7 +99,10 @@ static ofxiOSEAGLView * _instanceRef = nil;
 
         window = dynamic_pointer_cast<ofAppiOSWindow>(ofCreateWindow(windowSettings));
 
-        ofRunApp(app);
+        // UIKit already owns the application loop when a custom app delegate
+        // installs this view. Register the app with the recreated window
+        // without starting the main loop again.
+        ofRunApp(window, std::static_pointer_cast<ofBaseApp>(app));
     }
     
     if(window->isProgrammableRenderer() == true) {

--- a/addons/ofxiOS/src/core/ofxiOSGLKView.mm
+++ b/addons/ofxiOS/src/core/ofxiOSGLKView.mm
@@ -99,7 +99,10 @@ static ofxiOSGLKView * _instanceRef = nil;
 
         window = dynamic_pointer_cast<ofAppiOSWindow>(ofCreateWindow(windowSettings));
 
-        ofRunApp(app);
+        // UIKit already owns the application loop when a custom app delegate
+        // installs this view. Register the app with the recreated window
+        // without starting the main loop again.
+        ofRunApp(window, std::static_pointer_cast<ofBaseApp>(app));
     }
     
     if(window->isProgrammableRenderer() == true) {


### PR DESCRIPTION
## Summary

Fixes openFrameworks apps embedded in a native UIKit view-controller hierarchy through a custom app delegate.

When `startAppWithDelegate()` is used with `ofxiOSViewController` or `ofxiOSGLKViewController`, the embedded app is removed from the main loop immediately after registration and does not receive `setup()`, `update()`, or `draw()` callbacks.

## Cause

The view recreates the OF main loop and window, then registers the embedded app with:

```cpp
ofRunApp(app);
```

This overload also calls `ofRunMainLoop()`. Since `UIApplicationMain` is already running, `startAppWithDelegate()` returns immediately through its `bAppCreated` guard.

Since #8148, returning from the window loop calls `ofMainLoop::exit()`, which removes the app and its listeners.

## Fix

Register the app with the recreated window without starting the main loop again:

```cpp
ofRunApp(window, std::static_pointer_cast<ofBaseApp>(app));
```

The same change is applied to the EAGL and GLK implementations.

The standard iOS startup path is unaffected because it does not enter this code path.

## Testing

- Reproduced on a physical iPhone with a minimal custom-app-delegate test using `ofxiOSViewController`. Before the fix, UIKit installs the view controller but no OF callbacks are received. After the fix, `setup()`, `update()`, and `draw()` all run.
- Verified the GLK path with the same minimal setup on an iPhone 16 Pro (iOS 26.5.2) and an iOS 18.1 simulator.
- Runtime testing used openFrameworks 0.12.1. The PR is based on current `master`, where the affected code paths are unchanged.
- tvOS shares these view implementations but was not runtime-tested.