### PR TITLE
fix(gl): derive the GL index type from sizeof(ofIndexType) in indexed draws

### DIFF
--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -571,7 +571,8 @@ void ofGLProgrammableRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, 
 #ifdef TARGET_OPENGLES
 		glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void *)(sizeof(ofIndexType) * offsetelements));
 #else
-		glDrawElements(drawMode, amt, GL_UNSIGNED_INT, (void *)(sizeof(ofIndexType) * offsetelements));
+		// GL index type must match sizeof(ofIndexType) (16-bit on macOS via tess2); see commit message.
+		glDrawElements(drawMode, amt, sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void *)(sizeof(ofIndexType) * offsetelements));
 #endif
 		vbo.unbind();
 	}
@@ -610,7 +611,8 @@ void ofGLProgrammableRenderer::drawElementsInstanced(const ofVbo & vbo, GLuint d
 		#if defined(TARGET_OPENGLES)
 		glDrawElementsInstanced(drawMode, amt, GL_UNSIGNED_SHORT, nullptr, primCount);
 		#else
-		glDrawElementsInstanced(drawMode, amt, GL_UNSIGNED_INT, nullptr, primCount);
+		// GL index type must match sizeof(ofIndexType); see drawElements above.
+		glDrawElementsInstanced(drawMode, amt, sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, nullptr, primCount);
 		#endif
 #endif
 		vbo.unbind();

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -121,7 +121,8 @@ void ofGLRenderer::draw(const ofMesh & vertexData, ofPolyRenderMode renderType, 
 	#ifdef TARGET_OPENGLES
 		glDrawElements(ofGetGLPrimitiveMode(vertexData.getMode()), vertexData.getNumIndices(), GL_UNSIGNED_SHORT, vertexData.getIndexPointer());
 	#else
-		glDrawElements(ofGetGLPrimitiveMode(vertexData.getMode()), vertexData.getNumIndices(), GL_UNSIGNED_INT, vertexData.getIndexPointer());
+		// GL index type must match sizeof(ofIndexType); see ofGLProgrammableRenderer::drawElements.
+		glDrawElements(ofGetGLPrimitiveMode(vertexData.getMode()), vertexData.getNumIndices(), sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, vertexData.getIndexPointer());
 	#endif
 	} else {
 		glDrawArrays(ofGetGLPrimitiveMode(vertexData.getMode()), 0, vertexData.getNumVertices());
@@ -389,7 +390,8 @@ void ofGLRenderer::drawElements(const ofVbo & vbo, GLuint drawMode, int amt, int
 #ifdef TARGET_OPENGLES
 		glDrawElements(drawMode, amt, GL_UNSIGNED_SHORT, (void *)(sizeof(ofIndexType) * offsetelements));
 #else
-		glDrawElements(drawMode, amt, GL_UNSIGNED_INT, (void *)(sizeof(ofIndexType) * offsetelements));
+		// Index type follows sizeof(ofIndexType); see ofGLProgrammableRenderer::drawElements.
+		glDrawElements(drawMode, amt, sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void *)(sizeof(ofIndexType) * offsetelements));
 #endif
 		vbo.unbind();
 	}
@@ -423,7 +425,8 @@ void ofGLRenderer::drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int
 		ofLogWarning("ofVbo") << "drawElementsInstanced(): hardware instancing is not supported on OpenGL ES < 3.0";
 		// glDrawElementsInstanced(drawMode, amt, GL_UNSIGNED_SHORT, nullptr, primCount);
 #else
-		glDrawElementsInstanced(drawMode, amt, GL_UNSIGNED_INT, nullptr, primCount);
+		// Index type follows sizeof(ofIndexType); see ofGLProgrammableRenderer::drawElements.
+		glDrawElementsInstanced(drawMode, amt, sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, nullptr, primCount);
 #endif
 		vbo.unbind();
 	}


### PR DESCRIPTION
## Problem

On current macOS nightlies (verified against of_v20260730, macOS 26 / Apple silicon), every indexed VBO draw silently reads the index buffer with the wrong GL type, and instanced indexed draws (`ofVbo::drawElementsInstanced`) render garbage triangles or nothing at all, varying non-deterministically between launches and even between relinks of the same code.

## Cause

`ofIndexType` is `typedef TESSindex ofIndexType` (ofConstants.h), and the tess2 header shipped since apothecary [#552](https://github.com/openframeworks/apothecary/pull/552) picks its width with `#if defined(TARGET_OS_IPHONE) || …`. Apple's `TargetConditionals.h` defines **every** `TARGET_OS_*` macro on **every** Apple platform — as 1 or 0 — so on macOS `TARGET_OS_IPHONE` is defined as 0, the `defined()` test is true, and `TESSindex`/`ofIndexType` becomes `unsigned short`. (Apothecary [#558](https://github.com/openframeworks/apothecary/pull/558) later noticed Apple builds landing in the 16-bit branch, but guarded only the `__arm__`-family defines, which aren't defined on Apple arm64 — the actual trigger survived.)

Meanwhile the desktop branches of `drawElements` / `drawElementsInstanced` in both renderers hardcode `GL_UNSIGNED_INT`. `ofVbo` uploads `sizeof(ofIndexType) × count` bytes, so the draw reads **2× past the uploaded index buffer**: the first indices are misparsed short-pairs (out of range of the mesh), the rest are whatever follows in GPU memory — out-of-range vertex fetches that render as giant garbage triangles or degenerate/invisible ones depending on heap layout. No GL error is raised.

## Fix

Derive the GL index type from the compiled index width at the five desktop call sites:

```cpp
sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT
```

The ternary constant-folds, so there is no runtime cost, and the sites remain correct whatever width tess2 ends up giving `ofIndexType`. The GLES branches are untouched: every GLES platform lands in tess2's 16-bit branch, so their hardcoded `GL_UNSIGNED_SHORT` already matches.

A companion apothecary PR fixes the root-cause condition in `tess2.patch` itself: openframeworks/apothecary#561. Both fixes stand alone; this one keeps the renderers honest under either header, and the apothecary one also restores the full 32-bit index range for large meshes on macOS.

## Verification

- Reproduced on macOS 26 / Apple silicon with an instanced line renderer: 16-bit uploads (12-byte index buffer for a 6-index quad, confirmed via `GL_BUFFER_SIZE`) drawn with `GL_UNSIGNED_INT` produce garbage or missing geometry, flipping between relinks.
- With this patch, disassembly of both Release build systems (Xcode and makefile) shows the draw sites passing `GL_UNSIGNED_SHORT` (0x1403), matching the uploads; the renderer output is correct and stable across relinks.
- The pre-#552 tree (of_v20251123, 32-bit `ofIndexType`) is unaffected by the patch: the ternary folds to `GL_UNSIGNED_INT` there.
