### PR TITLE
Decouple GL from ofGraphics

### DIFF
--- a/addons/ofxGui/src/ofxToggle.h
+++ b/addons/ofxGui/src/ofxToggle.h
@@ -1,8 +1,8 @@
 #pragma once
-
 #include "ofParameter.h"
 #include "ofxBaseGui.h"
 #include "ofPath.h"
+#include "ofVboMesh.h"
 
 class ofxToggle : public ofxBaseGui{
 public:

--- a/libs/openFrameworks/app/ofAppNoWindow.cpp
+++ b/libs/openFrameworks/app/ofAppNoWindow.cpp
@@ -86,6 +86,7 @@ private:
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}
 	void draw(const ofShortImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const{}
 	void draw(const ofBaseVideoDraws & video, float x, float y, float w, float h) const{}
+	void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const {};
 
 	//--------------------------------------------
 	// transformations

--- a/libs/openFrameworks/gl/ofCubeMap.cpp
+++ b/libs/openFrameworks/gl/ofCubeMap.cpp
@@ -10,6 +10,7 @@
 #include "ofTexture.h"
 #include "ofFileUtils.h"
 #include "ofMaterial.h"
+#include "ofVboMesh.h"
 
 #ifdef TARGET_ANDROID
 #include "ofAppAndroidWindow.h"

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.cpp
@@ -37,6 +37,8 @@ bool ofIsGLProgrammableRenderer() {
 	return programmableRendererCreated;
 }
 
+static ofVboMesh gradientMesh;
+
 //----------------------------------------------------------
 ofGLProgrammableRenderer::ofGLProgrammableRenderer(const ofAppBaseWindow * _window)
 	: matrixStack(_window)
@@ -616,6 +618,66 @@ void ofGLProgrammableRenderer::drawElementsInstanced(const ofVbo & vbo, GLuint d
 		#endif
 #endif
 		vbo.unbind();
+	}
+}
+
+//----------------------------------------------------------
+void ofGLProgrammableRenderer::drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const {
+	float w = getViewportWidth(), h = getViewportHeight();
+	gradientMesh.clear();
+	gradientMesh.setMode(OF_PRIMITIVE_TRIANGLE_FAN);
+#ifndef TARGET_EMSCRIPTEN
+	gradientMesh.setUsage(GL_STREAM_DRAW);
+#endif
+	if (mode == OF_GRADIENT_CIRCULAR) {
+		// this could be optimized by building a single mesh once, then copying
+		// it and just adding the colors whenever the function is called.
+		///TODO: revert to glm::vec2!!
+		glm::vec2 center(w / 2, h / 2);
+		gradientMesh.addVertex(glm::vec3(center, 0.f));
+		gradientMesh.addColor(start);
+		float n = 32; // circular gradient resolution
+		float angleBisector = glm::two_pi<float>() / (n * 2.0);
+		float smallRadius = ofDist(0, 0, w / 2, h / 2);
+		float bigRadius = smallRadius / std::cos(angleBisector);
+		for (int i = 0; i <= n; i++) {
+			float theta = i * glm::two_pi<float>() / n;
+			gradientMesh.addVertex(glm::vec3(center + glm::vec2(std::sin(theta), std::cos(theta)) * bigRadius, 0));
+			gradientMesh.addColor(end);
+		}
+	} else if (mode == OF_GRADIENT_LINEAR) {
+		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
+		gradientMesh.addVertex({ w, 0.f, 0.f });
+		gradientMesh.addVertex({ w, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h, 0.f });
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+	} else if (mode == OF_GRADIENT_BAR) {
+		gradientMesh.addVertex({ w / 2.f, h / 2.f, 0.f });
+		gradientMesh.addVertex({ 0.f, h / 2.f, 0.f });
+		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
+		gradientMesh.addVertex({ w, 0.f, 0.f });
+		gradientMesh.addVertex({ w, h / 2.f, 0.f });
+		gradientMesh.addVertex({ w, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h / 2, 0.f });
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(start);
+	}
+	GLboolean depthMaskEnabled;
+	glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
+	glDepthMask(GL_FALSE);
+	gradientMesh.draw();
+	if (depthMaskEnabled) {
+		glDepthMask(GL_TRUE);
 	}
 }
 

--- a/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
+++ b/libs/openFrameworks/gl/ofGLProgrammableRenderer.h
@@ -8,6 +8,7 @@
 #include "ofPolyline.h"
 #include "ofBitmapFont.h"
 #include "ofPath.h"
+#include "ofVbo.h"
 
 class ofShapeTessellation;
 class ofFbo;
@@ -44,6 +45,8 @@ public:
 	void drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int amt, int primCount) const;
 	void draw(const ofVboMesh & mesh, ofPolyRenderMode renderType) const;
 	void drawInstanced(const ofVboMesh & mesh, ofPolyRenderMode renderType, int primCount) const;
+	void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const;
+	
     ofPath & getPath();
     
     

--- a/libs/openFrameworks/gl/ofGLRenderer.cpp
+++ b/libs/openFrameworks/gl/ofGLRenderer.cpp
@@ -20,6 +20,8 @@ using std::vector;
 
 const std::string ofGLRenderer::TYPE = "GL";
 
+static ofVboMesh gradientMesh;
+
 //----------------------------------------------------------
 ofGLRenderer::ofGLRenderer(const ofAppBaseWindow * _window)
 	: matrixStack(_window)
@@ -429,6 +431,66 @@ void ofGLRenderer::drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int
 		glDrawElementsInstanced(drawMode, amt, sizeof(ofIndexType) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, nullptr, primCount);
 #endif
 		vbo.unbind();
+	}
+}
+
+//----------------------------------------------------------
+void ofGLRenderer::drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const {
+	float w = getViewportWidth(), h = getViewportHeight();
+	gradientMesh.clear();
+	gradientMesh.setMode(OF_PRIMITIVE_TRIANGLE_FAN);
+#ifndef TARGET_EMSCRIPTEN
+	gradientMesh.setUsage(GL_STREAM_DRAW);
+#endif
+	if (mode == OF_GRADIENT_CIRCULAR) {
+		// this could be optimized by building a single mesh once, then copying
+		// it and just adding the colors whenever the function is called.
+		///TODO: revert to glm::vec2!!
+		glm::vec2 center(w / 2, h / 2);
+		gradientMesh.addVertex(glm::vec3(center, 0.f));
+		gradientMesh.addColor(start);
+		float n = 32; // circular gradient resolution
+		float angleBisector = glm::two_pi<float>() / (n * 2.0);
+		float smallRadius = ofDist(0, 0, w / 2, h / 2);
+		float bigRadius = smallRadius / std::cos(angleBisector);
+		for (int i = 0; i <= n; i++) {
+			float theta = i * glm::two_pi<float>() / n;
+			gradientMesh.addVertex(glm::vec3(center + glm::vec2(std::sin(theta), std::cos(theta)) * bigRadius, 0));
+			gradientMesh.addColor(end);
+		}
+	} else if (mode == OF_GRADIENT_LINEAR) {
+		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
+		gradientMesh.addVertex({ w, 0.f, 0.f });
+		gradientMesh.addVertex({ w, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h, 0.f });
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+	} else if (mode == OF_GRADIENT_BAR) {
+		gradientMesh.addVertex({ w / 2.f, h / 2.f, 0.f });
+		gradientMesh.addVertex({ 0.f, h / 2.f, 0.f });
+		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
+		gradientMesh.addVertex({ w, 0.f, 0.f });
+		gradientMesh.addVertex({ w, h / 2.f, 0.f });
+		gradientMesh.addVertex({ w, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h, 0.f });
+		gradientMesh.addVertex({ 0.f, h / 2, 0.f });
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(start);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(end);
+		gradientMesh.addColor(start);
+	}
+	GLboolean depthMaskEnabled;
+	glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
+	glDepthMask(GL_FALSE);
+	gradientMesh.draw();
+	if (depthMaskEnabled) {
+		glDepthMask(GL_TRUE);
 	}
 }
 

--- a/libs/openFrameworks/gl/ofGLRenderer.h
+++ b/libs/openFrameworks/gl/ofGLRenderer.h
@@ -43,6 +43,7 @@ public:
 	void drawElementsInstanced(const ofVbo & vbo, GLuint drawMode, int amt, int primCount) const;
 	void draw(const ofVboMesh & mesh, ofPolyRenderMode renderType) const;
 	void drawInstanced(const ofVboMesh & mesh, ofPolyRenderMode renderType, int primCount) const;
+	void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const;
 	ofPath & getPath();
 
 

--- a/libs/openFrameworks/graphics/ofCairoRenderer.h
+++ b/libs/openFrameworks/graphics/ofCairoRenderer.h
@@ -46,6 +46,8 @@ public:
 	void draw(const ofFloatImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofShortImage & image, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 	void draw(const ofBaseVideoDraws & video, float x, float y, float w, float h) const;
+	// TODO: This could probably be implemented.
+	void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const {};
 	ofPath & getPath();
 
 	//--------------------------------------------
@@ -85,6 +87,8 @@ public:
 	ofFillFlag getFillMode();
 	void setLineWidth(float lineWidth);
 	void setPointSize(float pointSize);
+	void enablePointSprites() {};
+	void disablePointSprites() {};
 	void setDepthTest(bool depthTest);
 	void setBlendMode(ofBlendMode blendMode);
 	void setLineSmoothing(bool smooth);

--- a/libs/openFrameworks/graphics/ofGraphics.cpp
+++ b/libs/openFrameworks/graphics/ofGraphics.cpp
@@ -1,4 +1,4 @@
-#include "ofGLRenderer.h"
+//#include "ofGLRenderer.h"
 #include "ofGraphics.h"
 #include "ofRendererCollection.h"
 #include "ofRectangle.h"
@@ -11,7 +11,7 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
-static ofVboMesh gradientMesh;
+//static ofVboMesh gradientMesh;
 
 void ofSetCurrentRenderer(shared_ptr<ofBaseRenderer> renderer, bool setDefaults) {
 	if (setDefaults) {
@@ -409,66 +409,7 @@ void ofBackgroundHex(int hexColor, int alpha){
 
 //----------------------------------------------------------
 void ofBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) {
-	float w = ofGetViewportWidth(), h = ofGetViewportHeight();
-	gradientMesh.clear();
-	gradientMesh.setMode(OF_PRIMITIVE_TRIANGLE_FAN);
-#ifndef TARGET_EMSCRIPTEN
-	#ifdef TARGET_OPENGLES
-	if (ofIsGLProgrammableRenderer()) gradientMesh.setUsage(GL_STREAM_DRAW);
-	#else
-	gradientMesh.setUsage(GL_STREAM_DRAW);
-	#endif
-#endif
-	if (mode == OF_GRADIENT_CIRCULAR) {
-		// this could be optimized by building a single mesh once, then copying
-		// it and just adding the colors whenever the function is called.
-		///TODO: revert to glm::vec2!!
-		glm::vec2 center(w / 2, h / 2);
-		gradientMesh.addVertex(glm::vec3(center, 0.f));
-		gradientMesh.addColor(start);
-		float n = 32; // circular gradient resolution
-		float angleBisector = glm::two_pi<float>() / (n * 2.0);
-		float smallRadius = ofDist(0, 0, w / 2, h / 2);
-		float bigRadius = smallRadius / std::cos(angleBisector);
-		for (int i = 0; i <= n; i++) {
-			float theta = i * glm::two_pi<float>() / n;
-			gradientMesh.addVertex(glm::vec3(center + glm::vec2(std::sin(theta), std::cos(theta)) * bigRadius, 0));
-			gradientMesh.addColor(end);
-		}
-	} else if (mode == OF_GRADIENT_LINEAR) {
-		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
-		gradientMesh.addVertex({ w, 0.f, 0.f });
-		gradientMesh.addVertex({ w, h, 0.f });
-		gradientMesh.addVertex({ 0.f, h, 0.f });
-		gradientMesh.addColor(start);
-		gradientMesh.addColor(start);
-		gradientMesh.addColor(end);
-		gradientMesh.addColor(end);
-	} else if (mode == OF_GRADIENT_BAR) {
-		gradientMesh.addVertex({ w / 2.f, h / 2.f, 0.f });
-		gradientMesh.addVertex({ 0.f, h / 2.f, 0.f });
-		gradientMesh.addVertex({ 0.f, 0.f, 0.f });
-		gradientMesh.addVertex({ w, 0.f, 0.f });
-		gradientMesh.addVertex({ w, h / 2.f, 0.f });
-		gradientMesh.addVertex({ w, h, 0.f });
-		gradientMesh.addVertex({ 0.f, h, 0.f });
-		gradientMesh.addVertex({ 0.f, h / 2, 0.f });
-		gradientMesh.addColor(start);
-		gradientMesh.addColor(start);
-		gradientMesh.addColor(end);
-		gradientMesh.addColor(end);
-		gradientMesh.addColor(start);
-		gradientMesh.addColor(end);
-		gradientMesh.addColor(end);
-		gradientMesh.addColor(start);
-	}
-	GLboolean depthMaskEnabled;
-	glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMaskEnabled);
-	glDepthMask(GL_FALSE);
-	gradientMesh.draw();
-	if (depthMaskEnabled) {
-		glDepthMask(GL_TRUE);
-	}
+	ofGetCurrentRenderer()->drawBackgroundGradient(start, end, mode);
 }
 
 //----------------------------------------------------------
@@ -638,16 +579,12 @@ void ofEnableBlendMode(ofBlendMode blendMode){
 
 //----------------------------------------------------------
 void ofEnablePointSprites() {
-	if (ofGetCurrentRenderer()->getType() == "GL" || ofGetCurrentRenderer()->getType() == "ProgrammableGL") {
-		static_cast<ofBaseGLRenderer *>(ofGetCurrentRenderer().get())->enablePointSprites();
-	}
+	ofGetCurrentRenderer()->enablePointSprites();
 }
 
 //----------------------------------------------------------
 void ofDisablePointSprites() {
-	if (ofGetCurrentRenderer()->getType() == "GL" || ofGetCurrentRenderer()->getType() == "ProgrammableGL") {
-		static_cast<ofBaseGLRenderer *>(ofGetCurrentRenderer().get())->disablePointSprites();
-	}
+	ofGetCurrentRenderer()->disablePointSprites();
 }
 
 //----------------------------------------------------------

--- a/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
+++ b/libs/openFrameworks/graphics/ofGraphicsBaseTypes.h
@@ -861,6 +861,10 @@ public:
 	///
 	/// \param pointSize The points size to request this renderer to use.
 	virtual void setPointSize(float pointSize) = 0;
+	/// \brief Enable point sprites via a shader.
+	virtual void enablePointSprites() = 0;
+	/// \brief Disable point sprites via a shader.
+	virtual void disablePointSprites() = 0;
 
 	/// \brief Enable/disable depth testing with this renderer.
 	///
@@ -1137,6 +1141,18 @@ public:
 	/// \param x The x position for the bottom of \p text.
 	/// \param y The y position for the left alignment of \p text.
 	virtual void drawString(const ofTrueTypeFont & font, std::string text, float x, float y) const = 0;
+	
+	/// \brief Sets the background color to a gradient.
+	///
+	/// It takes as input 2 ofColor() objects and a Gradient Mode.
+	/// Must be called in the draw() function.
+	///
+	/// Accepted modes are:
+	///
+	/// - Circular: `OF_GRADIENT_CIRCULAR`
+	/// - Linear: `OF_GRADIENT_LINEAR`
+	/// - Bar: `OF_GRADIENT_BAR`
+	virtual void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const = 0;
 
 	// returns true an ofPath to draw with, this allows to keep
 	// immediate mode rendering working in multiwindow with multiple

--- a/libs/openFrameworks/graphics/ofPath.h
+++ b/libs/openFrameworks/graphics/ofPath.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "ofPolyline.h"
-#include "ofVboMesh.h"
+//#include "ofVboMesh.h"
+#include "ofMesh.h"
 #include "ofTessellator.h"
 // MARK: ofConstants targets
 #include "ofConstants.h"
@@ -432,11 +433,11 @@ private:
 	std::vector<ofPolyline>  polylines;
 	std::vector<ofPolyline>  tessellatedContour; // if winding mode != ODD
 
-#ifdef TARGET_OPENGLES
+//#ifdef TARGET_OPENGLES
 	ofMesh				cachedTessellation;
-#else
-	ofVboMesh			cachedTessellation;
-#endif
+//#else
+//	ofVboMesh			cachedTessellation;
+//#endif
 #if defined(TARGET_EMSCRIPTEN)
 	static ofTessellator tessellator;
 #elif HAS_TLS

--- a/libs/openFrameworks/graphics/ofRendererCollection.cpp
+++ b/libs/openFrameworks/graphics/ofRendererCollection.cpp
@@ -91,6 +91,12 @@ void ofRendererCollection::draw(const ofBaseVideoDraws & video, float x, float y
    }
 }
 
+void ofRendererCollection::drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const {
+	for(auto renderer: renderers){
+		renderer->drawBackgroundGradient(start, end, mode);
+	}
+}
+
 /*void bind(const ofBaseVideoDraws & video) const{
    for(int i=0;i<(int)renderers.size();i++){
 	   renderers[i]->bind(video);
@@ -573,16 +579,12 @@ void ofRendererCollection::setCircleResolution(int res){
 }
 void ofRendererCollection::enablePointSprites(){
    for(auto renderer: renderers){
-		if(renderer->getType()=="GL" || renderer->getType()=="ProgrammableGL"){
-			std::dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->enablePointSprites();
-		}
+	   renderer->enablePointSprites();
 	}
 }
 void ofRendererCollection::disablePointSprites(){
    for(auto renderer: renderers){
-		if(renderer->getType()=="GL" || renderer->getType()=="ProgrammableGL"){
-			std::dynamic_pointer_cast<ofBaseGLRenderer>(renderer)->disablePointSprites();
-		}
+	   renderer->disablePointSprites();
 	}
 }
 

--- a/libs/openFrameworks/graphics/ofRendererCollection.h
+++ b/libs/openFrameworks/graphics/ofRendererCollection.h
@@ -39,6 +39,8 @@ public:
 	void draw(const ofShortImage & img, float x, float y, float z, float w, float h, float sx, float sy, float sw, float sh) const;
 
 	void draw(const ofBaseVideoDraws & video, float x, float y, float w, float h) const;
+	
+	void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const;
 
 	/*void bind(const ofBaseVideoDraws & video) const{
 		for(int i=0;i<(int)renderers.size();i++){


### PR DESCRIPTION
Removed GL specific code in ofGraphics and required the following definitions in renderers. 
```
void drawBackgroundGradient(const ofFloatColor& start, const ofFloatColor& end, ofGradientMode mode) const;
void enablePointSprites();
void disablePointSprites();
```

Removed `ofVboMesh` from `ofPath` and replaced with `ofMesh`. 
This makes it a bit easier to create new renderers without having certain functions and variables tied to GL specific code.