### PR TITLE
Use X11/Wayland GLFW on linux aarch64, not EGL/GLES

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -33,6 +33,8 @@
 	#include <GLFW/glfw3native.h>
 #endif
 
+#include <cstdlib>
+
 using std::numeric_limits;
 using std::shared_ptr;
 using std::vector;
@@ -40,10 +42,18 @@ using std::vector;
 namespace of{
 	namespace priv{
 		bool InitGLFW(){
-			#if defined(TARGET_LINUX) && defined(GLFW_PLATFORM_X11)
-			// GLFW 3.4+ auto-detects Wayland when $WAYLAND_DISPLAY is set,
-			// Force the X11 backend so XWayland bridges us into the Wayland
-			// session transparently — no sudo required.
+			#if defined(TARGET_LINUX) && defined(GLFW_PLATFORM_WAYLAND) && defined(GLFW_PLATFORM_X11)
+			const char *waylandDisplay = getenv("WAYLAND_DISPLAY");
+			if (waylandDisplay && waylandDisplay[0] != '\0') {
+				glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_WAYLAND);
+				if (glfwInit()) {
+					return true;
+				}
+				glfwTerminate();
+				ofLogNotice("ofAppGLFWWindow") << "Wayland init failed, trying X11";
+			}
+			glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
+			#elif defined(TARGET_LINUX) && defined(GLFW_PLATFORM_X11)
 			glfwInitHint(GLFW_PLATFORM, GLFW_PLATFORM_X11);
 			#endif
 			return glfwInit();

--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -121,7 +121,8 @@ enum ofTargetPlatform{
 #elif defined (__ANDROID__)
 	#define TARGET_ANDROID
 	#define TARGET_OPENGLES
-//#elif defined(__ARMEL__)
+#elif defined(__aarch64__) || defined(__ARM64__)
+	#define TARGET_LINUX // desktop GLFW (X11/Wayland), not EGL/GLES armv6/v7
 #elif defined(__ARM__)
 	#define TARGET_LINUX
 	#define TARGET_OPENGLES

--- a/libs/openFrameworksCompiled/project/linuxaarch64/config.linuxaarch64.default.mk
+++ b/libs/openFrameworksCompiled/project/linuxaarch64/config.linuxaarch64.default.mk
@@ -70,9 +70,7 @@ PLATFORM_CFLAGS += -pipe
 # Note: Leave a leading space when adding list items with the += operator
 ################################################################################
 
-PLATFORM_PKG_CONFIG_LIBRARIES += glesv1_cm
-PLATFORM_PKG_CONFIG_LIBRARIES += glesv2
-PLATFORM_PKG_CONFIG_LIBRARIES += egl
+# GLFW + desktop GL (X11/Wayland), same as linux64 — not EGL/GLES like armv6/v7
 
 
 ################################################################################

--- a/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
+++ b/libs/openFrameworksCompiled/project/makefileCommon/config.linux.common.mk
@@ -404,6 +404,15 @@ ifneq ($(LINUX_ARM),1)
 	PLATFORM_PKG_CONFIG_LIBRARIES += gl
 	PLATFORM_PKG_CONFIG_LIBRARIES += glu
 	PLATFORM_PKG_CONFIG_LIBRARIES += glew
+	# GLFW 3.4 static lib on desktop linux (x86_64 and aarch64) is built with
+	# both X11 and Wayland objects. Pull the Wayland link deps when present
+	# so that backend can actually resolve; X11 libs are already listed above.
+	GLFW_WL_PKGS := wayland-client wayland-cursor wayland-egl xkbcommon libdecor-0
+	ifeq ($(CROSS_COMPILING),1)
+		$(foreach pkg,$(GLFW_WL_PKGS),$(if $(shell export PKG_CONFIG_LIBDIR=$(PKG_CONFIG_LIBDIR); pkg-config --exists $(pkg) && echo 1),$(eval PLATFORM_PKG_CONFIG_LIBRARIES += $(pkg))))
+	else
+		$(foreach pkg,$(GLFW_WL_PKGS),$(if $(shell pkg-config --exists $(pkg) && echo 1),$(eval PLATFORM_PKG_CONFIG_LIBRARIES += $(pkg))))
+	endif
 endif
 
 

--- a/scripts/linux/archlinux/install_dependencies.sh
+++ b/scripts/linux/archlinux/install_dependencies.sh
@@ -11,7 +11,7 @@ fi
 
 ROOT=$(cd $(dirname $0); pwd -P)
 
-pacman -S --needed make pkgconf gcc openal glm glew freeglut gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav opencv libxcursor assimp glfw-x11 uriparser curl pugixml rtaudio poco brotli gum
+pacman -S --needed make pkgconf gcc openal glm glew freeglut gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-libav opencv libxcursor assimp glfw-x11 uriparser curl pugixml rtaudio poco brotli gum wayland libxkbcommon libdecor
 
 exit_code=$?
 if [ $exit_code != 0 ]; then


### PR DESCRIPTION
## Why

Native ARM64 Linux builds GLFW with **both** X11 and Wayland backends (the ARM64 setup already installs Wayland, xkbcommon, and X11 headers). `armv6l` / `armv7l` still disable those and use EGL/GLES.

`linuxaarch64` was still pulling `glesv1_cm` / `glesv2` / `egl`, and `InitGLFW()` always forced `GLFW_PLATFORM_X11`. That meant a packaged `libglfw3.a` with both backends could not actually run Wayland, and aarch64 looked like the Pi GLES target.

openFrameworks only needs to **link** the right windowing libs and **select** the backend at runtime.

## Changes

- `ofConstants.h`: `__aarch64__` / `__ARM64__` → desktop `TARGET_LINUX` (GLFW), not `TARGET_LINUX_ARM` + `TARGET_OPENGLES`
- `config.linuxaarch64.default.mk`: drop EGL/GLES pkg-config (desktop GL comes from `config.linux.common.mk` because `LINUX_ARM` is not set for aarch64)
- `config.linux.common.mk`: on desktop linux (x86_64 and aarch64), pkg-config-link `wayland-client`, `wayland-cursor`, `wayland-egl`, `xkbcommon`, `libdecor-0` when present
- `ofAppGLFWWindow`: if `WAYLAND_DISPLAY` is set, try Wayland, then fall back to X11
- Arch deps: `wayland`, `libxkbcommon`, `libdecor` (Debian/Ubuntu/Fedora already had them)

armv6l / armv7l are unchanged (EGL/GLES).