### PR TITLE
Warnings fixes

### DIFF
--- a/libs/openFrameworks/3d/of3dUtils.cpp
+++ b/libs/openFrameworks/3d/of3dUtils.cpp
@@ -2,8 +2,12 @@
 #include "ofAppRunner.h"
 #include "ofGraphicsBaseTypes.h"
 
+#if !defined(GLM_FORCE_CTOR_INIT)
 #define GLM_FORCE_CTOR_INIT
+#endif
+#if !defined(GLM_ENABLE_EXPERIMENTAL)
 #define GLM_ENABLE_EXPERIMENTAL
+#endif
 #include <glm/vec3.hpp>
 
 //--------------------------------------------------------------

--- a/libs/openFrameworks/3d/ofCamera.cpp
+++ b/libs/openFrameworks/3d/ofCamera.cpp
@@ -2,8 +2,12 @@
 #include "ofGraphics.h"
 #include "of3dGraphics.h"
 
+#if !defined(GLM_FORCE_CTOR_INIT)
 #define GLM_FORCE_CTOR_INIT
+#endif
+#if !defined(GLM_ENABLE_EXPERIMENTAL)
 #define GLM_ENABLE_EXPERIMENTAL
+#endif
 #include <glm/gtx/transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 

--- a/libs/openFrameworks/math/ofMatrix4x4.cpp
+++ b/libs/openFrameworks/math/ofMatrix4x4.cpp
@@ -56,7 +56,7 @@ void ofMatrix4x4::set( float a00, float a01, float a02, float a03,
 
 void ofMatrix4x4::setRotate(const ofQuaternion& q)
 {
-    double length2 = q.length2();
+    double length2 = q.lengthSquared();
     if (std::abs(length2) <= std::numeric_limits<double>::min())
     {
         _mat[0][0] = 1.0; _mat[1][0] = 0.0; _mat[2][0] = 0.0;

--- a/libs/openFrameworks/utils/ofURLFileLoader.cpp
+++ b/libs/openFrameworks/utils/ofURLFileLoader.cpp
@@ -550,10 +550,10 @@ ofHttpRequest::ofHttpRequest(const string & url, const string & name, bool saveT
 	: url(url)
 	, name(name)
 	, saveTo(saveTo)
-	, method(GET)
-	, id(nextID++)
 	, close(autoClose)
-	, verbose(verbose){
+	, verbose(verbose)
+	, method(GET)
+	, id(nextID++){
 }
 
 int ofHttpRequest::getId() const {

--- a/libs/openFrameworks/utils/ofURLFileLoader.h
+++ b/libs/openFrameworks/utils/ofURLFileLoader.h
@@ -17,7 +17,7 @@ public:
 	std::string url; ///< request url
 	std::string name; ///< optional name key for sorting
 	bool saveTo; ///< save to a file once the request is finished?
-	bool close; ///< auto close connection at each request - default true 
+	bool close; ///< auto close connection at each request - default true
 	bool verbose; ///< verbose packet logs
 	std::map<std::string, std::string> headers; ///< HTTP header keys & values
 	std::string body; ///< POST body data
@@ -27,17 +27,17 @@ public:
 	size_t timeoutSeconds = 0;
 	bool headerOnly = false;
 
-	/// \return the unique id for this request
-	int getId() const;
-	[[deprecated("Use getId().")]]
-	int getID();
-
 	/// HTTP request type
 	enum Method{
 		GET, //< request data from a specified resource (via url)
 		POST, //< submit data to be processed to a specified resource (via url)
 		PUT
 	} method;
+
+	/// \\return the unique id for this request
+	int getId() const;
+	[[deprecated("Use getId().")]]
+	int getID();
 
 private:
 	int id; ///< unique id for this request

--- a/libs/openFrameworks/video/ofMediaFoundationPlayer.cpp
+++ b/libs/openFrameworks/video/ofMediaFoundationPlayer.cpp
@@ -330,7 +330,7 @@ bool SharedDXGLTexture::transferFrame(IMFMediaEngine* aengine) {
     if (!mBValid || !mGLDX_Handle) {
         return false;
     }
-    RECT targetRect{ 0, 0, mWidth, mHeight };
+    RECT targetRect{ 0, 0, static_cast<LONG>(mWidth), static_cast<LONG>(mHeight) };
     if ((aengine->TransferVideoFrame(
         getDXTexture(),
         &mNormalizedVidRect, &targetRect, &bgColor)) == S_OK) {
@@ -501,7 +501,7 @@ bool WICTextureManager::transferFrame(IMFMediaEngine* aengine) {
     if (!mBValid || !mWicBitmap) {
         return false;
     }
-    RECT targetRect{ 0, 0, mWidth, mHeight };
+    RECT targetRect{ 0, 0, static_cast<LONG>(mWidth), static_cast<LONG>(mHeight) };
     if ((aengine->TransferVideoFrame(
         mWicBitmap.Get(),
         &mNormalizedVidRect, &targetRect, &bgColor)) == S_OK) {
@@ -515,7 +515,7 @@ bool WICTextureManager::draw(ofPixels& apix) {
 
     ComPtr<IWICBitmapLock> lockedData;
     DWORD flags = WICBitmapLockRead;
-    WICRect srcRect{ 0, 0, mWidth, mHeight };
+    WICRect srcRect{ 0, 0, static_cast<INT>(mWidth), static_cast<INT>(mHeight) };
 
     if (FAILED(mWicBitmap->Lock(&srcRect, flags, lockedData.GetAddressOf()))) {
         return false;


### PR DESCRIPTION
[GLM redefine warning fix]
[ofMatrix4x4 fix for depreciated length2, now using lengthSquared()](
[ofURLFileLoader order of declaration fixed warning]
[ofMediaFoundationPlayer static cast to type to fix warnings]