### PR TITLE
GLFW Window Focus Fix

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -94,6 +94,7 @@ void ofAppGLFWWindow::close() {
 		glfwSetScrollCallback( windowP, nullptr );
 		glfwSetDropCallback( windowP, nullptr );
   	glfwSetWindowRefreshCallback(windowP, nullptr);
+		glfwSetWindowFocusCallback(windowP, nullptr);
 
 		//hide the window before we destroy it stops a flicker on OS X on exit.
 		glfwHideWindow(windowP);
@@ -411,6 +412,7 @@ void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings) {
         glfwSetScrollCallback(windowP, scroll_cb);
         glfwSetDropCallback(windowP, drop_cb);
         glfwSetWindowRefreshCallback(windowP, refresh_cb);
+        glfwSetWindowFocusCallback(windowP, focus_cb);
         
 #ifdef TARGET_LINUX
         XSetLocaleModifiers("");
@@ -1626,6 +1628,12 @@ void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings) {
     }
     
     //------------------------------------------------------------
+    void ofAppGLFWWindow::focus_cb(GLFWwindow * windowP_, int focused) {
+        ofAppGLFWWindow * instance = setCurrent(windowP_);
+        instance->bWindowFocused = focused == GLFW_TRUE;
+    }
+
+    //------------------------------------------------------------
     void ofAppGLFWWindow::resize_cb(GLFWwindow * windowP_, int w, int h) {
         ofAppGLFWWindow * instance = setCurrent(windowP_);
         
@@ -1729,8 +1737,7 @@ void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings) {
     
     //------------------------------------------------------------
     bool ofAppGLFWWindow::isWindowActive() {
-        //	return glfwGetWindowParam(GLFW_ACTIVE);
-        return true;
+        return bWindowFocused;
     }
     
     //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -1632,6 +1632,7 @@ void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings) {
     void ofAppGLFWWindow::focus_cb(GLFWwindow * windowP_, int focused) {
         ofAppGLFWWindow * instance = setCurrent(windowP_);
         instance->bWindowFocused = focused == GLFW_TRUE;
+        ofNotifyEvent(instance->events().windowFocusChanged, instance->bWindowFocused, instance);
     }
 
     //------------------------------------------------------------

--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -413,6 +413,7 @@ void ofAppGLFWWindow::setup(const ofGLESWindowSettings & settings) {
         glfwSetDropCallback(windowP, drop_cb);
         glfwSetWindowRefreshCallback(windowP, refresh_cb);
         glfwSetWindowFocusCallback(windowP, focus_cb);
+        bWindowFocused = glfwGetWindowAttrib(windowP, GLFW_FOCUSED);
         
 #ifdef TARGET_LINUX
         XSetLocaleModifiers("");

--- a/libs/openFrameworks/app/ofAppGLFWWindow.h
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.h
@@ -208,6 +208,7 @@ private:
 	static void 	drop_cb(GLFWwindow* windowP_, int numFiles, const char** dropString);
 	static void		error_cb(int errorCode, const char* errorDescription);
  	static void   refresh_cb(GLFWwindow * windowP_);
+	static void   focus_cb(GLFWwindow * windowP_, int focused);
 
 	void close();
 
@@ -234,6 +235,7 @@ private:
 
 	int nFramesSinceWindowResized;
 	bool bWindowNeedsShowing;
+	bool bWindowFocused = true;
 
 #ifdef TARGET_RASPBERRY_PI
 	bool needsResizeCheck = false; /// Just for RPI at this point

--- a/libs/openFrameworks/events/ofEvents.h
+++ b/libs/openFrameworks/events/ofEvents.h
@@ -333,6 +333,7 @@ public:
 
 	ofEvent<ofResizeEventArgs> windowResized;
 	ofEvent<ofWindowPosEventArgs> windowMoved;
+	ofEvent<bool> windowFocusChanged;
 
 	ofEvent<ofKeyEventArgs> keyPressed;
 	ofEvent<ofKeyEventArgs> keyReleased;


### PR DESCRIPTION
## ofxGLFWWindow Focus
- Add `bWindowFocused` member to `ofAppGLFWWindow`
- Add `focus_cb` static callback (matches `GLFWfocusfun`), registered with
  `glfwSetWindowFocusCallback` alongside the other window callbacks in `setup()`
- Seed initial state from `glfwGetWindowAttrib(windowP, GLFW_FOCUSED)` right
  after registration, since a window isn't guaranteed to start focused
- Clear the callback in `close()` for symmetry with the other teardown calls
- `isWindowActive()` now returns `bWindowFocused` instead of the stub

ofAppGLFWWindow::isWindowActive()` was hardcoded to `return true`, so window now can be detected if active or not active... useful for backgrounding apps running machines, so you can now actively pause or sleep draw or update